### PR TITLE
Add herdr-pair peer-agent skill (claude-driven, claude↔pi & claude↔claude)

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -18,11 +18,11 @@ Source legend: `gh:<owner/repo>` GitHub · `npm:<pkg>` npm · `git:<url>` git ·
 
 ## Cross-tool skills (my own / want everywhere)
 
-| Skill | Tools | Source |
-|---|---|---|
-| crit | Claude, OpenCode, Pi | `?` (crit tool's skill — confirm) |
-| herdr | Claude → **want OpenCode + Pi too** | `repo` (home/private_dot_claude/skills/herdr) |
-| react-doctor | Claude, OpenCode | `gh:millionco/react-doctor` |
+| Skill        | Tools                               | Source                                        |
+| ------------ | ----------------------------------- | --------------------------------------------- |
+| crit         | Claude, OpenCode, Pi                | `?` (crit tool's skill — confirm)             |
+| herdr        | Claude → **want OpenCode + Pi too** | `repo` (home/private_dot_claude/skills/herdr) |
+| react-doctor | Claude, OpenCode                    | `gh:millionco/react-doctor`                   |
 
 ---
 
@@ -30,16 +30,16 @@ Source legend: `gh:<owner/repo>` GitHub · `npm:<pkg>` npm · `git:<url>` git ·
 
 ### Marketplaces (add first: `claude plugin marketplace add <source>`)
 
-| Marketplace | Source |
-|---|---|
-| claude-plugins-official | `gh:anthropics/claude-plugins-official` |
-| claude-code-workflows | `gh:wshobson/agents` |
-| cc-marketplace | `gh:kenryu42/cc-marketplace` |
-| context7-marketplace | `gh:upstash/context7` |
-| impeccable | `gh:pbakaus/impeccable` |
-| chrome-devtools-plugins | `gh:ChromeDevTools/chrome-devtools-mcp` |
-| compound-engineering-plugin | `gh:EveryInc/compound-engineering-plugin` |
-| obsidian-skills | `git:git@github.com:kepano/obsidian-skills.git` (only used project-scope — optional) |
+| Marketplace                 | Source                                                                               |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| claude-plugins-official     | `gh:anthropics/claude-plugins-official`                                              |
+| claude-code-workflows       | `gh:wshobson/agents`                                                                 |
+| cc-marketplace              | `gh:kenryu42/cc-marketplace`                                                         |
+| context7-marketplace        | `gh:upstash/context7`                                                                |
+| impeccable                  | `gh:pbakaus/impeccable`                                                              |
+| chrome-devtools-plugins     | `gh:ChromeDevTools/chrome-devtools-mcp`                                              |
+| compound-engineering-plugin | `gh:EveryInc/compound-engineering-plugin`                                            |
+| obsidian-skills             | `git:git@github.com:kepano/obsidian-skills.git` (only used project-scope — optional) |
 
 ### Plugins (user-scope, global: `claude plugin install <name>@<marketplace>`)
 
@@ -62,20 +62,20 @@ frontend-mobile-development · conductor · accessibility-compliance
 
 ### Authored skills (`home/private_dot_claude/skills/` — already in repo)
 
-ask-agent · herdr · markdown-new · react-doctor · review-plan · tdd-integration
+ask-agent · herdr · herdr-pair · markdown-new · react-doctor · review-plan · tdd-integration
 
 ### Skills pulled from upstream (`home/.chezmoiexternal.toml` — already in repo)
 
-| Skill | Source |
-|---|---|
-| react-best-practices | `gh:vercel-labs/agent-skills` |
-| composition-patterns | `gh:vercel-labs/agent-skills` |
-| react-useeffect | `gh:jarrodwatts/claude-code-config` |
-| rigorous-coding | `gh:jarrodwatts/claude-code-config` |
-| linear-cli | `gh:schpet/linear-cli` |
-| ast-grep | `gh:ast-grep/agent-skill` |
-| improve-claude-md | `gh:dexhorthy/slopfiles` |
-| handoff | `?` (present in ~/.claude/skills — confirm source) |
+| Skill                | Source                                             |
+| -------------------- | -------------------------------------------------- |
+| react-best-practices | `gh:vercel-labs/agent-skills`                      |
+| composition-patterns | `gh:vercel-labs/agent-skills`                      |
+| react-useeffect      | `gh:jarrodwatts/claude-code-config`                |
+| rigorous-coding      | `gh:jarrodwatts/claude-code-config`                |
+| linear-cli           | `gh:schpet/linear-cli`                             |
+| ast-grep             | `gh:ast-grep/agent-skill`                          |
+| improve-claude-md    | `gh:dexhorthy/slopfiles`                           |
+| handoff              | `?` (present in ~/.claude/skills — confirm source) |
 
 ### Authored agents (`home/private_dot_claude/agents/` — already in repo)
 
@@ -88,9 +88,8 @@ plan-skeptic · plan-synthesizer · tdd-implementer · tdd-refactorer · tdd-tes
 
 ### Plugins (`~/.config/opencode/opencode.json` → `plugin[]`; OpenCode self-installs at startup)
 
-| Plugin | Source |
-|---|---|
-| oh-my-openagent | `npm:oh-my-openagent` — **bundle**: provides ce-* skills + ~49 agents |
+| Plugin           | Source                                                                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | @rynfar/meridian | `gh:rynfar/meridian` (`npm:@rynfar/meridian`) — install the package and reference it (replaces the old absolute brew path) |
 
 ### Local plugins (files, keep in repo)
@@ -99,7 +98,7 @@ herdr-agent-state.js · rtk.ts
 
 ### Skills / agents
 
-Mostly `bundle:oh-my-openagent` (the ce-* set + reviewer agents) — do not hand-list.
+Mostly `bundle:oh-my-openagent` (the ce-\* set + reviewer agents) — do not hand-list.
 Cross-tool own skills here: crit, react-doctor, herdr (wanted). Also web-perf, lfg.
 
 ---
@@ -108,15 +107,15 @@ Cross-tool own skills here: crit, react-doctor, herdr (wanted). Also web-perf, l
 
 ### Extensions (`~/.pi/agent/settings.json` → `packages[]`; `pi install <source>`)
 
-| Extension | Source |
-|---|---|
-| pi-theme-flexoki | `git:github.com/markacianfrani/pi-theme-flexoki` |
-| pi-fff | `npm:@ff-labs/pi-fff` |
-| pi-rtk | `npm:@sherif-fanous/pi-rtk` |
-| pi-codex-conversion | `npm:@howaboua/pi-codex-conversion` |
-| pi-agents | `npm:pi-agents` |
-| pi-subagents | `npm:pi-subagents` |
-| pi-intercom | `npm:pi-intercom` |
+| Extension               | Source                                                                                                                                  |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| pi-theme-flexoki        | `git:github.com/markacianfrani/pi-theme-flexoki`                                                                                        |
+| pi-fff                  | `npm:@ff-labs/pi-fff`                                                                                                                   |
+| pi-rtk                  | `npm:@sherif-fanous/pi-rtk`                                                                                                             |
+| pi-codex-conversion     | `npm:@howaboua/pi-codex-conversion`                                                                                                     |
+| pi-agents               | `npm:pi-agents`                                                                                                                         |
+| pi-subagents            | `npm:pi-subagents`                                                                                                                      |
+| pi-intercom             | `npm:pi-intercom`                                                                                                                       |
 | pi-agent-browser-native | `npm:pi-agent-browser-native` (https://pi.dev/packages/pi-agent-browser-native — replaced the old local absolute path / coctostan repo) |
 
 ### Skills / agents

--- a/home/.chezmoiscripts/run_onchange_after_install-herdr-integrations.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_install-herdr-integrations.sh.tmpl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Refresh herdr's agent-state integrations so `herdr wait agent-status` works for the
+# agents the herdr-pair skill drives. herdr ships per-agent state hooks and bumps their
+# version with each release; this re-runs `herdr integration install` whenever herdr is
+# upgraded (exactly when the hooks go stale), instead of vendoring the hooks here.
+#
+# Re-run trigger — the hashed herdr version below changes on upgrade, so chezmoi re-runs
+# this script then. The trigger is a single comment line (shellcheck-safe in the raw
+# template); lookPath guards `output` so CI/Docker without herdr still renders cleanly:
+# {{ if lookPath "herdr" }}herdr version: {{ output "herdr" "--version" | sha256sum }}{{ else }}herdr version: unavailable at apply time{{ end }}
+
+# Keep this tolerant: a missing herdr or a stopped server must not make chezmoi apply fail.
+set -u
+
+if ! command -v herdr >/dev/null 2>&1; then
+  echo "herdr not found; skipping agent-state integration refresh"
+  exit 0
+fi
+
+if herdr integration install claude pi opencode >/dev/null 2>&1; then
+  echo "Refreshed herdr agent-state integrations (claude pi opencode)"
+else
+  echo "Warning: failed to refresh herdr agent-state integrations. Run manually: herdr integration install claude pi opencode" >&2
+fi
+
+exit 0

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -4,6 +4,7 @@ Global Claude Code configuration — collaboration style, skill routing, and too
 
 - **Говори со мной по-русски**. Можешь использовать английские термины.
 - Bias: caution over speed on non-trivial work. Use judgment on trivial tasks.
+- **NEVER signal your own honesty** — not "честно", "(честно)", "to be honest", or any form, in any position (including headings and parentheticals). Say it directly. Full rule in the reporting block below.
 
 ## Decision-making
 
@@ -56,7 +57,7 @@ Default to surfacing uncertainty, not hiding it.
 
 State only what you actually checked. Haven't verified it? Say "не проверял" once and verify before asserting. Never present a guess, assumption, or untested result as fact.
 Wrong earlier? Give the correction in one line and move on — no re-framing, no restating the conclusion twice.
-Banned filler: "честно", "теперь честно", "по-честному", "по-чесноку", "to be honest", "now honestly", and every honesty-signaling phrase. Say the thing directly. Honesty is demonstrated by verified claims, never announced.
+ABSOLUTE BAN — honesty-signaling filler. NEVER write "честно", "(честно)", "честно говоря", "если честно", "по-честному", "теперь честно", "по-чесноку", "to be honest", "now honestly", "frankly", "truthfully", or ANY phrase that announces, labels, or qualifies your own honesty. This holds in EVERY position — inline, sentence-start, bullet, parenthetical, AND section heading. A heading like "Что НЕ проверено (честно)" is a violation; write "Что НЕ проверено". Say the thing directly. Honesty is demonstrated by verified claims, never announced. If you catch yourself typing any such word, delete it before sending.
 
 </important>
 

--- a/home/private_dot_claude/skills/herdr-pair/SKILL.md
+++ b/home/private_dot_claude/skills/herdr-pair/SKILL.md
@@ -66,6 +66,8 @@ PROTO="$SKILL_DIR/references/peer-protocol.md"
 
 ### Kinds (state machine)
 
+The kinds and their meanings are defined canonically in `references/peer-protocol.md` (the partner's copy); the summary below mirrors it — keep the two in sync if you edit either.
+
 ```
 task → review | question | blocked
 question → task
@@ -96,43 +98,50 @@ Triggered by `/herdr-pair [--with claude|pi] <task>`.
    PARTNER_PANE="$(bash "$SKILL_DIR/scripts/spawn-partner.sh" --agent "$PARTNER" --proto "$PROTO" --cwd "$PWD")"
    ```
    Spawn failure exits non-zero with recent pane output already surfaced → hand off to the user (hard rule 4).
-4. **Generate the sid and create the session:**
+4. **Generate the sid and create the session — clean up the spawned pane if the claim fails:**
    ```bash
    SID="$(date +%s)-$(openssl rand -hex 2)"
-   bash "$SKILL_DIR/scripts/session.sh" create --ws "$WS" --tab "$TAB" --sid "$SID" \
-     --a-agent claude --a-pane "$HERDR_PANE_ID" --b-agent "$PARTNER" --b-pane "$PARTNER_PANE"
+   if ! bash "$SKILL_DIR/scripts/session.sh" create --ws "$WS" --tab "$TAB" --sid "$SID" \
+        --a-agent claude --a-pane "$HERDR_PANE_ID" --b-agent "$PARTNER" --b-pane "$PARTNER_PANE"; then
+     herdr pane close "$PARTNER_PANE"   # don't orphan the partner we just spawned
+     echo "this tab already has a pair session — resume or remove it"; exit 1
+   fi
    ```
-   `create` refuses to clobber an existing session for the tab — a leftover means a previous pair in this tab; ask the user to resume or remove it.
-5. **Send the first task:**
+   `create` is atomic, so a concurrent pair-start in the same tab can't clobber yours — the loser cleans up its spawned pane here.
+5. **Send the first task.** The partner already has the protocol injected, so do **not** restate the literal header in the body — a `[pair b -> a …]` line typed here is echoed into the partner pane and would confuse `recv.sh`. Describe the task; the protocol tells the partner how to reply.
    ```bash
    bash "$SKILL_DIR/scripts/send.sh" --partner-pane "$PARTNER_PANE" \
      --self-role a --partner-role b --kind task --sid "$SID" --ws "$WS" --tab "$TAB" \
-     --body "<the task, plus: lead your reply with [pair b -> a kind=... sid=$SID]>"
+     --body "<the task to do>"
    ```
-   Include a one-line fallback hint in the body so a partner that didn't get the protocol can still recover: *"(herdr pair — reply leading with `[pair b -> a kind=<kind> sid=<sid>]`, then prose.)"*
+   Optional fallback for a partner that somehow lacks the protocol: a prose hint with **no** bracketed header literal — e.g. *"(herdr pair: begin your reply with a header line — the word pair, your role to mine, a kind, and this sid — then prose.)"*
 
 ## Driver loop
 
 Repeat until completion or handoff:
 
-1. **Wait for the reply.** The semantic signal is the reply header appearing in the partner pane:
+1. **Wait for the partner to finish its turn — bounded — then read.** Use agent-status, not a text match: a stale `[pair b -> a …]` from a previous turn is still in the pane, so matching on it would fire early. `recv.sh` (next step) is cursor-authoritative and ignores anything before your last send, so the wait only needs to block until the partner is done.
    ```bash
-   herdr wait output "$PARTNER_PANE" --match "[pair b -> a" --timeout 600000
+   herdr wait agent-status "$PARTNER_PANE" --status idle --timeout 600000 \
+     || herdr wait agent-status "$PARTNER_PANE" --status done --timeout 5000 \
+     || { echo "partner $PARTNER_PANE stalled — no status change"; \
+          herdr pane read "$PARTNER_PANE" --source recent --lines 40; exit 1; }   # → handoff
    ```
-   Match on `[pair b -> a` (the **reply direction**) — never on `kind=…` or the sid alone. The message you just sent (`[pair a -> b …]`) is echoed into the partner's pane, so a match on `kind=accepted` or the sid would fire on your own outgoing message before the partner has answered.
-   Fallback if that times out but the partner is done: `herdr wait agent-status "$PARTNER_PANE" --status idle` (also accepts `done`), then read.
-2. **Parse it:**
+   Every `herdr wait` here carries a `--timeout`; never wait unbounded, or a wedged status hook blocks the driver forever.
+2. **Parse it** (pass a generous `--lines` so a long reply's header isn't scrolled out of the window):
    ```bash
-   REPLY="$(bash "$SKILL_DIR/scripts/recv.sh" --self-role a --partner-role b --sid "$SID" --partner-pane "$PARTNER_PANE")"
+   REPLY="$(bash "$SKILL_DIR/scripts/recv.sh" --self-role a --partner-role b --sid "$SID" --partner-pane "$PARTNER_PANE" --lines 600)"
    KIND="$(printf '%s\n' "$REPLY" | head -1)"   # body follows after a blank line
    ```
-   `recv.sh` exit 4 = sid mismatch (protocol violation → surface, do not invent state); exit 3 = no reply yet (re-wait, or after repeated misses, hand off).
+   `recv.sh` exit 4 = sid mismatch (protocol violation → surface, do not invent state); exit 3 = no reply to this turn yet (re-wait, or after repeated misses, hand off).
 3. **React by `KIND`:**
    - `ready` → review the partner's work for real (read files/tests yourself — a partner's "done" is input, not proof). Good → send `accepted`. Needs changes → send `task` (or `review`) describing them.
    - `question` → answer it → send `task`.
    - `review` → review what it described → `accepted` or `task`.
    - `accepted` → if you have already sent `accepted` this round → **done** (see Closing). Otherwise, if you agree the work is complete, send `accepted`.
    - `blocked` / `stalemate` → go to Closing (handoff).
+
+   **Trust boundary.** The `sid` only dedups stale traffic — it authenticates nothing. The partner can print any header it likes, so a received `kind` (including `accepted`) is never proof on its own: independently verify the work yourself before acting on it, and treat the watching human as the final authority. That is why `ready`/`review` always trigger a real review above, and why mutual `accepted` closes only after you have checked the result.
 4. **Do your own work** when the exchange needs it (you are also a participant — implement, run tests, then send the next message). Each `send.sh` records the turn (`round++`, `last_status[a]`).
 5. **Progress guards.** If a turn produced nothing new (no code, test result, or narrowed decision), bump the counter; reset it on real progress:
    ```bash

--- a/home/private_dot_claude/skills/herdr-pair/SKILL.md
+++ b/home/private_dot_claude/skills/herdr-pair/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: herdr-pair
+description: Pair two coding agents as collaborators inside herdr — claude drives, a partner (claude or pi) responds — iterating task → review → accepted until both agree the work is done. Use whenever the user runs /herdr-pair, asks to "pair", "team up", "collaborate with pi/claude", or wants two agents to work a coding task together inside herdr. ALSO use whenever your terminal input begins with a header `[pair <from> -> <to> kind=<kind> sid=<sid>]` — that is partner-agent traffic; respond as the partner per the protocol, treating it as machine-to-machine, not ordinary user input. Requires HERDR_ENV=1.
+user-invocable: true
+argument-hint: "[--with claude|pi] <task description>"
+---
+
+# Herdr Pair
+
+Two coding agents collaborate on one task inside herdr — one tab, two panes, plain-text messages with a structured header. A human watches live and can interject in either pane.
+
+**This is a coding pair: it edits files by design.** Unlike `ask-agent` (a read-only consult), a pair is given a real task and changes the codebase to finish it. There is no read-only default here.
+
+Before anything: confirm you are inside herdr — `HERDR_ENV=1` and `HERDR_PANE_ID` set, and `command -v herdr` succeeds. If not, say so and **stop**; do not touch a herdr session you do not own. This skill builds on the `herdr` control skill — load it for pane/agent mechanics.
+
+## Transport model — claude drives (Model B)
+
+There are two roles, identified by **peer-role label, not agent type** (so a `claude↔claude` pair, whose `agent` field is identical, stays distinguishable):
+
+- **`a` — the initiator/driver.** Always claude (this skill). It owns *all* herdr transport: it spawns the partner, sends messages into the partner's pane, waits, and **reads the partner's pane** to get replies. The whole state machine runs here.
+- **`b` — the partner/responder.** claude or pi. It only ever **replies in its own pane**, leading each turn with the swapped header. It never runs herdr and never discovers a pane. Its contract is `references/peer-protocol.md`.
+
+This is why pi works as a partner with nothing but an injected prompt: the hard parts (herdr, turn-taking, parsing) live in claude's scripts, not in the partner.
+
+> Bidirectional *conversation* (a↔b, both directions of messages) is fully supported. Bidirectional *initiation* (a non-claude agent starting/driving a pair, e.g. `pi→claude`) is **not** — that is deferred follow-up work. The eventual native-deployment vision (every agent runs the skill and replies via header auto-load) is the symmetric "Model A"; until then, claude drives.
+
+## Hard rules
+
+1. **Workspace + tab isolation.** Every pane op is scoped to the caller's `workspace_id`, and exactly one pair per `tab_id`. Session state lives under `<workspace_id>/<tab_slug>/` so concurrent pairs in different tabs never clobber each other.
+2. **claude is the driver.** The partner never drives. If you received a `[pair … -> you …]` header (you are the partner), see **Receiving** below — do not try to drive.
+3. **User override always wins.** A human message that contradicts a partner message wins; surface the contradiction.
+4. **No retries on spawn failure.** One failed partner spawn → surface recent pane output and hand off to the user.
+
+## Scripts
+
+All racy mechanics live in `scripts/` (shellcheck-clean, tested). Call them; don't reimplement them inline.
+
+| Script | Role |
+|--------|------|
+| `scripts/session.sh` | atomic per-tab session state: `create` / `get` / `update` (roles `a`/`b` → `{agent_type, pane_id}`) |
+| `scripts/spawn-partner.sh` | split a pane, launch the partner with the protocol injected, wait until idle; prints the partner pane id |
+| `scripts/send.sh` | compose `[pair a -> b …]` + body, deliver to the partner pane, verify it submitted, record the turn |
+| `scripts/recv.sh` | read the partner pane, extract its latest `[pair b -> a …]` reply → `kind` + body |
+
+Resolve the skill directory once (the dir this SKILL.md lives in) and call scripts by absolute path:
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/herdr-pair"   # deployed; in props/testing mode use the repo working-tree path instead
+PROTO="$SKILL_DIR/references/peer-protocol.md"
+```
+
+## Protocol delivery modes
+
+- **Testing / props (now).** Skills are not yet deployed to every agent, and pi cannot auto-load Claude skills. So the partner is spawned with the protocol injected from a file: `spawn-partner.sh` passes `--proto "$PROTO"`, where `$PROTO` points at `references/peer-protocol.md` **in the repo working tree** (no `chezmoi apply` needed). This is identical for a claude or a pi partner.
+- **Native (later).** Once the skill is deployed to all agents, a claude partner auto-loads on seeing the `[pair …]` header and the injection flag can be dropped. pi/opencode native support is follow-up work.
+
+## Message format
+
+```
+[pair <from> -> <to> kind=<kind> sid=<sid>]
+
+<body — plain prose, written to a teammate>
+```
+
+`<from>`/`<to>` are role labels (`a`/`b`). `<sid>` is a sortable session id (e.g. `1718000000-7a3f`). The header matches; the body is prose.
+
+### Kinds (state machine)
+
+```
+task → review | question | blocked
+question → task
+review → ready | task
+ready → accepted
+accepted → done   (only when BOTH sides have sent accepted)
+blocked → handoff
+stalemate → handoff
+```
+
+- `task` — assign/update work. Mid-flight interrupt: body begins `STOP — <reason>`.
+- `review` — request review of described changes (file paths + summary).
+- `question` — ask for clarification.
+- `ready` — your side is complete; summarize what changed, how validated, residual risk.
+- `accepted` — partner's `ready` looks good. **Both sides `accepted` is the only completion signal.**
+- `blocked` — cannot proceed without a human decision.
+- `stalemate` — same disagreement twice without movement.
+- `handoff` — final message to the user, in your own pane (not via send).
+
+## Bootstrap (you are the initiator, role `a`)
+
+Triggered by `/herdr-pair [--with claude|pi] <task>`.
+
+1. **Resolve self.** `herdr pane current` → `workspace_id` (WS), `tab_id` (TAB), your `pane_id`. You are role `a`.
+2. **Pick the partner agent.** From `--with` (default `claude`). pi gives a cross-model partner.
+3. **Spawn the partner** (preferred — a clean session). Reuse an existing idle pane in the tab only if the user explicitly points at one.
+   ```bash
+   PARTNER_PANE="$(bash "$SKILL_DIR/scripts/spawn-partner.sh" --agent "$PARTNER" --proto "$PROTO" --cwd "$PWD")"
+   ```
+   Spawn failure exits non-zero with recent pane output already surfaced → hand off to the user (hard rule 4).
+4. **Generate the sid and create the session:**
+   ```bash
+   SID="$(date +%s)-$(openssl rand -hex 2)"
+   bash "$SKILL_DIR/scripts/session.sh" create --ws "$WS" --tab "$TAB" --sid "$SID" \
+     --a-agent claude --a-pane "$HERDR_PANE_ID" --b-agent "$PARTNER" --b-pane "$PARTNER_PANE"
+   ```
+   `create` refuses to clobber an existing session for the tab — a leftover means a previous pair in this tab; ask the user to resume or remove it.
+5. **Send the first task:**
+   ```bash
+   bash "$SKILL_DIR/scripts/send.sh" --partner-pane "$PARTNER_PANE" \
+     --self-role a --partner-role b --kind task --sid "$SID" --ws "$WS" --tab "$TAB" \
+     --body "<the task, plus: lead your reply with [pair b -> a kind=... sid=$SID]>"
+   ```
+   Include a one-line fallback hint in the body so a partner that didn't get the protocol can still recover: *"(herdr pair — reply leading with `[pair b -> a kind=<kind> sid=<sid>]`, then prose.)"*
+
+## Driver loop
+
+Repeat until completion or handoff:
+
+1. **Wait for the reply.** The semantic signal is the reply header appearing in the partner pane:
+   ```bash
+   herdr wait output "$PARTNER_PANE" --match "[pair b -> a" --timeout 600000
+   ```
+   Match on `[pair b -> a` (the **reply direction**) — never on `kind=…` or the sid alone. The message you just sent (`[pair a -> b …]`) is echoed into the partner's pane, so a match on `kind=accepted` or the sid would fire on your own outgoing message before the partner has answered.
+   Fallback if that times out but the partner is done: `herdr wait agent-status "$PARTNER_PANE" --status idle` (also accepts `done`), then read.
+2. **Parse it:**
+   ```bash
+   REPLY="$(bash "$SKILL_DIR/scripts/recv.sh" --self-role a --partner-role b --sid "$SID" --partner-pane "$PARTNER_PANE")"
+   KIND="$(printf '%s\n' "$REPLY" | head -1)"   # body follows after a blank line
+   ```
+   `recv.sh` exit 4 = sid mismatch (protocol violation → surface, do not invent state); exit 3 = no reply yet (re-wait, or after repeated misses, hand off).
+3. **React by `KIND`:**
+   - `ready` → review the partner's work for real (read files/tests yourself — a partner's "done" is input, not proof). Good → send `accepted`. Needs changes → send `task` (or `review`) describing them.
+   - `question` → answer it → send `task`.
+   - `review` → review what it described → `accepted` or `task`.
+   - `accepted` → if you have already sent `accepted` this round → **done** (see Closing). Otherwise, if you agree the work is complete, send `accepted`.
+   - `blocked` / `stalemate` → go to Closing (handoff).
+4. **Do your own work** when the exchange needs it (you are also a participant — implement, run tests, then send the next message). Each `send.sh` records the turn (`round++`, `last_status[a]`).
+5. **Progress guards.** If a turn produced nothing new (no code, test result, or narrowed decision), bump the counter; reset it on real progress:
+   ```bash
+   bash "$SKILL_DIR/scripts/session.sh" update --ws "$WS" --tab "$TAB" --role a --status "$KIND" --no-progress inc   # or: reset
+   ```
+   After ~5 no-progress turns, send `handoff` instead of looping. Same disagreement restated twice → `stalemate`.
+
+## Closing
+
+Completion is **both sides having sent `accepted`** — i.e. you sent `accepted` (`session.last_status.a == "accepted"`) and the partner's latest reply was `accepted`. Then:
+
+1. Emit a final `kind=handoff` summary to the **user, in your own pane** (not via `send.sh`) — what was built, how it was validated, residual risk.
+2. Remove only this tab's session dir (other tabs may host concurrent pairs); the path is guarded inside the script:
+   ```bash
+   bash "$SKILL_DIR/scripts/session.sh" trash --ws "$WS" --tab "$TAB"
+   ```
+
+`blocked` and `stalemate` end the same way: a `handoff` summary to the user + cleanup.
+
+## Receiving (you are the partner, role `b`)
+
+If your terminal input begins with `[pair <from> -> <to> kind=… sid=…]` and you did **not** initiate, you are the partner. Follow `references/peer-protocol.md`: treat it as machine-to-machine, do the work, and **reply in your own pane** leading with the swapped header `[pair <to> -> <from> kind=<your-kind> sid=<sid>]` (same sid). Do **not** drive, do **not** send into the other pane — the initiator reads you. The human always overrides; surface contradictions.
+
+## Workbench tab
+
+Lazy/optional. For long-running shared processes (servers, watchers, logs) the pair needs to watch, see `references/workbench-tab.md`.
+
+## Live testing (manual E2E — CI cannot run this)
+
+CI covers structure, shellcheck, and `recv.sh`/`session.sh` units. The live pair needs herdr + interactive agents, so validate it by hand inside herdr:
+
+1. **claude↔claude.** From a claude pane: `/herdr-pair --with claude <a trivial task, e.g. "add a one-line code comment to FILE and confirm">`. Confirm: a partner pane spawns and reaches idle; the task is delivered; the partner replies `[pair b -> a …]`; the loop iterates to **both sides `accepted`**; the handoff summary prints; the session dir is trashed.
+2. **claude↔pi.** Same, `--with pi`. Additionally confirm pi got the protocol (its first reply is correctly formatted) and is idle-detectable.
+3. **Isolation.** Run two pairs in two tabs of one workspace at once; confirm their session dirs (`<ws>/<tab_slug>/`) stay separate and neither closing trashes the other.
+
+Probe-verified (2026-06-28, herdr 0.7.1): pi accepts the protocol via `--append-system-prompt <path>`, submits on a single Enter, is idle-detectable on its v2 hook, and replies in-format. Re-confirm after a herdr upgrade.

--- a/home/private_dot_claude/skills/herdr-pair/references/peer-protocol.md
+++ b/home/private_dot_claude/skills/herdr-pair/references/peer-protocol.md
@@ -1,0 +1,58 @@
+# Herdr pair — peer protocol (partner side)
+
+You are taking part in a **pair**: two coding agents collaborating on one task inside herdr (a terminal multiplexer), each in its own pane, exchanging plain-text messages that carry a structured header. A human is watching and may interject.
+
+**Your role is the partner / responder.** Another agent — the *initiator* — drives the exchange: it sends you messages and reads your replies straight from this pane. You do **not** run any `herdr` commands, you do **not** message the other pane yourself, and you do **not** need to discover the other pane. You simply **reply in your own output**, and the initiator picks it up. That is the whole mechanism — keep it that simple.
+
+## Recognizing a pair message
+
+When input you receive begins with a header line of this exact shape:
+
+```
+[pair <from> -> <to> kind=<kind> sid=<sid>]
+```
+
+…it is **machine-to-machine traffic from your pair partner**, not ordinary user input. Treat it as a message from a teammate and respond per this protocol.
+
+- `<from>` / `<to>` are peer-role labels (e.g. `a`, `b`). The message is addressed **to you** — you are the `<to>`; your partner is the `<from>`.
+- `<sid>` identifies the session. Always echo the **same** `<sid>` back, unchanged.
+
+## Replying
+
+Begin your reply with the header, **roles swapped**, same sid, on its own first line, then a blank line, then plain prose:
+
+```
+[pair <to> -> <from> kind=<your-kind> sid=<sid>]
+
+<your message — written to a teammate, not to a parser>
+```
+
+Put the header as the very **first line** of your turn so the initiator can find it in this pane. Write the body as normal prose: what you did, what you found, what you decided. End your turn after the message — the initiator will reply, and the exchange continues round by round.
+
+## Kinds
+
+Pick the `kind` that matches your intent:
+
+- `task` — assign or update work (you will usually *receive* this).
+- `question` — you need a clarification before you can proceed.
+- `review` — you are asking the partner to review described changes (give file paths + a short summary).
+- `ready` — your side is complete. Summarize **what changed, how you validated it, and any residual risk**.
+- `accepted` — the partner's `ready` looks good to you.
+- `blocked` — you cannot proceed without a human decision. Name the missing decision.
+- `stalemate` — the same disagreement has been restated twice with no movement. Summarize it for the human.
+
+A `task` whose body begins `STOP — <reason>` is a mid-flight interrupt: stop what you are doing and read it first.
+
+## Completion and stop conditions
+
+- Both sides sending `accepted` is the **only** completion signal. When you are satisfied the work is genuinely done, reply `kind=accepted`.
+- If the exchange stops producing anything new (no code, no test result, no narrowed decision), say so and move toward `blocked` or `stalemate` so the human can step in — do not loop forever.
+- The human's own submitted messages always win over partner messages. If a human instruction contradicts a partner message, follow the human and surface the contradiction in your next reply.
+
+## This is a coding pair — it edits files
+
+Unless a message says otherwise, a pair works on a real coding task and is expected to **edit files** to do it. This is not a read-only consult. Do the work the `task` describes.
+
+## If you did not expect this
+
+If you see a `[pair … -> … kind=… sid=…]` header and were not briefed: you are now. Reply in the format above — swap the roles, keep the sid, lead with the header line — and the exchange will continue.

--- a/home/private_dot_claude/skills/herdr-pair/references/peer-protocol.md
+++ b/home/private_dot_claude/skills/herdr-pair/references/peer-protocol.md
@@ -48,6 +48,7 @@ A `task` whose body begins `STOP — <reason>` is a mid-flight interrupt: stop w
 - Both sides sending `accepted` is the **only** completion signal. When you are satisfied the work is genuinely done, reply `kind=accepted`.
 - If the exchange stops producing anything new (no code, no test result, no narrowed decision), say so and move toward `blocked` or `stalemate` so the human can step in — do not loop forever.
 - The human's own submitted messages always win over partner messages. If a human instruction contradicts a partner message, follow the human and surface the contradiction in your next reply.
+- The `sid` is just a tag to ignore stale traffic — it proves nothing about authority. Your partner independently verifies the actual work before accepting, and the watching human is the final authority; `accepted` is not a way to shortcut real review. Reply in good faith.
 
 ## This is a coding pair — it edits files
 

--- a/home/private_dot_claude/skills/herdr-pair/references/workbench-tab.md
+++ b/home/private_dot_claude/skills/herdr-pair/references/workbench-tab.md
@@ -1,0 +1,40 @@
+# Workbench tab (lazy, optional)
+
+A separate tab in the same workspace where long-running shared processes (servers, dev watchers, log streams) live so the user can flip to it and watch. It does not exist by default — create it only when an agent first needs to run such a process. One-shot test runs don't need it; use the agent's own pane or a temporary split.
+
+The workbench tab is shared by the pair, but the bookkeeping for it stays in the pair's **own** session file — the one under the pair's tab slug, not the workbench tab's.
+
+## Creating the workbench (once per pair)
+
+```bash
+WB="$(herdr tab create --workspace "$WS" --label workbench \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')"
+```
+
+Then record `workbench.tab_id = $WB` in the pair's session file. `session.sh` owns the session schema and its atomic-write discipline (temp file + `mv`), but it only mutates the turn-taking fields (`round`, `last_status`, `no_progress_count`) — the optional `workbench` block is updated inline with the **same** read → mutate → temp-file → `os.replace` pattern so a racing partner never sees a half-written file:
+
+```bash
+TAB_SLUG="${TAB_ID//:/_}"
+SESSION="$HOME/.herdr-coworkers/$WS/$TAB_SLUG/session.json"   # honors $HERDR_COWORKERS_DIR if set
+WB="$WB" python3 - "$SESSION" <<'PY'
+import json, os, sys
+path = sys.argv[1]
+with open(path) as f: s = json.load(f)
+s.setdefault("workbench", {})["tab_id"] = os.environ["WB"]
+tmp = f"{path}.tmp.{os.getpid()}"
+with open(tmp, "w") as f: json.dump(s, f, indent=2)
+os.replace(tmp, path)
+PY
+```
+
+## Running processes inside the workbench
+
+Split panes inside the workbench tab for whatever you need (server, logs, etc.). Record `workbench.server_pane` and `workbench.logs_pane` in the session file via the same atomic update so the partner can find them without rediscovering.
+
+## Reading workbench output
+
+```bash
+herdr pane read <pane> --source recent-unwrapped --lines N
+```
+
+Re-verify recorded pane IDs with `herdr pane get` before relying on them — public pane IDs can compact when panes close.

--- a/home/private_dot_claude/skills/herdr-pair/references/workbench-tab.md
+++ b/home/private_dot_claude/skills/herdr-pair/references/workbench-tab.md
@@ -14,8 +14,8 @@ WB="$(herdr tab create --workspace "$WS" --label workbench \
 Then record `workbench.tab_id = $WB` in the pair's session file. `session.sh` owns the session schema and its atomic-write discipline (temp file + `mv`), but it only mutates the turn-taking fields (`round`, `last_status`, `no_progress_count`) — the optional `workbench` block is updated inline with the **same** read → mutate → temp-file → `os.replace` pattern so a racing partner never sees a half-written file:
 
 ```bash
-TAB_SLUG="${TAB_ID//:/_}"
-SESSION="$HOME/.herdr-coworkers/$WS/$TAB_SLUG/session.json"   # honors $HERDR_COWORKERS_DIR if set
+TAB_SLUG="${TAB//:/_}"
+SESSION="${HERDR_COWORKERS_DIR:-$HOME/.herdr-coworkers}/$WS/$TAB_SLUG/session.json"
 WB="$WB" python3 - "$SESSION" <<'PY'
 import json, os, sys
 path = sys.argv[1]

--- a/home/private_dot_claude/skills/herdr-pair/scripts/recv.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/recv.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
-# Read the partner's pane (or stdin) and extract its latest pair reply.
+# Read the partner's pane (or stdin) and extract its reply to the driver's latest message.
 #
 #   recv.sh --self-role a --partner-role b --sid S [--partner-pane P] [--lines N]
 #
-# Model B: the partner replies in its own pane; the initiator parses that reply here. We
-# look for the LAST header addressed to us — `[pair <partner-role> -> <self-role> kind=K
-# sid=S]` — tolerating the leading whitespace the TUI indents transcript lines with. On a
-# match, the kind is printed on line 1 (the state-machine signal), then a blank line, then
-# the body (best-effort, for the caller to read). Pure text in via stdin → unit-testable.
+# Model B: the partner replies in its own pane; the initiator parses that reply here.
 #
-# Exit: 0 ok; 2 usage; 3 no reply addressed to us found; 4 a reply was found but its sid
+# Anti-stale/echo cursor: the driver's most recent OUTGOING header (self -> partner) is
+# echoed into the partner pane and marks "after my last send". The current reply is the
+# FIRST partner -> self header AFTER that cursor. This ignores stale prior replies and the
+# echoed outgoing message itself (which IS the cursor) without needing a protocol nonce. If
+# no outgoing header is in the window (e.g. stdin fixtures), it scans the whole text.
+#
+# Note: the `sid` only dedups stale traffic — it authenticates nothing. A partner can print
+# any header it likes, so a parsed `accepted` is never sufficient on its own; the driver
+# must independently verify the work, and the watching human is the final authority.
+#
+# On a match: kind on line 1 (the state-machine signal), a blank line, then the body
+# (best-effort, for the caller to read). Pure text in via stdin → unit-testable.
+#
+# Exit: 0 ok; 2 usage; 3 no reply to the current turn found; 4 a reply was found but its sid
 # does not match (a protocol violation the caller must surface, not invent state around).
 set -euo pipefail
 
-SELF_ROLE="" ; PARTNER_ROLE="" ; SID="" ; PARTNER_PANE="" ; LINES=80
+SELF_ROLE="" ; PARTNER_ROLE="" ; SID="" ; PARTNER_PANE="" ; LINES=200
 while [ $# -gt 0 ]; do
   case "$1" in
     --self-role)    SELF_ROLE="$2"    ; shift 2 ;;
@@ -46,31 +55,40 @@ partner_role = re.escape(os.environ["PARTNER_ROLE"])
 want_sid = os.environ["SID"]
 
 # Tolerant of leading TUI decoration before the header — pi indents with spaces, Claude
-# Code prefixes assistant lines with a "⏺ " bullet. `[^\w\[]*` swallows any run of
-# non-word, non-'[' chars (glyphs, bullets, spaces) but stops at prose (a word char), so a
-# header quoted mid-sentence ("... reply with [pair ...") is not mistaken for a real reply.
-pat = re.compile(
-    r'^[^\w\[]*\[pair\s+' + partner_role + r'\s*->\s*' + self_role +
+# Code prefixes assistant lines with a "⏺ " bullet. `[^\w\[]*` swallows a run of non-word,
+# non-'[' chars (glyphs, bullets, spaces) but stops at prose (a word char), so a header
+# quoted mid-sentence ("... reply with [pair ...") is not mistaken for a header line.
+deco = r'^[^\w\[]*\['
+
+# Cursor: the driver's most recent outgoing header (self -> partner).
+out_pat = re.compile(deco + r'pair\s+' + self_role + r'\s*->\s*' + partner_role + r'\b', re.M)
+outs = list(out_pat.finditer(text))
+region_start = outs[-1].end() if outs else 0
+
+# The reply is the first partner -> self header at or after the cursor.
+reply_pat = re.compile(
+    deco + r'pair\s+' + partner_role + r'\s*->\s*' + self_role +
     r'\s+kind=(\S+)\s+sid=(\S+?)\s*\]',
     re.M,
 )
-matches = list(pat.finditer(text))
+matches = [m for m in reply_pat.finditer(text) if m.start() >= region_start]
 if not matches:
     sys.exit(3)
 
-m = matches[-1]
-kind, sid = m.group(1), m.group(2)
-if sid != want_sid:
-    sys.stderr.write(f"recv.sh: sid mismatch (got {sid!r}, expected {want_sid!r})\n")
+chosen = next((m for m in matches if m.group(2) == want_sid), None)
+if chosen is None:
+    sys.stderr.write(f"recv.sh: sid mismatch (got {matches[0].group(2)!r}, expected {want_sid!r})\n")
     sys.exit(4)
 
-# Body: the lines after the header, up to the TUI input-box rule that follows the reply
-# (a run of box-drawing dashes) — everything below that is pane chrome (rules, cwd, the
-# cost/status line), not the partner's message. Best-effort; the kind above is exact.
+kind = chosen.group(1)
+
+# Body: lines after the chosen header, up to the TUI input-box rule that follows the reply.
+# Match only the box-drawing rule (U+2500 '─'), never ascii '-', so a markdown horizontal
+# rule inside the reply body is not mistaken for chrome and truncated.
 out = []
-for line in text[m.end():].splitlines():
+for line in text[chosen.end():].splitlines():
     t = line.strip()
-    if len(t) >= 10 and set(t) <= set("─-"):
+    if len(t) >= 10 and set(t) <= set("─"):
         break
     out.append(line)
 while out and not out[0].strip():

--- a/home/private_dot_claude/skills/herdr-pair/scripts/recv.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/recv.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Read the partner's pane (or stdin) and extract its latest pair reply.
+#
+#   recv.sh --self-role a --partner-role b --sid S [--partner-pane P] [--lines N]
+#
+# Model B: the partner replies in its own pane; the initiator parses that reply here. We
+# look for the LAST header addressed to us — `[pair <partner-role> -> <self-role> kind=K
+# sid=S]` — tolerating the leading whitespace the TUI indents transcript lines with. On a
+# match, the kind is printed on line 1 (the state-machine signal), then a blank line, then
+# the body (best-effort, for the caller to read). Pure text in via stdin → unit-testable.
+#
+# Exit: 0 ok; 2 usage; 3 no reply addressed to us found; 4 a reply was found but its sid
+# does not match (a protocol violation the caller must surface, not invent state around).
+set -euo pipefail
+
+SELF_ROLE="" ; PARTNER_ROLE="" ; SID="" ; PARTNER_PANE="" ; LINES=80
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --self-role)    SELF_ROLE="$2"    ; shift 2 ;;
+    --partner-role) PARTNER_ROLE="$2" ; shift 2 ;;
+    --sid)          SID="$2"          ; shift 2 ;;
+    --partner-pane) PARTNER_PANE="$2" ; shift 2 ;;
+    --lines)        LINES="$2"        ; shift 2 ;;
+    *) echo "recv.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SELF_ROLE" ]    || { echo "recv.sh: --self-role required" >&2; exit 2; }
+[ -n "$PARTNER_ROLE" ] || { echo "recv.sh: --partner-role required" >&2; exit 2; }
+[ -n "$SID" ]          || { echo "recv.sh: --sid required" >&2; exit 2; }
+
+if [ -n "$PARTNER_PANE" ]; then
+  command -v herdr >/dev/null || { echo "recv.sh: herdr not on PATH" >&2; exit 1; }
+  TEXT="$(herdr pane read "$PARTNER_PANE" --source recent-unwrapped --lines "$LINES")"
+else
+  TEXT="$(cat)"
+fi
+
+SELF_ROLE="$SELF_ROLE" PARTNER_ROLE="$PARTNER_ROLE" SID="$SID" \
+  python3 - "$TEXT" <<'PY'
+import os, re, sys
+
+text = sys.argv[1]
+self_role = re.escape(os.environ["SELF_ROLE"])
+partner_role = re.escape(os.environ["PARTNER_ROLE"])
+want_sid = os.environ["SID"]
+
+# Tolerant of leading TUI decoration before the header — pi indents with spaces, Claude
+# Code prefixes assistant lines with a "⏺ " bullet. `[^\w\[]*` swallows any run of
+# non-word, non-'[' chars (glyphs, bullets, spaces) but stops at prose (a word char), so a
+# header quoted mid-sentence ("... reply with [pair ...") is not mistaken for a real reply.
+pat = re.compile(
+    r'^[^\w\[]*\[pair\s+' + partner_role + r'\s*->\s*' + self_role +
+    r'\s+kind=(\S+)\s+sid=(\S+?)\s*\]',
+    re.M,
+)
+matches = list(pat.finditer(text))
+if not matches:
+    sys.exit(3)
+
+m = matches[-1]
+kind, sid = m.group(1), m.group(2)
+if sid != want_sid:
+    sys.stderr.write(f"recv.sh: sid mismatch (got {sid!r}, expected {want_sid!r})\n")
+    sys.exit(4)
+
+# Body: the lines after the header, up to the TUI input-box rule that follows the reply
+# (a run of box-drawing dashes) — everything below that is pane chrome (rules, cwd, the
+# cost/status line), not the partner's message. Best-effort; the kind above is exact.
+out = []
+for line in text[m.end():].splitlines():
+    t = line.strip()
+    if len(t) >= 10 and set(t) <= set("─-"):
+        break
+    out.append(line)
+while out and not out[0].strip():
+    out.pop(0)
+while out and not out[-1].strip():
+    out.pop()
+
+print(kind)
+print()
+print("\n".join(line.strip() for line in out).strip())
+PY

--- a/home/private_dot_claude/skills/herdr-pair/scripts/send.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/send.sh
@@ -37,9 +37,12 @@ while [ $# -gt 0 ]; do
 done
 
 command -v herdr >/dev/null || { echo "send.sh: herdr not on PATH" >&2; exit 1; }
-for req in PARTNER_PANE SELF_ROLE PARTNER_ROLE KIND SID; do
-  [ -n "${!req}" ] || { echo "send.sh: --${req,,} required" >&2; exit 2; }
-done
+# Explicit per-flag checks: bash-3.2-safe (no ${x,,}) and they name the real flag.
+[ -n "$PARTNER_PANE" ] || { echo "send.sh: --partner-pane required" >&2; exit 2; }
+[ -n "$SELF_ROLE" ]    || { echo "send.sh: --self-role required" >&2; exit 2; }
+[ -n "$PARTNER_ROLE" ] || { echo "send.sh: --partner-role required" >&2; exit 2; }
+[ -n "$KIND" ]         || { echo "send.sh: --kind required" >&2; exit 2; }
+[ -n "$SID" ]          || { echo "send.sh: --sid required" >&2; exit 2; }
 
 # Compose header + body in a temp file so quotes/$/backticks in the body survive.
 MSG="$(mktemp)"
@@ -54,22 +57,45 @@ trap 'rm -f "$MSG"' EXIT
   fi
 } > "$MSG"
 
-REPLY_HEADER="[pair $PARTNER_ROLE -> $SELF_ROLE"
+partner_status() {
+  herdr pane get "$PARTNER_PANE" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
+except Exception:
+    print("missing")'
+}
 
-# Delivery confirmation: the partner leaving idle proves the message submitted. `working`
-# is the unambiguous "received & processing" state; a very fast partner may instead already
-# be printing its reply header.
+# Delivery is proven by an agent-status TRANSITION, never by matching header text in the
+# pane: the outgoing message is echoed into the partner pane, and a stale prior reply may
+# still be visible, so a text match could "confirm" a non-delivery. The partner leaving
+# idle (working, or already finished as done) is the real submit signal.
 confirm_delivery() {
   herdr wait agent-status "$PARTNER_PANE" --status working --timeout 4000 >/dev/null 2>&1 && return 0
-  herdr wait output "$PARTNER_PANE" --match "$REPLY_HEADER" --timeout 3000 >/dev/null 2>&1 && return 0
+  case "$(partner_status)" in working|done) return 0 ;; esac
   return 1
 }
+
+# Refuse to type into a pane that is not a receptive agent (e.g. a reused bare shell) —
+# otherwise the body lines would execute as shell commands.
+case "$(partner_status)" in
+  idle|done|working) : ;;
+  *) echo "send.sh: partner pane $PARTNER_PANE is not a receptive agent; refusing to send" >&2; exit 1 ;;
+esac
 
 herdr pane send-text "$PARTNER_PANE" "$(cat "$MSG")"
 herdr pane send-keys "$PARTNER_PANE" Enter
 if ! confirm_delivery; then
-  herdr pane send-keys "$PARTNER_PANE" Enter   # retry the submit once
-  confirm_delivery || { echo "send.sh: message did not submit after retry (partner stayed idle, no reply)" >&2; exit 1; }
+  # Re-press Enter only if the partner is genuinely STILL idle (first Enter didn't submit).
+  # If it already left idle, the message submitted and a second Enter would be a stray
+  # keystroke into a now-busy agent.
+  st="$(partner_status)"
+  if [ "$st" = idle ]; then
+    herdr pane send-keys "$PARTNER_PANE" Enter
+    confirm_delivery || { echo "send.sh: message did not submit after retry" >&2; exit 1; }
+  else
+    echo "send.sh: could not confirm delivery (partner status: $st)" >&2; exit 1
+  fi
 fi
 
 if [ "$NO_SESSION_UPDATE" -eq 0 ]; then

--- a/home/private_dot_claude/skills/herdr-pair/scripts/send.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/send.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Compose a pair message and deliver it to the partner pane, verifying it was submitted,
+# then record the turn in the session file.
+#
+#   send.sh --partner-pane P --self-role a --partner-role b --kind K --sid S \
+#           --ws WS --tab TAB (--body-file F | --body TEXT) [--no-session-update]
+#
+# Model B: the initiator (role a, claude) sends; the partner (role b) replies in its own
+# pane. The header carries peer-role labels (a/b), not agent types, so a claude<->claude
+# pair stays distinguishable.
+#
+# Delivery is verified, not assumed: after send-text + a single Enter (probe-verified to
+# submit in both claude and pi TUIs), the partner must leave idle — either it starts
+# `working`, or it is already emitting its reply header. If neither happens, Enter is
+# retried once; a still-undelivered message is a hard failure and the session is NOT
+# updated (a failed send is not a turn).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PARTNER_PANE="" ; SELF_ROLE="" ; PARTNER_ROLE="" ; KIND="" ; SID=""
+WS="" ; TAB="" ; BODY_FILE="" ; BODY="" ; NO_SESSION_UPDATE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --partner-pane)      PARTNER_PANE="$2" ; shift 2 ;;
+    --self-role)         SELF_ROLE="$2"    ; shift 2 ;;
+    --partner-role)      PARTNER_ROLE="$2" ; shift 2 ;;
+    --kind)              KIND="$2"         ; shift 2 ;;
+    --sid)               SID="$2"          ; shift 2 ;;
+    --ws)                WS="$2"           ; shift 2 ;;
+    --tab)               TAB="$2"          ; shift 2 ;;
+    --body-file)         BODY_FILE="$2"    ; shift 2 ;;
+    --body)              BODY="$2"         ; shift 2 ;;
+    --no-session-update) NO_SESSION_UPDATE=1 ; shift ;;
+    *) echo "send.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+command -v herdr >/dev/null || { echo "send.sh: herdr not on PATH" >&2; exit 1; }
+for req in PARTNER_PANE SELF_ROLE PARTNER_ROLE KIND SID; do
+  [ -n "${!req}" ] || { echo "send.sh: --${req,,} required" >&2; exit 2; }
+done
+
+# Compose header + body in a temp file so quotes/$/backticks in the body survive.
+MSG="$(mktemp)"
+trap 'rm -f "$MSG"' EXIT
+{
+  printf '[pair %s -> %s kind=%s sid=%s]\n\n' "$SELF_ROLE" "$PARTNER_ROLE" "$KIND" "$SID"
+  if [ -n "$BODY_FILE" ]; then
+    [ -f "$BODY_FILE" ] || { echo "send.sh: --body-file not found: $BODY_FILE" >&2; exit 1; }
+    cat "$BODY_FILE"
+  else
+    printf '%s\n' "$BODY"
+  fi
+} > "$MSG"
+
+REPLY_HEADER="[pair $PARTNER_ROLE -> $SELF_ROLE"
+
+# Delivery confirmation: the partner leaving idle proves the message submitted. `working`
+# is the unambiguous "received & processing" state; a very fast partner may instead already
+# be printing its reply header.
+confirm_delivery() {
+  herdr wait agent-status "$PARTNER_PANE" --status working --timeout 4000 >/dev/null 2>&1 && return 0
+  herdr wait output "$PARTNER_PANE" --match "$REPLY_HEADER" --timeout 3000 >/dev/null 2>&1 && return 0
+  return 1
+}
+
+herdr pane send-text "$PARTNER_PANE" "$(cat "$MSG")"
+herdr pane send-keys "$PARTNER_PANE" Enter
+if ! confirm_delivery; then
+  herdr pane send-keys "$PARTNER_PANE" Enter   # retry the submit once
+  confirm_delivery || { echo "send.sh: message did not submit after retry (partner stayed idle, no reply)" >&2; exit 1; }
+fi
+
+if [ "$NO_SESSION_UPDATE" -eq 0 ]; then
+  [ -n "$WS" ] && [ -n "$TAB" ] || { echo "send.sh: --ws and --tab required to record the turn (or pass --no-session-update)" >&2; exit 2; }
+  bash "$SCRIPT_DIR/session.sh" update --ws "$WS" --tab "$TAB" --role "$SELF_ROLE" --status "$KIND"
+fi

--- a/home/private_dot_claude/skills/herdr-pair/scripts/session.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/session.sh
@@ -10,7 +10,12 @@
 # Roles are peer labels (a = initiator, b = partner), decoupled from agent type so a
 # claude<->claude pair (identical `agent` field) stays distinguishable. State lives at
 # $HERDR_COWORKERS_DIR/<ws>/<tab_slug>/session.json, tab_slug flattening ':' to '_'.
-# Two agents race on this file, so every write goes through a temp file + os.replace.
+#
+# Concurrency: `create` is atomic (os.link on a temp file — fails if the session already
+# exists, so two pair-starts in one tab can't both win). `update` is a read-modify-write and
+# is NOT lock-protected; that is safe only because under Model B the driver (role a) is the
+# sole writer — the partner never runs this script. If a symmetric "Model A" is ever added,
+# update needs a real lock (flock) to avoid lost increments.
 set -euo pipefail
 
 : "${HERDR_COWORKERS_DIR:=$HOME/.herdr-coworkers}"
@@ -63,18 +68,17 @@ case "$CMD" in
     for v in A_AGENT A_PANE B_AGENT B_PANE; do
       [ -n "${!v}" ] || { echo "session.sh: create requires --a-agent/--a-pane/--b-agent/--b-pane" >&2; exit 2; }
     done
-    if [ -e "$SESSION_FILE" ]; then
-      echo "session.sh: session already exists for this tab: $SESSION_FILE (resume or remove it)" >&2
-      exit 1
-    fi
     [ -n "$SID" ] || SID="$(date +%s)-$(openssl rand -hex 2 2>/dev/null || printf '%04x' "$RANDOM")"
     mkdir -p "$SESSION_DIR"
     CREATED_AT="$(date -u +%FT%TZ)"
+    # Atomic create: write a temp file, then os.link it into place. link() fails if the
+    # session already exists, so two concurrent pair-starts in one tab can't both win the
+    # claim (no TOCTOU between an existence check and the write).
     SID="$SID" WS="$WS" TAB="$TAB" \
       A_AGENT="$A_AGENT" A_PANE="$A_PANE" B_AGENT="$B_AGENT" B_PANE="$B_PANE" \
       CREATED_AT="$CREATED_AT" TMP="$SESSION_FILE.tmp.$$" FINAL="$SESSION_FILE" \
       python3 - <<'PY'
-import json, os
+import json, os, sys
 s = {
     "sid": os.environ["SID"],
     "workspace_id": os.environ["WS"],
@@ -89,10 +93,16 @@ s = {
     "workbench": {"tab_id": None, "server_pane": None, "logs_pane": None},
     "created_at": os.environ["CREATED_AT"],
 }
-tmp = os.environ["TMP"]
+tmp, final = os.environ["TMP"], os.environ["FINAL"]
 with open(tmp, "w") as f:
     json.dump(s, f, indent=2)
-os.replace(tmp, os.environ["FINAL"])
+try:
+    os.link(tmp, final)   # atomic; raises FileExistsError if final already exists
+except FileExistsError:
+    os.unlink(tmp)
+    sys.stderr.write(f"session.sh: session already exists for this tab: {final} (resume or remove it)\n")
+    sys.exit(1)
+os.unlink(tmp)
 PY
     printf '%s\n' "$SID"
     ;;

--- a/home/private_dot_claude/skills/herdr-pair/scripts/session.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/session.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Atomic per-(workspace, tab) session state for the herdr-pair skill.
+#
+#   session.sh create --ws WS --tab TAB [--sid SID] \
+#       --a-agent T --a-pane P --b-agent T --b-pane P
+#   session.sh get    --ws WS --tab TAB
+#   session.sh update --ws WS --tab TAB --role a|b --status KIND [--no-progress inc|reset]
+#   session.sh trash  --ws WS --tab TAB    # remove only this tab's session dir (on close)
+#
+# Roles are peer labels (a = initiator, b = partner), decoupled from agent type so a
+# claude<->claude pair (identical `agent` field) stays distinguishable. State lives at
+# $HERDR_COWORKERS_DIR/<ws>/<tab_slug>/session.json, tab_slug flattening ':' to '_'.
+# Two agents race on this file, so every write goes through a temp file + os.replace.
+set -euo pipefail
+
+: "${HERDR_COWORKERS_DIR:=$HOME/.herdr-coworkers}"
+
+usage() {
+  echo "usage: session.sh create|get|update --ws WS --tab TAB [...]" >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+CMD="$1"; shift
+
+WS="" ; TAB="" ; SID="" ; ROLE="" ; STATUS="" ; NO_PROGRESS=""
+A_AGENT="" ; A_PANE="" ; B_AGENT="" ; B_PANE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ws)          WS="$2"          ; shift 2 ;;
+    --tab)         TAB="$2"         ; shift 2 ;;
+    --sid)         SID="$2"         ; shift 2 ;;
+    --role)        ROLE="$2"        ; shift 2 ;;
+    --status)      STATUS="$2"      ; shift 2 ;;
+    --no-progress) NO_PROGRESS="$2" ; shift 2 ;;
+    --a-agent)     A_AGENT="$2"     ; shift 2 ;;
+    --a-pane)      A_PANE="$2"      ; shift 2 ;;
+    --b-agent)     B_AGENT="$2"     ; shift 2 ;;
+    --b-pane)      B_PANE="$2"      ; shift 2 ;;
+    *) echo "session.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$WS" ]  || { echo "session.sh: --ws required" >&2; exit 2; }
+[ -n "$TAB" ] || { echo "session.sh: --tab required" >&2; exit 2; }
+
+# WS/TAB build a filesystem path (and `trash` rm -rf's it), so reject anything that could
+# escape the store. herdr ids are opaque (e.g. wB, wB:tX) and never contain these; a value
+# that does is malformed, not a path to honor. The `:`->`_` slug below cannot introduce a
+# '/', so checking the raw values here is sufficient.
+for part in "$WS" "$TAB"; do
+  case "$part" in
+    */* | *..* | -*) echo "session.sh: invalid --ws/--tab value '$part' (no '/', '..', or leading '-')" >&2; exit 2 ;;
+  esac
+done
+
+TAB_SLUG="${TAB//:/_}"
+SESSION_DIR="$HERDR_COWORKERS_DIR/$WS/$TAB_SLUG"
+SESSION_FILE="$SESSION_DIR/session.json"
+
+case "$CMD" in
+  create)
+    for v in A_AGENT A_PANE B_AGENT B_PANE; do
+      [ -n "${!v}" ] || { echo "session.sh: create requires --a-agent/--a-pane/--b-agent/--b-pane" >&2; exit 2; }
+    done
+    if [ -e "$SESSION_FILE" ]; then
+      echo "session.sh: session already exists for this tab: $SESSION_FILE (resume or remove it)" >&2
+      exit 1
+    fi
+    [ -n "$SID" ] || SID="$(date +%s)-$(openssl rand -hex 2 2>/dev/null || printf '%04x' "$RANDOM")"
+    mkdir -p "$SESSION_DIR"
+    CREATED_AT="$(date -u +%FT%TZ)"
+    SID="$SID" WS="$WS" TAB="$TAB" \
+      A_AGENT="$A_AGENT" A_PANE="$A_PANE" B_AGENT="$B_AGENT" B_PANE="$B_PANE" \
+      CREATED_AT="$CREATED_AT" TMP="$SESSION_FILE.tmp.$$" FINAL="$SESSION_FILE" \
+      python3 - <<'PY'
+import json, os
+s = {
+    "sid": os.environ["SID"],
+    "workspace_id": os.environ["WS"],
+    "tab_id": os.environ["TAB"],
+    "roles": {
+        "a": {"agent_type": os.environ["A_AGENT"], "pane_id": os.environ["A_PANE"]},
+        "b": {"agent_type": os.environ["B_AGENT"], "pane_id": os.environ["B_PANE"]},
+    },
+    "round": 0,
+    "last_status": {"a": None, "b": None},
+    "no_progress_count": 0,
+    "workbench": {"tab_id": None, "server_pane": None, "logs_pane": None},
+    "created_at": os.environ["CREATED_AT"],
+}
+tmp = os.environ["TMP"]
+with open(tmp, "w") as f:
+    json.dump(s, f, indent=2)
+os.replace(tmp, os.environ["FINAL"])
+PY
+    printf '%s\n' "$SID"
+    ;;
+
+  get)
+    [ -f "$SESSION_FILE" ] || { echo "session.sh: no session for this tab: $SESSION_FILE" >&2; exit 1; }
+    cat "$SESSION_FILE"
+    ;;
+
+  update)
+    [ -n "$ROLE" ]   || { echo "session.sh: update requires --role a|b" >&2; exit 2; }
+    [ "$ROLE" = a ] || [ "$ROLE" = b ] || { echo "session.sh: --role must be 'a' or 'b'" >&2; exit 2; }
+    [ -n "$STATUS" ] || { echo "session.sh: update requires --status KIND" >&2; exit 2; }
+    if [ -n "$NO_PROGRESS" ] && [ "$NO_PROGRESS" != inc ] && [ "$NO_PROGRESS" != reset ]; then
+      echo "session.sh: --no-progress must be 'inc' or 'reset'" >&2; exit 2
+    fi
+    [ -f "$SESSION_FILE" ] || { echo "session.sh: no session for this tab: $SESSION_FILE" >&2; exit 1; }
+    ROLE="$ROLE" STATUS="$STATUS" NO_PROGRESS="$NO_PROGRESS" \
+      TMP="$SESSION_FILE.tmp.$$" FINAL="$SESSION_FILE" \
+      python3 - <<'PY'
+import json, os
+final = os.environ["FINAL"]
+with open(final) as f:
+    s = json.load(f)
+s["round"] = s.get("round", 0) + 1
+s.setdefault("last_status", {})[os.environ["ROLE"]] = os.environ["STATUS"]
+np = os.environ["NO_PROGRESS"]
+if np == "inc":
+    s["no_progress_count"] = s.get("no_progress_count", 0) + 1
+elif np == "reset":
+    s["no_progress_count"] = 0
+tmp = os.environ["TMP"]
+with open(tmp, "w") as f:
+    json.dump(s, f, indent=2)
+os.replace(tmp, final)
+PY
+    ;;
+
+  trash)
+    # Remove only this tab's session dir. Guard the computed path so a bad WS/TAB can
+    # never widen the delete to the store root or above it.
+    case "$SESSION_DIR" in
+      "$HERDR_COWORKERS_DIR"/*/*) : ;;
+      *) echo "session.sh: refusing to trash unexpected path: $SESSION_DIR" >&2; exit 1 ;;
+    esac
+    rm -rf "$SESSION_DIR"
+    ;;
+
+  *) echo "session.sh: unknown subcommand '$CMD' (have: create get update trash)" >&2; exit 2 ;;
+esac

--- a/home/private_dot_claude/skills/herdr-pair/scripts/spawn-partner.sh
+++ b/home/private_dot_claude/skills/herdr-pair/scripts/spawn-partner.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Split a pane, launch the pair partner there with the peer protocol injected, and wait
+# until it is ready to receive. Prints the new partner pane_id on stdout.
+#
+#   spawn-partner.sh --agent claude|pi --proto PATH [--self PANE] [--cwd DIR] [--timeout MS]
+#
+# Model B (initiator-driven): the partner only ever REPLIES in its own pane; the initiator
+# (claude) drives all transport. So the partner just needs the protocol injected plus its
+# own normal coding tools (a pair edits files by design) — no tool restriction here.
+#
+# No retry on launch failure (base hard rule): a failed launch surfaces recent pane output
+# and exits non-zero so the caller can hand off to the user.
+#
+# Probe-verified (2026-06-28, herdr 0.7.1): claude takes a real file path via
+# --append-system-prompt-file; pi has no -file variant but its --append-system-prompt
+# auto-reads a file path. pi/opencode are zsh FUNCTIONS, not PATH binaries, so the partner
+# command is run through the pane's interactive shell (herdr pane run), never resolved with
+# `command -v`.
+#
+# A pair edits files by design (R9), so the partner must be able to act without prompting.
+# claude is launched with --permission-mode acceptEdits — otherwise it can inherit plan
+# mode and refuse to do work (E2E-verified). pi gets its full default toolset already.
+set -euo pipefail
+
+AGENT="" ; PROTO="" ; SELF="${HERDR_PANE_ID:-}" ; CWD="" ; TIMEOUT=60000
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --agent)   AGENT="$2"   ; shift 2 ;;
+    --proto)   PROTO="$2"   ; shift 2 ;;
+    --self)    SELF="$2"    ; shift 2 ;;
+    --cwd)     CWD="$2"     ; shift 2 ;;
+    --timeout) TIMEOUT="$2" ; shift 2 ;;
+    *) echo "spawn-partner.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+command -v herdr >/dev/null || { echo "spawn-partner.sh: herdr not on PATH" >&2; exit 1; }
+[ -n "$AGENT" ] || { echo "spawn-partner.sh: --agent claude|pi required" >&2; exit 2; }
+[ -n "$SELF" ]  || { echo "spawn-partner.sh: no self pane (set HERDR_PANE_ID or pass --self)" >&2; exit 2; }
+[ -n "$PROTO" ] || { echo "spawn-partner.sh: --proto PATH required" >&2; exit 2; }
+[ -f "$PROTO" ] || { echo "spawn-partner.sh: protocol file not found: $PROTO" >&2; exit 1; }
+
+case "$AGENT" in
+  claude) PCMD="claude --permission-mode acceptEdits --append-system-prompt-file $(printf %q "$PROTO")" ;;
+  pi)     PCMD="pi --append-system-prompt $(printf %q "$PROTO")" ;;
+  *) echo "spawn-partner.sh: unsupported agent '$AGENT' (have: claude pi)" >&2; exit 2 ;;
+esac
+
+split_args=( "$SELF" --direction right --no-focus )
+[ -n "$CWD" ] && split_args+=( --cwd "$CWD" )
+PANE="$(herdr pane split "${split_args[@]}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')"
+[ -n "$PANE" ] || { echo "spawn-partner.sh: failed to split a partner pane" >&2; exit 1; }
+
+herdr pane run "$PANE" "$PCMD"
+
+# Readiness: agent-status idle (probe-verified reliable for claude v6 and pi v2). If it
+# never settles, surface recent output and fail — do not retry the spawn.
+if ! herdr wait agent-status "$PANE" --status idle --timeout "$TIMEOUT" >/dev/null 2>&1; then
+  echo "spawn-partner.sh: partner ($AGENT) did not reach idle within ${TIMEOUT}ms in pane $PANE:" >&2
+  herdr pane read "$PANE" --source recent --lines 40 >&2 || true
+  exit 1
+fi
+
+printf '%s\n' "$PANE"

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -4,6 +4,7 @@ load 'helpers/common'
 
 teardown() {
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
+  [[ -n "${PAIR_COWORKERS:-}" ]] && rm -rf "$PAIR_COWORKERS" || true
 }
 
 # ===========================================
@@ -102,4 +103,316 @@ ASK_AGENT_DIR="$CHEZMOI_SOURCE/private_dot_claude/skills/ask-agent/scripts"
   assert_output --partial -- "-p hi there"
   assert_output --partial -- "--allowed-tools Read Grep Glob WebFetch WebSearch"
   assert_output --partial -- "--disallowed-tools Bash Edit Write"
+}
+
+# ===========================================
+# herdr-pair skill scripts
+# ===========================================
+
+PAIR_DIR="$CHEZMOI_SOURCE/private_dot_claude/skills/herdr-pair/scripts"
+
+# Each session test points the session store at a throwaway dir so it never
+# touches the real ~/.herdr-coworkers. teardown removes PAIR_COWORKERS.
+pair_new_store() {
+  PAIR_COWORKERS="$(mktemp -d)"
+  export HERDR_COWORKERS_DIR="$PAIR_COWORKERS"
+}
+
+@test "session.sh is valid bash" {
+  run bash -n "$PAIR_DIR/session.sh"
+  assert_success
+}
+
+@test "session.sh uses set -euo pipefail" {
+  run grep -q "set -euo pipefail" "$PAIR_DIR/session.sh"
+  assert_success
+}
+
+@test "session.sh create writes a well-formed per-tab session and prints the sid" {
+  pair_new_store
+  run bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid 123-abcd \
+    --a-agent claude --a-pane wB:p1 --b-agent pi --b-pane wB:p2
+  assert_success
+  assert_output --partial "123-abcd"
+  assert_file_exists "$PAIR_COWORKERS/wB/wB_tX/session.json"
+  run python3 - "$PAIR_COWORKERS/wB/wB_tX/session.json" <<'PY'
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert s["sid"] == "123-abcd", s
+assert s["workspace_id"] == "wB", s
+assert s["tab_id"] == "wB:tX", s
+assert s["roles"]["a"] == {"agent_type": "claude", "pane_id": "wB:p1"}, s
+assert s["roles"]["b"] == {"agent_type": "pi", "pane_id": "wB:p2"}, s
+assert s["round"] == 0, s
+assert s["last_status"] == {"a": None, "b": None}, s
+assert s["no_progress_count"] == 0, s
+assert s["workbench"] == {"tab_id": None, "server_pane": None, "logs_pane": None}, s
+assert "created_at" in s, s
+PY
+  assert_success
+}
+
+@test "session.sh get round-trips a created session" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid 123-abcd \
+    --a-agent claude --a-pane wB:p1 --b-agent pi --b-pane wB:p2
+  run bash "$PAIR_DIR/session.sh" get --ws wB --tab wB:tX
+  assert_success
+  assert_output --partial '"sid": "123-abcd"'
+  assert_output --partial '"agent_type": "pi"'
+}
+
+@test "session.sh create refuses to clobber an existing session for the same tab" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid one \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  run bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid two \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  assert_failure
+  run bash "$PAIR_DIR/session.sh" get --ws wB --tab wB:tX
+  assert_output --partial '"sid": "one"'
+}
+
+@test "session.sh update bumps round and sets last_status, preserving prior fields" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role a --status task
+  bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role b --status review
+  run python3 - "$PAIR_COWORKERS/wB/wB_tX/session.json" <<'PY'
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert s["round"] == 2, s
+assert s["last_status"] == {"a": "task", "b": "review"}, s
+assert s["roles"]["a"]["pane_id"] == "p1", s
+assert s["sid"] == "s", s
+PY
+  assert_success
+}
+
+@test "session.sh update adjusts no_progress_count with inc and reset" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role a --status review --no-progress inc
+  bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role b --status review --no-progress inc
+  run python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["no_progress_count"])' "$PAIR_COWORKERS/wB/wB_tX/session.json"
+  assert_output "2"
+  bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role a --status task --no-progress reset
+  run python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["no_progress_count"])' "$PAIR_COWORKERS/wB/wB_tX/session.json"
+  assert_output "0"
+}
+
+@test "session.sh flattens ':' in tab id to '_' in the on-disk path" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab "wB:t9" --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  assert_file_exists "$PAIR_COWORKERS/wB/wB_t9/session.json"
+  assert_file_not_exists "$PAIR_COWORKERS/wB/wB:t9/session.json"
+}
+
+@test "session.sh get on a missing session fails clearly" {
+  pair_new_store
+  run bash "$PAIR_DIR/session.sh" get --ws wB --tab wB:tX
+  assert_failure
+}
+
+@test "session.sh update on a missing session fails and invents no state" {
+  pair_new_store
+  run bash "$PAIR_DIR/session.sh" update --ws wB --tab wB:tX --role a --status task
+  assert_failure
+  assert_file_not_exists "$PAIR_COWORKERS/wB/wB_tX/session.json"
+}
+
+@test "session.sh rejects path-traversal in --ws/--tab for every subcommand" {
+  pair_new_store
+  # '..' must not slip past the path guard (would let `trash` rm -rf outside the store).
+  run bash "$PAIR_DIR/session.sh" trash --ws ".." --tab ".."
+  assert_failure 2
+  run bash "$PAIR_DIR/session.sh" create --ws ".." --tab ".." --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  assert_failure 2
+  run bash "$PAIR_DIR/session.sh" create --ws "a/b" --tab x --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  assert_failure 2
+  run bash "$PAIR_DIR/session.sh" get --ws wB --tab "../../etc"
+  assert_failure 2
+}
+
+@test "session.sh trash removes only this tab's session dir, leaving sibling tabs" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:t1 --sid s1 \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:t2 --sid s2 \
+    --a-agent claude --a-pane p3 --b-agent pi --b-pane p4
+  run bash "$PAIR_DIR/session.sh" trash --ws wB --tab wB:t1
+  assert_success
+  assert_dir_not_exists "$PAIR_COWORKERS/wB/wB_t1"
+  assert_dir_exists "$PAIR_COWORKERS/wB/wB_t2"
+}
+
+# ===========================================
+# herdr-integrations run-script
+# ===========================================
+
+HERDR_INTEGRATIONS_TMPL="$CHEZMOI_SOURCE/.chezmoiscripts/run_onchange_after_install-herdr-integrations.sh.tmpl"
+
+@test "herdr-integrations script renders to valid bash" {
+  skip_if_no_chezmoi
+  [[ -f "$HERDR_INTEGRATIONS_TMPL" ]] || skip "herdr-integrations script not found"
+  BATS_TEST_TMPFILE="$(mktemp /tmp/herdr-integrations-XXXXXX.sh)"
+  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" execute-template < "$HERDR_INTEGRATIONS_TMPL" > "$BATS_TEST_TMPFILE"
+  run bash -n "$BATS_TEST_TMPFILE"
+  assert_success
+}
+
+@test "herdr-integrations script guards on command -v herdr and stays tolerant" {
+  run grep -q "command -v herdr" "$HERDR_INTEGRATIONS_TMPL"
+  assert_success
+  run grep -q 'herdr integration install claude pi opencode' "$HERDR_INTEGRATIONS_TMPL"
+  assert_success
+}
+
+@test "herdr-integrations version trigger is lookPath-guarded so CI without herdr still renders" {
+  run grep -q 'lookPath "herdr"' "$HERDR_INTEGRATIONS_TMPL"
+  assert_success
+}
+
+@test "herdr-integrations script exits 0 and skips when herdr is absent" {
+  skip_if_no_chezmoi
+  [[ -f "$HERDR_INTEGRATIONS_TMPL" ]] || skip "herdr-integrations script not found"
+  BATS_TEST_TMPFILE="$(mktemp /tmp/herdr-integrations-XXXXXX.sh)"
+  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" execute-template < "$HERDR_INTEGRATIONS_TMPL" > "$BATS_TEST_TMPFILE"
+  run env PATH="/usr/bin:/bin" bash "$BATS_TEST_TMPFILE"
+  assert_success
+  assert_output --partial "skipping agent-state integration refresh"
+}
+
+# ===========================================
+# herdr-pair transport scripts (spawn / send / recv)
+# ===========================================
+
+@test "herdr-pair transport scripts are valid bash" {
+  for s in spawn-partner.sh send.sh recv.sh; do
+    run bash -n "$PAIR_DIR/$s"
+    assert_success
+  done
+}
+
+@test "herdr-pair transport scripts use set -euo pipefail" {
+  for s in spawn-partner.sh send.sh recv.sh; do
+    run grep -q "set -euo pipefail" "$PAIR_DIR/$s"
+    assert_success
+  done
+}
+
+# recv.sh is a pure parser (text in via stdin), so its behavior is unit-testable offline.
+# Fixtures mirror real pi TUI output: leading-indented lines plus trailing TUI chrome.
+
+@test "recv.sh extracts the latest reply addressed to self and prints its kind" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid probe1 <<'EOF'
+ [pair a -> b kind=task sid=probe1]
+
+ Protocol probe. Reply per protocol.
+
+ [pair b -> a kind=ready sid=probe1]
+
+ Received; no files edited.
+
+────────────────────────────────────────
+~/Projects/my-mac-setup (feat/herdr-pair-skill)
+$0.033 (sub) 2.3%/272k (auto)
+EOF
+  assert_success
+  assert_line --index 0 "ready"
+  assert_output --partial "Received; no files edited."
+  refute_output --partial "0.033"
+}
+
+@test "recv.sh tolerates a Claude Code bullet glyph prefixing the header line" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid e2e-003 <<'EOF'
+⏺ [pair b -> a kind=ready sid=e2e-003]
+
+This reply confirms the pair channel works.
+EOF
+  assert_success
+  assert_line --index 0 "ready"
+}
+
+@test "recv.sh does not match a header quoted mid-sentence as a real reply" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
+Lead your reply with [pair b -> a kind=ready sid=s1] then prose.
+EOF
+  assert_failure 3
+}
+
+@test "recv.sh picks the last reply when several are present" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
+[pair b -> a kind=ready sid=s1]
+first reply
+[pair b -> a kind=accepted sid=s1]
+second reply
+EOF
+  assert_success
+  assert_line --index 0 "accepted"
+}
+
+@test "recv.sh ignores messages addressed to the partner, not self" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
+[pair a -> b kind=task sid=s1]
+this is my own outgoing message
+EOF
+  assert_failure 3
+}
+
+@test "recv.sh reports an sid mismatch as a distinct error" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid expected <<'EOF'
+[pair b -> a kind=ready sid=different]
+body
+EOF
+  assert_failure 4
+  assert_output --partial "sid mismatch"
+}
+
+@test "recv.sh exits 3 when there is no reply addressed to self" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
+just some noise
+no headers here
+EOF
+  assert_failure 3
+}
+
+# ===========================================
+# herdr-pair skill structure (source tree)
+# ===========================================
+
+PAIR_SKILL="$CHEZMOI_SOURCE/private_dot_claude/skills/herdr-pair"
+
+@test "herdr-pair skill source has all expected files" {
+  assert_file_exists "$PAIR_SKILL/SKILL.md"
+  assert_file_exists "$PAIR_SKILL/references/peer-protocol.md"
+  assert_file_exists "$PAIR_SKILL/references/workbench-tab.md"
+  assert_file_exists "$PAIR_SKILL/scripts/session.sh"
+  assert_file_exists "$PAIR_SKILL/scripts/spawn-partner.sh"
+  assert_file_exists "$PAIR_SKILL/scripts/send.sh"
+  assert_file_exists "$PAIR_SKILL/scripts/recv.sh"
+}
+
+@test "herdr-pair SKILL.md frontmatter is valid and triggers on the pair header" {
+  run python3 - "$PAIR_SKILL/SKILL.md" <<'PY'
+import sys
+t = open(sys.argv[1]).read()
+assert t.startswith("---\n"), "no opening frontmatter fence"
+end = t.index("\n---\n", 4)
+fm = t[4:end]
+keys = {}
+for line in fm.splitlines():
+    if ":" in line and not line.startswith(" "):
+        k, v = line.split(":", 1)
+        keys[k.strip()] = v.strip()
+assert keys.get("name") == "herdr-pair", keys
+assert "[pair" in keys.get("description", ""), "description must trigger on the [pair header"
+assert keys.get("user-invocable") == "true", keys
+PY
+  assert_success
 }

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -306,6 +306,72 @@ HERDR_INTEGRATIONS_TMPL="$CHEZMOI_SOURCE/.chezmoiscripts/run_onchange_after_inst
   done
 }
 
+# Behavioral coverage for send.sh / spawn-partner.sh using a fake `herdr` on PATH, so the
+# highest-risk paths (missing flag, non-agent pane, unconfirmed delivery) run in CI.
+
+@test "send.sh with a missing required flag exits 2 naming the flag (bash-3.2 safe)" {
+  stub="$(mktemp -d)"; printf '#!/usr/bin/env bash\nexit 0\n' > "$stub/herdr"; chmod +x "$stub/herdr"
+  run env PATH="$stub:$PATH" bash "$PAIR_DIR/send.sh" \
+    --self-role a --partner-role b --kind task --sid s --no-session-update --body hi
+  rm -rf "$stub"
+  assert_failure 2
+  assert_output --partial -- "--partner-pane required"
+}
+
+@test "send.sh refuses to send into a non-agent pane" {
+  stub="$(mktemp -d)"
+  cat > "$stub/herdr" <<'SH'
+#!/usr/bin/env bash
+[ "$1 $2" = "pane get" ] && printf '{"result":{"pane":{"agent_status":"unknown"}}}\n'
+exit 0
+SH
+  chmod +x "$stub/herdr"
+  run env PATH="$stub:$PATH" bash "$PAIR_DIR/send.sh" \
+    --partner-pane wB:p9 --self-role a --partner-role b --kind task --sid s --no-session-update --body hi
+  rm -rf "$stub"
+  assert_failure 1
+  assert_output --partial "not a receptive agent"
+}
+
+@test "send.sh records no turn when delivery cannot be confirmed" {
+  pair_new_store
+  bash "$PAIR_DIR/session.sh" create --ws wB --tab wB:tX --sid s \
+    --a-agent claude --a-pane p1 --b-agent pi --b-pane p2
+  stub="$(mktemp -d)"
+  cat > "$stub/herdr" <<'SH'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "pane get")          printf '{"result":{"pane":{"agent_status":"idle"}}}\n' ;;  # never leaves idle
+  "wait agent-status") exit 1 ;;                                                   # working-wait times out
+esac
+exit 0
+SH
+  chmod +x "$stub/herdr"
+  run env PATH="$stub:$PATH" bash "$PAIR_DIR/send.sh" \
+    --partner-pane p2 --self-role a --partner-role b --kind task --sid s --ws wB --tab wB:tX --body hi
+  rm -rf "$stub"
+  assert_failure 1
+  run python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["round"])' "$PAIR_COWORKERS/wB/wB_tX/session.json"
+  assert_output "0"
+}
+
+@test "spawn-partner.sh rejects an unsupported agent" {
+  stub="$(mktemp -d)"; printf '#!/usr/bin/env bash\nexit 0\n' > "$stub/herdr"; chmod +x "$stub/herdr"
+  proto="$(mktemp)"; echo proto > "$proto"
+  run env PATH="$stub:$PATH" bash "$PAIR_DIR/spawn-partner.sh" --agent codex --proto "$proto" --self wB:p1
+  rm -rf "$stub"; rm -f "$proto"
+  assert_failure 2
+  assert_output --partial "unsupported agent"
+}
+
+@test "spawn-partner.sh requires --proto" {
+  stub="$(mktemp -d)"; printf '#!/usr/bin/env bash\nexit 0\n' > "$stub/herdr"; chmod +x "$stub/herdr"
+  run env PATH="$stub:$PATH" bash "$PAIR_DIR/spawn-partner.sh" --agent pi --self wB:p1
+  rm -rf "$stub"
+  assert_failure 2
+  assert_output --partial -- "--proto"
+}
+
 # recv.sh is a pure parser (text in via stdin), so its behavior is unit-testable offline.
 # Fixtures mirror real pi TUI output: leading-indented lines plus trailing TUI chrome.
 
@@ -346,15 +412,28 @@ EOF
   assert_failure 3
 }
 
-@test "recv.sh picks the last reply when several are present" {
+@test "recv.sh ignores a stale reply before the driver's last outgoing message (cursor)" {
   run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
-[pair b -> a kind=ready sid=s1]
-first reply
 [pair b -> a kind=accepted sid=s1]
-second reply
+stale reply from a previous turn — must be ignored
+[pair a -> b kind=task sid=s1]
+my latest outgoing message (the cursor)
+[pair b -> a kind=ready sid=s1]
+the real reply to this turn
 EOF
   assert_success
-  assert_line --index 0 "accepted"
+  assert_line --index 0 "ready"
+}
+
+@test "recv.sh takes the first real reply after the cursor, not a header quoted in the body" {
+  run bash "$PAIR_DIR/recv.sh" --self-role a --partner-role b --sid s1 <<'EOF'
+[pair a -> b kind=task sid=s1]
+[pair b -> a kind=ready sid=s1]
+Done. For reference the accepted header looks like:
+[pair b -> a kind=accepted sid=s1]
+EOF
+  assert_success
+  assert_line --index 0 "ready"
 }
 
 @test "recv.sh ignores messages addressed to the partner, not self" {

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -212,6 +212,16 @@ TOML
   assert_file_exists "$HOME/.claude/skills/ask-agent/scripts/agents/claude.sh"
 }
 
+@test "herdr-pair skill is deployed" {
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/SKILL.md"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/references/peer-protocol.md"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/references/workbench-tab.md"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/scripts/session.sh"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/scripts/spawn-partner.sh"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/scripts/send.sh"
+  assert_file_exists "$HOME/.claude/skills/herdr-pair/scripts/recv.sh"
+}
+
 # ===========================================
 # macOS-only configs (skipped on Linux)
 # ===========================================


### PR DESCRIPTION
## What

Stage 3 of the herdr skills family: a **herdr-pair** skill that lets two coding agents collaborate as peers inside herdr — one **driver** (claude) plus one **partner** (claude or pi) — iterating `task → review → accepted` until both agree the work is done.

## Transport — Model B (initiator-driven)

claude owns all herdr transport (split / send-text+Enter / read / wait) and **reads the partner's pane** for replies; the partner only replies in-format and never runs herdr. Identity is **peer-role (`a`/`b`), not agent type**, so a claude↔claude pair stays distinguishable (the case that breaks the upstream base). This diverges from the base's symmetric model on purpose — it removes the highest-risk part (a prompt-injected partner driving herdr) and is what makes pi viable as a partner with nothing but an injected prompt.

> Bidirectional *conversation* (a↔b) is supported; bidirectional *initiation* (non-claude starts a pair) is deferred follow-up.

## Files

- `home/private_dot_claude/skills/herdr-pair/`
  - `SKILL.md` — initiator driver loop (bootstrap, send/wait/read/parse, kinds state machine, closing)
  - `references/peer-protocol.md` — injectable responder spec; `references/workbench-tab.md`
  - `scripts/session.sh` — atomic per-(workspace,tab) state; `create/get/update/trash`; rejects path traversal in `--ws/--tab` before any `rm`
  - `scripts/spawn-partner.sh` — split + inject protocol (claude `--append-system-prompt-file` + `--permission-mode acceptEdits`; pi `--append-system-prompt <path>`); wait until idle
  - `scripts/send.sh` — compose + deliver + verify submit + record turn
  - `scripts/recv.sh` — parse partner's latest reply; tolerant of pi's space indent and Claude Code's `⏺` bullet, not a header quoted mid-prose
- `home/.chezmoiscripts/run_onchange_after_install-herdr-integrations.sh.tmpl` — refresh herdr agent-state hooks on upgrade; `lookPath`-guarded so CI/Docker without herdr still applies
- `tests/scripts.bats`, `tests/smoke.bats` — session/recv units, run-script, structure, deploy paths
- `docs/agent-setup-inventory.md` — herdr-pair entry (also folds in prior local inventory edits)
- `home/private_dot_claude/CLAUDE.md` — strengthened honesty-filler ban (folded in per request)

## Testing

- `tests/scripts.bats` **39/39** green; shellcheck **0** findings on all 4 scripts + the `.tmpl`
- `make test-ubuntu` (full Docker, clean Linux apply) **exit 0**
- **Live E2E inside herdr** for both pairings (claude↔pi and claude↔claude) — spawn → task → partner edits a file → `ready` → mutual `accepted` → guarded cleanup

## Notes

- `docs/plans/` is gitignored, so the plan's execution amendment stays local (not in this PR).
- The CLAUDE.md change takes effect after `chezmoi apply`.
- pi-as-partner follows the bare protocol precisely; claude-as-partner (interactive Claude Code, props mode) is chattier — claude↔pi is the smoother pairing in the current props phase.