### PR TITLE
feat(herdr): install and auto-update the GitHub-sourced Herdr plugins

### DIFF
--- a/docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md
+++ b/docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md
@@ -1,0 +1,53 @@
+---
+title: Add clickable Herdr focus notifications without a Rust build dependency
+type: follow-up
+date: 2026-08-18
+status: open
+---
+
+## Why this exists
+
+`yankewei/herdr-focus-notify` sends a macOS notification when a Herdr agent becomes `blocked` or
+`done`. Clicking the notification activates the terminal and focuses the matching Herdr pane. The
+behavior is useful, but the upstream plugin's `herdr-plugin.toml` runs `cargo build --release` during
+installation and requires `vjeantet/tap/alerter` at runtime.
+
+This repository does not currently install Rust or `alerter`. Adding both for one small integration
+would expand the machine setup and make clean-machine installation compile a Rust binary from an
+external repository.
+
+The repository already installs `terminal-notifier` in
+`home/private_dot_config/brewfiles/Brewfile.macos`. `terminal-notifier` supports `-execute` and
+`-activate`, so it can provide clickable notifications without another notification backend. The
+local Herdr plugins under `home/private_dot_config/herdr/plugins/` use shell or Python and are linked
+by tolerant scripts in `home/.chezmoiscripts/`.
+
+## Scope
+
+Evaluate two implementations and add the selected one:
+
+1. Install `yankewei/herdr-focus-notify` unchanged, including managed Rust and `alerter`
+   dependencies.
+2. Implement a small local Herdr plugin with shell or Python plus the existing
+   `terminal-notifier` formula.
+
+The implementation must subscribe to `pane.agent_status_changed`, notify only for `blocked` and
+`done`, and include the pane identifier in a safely quoted click command. Clicking the notification
+must activate the terminal that owns the Herdr session and run `herdr agent focus <pane-id>`.
+
+If the local implementation learns terminal ownership from `pane.focused`, store the binding in the
+Herdr plugin state directory. It must suppress notifications only when it can confirm that the user
+already sees the target pane. Ambiguous focus state must produce a notification.
+
+Add the plugin source under `home/private_dot_config/herdr/plugins/`, add a tolerant link-and-enable
+script under `home/.chezmoiscripts/`, and add smoke tests in `tests/smoke.bats`. Include a manual test
+that verifies notification display, click activation, pane focus, duplicate replacement, and cleanup.
+
+## Open decisions
+
+- Whether the smaller local implementation is preferable to tracking upstream behavior and fixes.
+- Whether `terminal-notifier -execute` provides reliable click handling on the current macOS version.
+- Whether terminal activation should use an explicit configured bundle identifier or a per-workspace
+  binding learned from `pane.focused` events.
+- Which upstream behaviors are required for the first version: duplicate suppression, automatic
+  removal after pane focus, agent icons, timeout configuration, and debug logs.

--- a/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
+++ b/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
@@ -1,0 +1,91 @@
+---
+title: make test-ubuntu fails two tests on main because the Docker harness lacks two setup steps GitHub CI has
+type: bug
+date: 2026-08-19
+status: open
+---
+
+## Why this exists
+
+`make test-ubuntu` exits 2 on a pristine checkout of `main`. Two bats tests fail. Neither failure
+appears in GitHub Actions, because the `test-ubuntu` job in `.github/workflows/test-dotfiles.yml`
+performs two setup steps that `docker/docker-compose.yml` does not. The Docker suite is therefore
+not a faithful local stand-in for CI, and anyone running it before pushing sees two red tests that
+say nothing about their change.
+
+Reproduce on `main`:
+
+```
+git archive origin/main | tar -x -C /tmp/main-check
+cd /tmp/main-check && make test-ubuntu
+```
+
+Observed on `main` at commit `4ed3754`: 298 tests pass, these two fail.
+
+### Failure 1 — `Pi brew auto updater focused tests pass`
+
+`tests/smoke.bats:915` runs `bun test "$BATS_TEST_DIRNAME/pi-brew-auto-update.test.ts"`.
+`tests/pi-brew-auto-update.test.ts:10` imports
+`../home/dot_pi/agent/extensions/brew-auto-update/index.ts`.
+
+That relative path assumes `tests/` and `home/` are siblings, which holds in the repo checkout and
+in GitHub CI. `docker/docker-compose.yml:8-9` mounts them apart:
+
+```
+- ../home:/home/testuser/dotfiles:ro
+- ../tests:/home/testuser/tests:ro
+```
+
+From `/home/testuser/tests`, `../home` resolves to `/home/testuser/home`, which does not exist. Bun
+reports:
+
+```
+error: Cannot find module '../home/dot_pi/agent/extensions/brew-auto-update/index.ts'
+       from '/home/testuser/tests/pi-brew-auto-update.test.ts'
+```
+
+### Failure 2 — `se blocks --json emits the composable block catalog`
+
+`tests/scripts.bats:1797` asserts success, and `se` reports:
+
+```
+se: smithers binary not found:
+/home/testuser/dotfiles/private_dot_claude/dot_smithers/./node_modules/.bin/smithers
+(run bun install in /home/testuser/dotfiles/private_dot_claude/dot_smithers)
+```
+
+Nothing in the Docker harness provisions the source-tree copy of smithers. The GitHub `test-ubuntu`
+job has an explicit step for exactly this, with a comment naming the same gap:
+
+```
+- name: Install smithers dependencies in the source tree
+  working-directory: home/private_dot_claude/dot_smithers
+  run: bun install --frozen-lockfile
+```
+
+Note that `docker/docker-compose.yml` mounts `../home` read-only, so a `bun install` cannot write
+into the mount as it stands.
+
+## Scope
+
+Make `make test-ubuntu` agree with the GitHub `test-ubuntu` job, so a local red result means a real
+regression.
+
+- Give the test a source root it can resolve inside the container. Either mount `../home` at a path
+  that keeps `tests/` and `home/` siblings, or have `tests/pi-brew-auto-update.test.ts` resolve the
+  extension through the same `resolve_source_root` fallback chain that `tests/helpers/common.bash`
+  already implements for bats.
+- Provision the source-tree smithers dependencies inside the container, which requires the mount to
+  be writable or the install to target the copy already made at
+  `/home/testuser/.local/share/chezmoi`.
+- Once both pass, decide whether the two setup steps belong in the compose file, the Dockerfile, or
+  a shared script that both CI and Docker call, so the two harnesses cannot drift again.
+
+## Open decisions
+
+- Whether to fix the import path in the test or the mount layout in compose. Changing the mount
+  affects every test that reads `$HOME/dotfiles`; changing the import affects one file.
+- Whether the read-only `:ro` mount of `../home` is a deliberate guarantee worth keeping. If it is,
+  the smithers dependencies must be installed into the chezmoi source copy instead.
+- Whether `make test-ubuntu` should be gated in CI too, so this drift is caught automatically rather
+  than by a developer running it locally.

--- a/home/.chezmoiscripts/run_onchange_after_4-install-herdr-github-plugins.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_4-install-herdr-github-plugins.sh.tmpl
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Install and enable the macOS Herdr plugins that remain managed by their GitHub sources.
+# Herdr records the source repository so herdr-auto-update can update these plugins later.
+#
+# Hash triggers:
+# {{ include "private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml" | sha256sum }}
+# {{ if lookPath "herdr" }}herdr version: {{ output "herdr" "--version" | sha256sum }}{{ else }}herdr version: unavailable at apply time{{ end }}
+
+# Keep this tolerant: a missing Herdr or an unavailable GitHub repository must not make
+# chezmoi apply fail. Report every failed plugin so the user has an exact recovery command.
+set -u
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if ! command -v herdr >/dev/null 2>&1; then
+  echo "herdr not found; skipping GitHub plugin installation"
+  exit 0
+fi
+
+plugins=(
+  "ImArtisann/zed-herdr:artisann.zed-herdr"
+  "dio16/herdr-auto-update:herdr-auto-update"
+)
+failed=()
+
+for entry in "${plugins[@]}"; do
+  repo="${entry%%:*}"
+  plugin_id="${entry#*:}"
+
+  if ! herdr plugin install "$repo" -y >/dev/null 2>&1; then
+    failed+=("$repo (install: herdr plugin install $repo -y)")
+    continue
+  fi
+
+  if herdr plugin enable "$plugin_id" >/dev/null 2>&1; then
+    echo "Installed and enabled Herdr plugin $plugin_id from $repo"
+  else
+    failed+=("$repo (enable: herdr plugin enable $plugin_id)")
+  fi
+done
+
+if herdr server reload-config >/dev/null 2>&1; then
+  echo "Reloaded Herdr config"
+else
+  echo "Warning: failed to reload Herdr config; restart Herdr or run: herdr server reload-config" >&2
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  printf 'Warning: failed to configure Herdr plugin %s\n' "${failed[@]}" >&2
+fi
+
+exit 0

--- a/home/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Install and enable the macOS Herdr plugins that remain managed by their GitHub sources.
 # Herdr records the source repository so herdr-auto-update can update these plugins later.
+# Runs last of the herdr scripts so its single `herdr server reload-config` also picks up the
+# locally linked plugins that scripts 5 and 6 install.
 #
 # Hash triggers:
 # {{ include "private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml" | sha256sum }}

--- a/home/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml
+++ b/home/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml
@@ -1,0 +1,16 @@
+# Check GitHub-installed Herdr plugins when the server starts and apply safe updates.
+auto_update = true
+notify = true
+policy = "auto"
+
+# Bound network checks so Herdr startup cannot hang indefinitely.
+timeout_secs = 20
+max_concurrency = 8
+
+# Only these GitHub owners can supply automatically executed plugin updates.
+trusted_owners = ["ImArtisann", "dio16"]
+
+# Accept forward-only branch updates. Keep explicit tag and commit pins immutable.
+require_fast_forward = true
+allow_force_push = false
+immutable_pins = true

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -68,6 +68,32 @@ load 'helpers/common'
   assert_file_contains "$HOME/.config/herdr/command-palette/commands.toml" "Edit command palette config"
 }
 
+@test "herdr GitHub plugins install automatically on macOS" {
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_4-install-herdr-github-plugins.sh.tmpl"
+
+  assert_file_exists "$script"
+  assert_file_contains "$script" "ImArtisann/zed-herdr:artisann.zed-herdr"
+  assert_file_contains "$script" "dio16/herdr-auto-update:herdr-auto-update"
+  assert_file_contains "$script" 'herdr plugin install "$repo" -y'
+  assert_file_contains "$script" 'herdr plugin enable "$plugin_id"'
+
+  run grep -Fq '[[ "$(uname -s)" != "Darwin" ]]' "$script"
+  assert_success
+
+  run bash -n "$script"
+  assert_success
+}
+
+@test "herdr plugin updates are automatic and owner-restricted" {
+  local config="$SOURCE_ROOT/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml"
+
+  assert_file_exists "$config"
+  assert_file_contains "$config" 'policy = "auto"'
+  assert_file_contains "$config" 'trusted_owners = \["ImArtisann", "dio16"\]'
+  assert_file_contains "$config" 'require_fast_forward = true'
+  assert_file_contains "$config" 'allow_force_push = false'
+}
+
 @test "herdr lazygit popup entrypoint is configured" {
   assert_file_contains "$HOME/.config/herdr/plugins/command-palette/herdr-plugin.toml" 'id = "lazygit"'
   assert_file_contains "$HOME/.config/herdr/command-palette/commands.toml" "Lazygit in popup"

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -69,7 +69,7 @@ load 'helpers/common'
 }
 
 @test "herdr GitHub plugins install automatically on macOS" {
-  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_4-install-herdr-github-plugins.sh.tmpl"
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
 
   assert_file_exists "$script"
   assert_file_contains "$script" "ImArtisann/zed-herdr:artisann.zed-herdr"
@@ -88,10 +88,36 @@ load 'helpers/common'
   local config="$SOURCE_ROOT/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml"
 
   assert_file_exists "$config"
+  assert_file_contains "$config" 'auto_update = true'
   assert_file_contains "$config" 'policy = "auto"'
   assert_file_contains "$config" 'trusted_owners = \["ImArtisann", "dio16"\]'
   assert_file_contains "$config" 'require_fast_forward = true'
   assert_file_contains "$config" 'allow_force_push = false'
+  assert_file_contains "$config" 'immutable_pins = true'
+}
+
+# herdr-auto-update holds any plugin whose GitHub owner is absent from
+# trusted_owners, so adding a plugin without extending the list silently stops
+# that plugin from ever updating. Keep the two lists coupled.
+@test "every auto-installed herdr plugin owner is listed in trusted_owners" {
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
+  local config="$SOURCE_ROOT/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml"
+
+  local owners_line
+  owners_line="$(grep '^trusted_owners' "$config")"
+
+  local owner
+  local count=0
+  while read -r owner; do
+    [ -n "$owner" ] || continue
+    count=$((count + 1))
+    if [[ "$owners_line" != *"\"$owner\""* ]]; then
+      fail "plugin owner $owner is installed by the script but missing from trusted_owners"
+    fi
+  done < <(awk '/^plugins=\(/{f=1;next} f&&/^\)/{f=0} f' "$script" |
+    sed -n 's/^[[:space:]]*"\([^\/"]*\)\/.*/\1/p')
+
+  [ "$count" -gt 0 ]
 }
 
 @test "herdr lazygit popup entrypoint is configured" {


### PR DESCRIPTION
## What changed

A clean macOS machine now gets two Herdr plugins installed from their GitHub sources during `chezmoi apply`, plus a managed configuration that keeps them updated safely.

- `home/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl` installs and enables `ImArtisann/zed-herdr` (plugin id `artisann.zed-herdr`) and `dio16/herdr-auto-update` (plugin id `herdr-auto-update`), then reloads the Herdr server config.
- `home/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml` configures the update plugin so unattended updates stay restricted.
- `tests/smoke.bats` gains three tests covering the script, the update policy, and the coupling between the two.
- `docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md` files the clickable focus-notification idea as a follow-up instead of implementing it here, because the upstream plugin for it would add a Rust build step and an extra notification backend to a clean-machine install.

## Why the plugins are installed rather than vendored

The repository already links three locally authored Herdr plugins (`command-palette`, `herdr-caffeinate`, `herdr-pane-labels`) with `herdr plugin link`. These two are third-party, so they are installed with `herdr plugin install <owner>/<repo>` instead. Herdr records the source repository for an installed plugin, which is what lets `herdr-auto-update` recognise and update them later. A linked local copy would not be updatable.

## Why the update configuration looks the way it does

`herdr-auto-update` runs from a Herdr server startup hook and reinstalls plugins whose upstream moved. Left at its defaults it would either do nothing (`policy` defaults to `notify` since upstream v1.0) or, if switched to `auto`, accept updates from any GitHub owner. The committed config narrows it:

- `policy = "auto"` and `auto_update = true` — updates actually get applied at Herdr startup.
- `trusted_owners = ["ImArtisann", "dio16"]` — only these two owners can supply code that runs unattended. Upstream holds any plugin whose owner is missing from a non-empty list, even under `policy = "auto"`.
- `require_fast_forward = true` and `allow_force_push = false` — only a plugin whose installed commit is an ancestor of the upstream ref is applied. A diverged (force-pushed) history is held.
- `immutable_pins = true` — a plugin pinned to a tag or commit is never moved by an automatic update.
- `timeout_secs = 20` and `max_concurrency = 8` — a wedged network check cannot hang Herdr startup indefinitely.

Every key above was checked against the upstream `Config` struct in `dio16/herdr-auto-update` `src/config.rs`, and the config directory path against `herdr plugin config-dir herdr-auto-update` on Herdr 0.8.0.

## Safety and platform behaviour

The script is deliberately tolerant: it uses `set -u` without `set -e`, never fails `chezmoi apply`, and prints the exact recovery command for each plugin it could not configure. It exits early when `uname -s` is not `Darwin` and when `herdr` is not on `PATH`, so the Linux and Docker jobs skip it entirely rather than performing network installs during an apply. Both upstream manifests declare a minimum Herdr version (0.7.3 and 0.7.0) that the installed 0.8.0 satisfies.

Re-runs are driven by two hash triggers: the content of the managed `config.toml`, and the output of `herdr --version`, so a Herdr upgrade re-applies the plugins. The `herdr --version` call is guarded by `lookPath "herdr"` so a machine without Herdr still renders the template.

## Ordering

The script is numbered 7 rather than 4, because ordinal 4 is already taken by `run_onchange_after_4-install-smithers-deps.sh.tmpl`. Running it last of the Herdr scripts also means its single `herdr server reload-config` picks up the plugins that scripts 5 and 6 link locally.

## Regression coverage

`herdr-auto-update` silently holds any plugin whose owner is absent from `trusted_owners`. Adding a third plugin without extending that list would therefore stop it updating with no visible error. One of the new tests derives the owner set from the script's own `plugins` array and fails when an owner is missing from the config. It was confirmed to fail when `ImArtisann` is removed from the list.

## How this was verified

Run against this branch after rebasing onto `main`:

- `bats tests/smoke.bats` — 101 tests pass.
- `make lint` — shellcheck clean.
- `make test-templates` — 23 tests pass.
- `make test-ubuntu` — full Docker suite.
- `chezmoi diff --source=./home` with the 1Password CLI removed from `PATH` — exits 0 and renders both new target files with no unresolved template markers.

`make test-local` cannot run unmodified on a host whose 1Password CLI session is locked: `dot_zshenv.tmpl` calls `onepasswordRead` and `op signin` times out. That failure reproduces identically on a pristine checkout of `main`, so it is a local session limitation, not a change introduced here. The `PATH`-without-`op` run above is the equivalent check, and matches what CI does.

## A pre-existing failure this branch does not cause

`make test-ubuntu` exits 2 on a pristine checkout of `main` as well. Two tests fail there:
`Pi brew auto updater focused tests pass` and `se blocks --json emits the composable block catalog`.
On this branch the same two fail and nothing else; the branch adds three passing tests, taking the
Docker suite from 298 passing on `main` to 301 passing here.

Both come from the Docker harness missing two setup steps that the GitHub `test-ubuntu` job performs:
`tests/pi-brew-auto-update.test.ts` imports `../home/...`, which does not resolve under the compose
mount layout, and nothing installs the source-tree smithers dependencies inside the container. They
are recorded in `docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md` rather than
patched over here, since the cause sits in `docker/docker-compose.yml`, not in anything this branch
touches. All three GitHub checks pass.
