### PR TITLE
feat(pi): update Homebrew-managed Pi at startup

### DIFF
--- a/home/dot_pi/agent/extensions/brew-auto-update/index.ts
+++ b/home/dot_pi/agent/extensions/brew-auto-update/index.ts
@@ -1,0 +1,322 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rmdir, stat, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const STATUS_ID = "brew-auto-update";
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_STALE_LOCK_MS = 20 * 60_000;
+const OWNER_FILE = "owner.json";
+
+type Trigger = "startup" | "manual";
+type NotificationLevel = "info" | "warning" | "error";
+
+export interface UpdateUi {
+  setStatus(id: string, value: string | undefined): void;
+  notify(message: string, level: NotificationLevel): void;
+}
+
+interface ExecResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  killed: boolean;
+}
+
+interface ExecOptions {
+  timeout: number;
+}
+
+export interface BrewAutoUpdateDependencies {
+  exec(command: string, args: string[], options: ExecOptions): Promise<ExecResult>;
+  env: Record<string, string | undefined>;
+  lockPath: string;
+  now(): number;
+  pid: number;
+  processAlive(pid: number): boolean;
+  token: string;
+  timeoutMs: number;
+  staleLockMs: number;
+}
+
+interface LockOwner {
+  pid: number;
+  startedAt: number;
+  token: string;
+}
+
+interface AcquiredLock {
+  acquired: true;
+  release(): Promise<void>;
+}
+
+interface ContendedLock {
+  acquired: false;
+}
+
+type UpdateLock = AcquiredLock | ContendedLock;
+
+export interface UpdateResult {
+  status: "complete" | "skipped" | "contended" | "failed";
+  message: string;
+}
+
+interface UpdateStep {
+  command: string;
+  args: string[];
+  status: string;
+  label: string;
+}
+
+const UPDATE_STEPS: UpdateStep[] = [
+  {
+    command: "brew",
+    args: ["update"],
+    status: "Refreshing Homebrew metadata…",
+    label: "Homebrew metadata refresh",
+  },
+  {
+    command: "brew",
+    args: ["upgrade", "pi-coding-agent"],
+    status: "Upgrading pi-coding-agent through Homebrew…",
+    label: "pi-coding-agent Homebrew upgrade",
+  },
+  {
+    command: "pi",
+    args: ["update", "--extensions"],
+    status: "Updating Pi packages…",
+    label: "Pi package update",
+  },
+];
+
+function defaultLockPath(env: Record<string, string | undefined>): string {
+  const stateHome = env.XDG_STATE_HOME || join(homedir(), ".local", "state");
+  return join(stateHome, "pi", "brew-auto-update.lock");
+}
+
+function defaultProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function createDefaultDependencies(pi: ExtensionAPI): BrewAutoUpdateDependencies {
+  return {
+    exec: (command, args, options) => pi.exec(command, args, options),
+    env: process.env,
+    lockPath: defaultLockPath(process.env),
+    now: () => Date.now(),
+    pid: process.pid,
+    processAlive: defaultProcessAlive,
+    token: randomUUID(),
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    staleLockMs: DEFAULT_STALE_LOCK_MS,
+  };
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException | undefined)?.code;
+}
+
+async function readOwner(lockPath: string): Promise<LockOwner | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(join(lockPath, OWNER_FILE), "utf8")) as Partial<LockOwner>;
+    if (
+      Number.isSafeInteger(parsed.pid) &&
+      typeof parsed.startedAt === "number" &&
+      Number.isFinite(parsed.startedAt) &&
+      typeof parsed.token === "string" &&
+      parsed.token.length > 0
+    ) {
+      return parsed as LockOwner;
+    }
+  } catch {
+    // A process can stop between the atomic directory create and owner write.
+  }
+  return undefined;
+}
+
+async function lockAge(lockPath: string, now: number, owner?: LockOwner): Promise<number> {
+  if (owner) return Math.max(0, now - owner.startedAt);
+  try {
+    const lockStat = await stat(lockPath);
+    return Math.max(0, now - lockStat.mtimeMs);
+  } catch {
+    return 0;
+  }
+}
+
+async function removeLockDirectory(lockPath: string): Promise<void> {
+  try {
+    await unlink(join(lockPath, OWNER_FILE));
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+  await rmdir(lockPath);
+}
+
+async function reclaimStaleLock(lockPath: string, deps: BrewAutoUpdateDependencies): Promise<boolean> {
+  const stalePath = `${lockPath}.stale-${deps.pid}-${deps.token}`;
+  try {
+    await rename(lockPath, stalePath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT" || errorCode(error) === "EEXIST") return false;
+    throw error;
+  }
+  await removeLockDirectory(stalePath);
+  return true;
+}
+
+async function acquireLock(deps: BrewAutoUpdateDependencies): Promise<UpdateLock> {
+  await mkdir(dirname(deps.lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await mkdir(deps.lockPath);
+      const owner: LockOwner = { pid: deps.pid, startedAt: deps.now(), token: deps.token };
+      try {
+        await writeFile(join(deps.lockPath, OWNER_FILE), `${JSON.stringify(owner)}\n`, {
+          encoding: "utf8",
+          flag: "wx",
+        });
+      } catch (error) {
+        await removeLockDirectory(deps.lockPath).catch(() => {});
+        throw error;
+      }
+
+      return {
+        acquired: true,
+        release: async () => {
+          const currentOwner = await readOwner(deps.lockPath);
+          if (currentOwner?.token !== deps.token) return;
+          await removeLockDirectory(deps.lockPath).catch(() => {});
+        },
+      };
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+    }
+
+    const owner = await readOwner(deps.lockPath);
+    const age = await lockAge(deps.lockPath, deps.now(), owner);
+    const ownerIsDead = owner ? !deps.processAlive(owner.pid) : false;
+    if (!ownerIsDead && age <= deps.staleLockMs) return { acquired: false };
+    if (!(await reclaimStaleLock(deps.lockPath, deps))) return { acquired: false };
+  }
+
+  return { acquired: false };
+}
+
+function setStatus(ui: UpdateUi, value: string): void {
+  try {
+    ui.setStatus(STATUS_ID, value);
+  } catch {
+    // UI reporting must never interrupt startup or lock cleanup.
+  }
+}
+
+function notify(ui: UpdateUi, message: string, level: NotificationLevel): void {
+  try {
+    ui.notify(message, level);
+  } catch {
+    // Headless modes can omit UI behavior. Updating remains best-effort.
+  }
+}
+
+function failureDetail(result: ExecResult): string {
+  const output = result.stderr.trim() || result.stdout.trim();
+  if (!output) return `exit code ${result.code ?? "unknown"}`;
+  return output.length > 500 ? `…${output.slice(-500)}` : output;
+}
+
+function reportFailure(ui: UpdateUi, message: string): UpdateResult {
+  setStatus(ui, message);
+  notify(ui, message, "error");
+  return { status: "failed", message };
+}
+
+export async function runBrewAutoUpdate(
+  trigger: Trigger,
+  ui: UpdateUi,
+  deps: BrewAutoUpdateDependencies,
+): Promise<UpdateResult> {
+  if (deps.env.PI_OFFLINE === "1") {
+    const message = "Pi update skipped: offline mode is active.";
+    setStatus(ui, message);
+    return { status: "skipped", message };
+  }
+  if (trigger === "startup" && deps.env.PI_BREW_AUTO_UPDATE === "0") {
+    const message = "Pi startup update is disabled.";
+    setStatus(ui, message);
+    return { status: "skipped", message };
+  }
+
+  let lock: AcquiredLock | undefined;
+  try {
+    const candidate = await acquireLock(deps);
+    if (!candidate.acquired) {
+      const message = "Pi update skipped: another Pi process owns the update lock.";
+      setStatus(ui, message);
+      notify(ui, message, "info");
+      return { status: "contended", message };
+    }
+    lock = candidate;
+
+    for (const step of UPDATE_STEPS) {
+      setStatus(ui, step.status);
+      let result: ExecResult;
+      try {
+        result = await deps.exec(step.command, [...step.args], { timeout: deps.timeoutMs });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return reportFailure(ui, `${step.label} failed: ${detail}`);
+      }
+
+      if (result.killed) {
+        return reportFailure(
+          ui,
+          `${step.label} timed out after ${Math.round(deps.timeoutMs / 60_000)} minutes.`,
+        );
+      }
+      if (result.code !== 0) {
+        return reportFailure(ui, `${step.label} failed: ${failureDetail(result)}`);
+      }
+    }
+
+    const message = "Pi update check complete. Installed updates become active in the next Pi process.";
+    setStatus(ui, message);
+    notify(ui, message, "info");
+    return { status: "complete", message };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return reportFailure(ui, `Pi update failed without blocking startup: ${detail}`);
+  } finally {
+    await lock?.release();
+  }
+}
+
+export default function registerBrewAutoUpdater(
+  pi: ExtensionAPI,
+  injectedDependencies?: BrewAutoUpdateDependencies,
+): void {
+  const deps = injectedDependencies ?? createDefaultDependencies(pi);
+
+  pi.on("session_start", (event, ctx) => {
+    if (event.reason !== "startup") return;
+    void runBrewAutoUpdate("startup", ctx.ui, deps).catch(() => {
+      // runBrewAutoUpdate reports failures itself. This guard prevents a
+      // cleanup defect from becoming an unhandled startup rejection.
+    });
+  });
+
+  pi.registerCommand("brew-auto-update-now", {
+    description: "Update Homebrew-managed Pi and installed Pi packages now",
+    handler: async (_args, ctx) => {
+      await runBrewAutoUpdate("manual", ctx.ui, deps);
+    },
+  });
+}

--- a/tests/pi-brew-auto-update.test.ts
+++ b/tests/pi-brew-auto-update.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import registerBrewAutoUpdater, {
+  runBrewAutoUpdate,
+  type BrewAutoUpdateDependencies,
+  type UpdateUi,
+} from "../home/dot_pi/agent/extensions/brew-auto-update/index.ts";
+
+const cleanupPaths: string[] = [];
+
+async function temporaryLockPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pi-brew-auto-update-test-"));
+  cleanupPaths.push(root);
+  return join(root, "state", "pi", "brew-auto-update.lock");
+}
+
+afterEach(async () => {
+  for (const path of cleanupPaths.splice(0)) {
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function fakeUi() {
+  const statuses: Array<string | undefined> = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ui: UpdateUi = {
+    setStatus: (_id, value) => statuses.push(value),
+    notify: (message, level) => notifications.push({ message, level }),
+  };
+  return { ui, statuses, notifications };
+}
+
+async function dependencies(
+  overrides: Partial<BrewAutoUpdateDependencies> = {},
+): Promise<{ deps: BrewAutoUpdateDependencies; calls: Array<[string, string[]]> }> {
+  const calls: Array<[string, string[]]> = [];
+  const deps: BrewAutoUpdateDependencies = {
+    exec: async (command, args) => {
+      calls.push([command, args]);
+      return { code: 0, stdout: "", stderr: "", killed: false };
+    },
+    env: {},
+    lockPath: await temporaryLockPath(),
+    now: () => 1_000_000,
+    pid: 4242,
+    processAlive: () => true,
+    token: "test-owner",
+    timeoutMs: 300_000,
+    staleLockMs: 1_200_000,
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe("brew auto update sequence", () => {
+  test("runs scoped Homebrew and Pi package commands in order", async () => {
+    const { deps, calls } = await dependencies();
+    const { ui, statuses, notifications } = fakeUi();
+
+    const result = await runBrewAutoUpdate("manual", ui, deps);
+
+    expect(result.status).toBe("complete");
+    expect(calls).toEqual([
+      ["brew", ["update"]],
+      ["brew", ["upgrade", "pi-coding-agent"]],
+      ["pi", ["update", "--extensions"]],
+    ]);
+    expect(statuses).toContain("Refreshing Homebrew metadata…");
+    expect(statuses).toContain("Updating Pi packages…");
+    expect(notifications.at(-1)?.message).toContain("next Pi process");
+  });
+
+  test("skips all network work when PI_OFFLINE is set", async () => {
+    const { deps, calls } = await dependencies({ env: { PI_OFFLINE: "1" } });
+    const { ui, statuses } = fakeUi();
+
+    const result = await runBrewAutoUpdate("manual", ui, deps);
+
+    expect(result.status).toBe("skipped");
+    expect(calls).toEqual([]);
+    expect(statuses.at(-1)).toContain("offline");
+  });
+
+  test("disables startup only when PI_BREW_AUTO_UPDATE is zero", async () => {
+    const startup = await dependencies({ env: { PI_BREW_AUTO_UPDATE: "0" } });
+    const manual = await dependencies({ env: { PI_BREW_AUTO_UPDATE: "0" } });
+
+    expect((await runBrewAutoUpdate("startup", fakeUi().ui, startup.deps)).status).toBe("skipped");
+    expect(startup.calls).toEqual([]);
+    expect((await runBrewAutoUpdate("manual", fakeUi().ui, manual.deps)).status).toBe("complete");
+    expect(manual.calls).toHaveLength(3);
+  });
+
+  test("stops after a timed-out command and reports the failure", async () => {
+    const { deps, calls } = await dependencies({
+      exec: async (command, args) => {
+        calls.push([command, args]);
+        return { code: null, stdout: "", stderr: "", killed: true };
+      },
+    });
+    const { ui, statuses, notifications } = fakeUi();
+
+    const result = await runBrewAutoUpdate("manual", ui, deps);
+
+    expect(result.status).toBe("failed");
+    expect(calls).toHaveLength(1);
+    expect(statuses.at(-1)).toContain("timed out");
+    expect(notifications.at(-1)?.level).toBe("error");
+  });
+
+  test("stops on command failure without aborting the caller", async () => {
+    const { deps, calls } = await dependencies({
+      exec: async (command, args) => {
+        calls.push([command, args]);
+        return { code: 7, stdout: "", stderr: "network failed", killed: false };
+      },
+    });
+    const { ui, notifications } = fakeUi();
+
+    await expect(runBrewAutoUpdate("manual", ui, deps)).resolves.toMatchObject({ status: "failed" });
+    expect(calls).toHaveLength(1);
+    expect(notifications.at(-1)?.message).toContain("network failed");
+  });
+});
+
+describe("cross-process update lock", () => {
+  test("reports contention and does not wait for a live owner", async () => {
+    const { deps, calls } = await dependencies();
+    await mkdir(deps.lockPath, { recursive: true });
+    await writeFile(
+      join(deps.lockPath, "owner.json"),
+      JSON.stringify({ pid: 9001, startedAt: deps.now(), token: "other" }),
+    );
+    const { ui, statuses } = fakeUi();
+
+    const result = await runBrewAutoUpdate("startup", ui, deps);
+
+    expect(result.status).toBe("contended");
+    expect(calls).toEqual([]);
+    expect(statuses.at(-1)).toContain("another Pi process");
+  });
+
+  test("recovers a lock whose owner process is dead", async () => {
+    const { deps, calls } = await dependencies({ processAlive: () => false });
+    await mkdir(deps.lockPath, { recursive: true });
+    await writeFile(
+      join(deps.lockPath, "owner.json"),
+      JSON.stringify({ pid: 9001, startedAt: deps.now(), token: "dead" }),
+    );
+
+    const result = await runBrewAutoUpdate("startup", fakeUi().ui, deps);
+
+    expect(result.status).toBe("complete");
+    expect(calls).toHaveLength(3);
+    await expect(stat(deps.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("recovers a lock older than the bounded stale age", async () => {
+    const { deps, calls } = await dependencies();
+    await mkdir(deps.lockPath, { recursive: true });
+    await writeFile(
+      join(deps.lockPath, "owner.json"),
+      JSON.stringify({ pid: 9001, startedAt: deps.now() - deps.staleLockMs - 1, token: "old" }),
+    );
+
+    expect((await runBrewAutoUpdate("startup", fakeUi().ui, deps)).status).toBe("complete");
+    expect(calls).toHaveLength(3);
+  });
+
+  test("does not delete a replacement lock while releasing its own lock", async () => {
+    const { deps } = await dependencies();
+    let releaseFirstCommand!: () => void;
+    deps.exec = async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirstCommand = resolve;
+      });
+      return { code: 1, stdout: "", stderr: "stop", killed: false };
+    };
+
+    const running = runBrewAutoUpdate("manual", fakeUi().ui, deps);
+    while (!releaseFirstCommand) await Bun.sleep(1);
+    await writeFile(
+      join(deps.lockPath, "owner.json"),
+      JSON.stringify({ pid: 9999, startedAt: deps.now(), token: "replacement" }),
+    );
+    releaseFirstCommand();
+    await running;
+
+    const owner = JSON.parse(await readFile(join(deps.lockPath, "owner.json"), "utf8"));
+    expect(owner.token).toBe("replacement");
+  });
+});
+
+test("registers startup-only background execution and the manual command", async () => {
+  const handlers = new Map<string, Function>();
+  let commandHandler: Function | undefined;
+  const fakePi = {
+    on: (event: string, handler: Function) => handlers.set(event, handler),
+    registerCommand: (name: string, options: { handler: Function }) => {
+      expect(name).toBe("brew-auto-update-now");
+      commandHandler = options.handler;
+    },
+  };
+  let finishExec!: () => void;
+  const { deps, calls } = await dependencies({
+    exec: async (command, args) => {
+      calls.push([command, args]);
+      await new Promise<void>((resolve) => {
+        finishExec = resolve;
+      });
+      return { code: 1, stdout: "", stderr: "stop", killed: false };
+    },
+  });
+
+  registerBrewAutoUpdater(fakePi as never, deps);
+  const startup = handlers.get("session_start")!;
+  const ctx = { ui: fakeUi().ui };
+
+  expect(startup({ reason: "reload" }, ctx)).toBeUndefined();
+  expect(calls).toEqual([]);
+  expect(startup({ reason: "startup" }, ctx)).toBeUndefined();
+  while (!finishExec) await Bun.sleep(1);
+  expect(calls).toHaveLength(1);
+  finishExec();
+  expect(commandHandler).toBeDefined();
+});

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -820,6 +820,44 @@ PY
   assert_file_contains "$ext" 'getSessionName'
 }
 
+@test "Pi brew auto updater is deployed with startup and manual entry points" {
+  local ext="$HOME/.pi/agent/extensions/brew-auto-update/index.ts"
+  assert_file_exists "$ext"
+  assert_file_contains "$ext" 'pi.on("session_start"'
+  assert_file_contains "$ext" 'event.reason !== "startup"'
+  assert_file_contains "$ext" 'registerCommand("brew-auto-update-now"'
+  assert_file_contains "$ext" 'PI_OFFLINE'
+  assert_file_contains "$ext" 'PI_BREW_AUTO_UPDATE'
+}
+
+@test "Pi brew auto updater keeps package-manager commands scoped" {
+  local ext="$HOME/.pi/agent/extensions/brew-auto-update/index.ts"
+  run python3 - "$ext" <<'PY'
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+required = [
+    r'command: "brew",\s+args: \["update"\]',
+    r'command: "brew",\s+args: \["upgrade", "pi-coding-agent"\]',
+    r'command: "pi",\s+args: \["update", "--extensions"\]',
+    r'deps\.exec\(step\.command, \[\.\.\.step\.args\]',
+]
+for pattern in required:
+    assert re.search(pattern, source), pattern
+for forbidden in ('"--self"', '"--all"', 'command: "npm"'):
+    assert forbidden not in source, forbidden
+assert len(re.findall(r'command: "brew"', source)) == 2
+assert len(re.findall(r'command: "pi"', source)) == 1
+PY
+  assert_success
+}
+
+@test "Pi brew auto updater focused tests pass" {
+  run bun test "$BATS_TEST_DIRNAME/pi-brew-auto-update.test.ts"
+  assert_success
+}
+
 @test "herdr-task-sync opencode plugin is deployed and filters child sessions" {
   local plugin="$HOME/.config/opencode/plugins/herdr-task-sync.ts"
   assert_file_exists "$plugin"


### PR DESCRIPTION
## Summary

Pi startup now keeps Homebrew authoritative for the Pi executable while refreshing installed Pi packages. The update runs in the background, and concurrent Pi processes use one cross-process lock instead of starting competing package managers.

## Design decisions

- Homebrew metadata refreshes before a formula-scoped `brew upgrade pi-coding-agent`.
- Pi runs only `pi update --extensions`; the updater never invokes Pi self-update or an unscoped Homebrew upgrade.
- Each command has a five-minute timeout. The XDG state lock recovers dead owners immediately and live owners after a bounded 20-minute age.
- `PI_OFFLINE=1` skips all network work. `PI_BREW_AUTO_UPDATE=0` disables automatic startup runs while preserving `/brew-auto-update-now`.
- The current Pi process keeps its loaded executable and extension code. Installed updates become active in the next Pi process.

## Validation

- `bun test tests/pi-brew-auto-update.test.ts` — 10 focused tests passed.
- `bats --filter 'Pi brew auto updater focused tests pass' tests/smoke.bats` — passed.
- `make lint` — passed.
- `make test-local` — passed as a chezmoi dry-run.
- A macOS trial started two Pi RPC processes concurrently with stub package managers. One process ran the three allowed commands in order; the other reported lock contention without waiting.
- Code review: skipped because the Pi harness exposed no independent reviewer contexts or native review tool. A manual final diff scan found no actionable defect.

## Post-Deploy Monitoring & Validation

- **Search terms:** `Refreshing Homebrew metadata`, `Upgrading pi-coding-agent`, `Updating Pi packages`, `another Pi process owns the update lock`, `timed out`, and `failed without blocking startup`.
- **Healthy signals:** one process completes the update sequence; concurrent processes skip immediately; Pi remains usable during the background run; the next Pi process reports the installed version.
- **Failure signals:** repeated timeout or failure notices, a lock older than 20 minutes, or more than one active Homebrew/Pi package process.
- **Mitigation trigger:** if startup updates repeatedly fail or compete, set `PI_BREW_AUTO_UPDATE=0`. Revert the extension if lock recovery or command scoping is incorrect.
- **Validation window and owner:** the dotfiles maintainer validates the first three Pi starts after chezmoi deployment, including one concurrent Herdr-pane start.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
