### PR TITLE
fix(pi): notify only when updates are installed

### DIFF
--- a/home/dot_pi/agent/extensions/brew-auto-update/index.ts
+++ b/home/dot_pi/agent/extensions/brew-auto-update/index.ts
@@ -67,6 +67,7 @@ interface UpdateStep {
   args: string[];
   status: string;
   label: string;
+  installedUpdatePattern?: RegExp;
 }
 
 const UPDATE_STEPS: UpdateStep[] = [
@@ -81,12 +82,14 @@ const UPDATE_STEPS: UpdateStep[] = [
     args: ["upgrade", "pi-coding-agent"],
     status: "Upgrading pi-coding-agent through Homebrew…",
     label: "pi-coding-agent Homebrew upgrade",
+    installedUpdatePattern: /^==>\s+Upgrading(?:[^\n]*\n)?[^\n]*pi-coding-agent/im,
   },
   {
     command: "pi",
     args: ["update", "--extensions"],
     status: "Updating Pi packages…",
     label: "Pi package update",
+    installedUpdatePattern: /^Updating .+\.\.\.$/m,
   },
 ];
 
@@ -211,7 +214,7 @@ async function acquireLock(deps: BrewAutoUpdateDependencies): Promise<UpdateLock
   return { acquired: false };
 }
 
-function setStatus(ui: UpdateUi, value: string): void {
+function setStatus(ui: UpdateUi, value: string | undefined): void {
   try {
     ui.setStatus(STATUS_ID, value);
   } catch {
@@ -266,6 +269,7 @@ export async function runBrewAutoUpdate(
     }
     lock = candidate;
 
+    let installedUpdate = false;
     for (const step of UPDATE_STEPS) {
       setStatus(ui, step.status);
       let result: ExecResult;
@@ -285,11 +289,16 @@ export async function runBrewAutoUpdate(
       if (result.code !== 0) {
         return reportFailure(ui, `${step.label} failed: ${failureDetail(result)}`);
       }
+      if (step.installedUpdatePattern) {
+        installedUpdate ||= step.installedUpdatePattern.test(`${result.stdout}\n${result.stderr}`);
+      }
     }
 
-    const message = "Pi update check complete. Installed updates become active in the next Pi process.";
-    setStatus(ui, message);
-    notify(ui, message, "info");
+    const message = installedUpdate
+      ? "Pi updates installed. They become active in the next Pi process."
+      : "Pi is up to date.";
+    setStatus(ui, installedUpdate ? message : undefined);
+    if (installedUpdate) notify(ui, message, "info");
     return { status: "complete", message };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);

--- a/tests/pi-brew-auto-update.test.ts
+++ b/tests/pi-brew-auto-update.test.ts
@@ -56,8 +56,21 @@ async function dependencies(
 }
 
 describe("brew auto update sequence", () => {
-  test("runs scoped Homebrew and Pi package commands in order", async () => {
-    const { deps, calls } = await dependencies();
+  test("does not notify when successful commands install no updates", async () => {
+    const { deps, calls } = await dependencies({
+      exec: async (command, args) => {
+        calls.push([command, args]);
+        return {
+          code: 0,
+          stdout: command === "pi" ? "Updated packages\n" : "",
+          stderr:
+            command === "brew" && args[0] === "upgrade"
+              ? "Warning: pi-coding-agent 0.84.2 already installed\n"
+              : "",
+          killed: false,
+        };
+      },
+    });
     const { ui, statuses, notifications } = fakeUi();
 
     const result = await runBrewAutoUpdate("manual", ui, deps);
@@ -70,7 +83,47 @@ describe("brew auto update sequence", () => {
     ]);
     expect(statuses).toContain("Refreshing Homebrew metadata…");
     expect(statuses).toContain("Updating Pi packages…");
-    expect(notifications.at(-1)?.message).toContain("next Pi process");
+    expect(statuses.at(-1)).toBeUndefined();
+    expect(notifications).toEqual([]);
+  });
+
+  test.each([
+    {
+      label: "Homebrew",
+      command: "brew",
+      args: ["upgrade", "pi-coding-agent"],
+      stdout: "==> Upgrading pi-coding-agent\n  0.84.1 -> 0.84.2\n",
+    },
+    {
+      label: "Pi package",
+      command: "pi",
+      args: ["update", "--extensions"],
+      stdout: "Updating npm:example-extension...\nUpdated packages\n",
+    },
+  ])("notifies when a $label update was installed", async (updated) => {
+    const { deps, calls } = await dependencies({
+      exec: async (command, args) => {
+        calls.push([command, args]);
+        return {
+          code: 0,
+          stdout:
+            command === updated.command && Bun.deepEquals(args, updated.args) ? updated.stdout : "",
+          stderr: "",
+          killed: false,
+        };
+      },
+    });
+    const { ui, notifications } = fakeUi();
+
+    const result = await runBrewAutoUpdate("manual", ui, deps);
+
+    expect(result.status).toBe("complete");
+    expect(notifications).toEqual([
+      {
+        message: "Pi updates installed. They become active in the next Pi process.",
+        level: "info",
+      },
+    ]);
   });
 
   test("skips all network work when PI_OFFLINE is set", async () => {


### PR DESCRIPTION
Pi's startup updater now clears its status without a notification when all packages are already current. It shows the restart notice only when Homebrew or Pi package output confirms an installed update.

Validated with `bun test` (617 tests) and the focused Bats smoke tests (3 tests).
