### PR TITLE
feat(pi): manage web, context, and search extensions

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -110,7 +110,9 @@ Local plugins kept in repo: `herdr-agent-state.js`.
 | ---------------------------- | --------------------------------------------------------- | ------- |
 | compound-engineering-plugin  | `git:github.com/EveryInc/compound-engineering-plugin`     | repo    |
 | pi-theme-flexoki             | `git:github.com/markacianfrani/pi-theme-flexoki`          | manual  |
-| pi-fff                       | `npm:@ff-labs/pi-fff`                                     | manual  |
+| pi-web-access                | `npm:pi-web-access`                                       | repo    |
+| pi-context-view              | `npm:pi-context-view`                                     | repo    |
+| pi-fff                       | `npm:@ff-labs/pi-fff`                                     | repo    |
 | pi-codex-conversion          | `npm:@howaboua/pi-codex-conversion`                       | manual  |
 | pi-agents                    | `npm:pi-agents`                                           | manual  |
 | pi-subagents                 | `npm:pi-subagents`                                        | manual  |

--- a/docs/issues/2026-08-19-001-pi-package-inventory-drift.md
+++ b/docs/issues/2026-08-19-001-pi-package-inventory-drift.md
@@ -1,0 +1,24 @@
+---
+title: Pi package inventory does not match current managed settings
+type: follow-up
+date: 2026-08-19
+status: open
+---
+
+## Why this exists
+
+`docs/agent-setup-inventory.md` lists several manually managed Pi packages, including `npm:@ff-labs/pi-fff`.
+
+The current `~/.pi/agent/settings.json` and `pi list` output contain only the compound engineering plugin, `pi-ask-user`, and `pi-subagentura`. The documented manual package inventory therefore does not describe the reproducible or current Pi setup.
+
+## Scope
+
+Decide which documented Pi packages remain useful. Add selected packages to `home/dot_pi/agent/modify_settings.json`, add smoke coverage, and update `docs/agent-setup-inventory.md`. Remove obsolete entries from the inventory.
+
+## Open decisions
+
+- Whether any older manual Pi packages should remain in the inventory.
+
+## Progress
+
+Chezmoi now manages `pi-web-access`, `pi-context-view`, and `npm:@ff-labs/pi-fff`. The broader manual-package inventory audit remains open.

--- a/home/dot_pi/agent/modify_settings.json
+++ b/home/dot_pi/agent/modify_settings.json
@@ -23,6 +23,9 @@ fi
     "git:github.com/EveryInc/compound-engineering-plugin",
     "npm:pi-ask-user",
     "npm:pi-subagentura",
+    "npm:pi-web-access",
+    "npm:pi-context-view",
+    "npm:@ff-labs/pi-fff",
   ];
   const packages = Array.isArray(settings.packages) ? settings.packages : [];
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1805,7 +1805,7 @@ se_fake_runtime() {
 # Pi settings modifier
 # ===========================================
 
-@test "Pi settings modifier adds subagentura and preserves runtime settings" {
+@test "Pi settings modifier adds managed packages and preserves runtime settings" {
   local modifier="$SOURCE_ROOT/dot_pi/agent/modify_settings.json"
   local input='{"theme":"light","lastChangelogVersion":"0.84.2","packages":["npm:pi-ask-user"]}'
 
@@ -1817,19 +1817,31 @@ se_fake_runtime() {
     .lastChangelogVersion == "0.84.2" and
     (.packages | index("git:github.com/EveryInc/compound-engineering-plugin") != null) and
     (.packages | index("npm:pi-ask-user") != null) and
-    (.packages | index("npm:pi-subagentura") != null)
+    (.packages | index("npm:pi-subagentura") != null) and
+    (.packages | index("npm:pi-web-access") != null) and
+    (.packages | index("npm:pi-context-view") != null) and
+    (.packages | index("npm:@ff-labs/pi-fff") != null)
   ' <<< "$output"
   assert_success
 }
 
 @test "Pi settings modifier is idempotent" {
   local modifier="$SOURCE_ROOT/dot_pi/agent/modify_settings.json"
-  local input='{"packages":["npm:pi-subagentura","npm:pi-ask-user"]}'
+  local input='{"packages":["npm:pi-subagentura","npm:pi-ask-user","npm:pi-web-access","npm:pi-context-view","npm:@ff-labs/pi-fff"]}'
 
   run bash "$modifier" <<< "$input"
 
   assert_success
-  run jq -e '[.packages[] | select(. == "npm:pi-subagentura")] | length == 1' <<< "$output"
+  run jq -e '
+    [
+      "npm:pi-subagentura",
+      "npm:pi-web-access",
+      "npm:pi-context-view",
+      "npm:@ff-labs/pi-fff"
+    ] as $required |
+    .packages as $packages |
+    all($required[]; . as $package | [$packages[] | select(. == $package)] | length == 1)
+  ' <<< "$output"
   assert_success
 }
 

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -284,10 +284,15 @@ TOML
   assert_success
 }
 
-@test "pi settings include the managed subagent package" {
+@test "pi settings include all managed packages" {
   local settings="$HOME/.pi/agent/settings.json"
   assert_file_exists "$settings"
-  run jq -e '.packages | index("npm:pi-subagentura") != null' "$settings"
+  run jq -e '
+    (.packages | index("npm:pi-subagentura") != null) and
+    (.packages | index("npm:pi-web-access") != null) and
+    (.packages | index("npm:pi-context-view") != null) and
+    (.packages | index("npm:@ff-labs/pi-fff") != null)
+  ' "$settings"
   assert_success
 }
 


### PR DESCRIPTION
## Summary

New machines can now install Pi web access, context inspection, and FFF-powered repository search through the existing chezmoi settings workflow. The package inventory now distinguishes these reproducible packages from manually managed Pi packages.

## Validation

- `bats tests/scripts.bats`: 115 tests passed.
- `make test-templates`: 23 tests passed, with 3 environment-dependent skips.
- `make lint`: passed.
- `make test-ubuntu`: package deployment, chezmoi apply, idempotence, and 269 of 270 smoke tests passed. The unrelated `pi-brew-auto-update.test.ts` source-path import test failed.
- Dedicated code review could not start its independent reviewer processes. Its inline fallback found no actionable findings.

## Post-Deploy Monitoring & Validation

After the next chezmoi apply and Pi restart, run `pi list` and confirm that `pi-web-access`, `pi-context-view`, and `@ff-labs/pi-fff` are present. Confirm `/context` and `/fff-health` load, then run one web search. Missing tools or Pi startup errors are failure signals. If a package blocks startup, revert this commit and apply chezmoi again. Validate during the first Pi session after deployment; the machine owner is responsible.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
