### PR TITLE
Share global agent rules and add ask-agent consult skill

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -9,6 +9,9 @@ on:
 env:
   CHEZMOI_NAME: "Test User"
   CHEZMOI_EMAIL: "test@example.com"
+  # Runners lack node's release GPG key, so mise's signature check on
+  # `node@lts` fails. Skip it in CI; local installs keep verification.
+  MISE_NODE_VERIFY: "false"
 
 jobs:
   test-ubuntu:

--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -1,0 +1,156 @@
+# Agent setup inventory
+
+Created: 2026-06-26
+
+The curated list of agent skills / agents / plugins I actually **choose**, for
+manual reinstall across Claude Code, OpenCode, and Pi. Bundle internals (skills
+and agents that ship inside a plugin/extension) are **not** listed individually —
+they come back when the bundle is installed. Maintained by hand; install
+manually. No scripts, templates, or tests.
+
+Ignored on purpose: Codex / Gemini CLI / GitHub Copilot targets.
+
+Source legend: `gh:<owner/repo>` GitHub · `npm:<pkg>` npm · `git:<url>` git ·
+`repo` authored in this dotfiles repo · `bundle:<name>` provided by a bundle ·
+`?` source unconfirmed — fill in.
+
+---
+
+## Cross-tool skills (my own / want everywhere)
+
+| Skill | Tools | Source |
+|---|---|---|
+| crit | Claude, OpenCode, Pi | `?` (crit tool's skill — confirm) |
+| herdr | Claude → **want OpenCode + Pi too** | `repo` (home/private_dot_claude/skills/herdr) |
+| react-doctor | Claude, OpenCode | `gh:millionco/react-doctor` |
+
+---
+
+## Claude Code
+
+### Marketplaces (add first: `claude plugin marketplace add <source>`)
+
+| Marketplace | Source |
+|---|---|
+| claude-plugins-official | `gh:anthropics/claude-plugins-official` |
+| claude-code-workflows | `gh:wshobson/agents` |
+| cc-marketplace | `gh:kenryu42/cc-marketplace` |
+| context7-marketplace | `gh:upstash/context7` |
+| impeccable | `gh:pbakaus/impeccable` |
+| chrome-devtools-plugins | `gh:ChromeDevTools/chrome-devtools-mcp` |
+| compound-engineering-plugin | `gh:EveryInc/compound-engineering-plugin` |
+| obsidian-skills | `git:git@github.com:kepano/obsidian-skills.git` (only used project-scope — optional) |
+
+### Plugins (user-scope, global: `claude plugin install <name>@<marketplace>`)
+
+**claude-plugins-official:** code-review · playwright · pr-review-toolkit ·
+explanatory-output-style · learning-output-style · hookify · superpowers ·
+playground · claude-md-management · plugin-dev · chrome-devtools-mcp
+
+**claude-code-workflows:** code-documentation · debugging-toolkit · unit-testing ·
+code-refactoring · javascript-typescript · c4-architecture ·
+frontend-mobile-development · conductor · accessibility-compliance
+
+**cc-marketplace:** safety-net
+**context7-marketplace:** context7-plugin
+**impeccable:** impeccable
+**compound-engineering-plugin:** compound-engineering
+**chrome-devtools-plugins:** chrome-devtools-mcp
+
+> ⚠️ `chrome-devtools-mcp` is installed from **both** claude-plugins-official and
+> chrome-devtools-plugins — pick one source to avoid a duplicate.
+
+### Authored skills (`home/private_dot_claude/skills/` — already in repo)
+
+ask-agent · herdr · markdown-new · react-doctor · review-plan · tdd-integration
+
+### Skills pulled from upstream (`home/.chezmoiexternal.toml` — already in repo)
+
+| Skill | Source |
+|---|---|
+| react-best-practices | `gh:vercel-labs/agent-skills` |
+| composition-patterns | `gh:vercel-labs/agent-skills` |
+| react-useeffect | `gh:jarrodwatts/claude-code-config` |
+| rigorous-coding | `gh:jarrodwatts/claude-code-config` |
+| linear-cli | `gh:schpet/linear-cli` |
+| ast-grep | `gh:ast-grep/agent-skill` |
+| improve-claude-md | `gh:dexhorthy/slopfiles` |
+| handoff | `?` (present in ~/.claude/skills — confirm source) |
+
+### Authored agents (`home/private_dot_claude/agents/` — already in repo)
+
+agent-enhancer · open-source-librarian · plan-architect · plan-pragmatist ·
+plan-skeptic · plan-synthesizer · tdd-implementer · tdd-refactorer · tdd-test-writer
+
+---
+
+## OpenCode
+
+### Plugins (`~/.config/opencode/opencode.json` → `plugin[]`; OpenCode self-installs at startup)
+
+| Plugin | Source |
+|---|---|
+| oh-my-openagent | `npm:oh-my-openagent` — **bundle**: provides ce-* skills + ~49 agents |
+| @rynfar/meridian | `gh:rynfar/meridian` (`npm:@rynfar/meridian`) — install the package and reference it (replaces the old absolute brew path) |
+
+### Local plugins (files, keep in repo)
+
+herdr-agent-state.js · rtk.ts
+
+### Skills / agents
+
+Mostly `bundle:oh-my-openagent` (the ce-* set + reviewer agents) — do not hand-list.
+Cross-tool own skills here: crit, react-doctor, herdr (wanted). Also web-perf, lfg.
+
+---
+
+## Pi
+
+### Extensions (`~/.pi/agent/settings.json` → `packages[]`; `pi install <source>`)
+
+| Extension | Source |
+|---|---|
+| pi-theme-flexoki | `git:github.com/markacianfrani/pi-theme-flexoki` |
+| pi-fff | `npm:@ff-labs/pi-fff` |
+| pi-rtk | `npm:@sherif-fanous/pi-rtk` |
+| pi-codex-conversion | `npm:@howaboua/pi-codex-conversion` |
+| pi-agents | `npm:pi-agents` |
+| pi-subagents | `npm:pi-subagents` |
+| pi-intercom | `npm:pi-intercom` |
+| pi-agent-browser-native | `npm:pi-agent-browser-native` (https://pi.dev/packages/pi-agent-browser-native — replaced the old local absolute path / coctostan repo) |
+
+### Skills / agents
+
+Skills: crit, web-perf, web-research.
+Agents (`~/.pi/agent/agents/`, hand-authored — keep): ask-claude · ask-external ·
+ask-opencode · ask-pi · brainstorm-doc-reviewer · reviewer · se-plan-review ·
+se-report-writer · synthes-agent.
+
+---
+
+## Excluded / cleaned up
+
+- **Codex / Gemini / Copilot** targets (e.g. `web-perf` in `~/.codex/skills/`) — ignored.
+- **Claude project-scope plugins** (not global): frontend-design, feature-dev,
+  security-guidance, code-simplifier, typescript-lsp (all @ `Projects/platform`),
+  obsidian (@ Dropbox Knowledge Base).
+- **Pi compound-engineering orphan** — deleted 2026-06-26 (was an uncoordinated
+  install: 49 agent files + a private manifest, never in `packages[]`).
+
+---
+
+## Manual install quickref
+
+- **Claude:** `claude plugin marketplace add <source>` then
+  `claude plugin install <name>@<marketplace>`. Authored + upstream skills come
+  via `chezmoi apply` (already managed).
+- **OpenCode:** ensure entries in `~/.config/opencode/opencode.json` `plugin[]`;
+  install the meridian package; OpenCode self-installs npm plugins at startup.
+- **Pi:** `pi install <source>` for each `packages[]` entry (`pi list` to check,
+  `pi update --all` to refresh).
+
+## To confirm
+
+- Sources marked `?`: crit, handoff.
+- Whether to make herdr multi-tool now (currently Claude-only).
+- Drop the duplicate `chrome-devtools-mcp` marketplace source.

--- a/docs/brainstorms/2026-06-26-reproduce-agent-setup-requirements.md
+++ b/docs/brainstorms/2026-06-26-reproduce-agent-setup-requirements.md
@@ -1,0 +1,320 @@
+---
+date: 2026-06-26
+topic: reproduce-agent-setup
+---
+
+# Reproduce agent setup (skills, agents, plugins) across reinstalls
+
+## Summary
+
+Make the full agent environment — skills, agents, and tool plugins for Claude
+Code, OpenCode, and Pi — reproducible across machines and reinstalls through
+chezmoi. Everything is handled as one of three kinds: *vendored files*
+(committed and copied into place), *upstream-fetched* (chezmoi pulls from a
+pinned upstream via `.chezmoiexternal.toml`), or *declarative reinstall*
+(recorded in a manifest and reinstalled by the tool itself). No bespoke
+management tool and no `npx skills`.
+
+## Problem Frame
+
+Agent configuration today comes from several uncoordinated paths and drifts:
+
+- `home/.chezmoiexternal.toml` pulls 7 skills as GitHub archives into
+  `~/.claude/skills/` (Claude only).
+- `home/private_dot_claude/skills/` holds 4 authored skills (Claude only).
+- Claude marketplace plugins (e.g. compound-engineering) ship skills **and**
+  ~50 agents, tracked in `~/.claude/plugins/installed_plugins.json` and
+  `known_marketplaces.json`.
+- OpenCode carries skills as files, local plugins as files, and npm plugins
+  declared in `opencode.json`.
+- Pi carries standalone skills and agents as files in `~/.pi/agent/` and installs
+  extensions via `pi install` (tracked in `settings.json` `packages[]`). An
+  earlier uncoordinated `compound-engineering` install (files + a private
+  manifest, never in `packages[]`) has been removed, leaving only tracked
+  extensions and hand-authored agents.
+
+The cost is concrete drift — `ce-brainstorm` is `3.14.3` on Claude but a May
+copy on OpenCode — and no single place reproduces the setup on a fresh machine.
+
+An earlier direction explored a declarative skill-management layer
+(`Skillfile` + a custom CLI on top of `npx skills`). It was rejected after
+verifying `npx skills` against `skills@1.5.13` source: its only replay command
+(`experimental_install`) is project-scoped and reinstalls to universal agents
+(no per-tool targeting), its global lockfile records only `skills add` installs,
+and it adds a runtime dependency plus symlinks under `~/.agents` outside
+chezmoi. The real need is **preservation and restore**, not a management CLI —
+and chezmoi already reproduces files.
+
+## Key Decisions
+
+- **Reframe to reproduction, not management.** The goal is restoring the
+  current skills/agents/plugins on a reinstall, with chezmoi as the umbrella —
+  not a tool that curates or discovers skills.
+
+- **Drop `npx skills` entirely.** The two capabilities it seemed to provide are
+  already native: per-tool rollout is just placing files in each tool's dir via
+  chezmoi, and third-party fetch+refresh is already done by
+  `.chezmoiexternal.toml`. The only thing lost is catalog discovery
+  (`skills find`) — a nice-to-have, not core.
+
+- **Three restore mechanisms, nothing else.** *Vendored files* for skills,
+  agents, and local plugins (commit the bytes, chezmoi copies them).
+  *Upstream-fetched* for third-party skills (chezmoi pulls from a pinned ref).
+  *Declarative reinstall* for marketplace/npm plugins (record what to install;
+  the tool reinstalls). The R15 inventory uses exactly these three buckets.
+
+- **Bundle-provided agents restore with their bundle, not separately.** Claude's
+  ~50 `ce-*` agents and OpenCode's bundle agents come back when the bundle is
+  reinstalled — they are never vendored as standalone files (that would
+  duplicate and drift from the bundle). Only standalone, hand-authored agents
+  are vendored.
+
+- **All three tools are first-class targets.** Claude, OpenCode, and Pi each
+  receive skills/agents and are reproduced by the same two mechanisms. Pi is not
+  deferred — it already carries skills (`crit`, `web-perf`, `web-research`),
+  agents, and a bundle install on disk.
+
+- **Skills and agents are files.** All three tools discover skills by scanning
+  directories for `SKILL.md`; agents are likewise files. Restore = copy.
+  Selective per-tool rollout uses one canonical body in
+  `home/.chezmoitemplates/` with thin per-tool include files — present where the
+  skill should exist, absent where it shouldn't.
+
+- **OpenCode self-installs its npm plugins.** OpenCode runs `bun install` at
+  startup for entries in `opencode.json` → `plugin[]`. Committing `opencode.json`
+  reproduces npm plugins; local plugins and skills are committed as files.
+
+- **Claude marketplace plugins use a reinstall manifest.** The raw config files
+  (`installed_plugins.json`, `known_marketplaces.json`) are non-portable
+  (absolute paths, timestamps, machine state, project-scoped entries). Instead a
+  small manifest records marketplace sources and user-scope plugins, and a run
+  script reinstalls via `claude plugin marketplace add` / `claude plugin
+  install`. The manifest is seeded by generating once from the `scope: user`
+  entries in `installed_plugins.json`, then curated by hand.
+
+- **Third-party skills stay re-fetched, not vendored.** They remain on
+  `.chezmoiexternal.toml` (fetch + refresh from upstream) rather than copied into
+  the repo — chosen for freshness and a thin repo, accepting the network
+  dependency.
+
+- **One canonical skill body, per-tool includes.** Multi-tool skills live once
+  in `home/.chezmoitemplates/` with thin per-tool include files, rather than
+  duplicated copies per tool — edited in one place, drift-free.
+
+- **`oh-my-openagent.json` is out of scope.** Not preserved or managed, per the
+  user's call. Accepted consequence: the `oh-my-openagent` plugin may need
+  one-time reconfiguration (its agent→model mapping) on a fresh machine.
+
+- **Track current by default; pin only by exception.** The goal is the same
+  *set* of skills/plugins on every machine, kept current — not a frozen
+  byte-snapshot. Sources track their normal channel (latest / a moving branch)
+  and every machine updates uniformly; pin a source to an immutable ref only
+  when a specific item must be frozen. The original drift (stale OpenCode copy
+  of `ce-brainstorm`) was an update-consistency failure — nothing refreshed that
+  copy — not an unpinned-version failure; uniform reinstall/refresh fixes it.
+  Pinning every source would instead freeze you on old skills, the opposite of
+  what's wanted. Tests verify presence and set-matches-manifest, not versions.
+
+- **Pi is first-class by active use, not by disk presence.** Pi is included
+  because all three tools are in active daily use (user-stated), not merely
+  because files exist under `~/.pi/`.
+
+## Requirements
+
+### Skills and agents (vendored files)
+
+- R1. Authored and third-party-vendored skills are committed and placed into
+  each target tool's skills dir by chezmoi.
+- R2. A skill intended for multiple tools has one canonical body in
+  `home/.chezmoitemplates/`, included by a thin per-tool file; the skill exists
+  in a tool only when its include is present (selective rollout).
+- R3. Standalone agents (Claude `~/.claude/agents/`) are committed as files.
+- R4. Third-party skills stay upstream-fetched via `.chezmoiexternal.toml` and
+  refresh uniformly across machines so all stay current; they are not duplicated
+  as vendored files. Pin a specific source to an immutable ref only when it must
+  be frozen (exception, not default).
+- R4b. Vendored and upstream-fetched skills must not collide on name within a
+  single tool's skills dir (chezmoi reports inconsistent state on overlap); the
+  inventory checks for name overlap.
+
+### OpenCode plugins
+
+- R5. `opencode.json` is committed as a template (`.tmpl` with an `.is_darwin`
+  guard) so OpenCode self-installs npm plugins at startup, while macOS-only
+  entries (the `@rynfar/meridian` `file://` brew path) are emitted only on
+  darwin and never break a Linux/Docker apply.
+- R5b. OpenCode npm plugins in `plugin[]` track their normal version channel;
+  pin an exact version only for an item that must be frozen.
+- R6. Local OpenCode plugins (`~/.config/opencode/plugins/*.ts,*.js`),
+  standalone agents (`~/.config/opencode/agents/` that are not bundle-provided),
+  and skill files (`~/.config/opencode/skills/`) are committed as files.
+- R7. `node_modules/` is not committed.
+
+### Claude marketplace plugins
+
+- R8. A manifest records the portable essence: each marketplace's source
+  (GitHub repo / git url) and each user-scope plugin to install
+  (`plugin@marketplace`). Versions track upstream; pin only an item that must be
+  frozen.
+- R9. A run script reinstalls from the manifest via `claude plugin marketplace
+  add` and `claude plugin install`, idempotently, and reports partial failures
+  (e.g. marketplace added but install failed) rather than exiting as success.
+- R10. Project-scoped plugins are excluded from global reproduction (they belong
+  to specific project paths).
+- R11. The raw `installed_plugins.json` / `known_marketplaces.json` are not
+  committed verbatim.
+- R11b. A drift check regenerates the manifest from live `installed_plugins.json`
+  (user-scope) and diffs it against the committed manifest, surfacing plugins
+  installed or removed outside the repo. Run on demand and in CI.
+
+### Pi
+
+- R12. Standalone Pi skills (`~/.pi/agent/skills/`) and hand-authored agents
+  (`~/.pi/agent/agents/` not provided by an extension) are committed as files,
+  on the same canonical-plus-include model as Claude and OpenCode.
+- R13. Pi extensions are reproduced via `pi install <source>` from the committed
+  `settings.json` `packages[]` (git/npm sources are portable), with `pi update`
+  keeping them current. Any future bundle (e.g. a clean `compound-engineering`)
+  must enter through `packages[]` to be reproduced — uncoordinated installs
+  outside it are not covered and are pruned during consolidation (R15).
+- R14. Pi secrets (`~/.pi/agent/auth.json`) are excluded from the committed set;
+  any secret injection is guarded by `{{ if lookPath "op" }}` so a Docker/CI
+  apply without 1Password does not fail.
+
+### Consolidation and testing
+
+- R15. Inventory only the items that will be reproduced (the input to the
+  manifests), classifying each into one of the three buckets: vendored,
+  upstream-fetched, declarative-reinstall. Not a standalone full audit.
+- R16. Offline Docker verification (`make test-ubuntu` / `make test-docker`): a
+  fresh container applies the repo and asserts vendored skills/agents land in
+  each tool's expected dirs, the `.tmpl` files render on Linux, and the
+  manifests/scripts are well-formed. Runs without 1Password or network. Covers
+  vendored bytes + manifest shape only.
+- R17. Live restore verification (real machine): a smoke step that runs the
+  actual network-dependent paths — upstream skill fetch (R4), Claude
+  `claude plugin install` (R9), OpenCode startup `bun install` (R5), Pi
+  `pi install` (R13) — and confirms plugins land and function. Triggered after
+  manifest changes; not part of offline CI. R16 and R17 together cover the full
+  restore; neither alone does.
+
+## Key Flows
+
+- F1. Fresh-machine restore
+  - **Trigger:** `chezmoi apply` on a new machine.
+  - **Steps:** chezmoi places vendored skills/agents/local-plugins for all three
+    tools → writes `opencode.json` (OpenCode self-installs npm plugins at next
+    startup) → `run_onchange` reinstalls Claude marketplace plugins and Pi
+    bundles from their manifests.
+  - **Outcome:** Skills, agents, and plugins match the committed setup across
+    Claude, OpenCode, and Pi.
+  - **Covered by:** R1, R3, R5, R6, R8, R9, R12, R13.
+
+- F2. Selective skill rollout
+  - **Trigger:** A skill should be available on some tools but not others.
+  - **Steps:** Canonical body lives once in `.chezmoitemplates/`; per-tool
+    include files are added only for the intended tools.
+  - **Outcome:** The skill appears only where its include exists.
+  - **Covered by:** R2.
+
+- F3. Claude plugin reinstall
+  - **Trigger:** Manifest changes or fresh machine.
+  - **Steps:** Script ensures each marketplace is added, then installs each
+    user-scope plugin; re-running is a no-op when already present.
+  - **Outcome:** Marketplace plugins (with their bundled agents) restored.
+  - **Covered by:** R8, R9, R10.
+
+## Acceptance Examples
+
+- AE1. **Covers R2.** Given a skill with includes for Claude and OpenCode but not
+  Pi, when `chezmoi apply` runs, then the skill exists in the Claude and
+  OpenCode skills dirs and is absent from Pi's.
+- AE2. **Covers R5.** Given `opencode.json` lists `oh-my-openagent`, when it is
+  applied on a fresh machine and OpenCode starts, then OpenCode installs the
+  plugin without manual steps.
+- AE3. **Covers R9, R10.** Given the Claude manifest lists user-scope plugins and
+  their marketplaces, when the reinstall script runs, then those marketplaces are
+  added and plugins installed, and project-scoped plugins are not.
+- AE4. **Covers R11.** Given a reinstall on a second machine, then no
+  machine-specific absolute paths or timestamps from the original machine appear
+  in committed Claude plugin state.
+
+## Scope Boundaries
+
+Deferred for later:
+
+- Catalog/discovery UX for finding new skills.
+- Supply-chain hardening (marketplace allowlisting, per-addition review gating,
+  cryptographic checksum/signature enforcement, mandatory version pinning) —
+  single-user personal dotfiles; trusting the chosen upstreams and updating
+  uniformly is the proportionate boundary. Optional per-item pinning is the
+  escape hatch when something must be frozen.
+
+Outside this effort's identity:
+
+- `npx skills` and any bespoke skill-management CLI.
+- `oh-my-openagent.json` (agent→model config) — not preserved.
+- Project-scoped Claude plugins — per-project, not global setup.
+- Managing skills purely to roll them out to many tools at once — the goal is
+  reproducing the chosen setup, not maximizing distribution.
+
+## Dependencies / Assumptions
+
+- `claude plugin` exposes non-interactive `install` and `marketplace`
+  subcommands (verified present in the local CLI).
+- OpenCode auto-installs `plugin[]` npm packages at startup into
+  `~/.cache/opencode/node_modules/`.
+- Brew-installed packages referenced by absolute path in OpenCode's `plugin[]`
+  (e.g. `@rynfar/meridian` at `/opt/homebrew/lib/node_modules/...`) are present
+  via the repo's Brewfile on macOS; the `.is_darwin` guard in R5 keeps this
+  entry off Linux so a Docker apply doesn't break.
+- Pi reinstalls extensions via `pi install <source>` / `pi update` from
+  `settings.json` `packages[]` (confirmed); `pi list` enumerates them.
+- `~/.pi/agent/auth.json` and other per-machine secrets are handled via the
+  repo's existing 1Password/secret path, not committed.
+- chezmoi remains the delivery mechanism; host constraint stands — never
+  `chezmoi apply` on the host, validate via `make test-local` / `make
+  test-ubuntu`.
+
+## Outstanding Questions
+
+Deferred to planning:
+
+- **`pi-agent-browser` local path:** `settings.json` `packages[]` includes the
+  absolute path `/Users/seigiard/.pi/agent/local/pi-agent-browser` — make
+  portable or vendor the local package.
+- **Out-of-repo install frequency:** how often plugins/skills are installed
+  outside the repo — sets how valuable the R11b drift check is.
+
+## Sources / Research
+
+- `npx skills` (`skills@1.5.13`, `dist/cli.mjs`): `experimental_install` replays
+  the project `skills-lock.json` to universal agents only (cli.mjs:4955); global
+  lockfile records only `skills add` installs (cli.mjs:749);
+  `listInstalledSkills` scans the filesystem (cli.mjs:2115); `copyDirectory`
+  copies whole skill folders but there is no cross-component dependency
+  resolution (cli.mjs:1849, 945) — a bundle's sibling agents never travel.
+- Claude plugin state: `~/.claude/plugins/installed_plugins.json` (25 user-scope
+  + 6 project-scope) and `known_marketplaces.json` carry absolute paths and
+  timestamps (non-portable verbatim); `claude plugin install` / `claude plugin
+  marketplace` provide a scriptable reinstall path.
+- OpenCode (`sst/opencode`): plugins declared in `opencode.json` → `plugin[]`
+  (npm names or `file://`), auto-installed via Bun at startup; skills discovered
+  by scanning dirs for `SKILL.md`; local plugins loaded from
+  `~/.config/opencode/plugins/`. Local `plugin[]` has `oh-my-openagent@latest`
+  and an absolute brew path to `@rynfar/meridian`.
+- Pi on disk: skills in `~/.pi/agent/skills/` (`crit`, `web-perf`,
+  `web-research` — files), 58 agent files in `~/.pi/agent/agents/`, config
+  (`settings.json`, `models.json`, `trust.json`, `chains/`), secret `auth.json`.
+  `pi` CLI (`~/.local/bin/pi`) manages extensions: `pi install <source>` adds to
+  `settings.json` `packages[]` (git/npm sources, one local abs-path), `pi list`,
+  `pi update`. An earlier uncoordinated `compound-engineering` install (private
+  `install-manifest.json` + 49 agent files, absent from `packages[]`) was
+  removed; only `packages[]`-tracked extensions and 9 hand-authored agents
+  remain.
+- `oh-my-openagent` (`code-yeongyu/oh-my-openagent`): an OpenCode npm plugin
+  installed via `opencode.json`; its `oh-my-openagent.json` holds agent→model
+  mappings — out of scope here.
+- Existing repo idioms: `home/.chezmoiexternal.toml` (7 skill archives),
+  `home/private_dot_config/brewfiles/` + run-scripts (the manifest→apply pattern
+  to mirror), `home/dot_zshenv.tmpl` (`OPENCODE_DISABLE_*` env vars).

--- a/home/dot_pi/agent/symlink_AGENTS.md.tmpl
+++ b/home/dot_pi/agent/symlink_AGENTS.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.claude/CLAUDE.md

--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -49,6 +49,14 @@ export EDITOR="zed"
 # -------------------------------------------
 export LINEAR_ISSUE_SORT="manual"
 
+# -------------------------------------------
+# OpenCode
+# Keep OpenCode skill discovery scoped to OpenCode's native skill paths.
+# These are env-var escape hatches, not valid opencode.json keys.
+# -------------------------------------------
+export OPENCODE_DISABLE_EXTERNAL_SKILLS=1
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1
+
 {{ if .is_darwin }}
 # -------------------------------------------
 # Agent Browser

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -52,6 +52,14 @@ Default to surfacing uncertainty, not hiding it.
 
 </important>
 
+<important if="you are about to claim something is done, working, verified, true, or fixed — or to correct an earlier claim">
+
+State only what you actually checked. Haven't verified it? Say "не проверял" once and verify before asserting. Never present a guess, assumption, or untested result as fact.
+Wrong earlier? Give the correction in one line and move on — no re-framing, no restating the conclusion twice.
+Banned filler: "честно", "теперь честно", "по-честному", "по-чесноку", "to be honest", "now honestly", and every honesty-signaling phrase. Say the thing directly. Honesty is demonstrated by verified claims, never announced.
+
+</important>
+
 <important if="you are starting a new user request">
 
 Check for project-local instructions: `CLAUDE.local.md`, `AGENTS.local.md`.

--- a/home/private_dot_claude/skills/ask-agent/SKILL.md
+++ b/home/private_dot_claude/skills/ask-agent/SKILL.md
@@ -74,5 +74,5 @@ bash ~/.claude/skills/ask-agent/scripts/ask.sh pi "Add a missing null check in s
 ## Notes & limits
 
 - Read-only is enforced by a tool **allowlist** for claude and pi (no Bash, so no writes at all), but only by **prompt** for opencode (not a hard guarantee). Use `--rw` when you want the agent to make changes.
-- Keep `--cwd`/`--skills` paths space-free (the herdr-pane path passes flags positionally).
+- `--cwd`/`--skills` paths with spaces are fine (ask.sh shell-escapes values for the herdr-pane path).
 - This skill consults agents that are installed and on PATH: `claude`, `opencode`, `pi`. A missing CLI fails fast.

--- a/home/private_dot_claude/skills/ask-agent/SKILL.md
+++ b/home/private_dot_claude/skills/ask-agent/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ask-agent
+description: "Ask another coding agent — opencode, pi, or claude — a one-shot question and get its answer back: a second opinion, a code review, or independent verification from a peer. Use when the user says ask/consult opencode/pi/claude, wants a second opinion or cross-check from another agent, or when you want a peer agent to review your work. Read-only by default (the asked agent answers, does not edit)."
+---
+
+# ask-agent — consult a peer agent
+
+Run another coding-agent CLI as a one-shot, hand it a question, and get its answer back. By default it is a **read-only consult**: the asked agent answers or reviews but does not edit files.
+
+All invocation logic lives in scripts (not inline here), because each agent loads its skills/context differently and the argument-building is agent-specific. You call one entrypoint:
+
+```bash
+bash ~/.claude/skills/ask-agent/scripts/ask.sh <agent> "<question>" [flags]
+```
+
+- `<agent>` — `claude`, `opencode`, or `pi`.
+- Returns the agent's answer on stdout.
+
+## Modes (auto-detected)
+
+- **Inside herdr** (`HERDR_ENV=1`): the consult runs in a **visible herdr pane** beside you — you watch it live, and the pane stays open so you (or the user) can follow up in it. Its output is still captured back to stdout.
+- **Outside herdr**: runs as a **headless subprocess**; stdout is the answer.
+- `--headless` forces the subprocess path even inside herdr (no pane).
+
+## Flags
+
+| Flag | Meaning |
+|------|---------|
+| `--rw` | allow the asked agent to edit files (default is read-only consult) |
+| `--model M` | model override (agent-native format, e.g. `openai-codex/gpt-5.5` for pi, `provider/model` for opencode) |
+| `--effort L` | reasoning effort for **pi** only: `off\|minimal\|low\|medium\|high\|xhigh` (default `medium`) |
+| `--cwd DIR` | working directory / project context for the consult |
+| `--skills DIR` | add an extra skill directory (repeatable; only `pi` and `claude` honor it — see below) |
+| `--agent NAME` | opencode only: pick a configured opencode agent |
+
+**Default model.** Both `pi` (`openai-codex/gpt-5.5`) and `opencode` (`openai/gpt-5.5`) default to **GPT-5.5** — a genuine *cross-model* second opinion (different family than `claude`, which runs its own Anthropic model). pi additionally applies `--effort medium`; opencode's reasoning variant is left at its default (`--effort` applies to pi only). Override any agent's model with `--model`.
+
+## Skills & read-only per agent
+
+Each agent keeps **all of its own skills** by default (discovery stays on); we never strip an agent down to bare. How extra skills and read-only are wired differs:
+
+| Agent | Extra skills (`--skills`) | Read-only enforcement |
+|-------|---------------------------|------------------------|
+| **claude** | auto-loads `~/.claude/skills`+`CLAUDE.md`; `--skills DIR` → `--add-dir` | `--allowed-tools Read Grep Glob WebFetch WebSearch` — read, search, **web**; **cannot** Bash/Edit/Write (verified) |
+| **pi** | auto-discovers its own skills; `--skills DIR` → native `--skill` (repeatable) | `--tools read,grep,find,ls` — read + search; **no** bash/edit/write (verified). No built-in web (extension only). |
+| **opencode** | loads its own config/agents; `--skills` ignored (no flag); `--agent` picks one | **prompt preamble only (interim).** opencode 1.17.5 has no per-call `--permission`; hard read-only needs a read-only **agent** in `opencode.json` selected via `--agent`. |
+
+**Read-only allows web, not shell.** Read-only denies Bash/Edit/Write, so a consult **cannot run `git`, tests, or builds** — but it *can* read, search, and (claude) reach the web (`WebFetch`/`WebSearch`) to check docs/facts. If the agent needs a diff or test output, **pipe it into the question** (see examples) or pass `--rw`. Note: excluding only edit/write is NOT read-only — `bash echo > file` slips through; that is why read-only uses an allowlist.
+
+## Examples
+
+```bash
+# Second opinion from pi, read-only:
+bash ~/.claude/skills/ask-agent/scripts/ask.sh pi "Is this regex catastrophic-backtracking safe? $(cat pattern.txt)"
+
+# Review the staged diff — pipe it in, because a read-only consult can't run git itself:
+bash ~/.claude/skills/ask-agent/scripts/ask.sh claude "Review this diff for bugs. Verdict APPROVE or CHANGES:
+
+$(git diff --cached)"
+
+# Ask claude to do herdr work, giving it the herdr skill explicitly:
+bash ~/.claude/skills/ask-agent/scripts/ask.sh claude "How do I split a pane and wait for a server?" --skills ~/.claude/skills/herdr
+
+# Let pi actually apply a small fix (read-write):
+bash ~/.claude/skills/ask-agent/scripts/ask.sh pi "Add a missing null check in src/api/load.ts" --rw --cwd "$PWD"
+```
+
+## Using the answer
+
+- The answer is on stdout — read it, then **verify before trusting it** (check the claim against the code/tests yourself; a peer agent's "done"/opinion is input, not proof).
+- **opencode** prefixes its output with a banner line (e.g. `> Sisyphus · model`); the answer follows it. Ignore the banner.
+- In herdr mode the consult pane is left open; close it with `herdr pane close <pane_id>` (the id is printed on stderr when the consult finishes) or keep it to continue the conversation there.
+
+## Notes & limits
+
+- Read-only is enforced by a tool **allowlist** for claude and pi (no Bash, so no writes at all), but only by **prompt** for opencode (not a hard guarantee). Use `--rw` when you want the agent to make changes.
+- Keep `--cwd`/`--skills` paths space-free (the herdr-pane path passes flags positionally).
+- This skill consults agents that are installed and on PATH: `claude`, `opencode`, `pi`. A missing CLI fails fast.

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
@@ -1,27 +1,17 @@
 #!/usr/bin/env bash
-# Run a one-shot claude consult. Invoked by ask.sh; runnable standalone.
-# claude auto-loads ~/.claude/skills + CLAUDE.md, so it keeps all its own skills.
+# Thin claude adapter for ask.sh — no flag parsing of its own. Inputs come from the
+# environment (QF, RW, MODEL, CWD) set by ask.sh; --skills dirs arrive as positional
+# args. claude auto-loads ~/.claude/skills + CLAUDE.md, so it keeps all its own
+# skills. --effort does not apply to claude.
+# Runnable standalone: QF=<file> [RW=1] [MODEL=…] [CWD=…] claude.sh [DIR…]
 set -euo pipefail
-
-QF="" ; RW=0 ; MODEL="" ; CWD="" ; SKILLS=()
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --qf)     QF="$2"      ; shift 2 ;;
-    --rw)     RW=1         ; shift   ;;
-    --model)  MODEL="$2"   ; shift 2 ;;
-    --effort) shift 2 ;;   # claude -p has no clean effort flag; effort applies to pi
-    --cwd)    CWD="$2"     ; shift 2 ;;
-    --skills) SKILLS+=("$2"); shift 2 ;;
-    *)        shift ;;
-  esac
-done
-[ -n "$QF" ] || { echo "claude.sh: --qf <question-file> required" >&2; exit 2; }
+: "${QF:?claude.sh: QF env var (question file) required}"
 
 args=( -p "$(cat "$QF")" )
-[ -n "$MODEL" ] && args+=( --model "$MODEL" )
-[ -n "$CWD" ]   && args+=( --add-dir "$CWD" )
-for s in ${SKILLS[@]+"${SKILLS[@]}"}; do args+=( --add-dir "$s" ); done
+[ -n "${MODEL:-}" ] && args+=( --model "$MODEL" )
+[ -n "${CWD:-}" ]   && args+=( --add-dir "$CWD" )
+for s in "$@"; do args+=( --add-dir "$s" ); done
 # read-only = allowlist read/search/web tools (blocks Bash/Edit/Write); rw = let it edit
-if [ "$RW" -eq 1 ]; then args+=( --permission-mode acceptEdits ); else args+=( --allowed-tools Read Grep Glob WebFetch WebSearch ); fi
+if [ "${RW:-0}" -eq 1 ]; then args+=( --permission-mode acceptEdits ); else args+=( --allowed-tools Read Grep Glob WebFetch WebSearch ); fi
 
 exec claude "${args[@]}"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run a one-shot claude consult. Invoked by ask.sh; runnable standalone.
+# claude auto-loads ~/.claude/skills + CLAUDE.md, so it keeps all its own skills.
+set -euo pipefail
+
+QF="" ; RW=0 ; MODEL="" ; CWD="" ; SKILLS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --qf)     QF="$2"      ; shift 2 ;;
+    --rw)     RW=1         ; shift   ;;
+    --model)  MODEL="$2"   ; shift 2 ;;
+    --effort) shift 2 ;;   # claude -p has no clean effort flag; effort applies to pi
+    --cwd)    CWD="$2"     ; shift 2 ;;
+    --skills) SKILLS+=("$2"); shift 2 ;;
+    *)        shift ;;
+  esac
+done
+[ -n "$QF" ] || { echo "claude.sh: --qf <question-file> required" >&2; exit 2; }
+
+args=( -p "$(cat "$QF")" )
+[ -n "$MODEL" ] && args+=( --model "$MODEL" )
+[ -n "$CWD" ]   && args+=( --add-dir "$CWD" )
+for s in ${SKILLS[@]+"${SKILLS[@]}"}; do args+=( --add-dir "$s" ); done
+# read-only = allowlist read/search/web tools (blocks Bash/Edit/Write); rw = let it edit
+if [ "$RW" -eq 1 ]; then args+=( --permission-mode acceptEdits ); else args+=( --allowed-tools Read Grep Glob WebFetch WebSearch ); fi
+
+exec claude "${args[@]}"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
-# Run a one-shot opencode consult. Invoked by ask.sh; runnable standalone.
-# opencode loads its own config/agents (all its skills). It has no --skill flag,
-# so read-only is enforced via prompt framing; --skills is accepted but unused.
+# Thin opencode adapter for ask.sh — no flag parsing of its own. Inputs come from
+# the environment (QF, RW, MODEL, CWD, AGENT_NAME) set by ask.sh. opencode loads its
+# own config/agents (all its skills); it has no --skill flag, so read-only is
+# enforced via prompt framing and --skills dirs (positional args) are ignored.
+# --effort does not apply here.
+# Runnable standalone: QF=<file> [RW=1] [MODEL=…] [CWD=…] [AGENT_NAME=…] opencode.sh
 set -euo pipefail
-
-QF="" ; RW=0 ; MODEL="" ; CWD="" ; AGENT=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --qf)     QF="$2"    ; shift 2 ;;
-    --rw)     RW=1       ; shift   ;;
-    --model)  MODEL="$2" ; shift 2 ;;
-    --cwd)    CWD="$2"   ; shift 2 ;;
-    --agent)  AGENT="$2" ; shift 2 ;;
-    --effort) shift 2 ;;   # opencode here has no GPT/effort wiring; effort applies to pi
-    --skills) shift 2 ;;
-    *)        shift ;;
-  esac
-done
-[ -n "$QF" ] || { echo "opencode.sh: --qf <question-file> required" >&2; exit 2; }
+: "${QF:?opencode.sh: QF env var (question file) required}"
 
 Q="$(cat "$QF")"
-if [ "$RW" -eq 0 ]; then
+if [ "${RW:-0}" -eq 0 ]; then
   Q="[Read-only consult from another agent. Do NOT edit, write, create, or delete any files — answer/review only.]
 
 $Q"
@@ -29,7 +18,7 @@ fi
 # default to GPT-5.5 (opencode's openai provider) for a cross-model second opinion
 MODEL="${MODEL:-openai/gpt-5.5}"
 args=( run --model "$MODEL" )
-[ -n "$AGENT" ] && args+=( --agent "$AGENT" )
-[ -n "$CWD" ]   && args+=( --dir "$CWD" )
+[ -n "${AGENT_NAME:-}" ] && args+=( --agent "$AGENT_NAME" )
+[ -n "${CWD:-}" ]       && args+=( --dir "$CWD" )
 
 exec opencode "${args[@]}" "$Q"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run a one-shot opencode consult. Invoked by ask.sh; runnable standalone.
+# opencode loads its own config/agents (all its skills). It has no --skill flag,
+# so read-only is enforced via prompt framing; --skills is accepted but unused.
+set -euo pipefail
+
+QF="" ; RW=0 ; MODEL="" ; CWD="" ; AGENT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --qf)     QF="$2"    ; shift 2 ;;
+    --rw)     RW=1       ; shift   ;;
+    --model)  MODEL="$2" ; shift 2 ;;
+    --cwd)    CWD="$2"   ; shift 2 ;;
+    --agent)  AGENT="$2" ; shift 2 ;;
+    --effort) shift 2 ;;   # opencode here has no GPT/effort wiring; effort applies to pi
+    --skills) shift 2 ;;
+    *)        shift ;;
+  esac
+done
+[ -n "$QF" ] || { echo "opencode.sh: --qf <question-file> required" >&2; exit 2; }
+
+Q="$(cat "$QF")"
+if [ "$RW" -eq 0 ]; then
+  Q="[Read-only consult from another agent. Do NOT edit, write, create, or delete any files — answer/review only.]
+
+$Q"
+fi
+
+# default to GPT-5.5 (opencode's openai provider) for a cross-model second opinion
+MODEL="${MODEL:-openai/gpt-5.5}"
+args=( run --model "$MODEL" )
+[ -n "$AGENT" ] && args+=( --agent "$AGENT" )
+[ -n "$CWD" ]   && args+=( --dir "$CWD" )
+
+exec opencode "${args[@]}" "$Q"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/pi.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/pi.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run a one-shot pi consult. Invoked by ask.sh; runnable standalone.
+# pi auto-discovers its own skills (kept on). --skills maps to pi's --skill flag.
+set -euo pipefail
+
+QF="" ; RW=0 ; MODEL="" ; EFFORT="" ; CWD="" ; SKILLS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --qf)     QF="$2"      ; shift 2 ;;
+    --rw)     RW=1         ; shift   ;;
+    --model)  MODEL="$2"   ; shift 2 ;;
+    --effort) EFFORT="$2"  ; shift 2 ;;
+    --cwd)    CWD="$2"     ; shift 2 ;;
+    --skills) SKILLS+=("$2"); shift 2 ;;
+    *)        shift ;;
+  esac
+done
+[ -n "$QF" ] || { echo "pi.sh: --qf <question-file> required" >&2; exit 2; }
+
+# default to the latest GPT (different model family than claude) at medium effort.
+# fully-qualified provider/model — bare "gpt-5.5" mis-resolves to an unauthed provider.
+MODEL="${MODEL:-openai-codex/gpt-5.5}"
+EFFORT="${EFFORT:-medium}"
+args=( -p --model "$MODEL" --thinking "$EFFORT" )
+for s in ${SKILLS[@]+"${SKILLS[@]}"}; do args+=( --skill "$s" ); done
+# read-only = allowlist pi's read/search tools (no bash/edit/write, so it truly cannot mutate).
+# pi has no built-in web tool; web is only available via an extension (e.g. pi-agent-browser).
+[ "$RW" -eq 0 ] && args+=( --tools read,grep,find,ls )
+[ -n "$CWD" ] && cd "$CWD"
+
+exec pi "${args[@]}" "$(cat "$QF")"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/pi.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/pi.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
-# Run a one-shot pi consult. Invoked by ask.sh; runnable standalone.
-# pi auto-discovers its own skills (kept on). --skills maps to pi's --skill flag.
+# Thin pi adapter for ask.sh — no flag parsing of its own. Inputs come from the
+# environment (QF, RW, MODEL, EFFORT, CWD) set by ask.sh; --skills dirs arrive as
+# positional args and map to pi's --skill flag. pi auto-discovers its own skills.
+# Runnable standalone: QF=<file> [RW=1] [MODEL=…] [EFFORT=…] [CWD=…] pi.sh [SKILL…]
 set -euo pipefail
-
-QF="" ; RW=0 ; MODEL="" ; EFFORT="" ; CWD="" ; SKILLS=()
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --qf)     QF="$2"      ; shift 2 ;;
-    --rw)     RW=1         ; shift   ;;
-    --model)  MODEL="$2"   ; shift 2 ;;
-    --effort) EFFORT="$2"  ; shift 2 ;;
-    --cwd)    CWD="$2"     ; shift 2 ;;
-    --skills) SKILLS+=("$2"); shift 2 ;;
-    *)        shift ;;
-  esac
-done
-[ -n "$QF" ] || { echo "pi.sh: --qf <question-file> required" >&2; exit 2; }
+: "${QF:?pi.sh: QF env var (question file) required}"
 
 # default to the latest GPT (different model family than claude) at medium effort.
 # fully-qualified provider/model — bare "gpt-5.5" mis-resolves to an unauthed provider.
 MODEL="${MODEL:-openai-codex/gpt-5.5}"
 EFFORT="${EFFORT:-medium}"
 args=( -p --model "$MODEL" --thinking "$EFFORT" )
-for s in ${SKILLS[@]+"${SKILLS[@]}"}; do args+=( --skill "$s" ); done
+for s in "$@"; do args+=( --skill "$s" ); done
 # read-only = allowlist pi's read/search tools (no bash/edit/write, so it truly cannot mutate).
 # pi has no built-in web tool; web is only available via an extension (e.g. pi-agent-browser).
-[ "$RW" -eq 0 ] && args+=( --tools read,grep,find,ls )
-[ -n "$CWD" ] && cd "$CWD"
+[ "${RW:-0}" -eq 0 ] && args+=( --tools read,grep,find,ls )
+[ -n "${CWD:-}" ] && cd "$CWD"
 
 exec pi "${args[@]}" "$(cat "$QF")"

--- a/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
@@ -15,6 +15,10 @@
 #
 # Default is a READ-ONLY consult (the asked agent answers but does not edit files);
 # pass --rw to allow edits. Each agent keeps all of its own skills.
+#
+# Flag parsing lives here only. agents/<name>.sh are thin adapters: they read the
+# parsed values from the environment (QF, RW, MODEL, EFFORT, CWD, AGENT_NAME), take
+# any --skills dirs as positional args, and map them to that agent's own CLI.
 set -euo pipefail
 
 [ $# -ge 2 ] || { sed -n '2,17p' "$0"; exit 2; }
@@ -24,18 +28,23 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$DIR/agents/$AGENT.sh"
 [ -f "$SCRIPT" ] || { echo "ask.sh: unknown agent '$AGENT' (have: claude opencode pi)" >&2; exit 2; }
 
-HEADLESS=0 ; PASS=()
+HEADLESS=0 ; RW=0 ; MODEL="" ; EFFORT="" ; CWD="" ; AGENT_NAME="" ; SKILLS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --headless)                  HEADLESS=1            ; shift   ;;
-    --rw)                        PASS+=( --rw )        ; shift   ;;
-    --model|--effort|--cwd|--skills|--agent) PASS+=( "$1" "$2" ); shift 2 ;;
+    --headless) HEADLESS=1      ; shift   ;;
+    --rw)       RW=1            ; shift   ;;
+    --model)    MODEL="$2"      ; shift 2 ;;
+    --effort)   EFFORT="$2"     ; shift 2 ;;
+    --cwd)      CWD="$2"        ; shift 2 ;;
+    --skills)   SKILLS+=( "$2" ); shift 2 ;;
+    --agent)    AGENT_NAME="$2" ; shift 2 ;;
     *) echo "ask.sh: unknown flag '$1'" >&2; exit 2 ;;
   esac
 done
 
 QF="$(mktemp)" ; printf '%s' "$Q" > "$QF"
 trap 'rm -f "$QF"' EXIT
+export QF RW MODEL EFFORT CWD AGENT_NAME
 
 if [ "${HERDR_ENV:-}" = "1" ] && [ "$HEADLESS" -eq 0 ]; then
   command -v herdr >/dev/null || { echo "ask.sh: HERDR_ENV set but herdr not on PATH" >&2; exit 1; }
@@ -43,13 +52,16 @@ if [ "${HERDR_ENV:-}" = "1" ] && [ "$HEADLESS" -eq 0 ]; then
   MARK="ASKEND$$"             # completion marker we wait on
   ESC="ASK''${MARK#ASK}"     # same text, quote-broken, so the typed command line
                               # never matches MARK — only the printed line does
+  ENVP="QF=$(printf %q "$QF") RW=$(printf %q "$RW") MODEL=$(printf %q "$MODEL")"
+  ENVP="$ENVP EFFORT=$(printf %q "$EFFORT") CWD=$(printf %q "$CWD") AGENT_NAME=$(printf %q "$AGENT_NAME")"
+  SK="" ; for s in ${SKILLS[@]+"${SKILLS[@]}"}; do SK="$SK $(printf %q "$s")"; done
   PANE="$(herdr pane split "$HERDR_PANE_ID" --direction right --no-focus \
     | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')"
-  herdr pane run "$PANE" "bash '$SCRIPT' --qf '$QF' ${PASS[*]+${PASS[*]}} 2>&1 | tee '$OUT'; printf '%s\\n' '$ESC'"
+  herdr pane run "$PANE" "$ENVP bash $(printf %q "$SCRIPT")$SK 2>&1 | tee $(printf %q "$OUT"); printf '%s\\n' '$ESC'"
   herdr wait output "$PANE" --match "$MARK" --timeout 1800000 >/dev/null || true
   cat "$OUT"
   rm -f "$OUT"
   echo "ask.sh: consult ran in herdr pane $PANE (left open for follow-up; close with: herdr pane close $PANE)" >&2
 else
-  bash "$SCRIPT" --qf "$QF" ${PASS[@]+"${PASS[@]}"}
+  bash "$SCRIPT" ${SKILLS[@]+"${SKILLS[@]}"}
 fi

--- a/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# ask another agent a one-shot question and return its answer.
+#
+#   ask.sh <claude|opencode|pi> "<question>" [--rw] [--model M] [--effort L] \
+#          [--cwd DIR] [--skills DIR]... [--agent NAME] [--headless]
+#
+# pi defaults to the latest GPT (openai-codex/gpt-5.5) at --effort medium — a genuine
+# cross-model second opinion. claude/opencode use their own model; --effort
+# applies to pi only.
+#
+# Mode is auto-detected: inside herdr (HERDR_ENV=1) the consult runs in a visible
+# herdr pane beside you (you watch it live, the pane stays for follow-up) and its
+# output is captured back here. Outside herdr it runs as a headless subprocess.
+# --headless forces the subprocess path even inside herdr.
+#
+# Default is a READ-ONLY consult (the asked agent answers but does not edit files);
+# pass --rw to allow edits. Each agent keeps all of its own skills.
+set -euo pipefail
+
+[ $# -ge 2 ] || { sed -n '2,17p' "$0"; exit 2; }
+AGENT="$1" ; Q="$2" ; shift 2
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$DIR/agents/$AGENT.sh"
+[ -f "$SCRIPT" ] || { echo "ask.sh: unknown agent '$AGENT' (have: claude opencode pi)" >&2; exit 2; }
+
+HEADLESS=0 ; PASS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --headless)                  HEADLESS=1            ; shift   ;;
+    --rw)                        PASS+=( --rw )        ; shift   ;;
+    --model|--effort|--cwd|--skills|--agent) PASS+=( "$1" "$2" ); shift 2 ;;
+    *) echo "ask.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+QF="$(mktemp)" ; printf '%s' "$Q" > "$QF"
+trap 'rm -f "$QF"' EXIT
+
+if [ "${HERDR_ENV:-}" = "1" ] && [ "$HEADLESS" -eq 0 ]; then
+  command -v herdr >/dev/null || { echo "ask.sh: HERDR_ENV set but herdr not on PATH" >&2; exit 1; }
+  OUT="$(mktemp)"
+  MARK="ASKEND$$"             # completion marker we wait on
+  ESC="ASK''${MARK#ASK}"     # same text, quote-broken, so the typed command line
+                              # never matches MARK — only the printed line does
+  PANE="$(herdr pane split "$HERDR_PANE_ID" --direction right --no-focus \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')"
+  herdr pane run "$PANE" "bash '$SCRIPT' --qf '$QF' ${PASS[*]+${PASS[*]}} 2>&1 | tee '$OUT'; printf '%s\\n' '$ESC'"
+  herdr wait output "$PANE" --match "$MARK" --timeout 1800000 >/dev/null || true
+  cat "$OUT"
+  rm -f "$OUT"
+  echo "ask.sh: consult ran in herdr pane $PANE (left open for follow-up; close with: herdr pane close $PANE)" >&2
+else
+  bash "$SCRIPT" --qf "$QF" ${PASS[@]+"${PASS[@]}"}
+fi

--- a/home/private_dot_config/agents/symlink_AGENTS.md.tmpl
+++ b/home/private_dot_config/agents/symlink_AGENTS.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.claude/CLAUDE.md

--- a/home/private_dot_config/brewfiles/Brewfile.macos
+++ b/home/private_dot_config/brewfiles/Brewfile.macos
@@ -1,5 +1,9 @@
 # macOS-specific packages
 
+# Third-party taps (declare before their formulas so `brew bundle` taps them)
+tap "lazywalker/rgrc"
+tap "schpet/tap"
+
 # CLI tools (macOS only)
 brew "elio"         # terminal file manager (theme synced under Library/)
 brew "lazywalker/rgrc/rgrc"

--- a/home/private_dot_config/brewfiles/Brewfile.macos
+++ b/home/private_dot_config/brewfiles/Brewfile.macos
@@ -1,8 +1,9 @@
 # macOS-specific packages
 
-# Third-party taps (declare before their formulas so `brew bundle` taps them)
-tap "lazywalker/rgrc"
-tap "schpet/tap"
+# Third-party taps (declare before their formulas; trusted so `brew bundle`
+# will install formulas from them on a clean machine)
+tap "lazywalker/rgrc", trusted: true
+tap "schpet/tap", trusted: true
 
 # CLI tools (macOS only)
 brew "elio"         # terminal file manager (theme synced under Library/)

--- a/home/private_dot_config/opencode/opencode.json
+++ b/home/private_dot_config/opencode/opencode.json
@@ -2,10 +2,10 @@
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "external_directory": {
-      "/Users/seigiard/Projects/core/docs/*": "allow",
-      "/Users/seigiard/Projects/core/docs/**/*": "allow",
-      "/Users/seigiard/.crit/reviews/*": "allow",
-      "/Users/seigiard/.crit/reviews/*/**": "allow"
+      "~/Projects/core/docs/*": "allow",
+      "~/Projects/core/docs/**/*": "allow",
+      "~/.crit/reviews/*": "allow",
+      "~/.crit/reviews/*/**": "allow"
     }
   },
   "mcp": {

--- a/home/private_dot_config/opencode/opencode.json
+++ b/home/private_dot_config/opencode/opencode.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "/Users/seigiard/Projects/core/docs/*": "allow",
+      "/Users/seigiard/Projects/core/docs/**/*": "allow",
+      "/Users/seigiard/.crit/reviews/*": "allow",
+      "/Users/seigiard/.crit/reviews/*/**": "allow"
+    }
+  },
+  "mcp": {
+    "fff": {
+      "type": "local",
+      "command": [
+        "fff-mcp"
+      ],
+      "enabled": true
+    },
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/mcp",
+      "enabled": true
+    },
+    "jina": {
+      "type": "remote",
+      "url": "https://mcp.jina.ai/v1",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer {env:JINA_API_KEY}"
+      }
+    },
+    "tavily-mcp": {
+      "type": "remote",
+      "url": "https://mcp.tavily.com/mcp/?tavilyApiKey={env:TAVILY_API_KEY}",
+      "enabled": true
+    }
+  },
+  "provider": {
+    "openrouter": {
+      "models": {
+        "qwen/qwen3-coder:free": {},
+        "cohere/north-mini-code:free": {},
+        "nvidia/nemotron-3-ultra-550b-a55b:free": {},
+        "nex-agi/nex-n2-pro:free": {}
+      }
+    }
+  },
+  "plugin": [
+    "/opt/homebrew/lib/node_modules/@rynfar/meridian/plugin/meridian.ts"
+  ]
+}

--- a/home/private_dot_config/opencode/symlink_AGENTS.md.tmpl
+++ b/home/private_dot_config/opencode/symlink_AGENTS.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.claude/CLAUDE.md


### PR DESCRIPTION
## What

Two related pieces of the multi-agent setup:

1. **Shared global rules** — opencode and pi now follow the same instructions as Claude Code. A verified-facts behavioral rule was added to `~/.claude/CLAUDE.md` (state only what was checked; ban honesty-signaling filler), and each agent's global instruction file is symlinked to it:

   | Live path | → | Target |
   |---|---|---|
   | `~/.config/opencode/AGENTS.md` | → | `~/.claude/CLAUDE.md` |
   | `~/.pi/agent/AGENTS.md` | → | `~/.claude/CLAUDE.md` |
   | `~/.config/agents/AGENTS.md` | → | `~/.claude/CLAUDE.md` |

   The `oh-my-openagent` plugin is dropped from `opencode.json` because its Sisyphus agent overrode all file-based instructions; without it the default `build` agent reads the symlinked rules. `OPENCODE_DISABLE_*` env vars in `zshenv` scope opencode skill discovery to its native paths.

2. **`ask-agent` skill** — one-shot read-only consults. `ask.sh` routes a question to claude / opencode / pi, defaulting to read-only tool allowlists and gpt-5.5 at medium effort. Per-agent invocation lives in `scripts/agents/*.sh` so each agent loads its own skills/context. Runs headless or in a herdr pane.

## Verification

Each agent quoted the rule content from its own path:

- **claude** ← `~/.claude/CLAUDE.md`
- **pi** ← `~/.pi/agent/AGENTS.md` → CLAUDE.md
- **opencode** ← `~/.config/opencode/AGENTS.md` → CLAUDE.md (`opencode run`, build agent)

```
$ opencode run 'Per your loaded instructions: is the Russian word "честно" used as filler banned? ...'
> build · gpt-5.5
YES. State verified facts directly and label uncertainty.
```

## Notes

- `home/dot_zshenv.tmpl` change pre-dated this session but is part of the same agent-setup effort.
- Brainstorm doc captures the broader agent-setup reproduction requirements.