### PR TITLE
feat(claude): add ANSI daltonized theme

### DIFF
--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -138,5 +138,5 @@
     "command": "~/.claude/hooks/statusline.sh",
     "type": "command"
   },
-  "theme": "light-ansi"
+  "theme": "custom:light-ansi-daltonized"
 }

--- a/home/private_dot_claude/themes/light-ansi-daltonized.json
+++ b/home/private_dot_claude/themes/light-ansi-daltonized.json
@@ -1,0 +1,20 @@
+{
+  "name": "Light ANSI Daltonized",
+  "base": "light-ansi",
+  "overrides": {
+    "claude": "ansi:cyan",
+    "permission": "ansi:magenta",
+    "success": "ansi:cyan",
+    "error": "ansi:magenta",
+    "warning": "ansi:yellow",
+    "merged": "ansi:blue",
+    "promptBorder": "ansi:blue",
+    "planMode": "ansi:cyan",
+    "autoAccept": "ansi:cyan",
+    "bashBorder": "ansi:yellow",
+    "ide": "ansi:blue",
+    "fastMode": "ansi:magenta",
+    "userMessageBackground": "ansi:whiteBright",
+    "userMessageBackgroundHover": "ansi:white"
+  }
+}

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1861,6 +1861,17 @@ se_fake_runtime() {
   assert_success
 }
 
+@test "Claude Code daltonized theme extends light ANSI with terminal colors" {
+  local theme="$SOURCE_ROOT/private_dot_claude/themes/light-ansi-daltonized.json"
+
+  run jq -e '
+    .base == "light-ansi" and
+    (.overrides | length > 0) and
+    ([.overrides[] | select(startswith("ansi:") | not)] | length == 0)
+  ' "$theme"
+  assert_success
+}
+
 # ===========================================
 # morning-cleanup script
 # ===========================================

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -359,8 +359,9 @@ TOML
 }
 
 @test "coding agents use terminal color palettes" {
-  run jq -e '.theme == "light-ansi"' "$HOME/.claude/settings.json"
+  run jq -e '.theme == "custom:light-ansi-daltonized"' "$HOME/.claude/settings.json"
   assert_success
+  assert_file_exists "$HOME/.claude/themes/light-ansi-daltonized.json"
 
   run jq -e '.theme == "terminal"' "$HOME/.pi/agent/settings.json"
   assert_success


### PR DESCRIPTION
## Summary

Claude Code now keeps the terminal-backed light ANSI palette while assigning status and mode roles to cyan, magenta, yellow, and blue for better color differentiation. User messages use the terminal's bright white background slot instead of the dark bright-black slot.

## Validation

- `bats --filter 'Claude Code daltonized|coding agents use terminal color palettes' tests/scripts.bats tests/smoke.bats`
- `bats tests/templates.bats`
- Confirmed the theme in a live Claude Code session.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
