### PR TITLE
feat(pi): manage subagentura with chezmoi

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -107,16 +107,18 @@ Local plugins kept in repo: `herdr-agent-state.js`.
 
 ### Packages (`~/.pi/agent/settings.json` → `packages[]`) — `pi install <source>`
 
-| Package                 | Source                                           |
-| ----------------------- | ------------------------------------------------ |
-| pi-theme-flexoki        | `git:github.com/markacianfrani/pi-theme-flexoki` |
-| pi-fff                  | `npm:@ff-labs/pi-fff`                            |
-| pi-codex-conversion     | `npm:@howaboua/pi-codex-conversion`              |
-| pi-agents               | `npm:pi-agents`                                  |
-| pi-subagents            | `npm:pi-subagents`                               |
-| pi-intercom             | `npm:pi-intercom`                                |
-| pi-agent-browser-native | `npm:pi-agent-browser-native`                    |
-| pi-ask-user             | `npm:pi-ask-user`                                |
+| Package                      | Source                                                    | Managed |
+| ---------------------------- | --------------------------------------------------------- | ------- |
+| compound-engineering-plugin  | `git:github.com/EveryInc/compound-engineering-plugin`     | repo    |
+| pi-theme-flexoki             | `git:github.com/markacianfrani/pi-theme-flexoki`          | manual  |
+| pi-fff                       | `npm:@ff-labs/pi-fff`                                     | manual  |
+| pi-codex-conversion          | `npm:@howaboua/pi-codex-conversion`                       | manual  |
+| pi-agents                    | `npm:pi-agents`                                           | manual  |
+| pi-subagents                 | `npm:pi-subagents`                                        | manual  |
+| pi-intercom                  | `npm:pi-intercom`                                         | manual  |
+| pi-agent-browser-native      | `npm:pi-agent-browser-native`                             | manual  |
+| pi-ask-user                  | `npm:pi-ask-user`                                         | repo    |
+| pi-subagentura               | `npm:pi-subagentura`                                      | repo    |
 
 ### Skills (`~/.pi/agent/skills/`)
 

--- a/home/dot_pi/agent/modify_settings.json
+++ b/home/dot_pi/agent/modify_settings.json
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Keep required Pi packages in settings while preserving Pi-managed runtime fields.
+
+set -euo pipefail
+
+if command -v bun >/dev/null 2>&1; then
+  runtime=(bun -e)
+elif command -v node >/dev/null 2>&1; then
+  runtime=(node -e)
+else
+  printf 'Pi settings modifier requires bun or node\n' >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2016 # JavaScript template syntax must stay literal.
+"${runtime[@]}" '
+(async () => {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+
+  const settings = input.trim() === "" ? {} : JSON.parse(input);
+  const required = [
+    "git:github.com/EveryInc/compound-engineering-plugin",
+    "npm:pi-ask-user",
+    "npm:pi-subagentura",
+  ];
+  const packages = Array.isArray(settings.packages) ? settings.packages : [];
+
+  for (const packageSource of required) {
+    if (!packages.includes(packageSource)) packages.push(packageSource);
+  }
+
+  settings.packages = packages;
+  process.stdout.write(`${JSON.stringify(settings, null, 2)}\n`);
+})().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+'

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1802,6 +1802,38 @@ se_fake_runtime() {
 }
 
 # ===========================================
+# Pi settings modifier
+# ===========================================
+
+@test "Pi settings modifier adds subagentura and preserves runtime settings" {
+  local modifier="$SOURCE_ROOT/dot_pi/agent/modify_settings.json"
+  local input='{"theme":"light","lastChangelogVersion":"0.84.2","packages":["npm:pi-ask-user"]}'
+
+  run bash "$modifier" <<< "$input"
+
+  assert_success
+  run jq -e '
+    .theme == "light" and
+    .lastChangelogVersion == "0.84.2" and
+    (.packages | index("git:github.com/EveryInc/compound-engineering-plugin") != null) and
+    (.packages | index("npm:pi-ask-user") != null) and
+    (.packages | index("npm:pi-subagentura") != null)
+  ' <<< "$output"
+  assert_success
+}
+
+@test "Pi settings modifier is idempotent" {
+  local modifier="$SOURCE_ROOT/dot_pi/agent/modify_settings.json"
+  local input='{"packages":["npm:pi-subagentura","npm:pi-ask-user"]}'
+
+  run bash "$modifier" <<< "$input"
+
+  assert_success
+  run jq -e '[.packages[] | select(. == "npm:pi-subagentura")] | length == 1' <<< "$output"
+  assert_success
+}
+
+# ===========================================
 # morning-cleanup script
 # ===========================================
 

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -232,6 +232,13 @@ TOML
   assert_success
 }
 
+@test "pi settings include the managed subagent package" {
+  local settings="$HOME/.pi/agent/settings.json"
+  assert_file_exists "$settings"
+  run jq -e '.packages | index("npm:pi-subagentura") != null' "$settings"
+  assert_success
+}
+
 @test "opencode reads the shared writing-style file via instructions" {
   assert_file_exists "$HOME/.config/agents/writing-style.md"
   run grep -q 'Answer first: the conclusion is line one.' "$HOME/.config/agents/writing-style.md"


### PR DESCRIPTION
## Summary

A fresh chezmoi apply can now restore `pi-subagentura` as part of the selected Pi package set. Pi still owns package installation and updates; chezmoi owns only the package declaration.

The settings modifier preserves Pi-managed fields such as the theme, default model, and changelog state. It adds the required package sources without replacing manual packages or creating duplicates.

## Validation

- `make test-ubuntu`: 267 tests passed, including apply, second apply, and verify.
- `make lint`: passed.
- Modifier tests confirm runtime fields survive and repeated application remains idempotent.
- Smoke coverage confirms the deployed Pi settings contain `npm:pi-subagentura`.
