### PR TITLE
Harden ask-agent scripts and fix opencode.json Linux delivery

### DIFF
--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/claude.sh
@@ -11,7 +11,10 @@ args=( -p "$(cat "$QF")" )
 [ -n "${MODEL:-}" ] && args+=( --model "$MODEL" )
 [ -n "${CWD:-}" ]   && args+=( --add-dir "$CWD" )
 for s in "$@"; do args+=( --add-dir "$s" ); done
-# read-only = allowlist read/search/web tools (blocks Bash/Edit/Write); rw = let it edit
-if [ "${RW:-0}" -eq 1 ]; then args+=( --permission-mode acceptEdits ); else args+=( --allowed-tools Read Grep Glob WebFetch WebSearch ); fi
+# read-only = allowlist read/search/web AND explicitly deny mutating tools. The deny is
+# load-bearing: --allowed-tools is additive over settings.json permissions.allow (which
+# may already allow Bash), so without --disallowed-tools a "read-only" consult could
+# still shell out and write. Deny takes precedence over allow. rw = let it edit.
+if [ "${RW:-0}" -eq 1 ]; then args+=( --permission-mode acceptEdits ); else args+=( --allowed-tools Read Grep Glob WebFetch WebSearch --disallowed-tools Bash Edit Write ); fi
 
 exec claude "${args[@]}"

--- a/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/agents/opencode.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 Q="$(cat "$QF")"
 if [ "${RW:-0}" -eq 0 ]; then
+  echo "ask.sh: opencode read-only is prompt-enforced only (not a hard tool block); for a hard guarantee configure a read-only --agent" >&2
   Q="[Read-only consult from another agent. Do NOT edit, write, create, or delete any files — answer/review only.]
 
 $Q"

--- a/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
+++ b/home/private_dot_claude/skills/ask-agent/scripts/ask.sh
@@ -4,9 +4,10 @@
 #   ask.sh <claude|opencode|pi> "<question>" [--rw] [--model M] [--effort L] \
 #          [--cwd DIR] [--skills DIR]... [--agent NAME] [--headless]
 #
-# pi defaults to the latest GPT (openai-codex/gpt-5.5) at --effort medium — a genuine
-# cross-model second opinion. claude/opencode use their own model; --effort
-# applies to pi only.
+# pi and opencode default to a cross-model GPT for a genuine second opinion (a different
+# family than claude, which uses its own model). The exact default model IDs live in the
+# agents/<name>.sh adapters and are documented in SKILL.md — not duplicated here, to
+# avoid drift. --effort applies to pi only.
 #
 # Mode is auto-detected: inside herdr (HERDR_ENV=1) the consult runs in a visible
 # herdr pane beside you (you watch it live, the pane stays for follow-up) and its
@@ -42,13 +43,18 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$AGENT" = opencode ] && [ "${#SKILLS[@]}" -gt 0 ]; then
+  echo "ask.sh: --skills is ignored for opencode (no --skill flag; use --agent for a configured agent)" >&2
+fi
+
 QF="$(mktemp)" ; printf '%s' "$Q" > "$QF"
-trap 'rm -f "$QF"' EXIT
+OUT="" ; ECF=""   # set in herdr mode below; in the trap so every exit path cleans them
+trap 'rm -f "$QF" ${OUT:+"$OUT"} ${ECF:+"$ECF"}' EXIT
 export QF RW MODEL EFFORT CWD AGENT_NAME
 
 if [ "${HERDR_ENV:-}" = "1" ] && [ "$HEADLESS" -eq 0 ]; then
   command -v herdr >/dev/null || { echo "ask.sh: HERDR_ENV set but herdr not on PATH" >&2; exit 1; }
-  OUT="$(mktemp)"
+  OUT="$(mktemp)" ; ECF="$(mktemp)"   # OUT = captured answer; ECF = consult exit code
   MARK="ASKEND$$"             # completion marker we wait on
   ESC="ASK''${MARK#ASK}"     # same text, quote-broken, so the typed command line
                               # never matches MARK — only the printed line does
@@ -57,11 +63,20 @@ if [ "${HERDR_ENV:-}" = "1" ] && [ "$HEADLESS" -eq 0 ]; then
   SK="" ; for s in ${SKILLS[@]+"${SKILLS[@]}"}; do SK="$SK $(printf %q "$s")"; done
   PANE="$(herdr pane split "$HERDR_PANE_ID" --direction right --no-focus \
     | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')"
-  herdr pane run "$PANE" "$ENVP bash $(printf %q "$SCRIPT")$SK 2>&1 | tee $(printf %q "$OUT"); printf '%s\\n' '$ESC'"
-  herdr wait output "$PANE" --match "$MARK" --timeout 1800000 >/dev/null || true
+  # Subshell captures the consult's own exit status (not tee's) into ECF, while its
+  # stdout still streams through tee for the live pane view + OUT capture. $? is read
+  # inside the subshell, so this works under bash and zsh alike (no PIPESTATUS).
+  herdr pane run "$PANE" "( $ENVP bash $(printf %q "$SCRIPT")$SK 2>&1; printf '%d' \"\$?\" > $(printf %q "$ECF") ) | tee $(printf %q "$OUT"); printf '%s\\n' '$ESC'"
+  WAIT_RC=0
+  herdr wait output "$PANE" --match "$MARK" --timeout 1800000 >/dev/null || WAIT_RC=$?
   cat "$OUT"
-  rm -f "$OUT"
   echo "ask.sh: consult ran in herdr pane $PANE (left open for follow-up; close with: herdr pane close $PANE)" >&2
+  if [ "$WAIT_RC" -ne 0 ]; then
+    echo "ask.sh: WARNING: timed out waiting for the consult (30 min); output above may be incomplete (pane $PANE still running)" >&2
+    exit 124
+  fi
+  EC="$(cat "$ECF" 2>/dev/null || true)"
+  exit "${EC:-1}"   # propagate the consult's exit code; empty ECF = it never finished
 else
   bash "$SCRIPT" ${SKILLS[@]+"${SKILLS[@]}"}
 fi

--- a/home/private_dot_config/opencode/opencode.json.tmpl
+++ b/home/private_dot_config/opencode/opencode.json.tmpl
@@ -44,8 +44,8 @@
         "nex-agi/nex-n2-pro:free": {}
       }
     }
-  },
+  }{{ if .is_darwin }},
   "plugin": [
     "/opt/homebrew/lib/node_modules/@rynfar/meridian/plugin/meridian.ts"
-  ]
+  ]{{- end }}
 }

--- a/home/private_dot_config/opencode/tui.json
+++ b/home/private_dot_config/opencode/tui.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "theme": "flexoki-light-forced",
+  "plugin": []
+}

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -62,3 +62,44 @@ teardown() {
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed
   refute_output --partial "run_once_after_macos-tunes"
 }
+
+# ===========================================
+# ask-agent skill scripts
+# ===========================================
+
+ASK_AGENT_DIR="$CHEZMOI_SOURCE/private_dot_claude/skills/ask-agent/scripts"
+
+@test "ask-agent scripts are valid bash" {
+  for s in ask.sh agents/claude.sh agents/opencode.sh agents/pi.sh; do
+    run bash -n "$ASK_AGENT_DIR/$s"
+    assert_success
+  done
+}
+
+@test "ask.sh uses set -euo pipefail" {
+  run grep -q "set -euo pipefail" "$ASK_AGENT_DIR/ask.sh"
+  assert_success
+}
+
+@test "ask.sh with no args exits 2" {
+  run bash "$ASK_AGENT_DIR/ask.sh"
+  assert_failure 2
+}
+
+@test "ask.sh with an unknown agent exits 2 and lists the valid agents" {
+  run bash "$ASK_AGENT_DIR/ask.sh" bogus "question"
+  assert_failure 2
+  assert_output --partial "claude opencode pi"
+}
+
+@test "ask.sh claude read-only maps to allowlist plus explicit deny" {
+  local stubdir; stubdir="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*"\n' > "$stubdir/claude"
+  chmod +x "$stubdir/claude"
+  run env PATH="$stubdir:$PATH" HERDR_ENV="" bash "$ASK_AGENT_DIR/ask.sh" claude "hi there"
+  rm -rf "$stubdir"
+  assert_success
+  assert_output --partial -- "-p hi there"
+  assert_output --partial -- "--allowed-tools Read Grep Glob WebFetch WebSearch"
+  assert_output --partial -- "--disallowed-tools Bash Edit Write"
+}

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -206,6 +206,12 @@ TOML
   assert_file_exists "$HOME/.claude/CLAUDE.md"
 }
 
+@test "ask-agent skill is deployed" {
+  assert_file_exists "$HOME/.claude/skills/ask-agent/SKILL.md"
+  assert_file_exists "$HOME/.claude/skills/ask-agent/scripts/ask.sh"
+  assert_file_exists "$HOME/.claude/skills/ask-agent/scripts/agents/claude.sh"
+}
+
 # ===========================================
 # macOS-only configs (skipped on Linux)
 # ===========================================

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -83,3 +83,34 @@ teardown() {
   render_template "$CHEZMOI_SOURCE/dot_zshrc.tmpl" > "$BATS_TEST_TMPFILE"
   assert_no_template_markers "$BATS_TEST_TMPFILE"
 }
+
+# ===========================================
+# opencode.json.tmpl (macOS-only plugin path guarded by .is_darwin)
+# ===========================================
+
+@test "opencode.json.tmpl renders valid JSON" {
+  BATS_TEST_TMPFILE="$(mktemp)"
+  render_template "$CHEZMOI_SOURCE/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
+  if command_exists jq; then
+    run jq empty "$BATS_TEST_TMPFILE"
+  elif command_exists python3; then
+    run python3 -m json.tool "$BATS_TEST_TMPFILE"
+  elif command_exists node; then
+    run node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"))' "$BATS_TEST_TMPFILE"
+  else
+    skip "no JSON parser available (jq/python3/node)"
+  fi
+  assert_success
+}
+
+@test "opencode.json.tmpl renders with no unresolved template markers" {
+  BATS_TEST_TMPFILE="$(mktemp)"
+  render_template "$CHEZMOI_SOURCE/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
+  assert_no_template_markers "$BATS_TEST_TMPFILE"
+}
+
+@test "opencode.json.tmpl omits the macOS brew plugin path on Linux" {
+  is_linux || skip "Only relevant on Linux"
+  run render_template "$CHEZMOI_SOURCE/private_dot_config/opencode/opencode.json.tmpl"
+  refute_output --partial "/opt/homebrew"
+}


### PR DESCRIPTION
## Summary

Follow-up fixes from the code review of #3 (the `ask-agent` skill). Three things were broken or fragile and are now fixed: a "read-only" consult could still write, herdr-mode consults hid every failure from the calling agent, and `opencode.json` shipped a macOS-only plugin path that broke a Linux apply.

### Read-only consults are now actually read-only

`claude` read-only previously passed only `--allowed-tools …`. That list is **additive** over `~/.claude/settings.json` `permissions.allow` (which can already allow `Bash`), so a consult advertised as read-only could still shell out and write. It now also passes `--disallowed-tools Bash Edit Write` — deny takes precedence, so the guarantee no longer depends on ambient settings. `opencode` read-only is prompt-only (opencode has no per-call permission flag); it now says so on stderr so the caller isn't misled.

### herdr consults report success and failure honestly

A herdr-pane consult used to always exit `0` and leak temp files: the called agent's exit code was lost behind `tee`, a 30-minute timeout was swallowed by `|| true`, and the `OUT` capture file was never in the cleanup trap. Now the consult's **own** exit code is propagated (captured in a sidecar file read inside a subshell, so it works under both bash and zsh), a timeout warns and exits `124`, and all temp files are cleaned on every exit path. This matters because the whole point of `ask-agent` is one agent consuming another's result — it needs to tell an answer from a failure.

### opencode.json no longer breaks on Linux

It was a plain JSON file with the absolute path `/opt/homebrew/.../@rynfar/meridian` hardcoded, so a Linux/Docker `chezmoi apply` wrote a macOS-only path that opencode then failed to load. It is now `opencode.json.tmpl` with the plugin array guarded by `{{ if .is_darwin }}` — valid JSON on both platforms, plugin emitted on macOS only. This matches the repo's existing `.tmpl` + `.is_darwin` pattern.

Minor: `--skills` now warns when passed to `opencode` (it was silently dropped), and the default-model IDs were removed from the `ask.sh` header so they live in one place (the adapters + SKILL.md) instead of drifting.

## Validation

- `make test-ubuntu` (full Docker suite): helpers 7/7, templates 13/13, **smoke 56/56** — including `ask-agent skill is deployed` and `chezmoi apply` / idempotency / empty-`diff` / `verify` all green, which proves `opencode.json.tmpl` applies cleanly on Linux without the brew path.
- Host (macOS): `scripts.bats` 12/12, `templates.bats` all pass (rendered JSON strict-validated via `jq`).
- Manual: read-only → allowlist + explicit deny; `--rw` → `acceptEdits`; no-args / unknown-agent → exit 2; the opencode `--skills` and read-only warnings fire.
- Read-only deny **verified empirically**: a `claude` consult run with `--permission-mode acceptEdits` (plan-mode protection off) **plus** `--disallowed-tools Bash Edit Write` reported it had no shell tool available (only Read/Glob/Grep) and did not write to disk. So the deny flag is the self-contained guarantee — it removes Bash/Edit/Write from the toolset regardless of `defaultMode: plan`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)

