### PR TITLE
fix: close the six open issues from the label-system review cycle

### DIFF
--- a/docs/issues/2026-08-18-025-harden-herdr-task-sync-and-show-worktree.md
+++ b/docs/issues/2026-08-18-025-harden-herdr-task-sync-and-show-worktree.md
@@ -2,7 +2,8 @@
 title: Harden herdr-task-sync and show worktree identity
 type: follow-up
 date: 2026-08-18
-status: open
+status: done
+closed: 2026-08-20
 ---
 
 ## Why this exists
@@ -38,3 +39,85 @@ The comparison in `docs/ideation/2026-08-18-herdr-title-plugins-pov.html` found 
 - Reclaim actions use durable request IDs and report an end-to-end result through Herdr notifications within five seconds.
 - Icons, Nerd Font integration, and decorative formatters are outside scope.
 - The implementation contract lives in `docs/plans/2026-08-18-001-feat-herdr-worktree-aware-labels-plan.md`.
+
+## Resolution
+
+Closed by audit on 2026-08-20: every scope bullet shipped on main through the
+worktree-aware-labels work (`docs/plans/2026-08-18-001-feat-herdr-worktree-aware-labels-plan.md`)
+and the label-system merge that followed it
+(`docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md`, commits
+`f7fd73c`..`9e69d0b`). No code change was needed here. All pointers are into
+`home/dot_local/bin/executable_herdr-task-sync` unless stated.
+
+Scope bullets, one by one:
+
+- **Derive `repo`, `worktree`, `branch` from the pane cwd** — done.
+  `resolve_pane_location` (line 672) resolves checkout root, common git dir,
+  repo, symbolic branch, linked-worktree flag, and detached short SHA from the
+  pane's `cwd`/`foreground_cwd`, under a 75 ms per-pane Git budget.
+- **Source-owned location metadata with stale-token cleanup** — done.
+  Location tokens publish via `herdr pane report-metadata --source
+  location-sync` (lines 1615-1626); leaving Git clears `repo`, `worktree`,
+  `branch`, `location_status`, `git_ref`; every write path also clears the
+  retired `location_label` token. Tests: `tests/scripts.bats` "clears the
+  retired location_label token on both publish and non-git clear paths" and
+  "clears a retired location_label even when every published token already
+  matches".
+- **Concise worktree identity in sidebar and once per tab** — done.
+  `build_worktree_tokens` (line 836) implements exactly the planned budget:
+  18-column basename, shortest session-unique path suffix, collision-checked
+  basename-plus-digest, ordinal fallback. The `$git_ref` token renders it in
+  the two-row sidebar (`home/private_dot_config/herdr/config.toml:57`), and
+  `compose_tab_intents` (line 1142) hoists a shared ref once per tab.
+- **One local label owner** — done. `herdr-task-sync` is the only pane/tab
+  label writer; the herdr plugin only requests reconciliation, and a
+  reconciliation pass converges externally renamed labels back to computed
+  intent (test "presentation automatically corrects divergent pane and tab
+  labels").
+- **Serialize/coalesce overlapping naming workers** — done. Per-pane
+  `control.lock` inbox + `worker.claim` single worker with monotonic
+  generations (`run_worker`, line 1974; `commit_task_result`, line 1875);
+  only the latest committed generation for the active session publishes
+  (tests "latest committed request survives stale completion and a third
+  request", "orders adapter calls by inbox commit rather than invocation
+  start").
+- **Atomic state writes + generation validation before renames** — done.
+  All records go through `atomic_write` (mktemp + mv, line 190);
+  `presentation_generation_valid` (line 1033) gates every metadata write and
+  rename (tests "atomic records never expose truncation or mixed fields",
+  "presentation publishes only the newest accepted generation", "presentation
+  resumes safely across durable crash boundaries").
+- **Events as invalidation; re-read targets before rename** — done. `--event`
+  bumps the pending generation and each pass takes a fresh snapshot, then
+  `herdr pane get`/`herdr tab get` immediately before each mutation with full
+  target-identity matching (tests "presentation coalesces event bursts…",
+  "presentation skips reused pane and tab identities at the final read").
+- **Periodic sweep as fallback** — done. `run_sweep_daemon` (line 1717) keeps
+  the 5 s sweep for foreground changes herdr does not emit (tests "sweep
+  repairs an external pane rename without pane.updated", "sweep repairs
+  process and CWD changes through the presentation coordinator").
+- **Concurrency, manual-ownership, mixed-worktree, stale-token tests** — done.
+  Concurrency: shared-tab concurrent panes, event bursts, colliding sockets,
+  eight-pane concurrent location resolution. Manual ownership: covered under
+  the superseded design (see below) as "divergence is repaired, no ownership
+  state" — the forbidden-state test greps for
+  `manual_owner|reclaim|label_ledger|server_epoch|takeover`. Mixed-worktree:
+  token suffix/digest/ordinal tests plus the mixed-identity formatter tests.
+  Stale-token: transient-retention, detached-SHA-failure, and both
+  location_label-clearing tests.
+
+Superseded, not skipped: the manual-ownership durability, reclaim request IDs
++ notifications, and versioned-takeover rollout machinery listed under
+Planning decisions were explicitly dropped during plan deepening —
+`docs/plans/2026-08-18-001-feat-herdr-worktree-aware-labels-plan.md` scopes
+this issue "except for its superseded manual-label and reclaim scope", and its
+R7-R9 replace them: labels are fully automatic, divergent live labels are
+converged back, restarts recompute rather than adopt, and no ownership or
+takeover state exists (enforced by test).
+
+Residual gaps found by the audit are already filed separately and stay open on
+their own: `docs/issues/2026-08-20-005` (pane_inline published but unused),
+`2026-08-20-007` (label-system test gaps), `2026-08-20-008` (positional record
+bus), `2026-08-20-010` (two tests flake under full-suite load), `2026-08-20-011`
+(deferred simplify findings), `2026-08-20-012` (same-name repos defeat tab
+repo qualification).

--- a/docs/issues/2026-08-20-001-opencode-forced-theme-live-leftover.md
+++ b/docs/issues/2026-08-20-001-opencode-forced-theme-live-leftover.md
@@ -2,7 +2,8 @@
 title: Live leftover ~/.config/opencode/themes/flexoki-light-forced.json fails smoke deployment contract
 type: bug
 date: 2026-08-20
-status: open
+status: done
+closed: 2026-08-20
 ---
 
 ## Why this exists
@@ -30,3 +31,22 @@ missing).
 
 - Whether other retired opencode theme files linger live (check
   `~/.config/opencode/themes/` against `chezmoi managed`).
+
+## Resolution
+
+Took the declarative path: added
+`.config/opencode/themes/flexoki-light-forced.json` to `home/.chezmoiremove`,
+so `chezmoi apply` deletes the leftover on every machine that deployed the old
+forced theme. Added a guard test in `tests/templates.bats`
+(".chezmoiremove deletes the retired opencode forced theme"); the existing
+".chezmoiremove entries are absent from the source tree" test confirms no
+create/delete conflict.
+
+Open decision checked: `~/.config/opencode/themes/` on the live machine
+contains only `flexoki-light-forced.json`, and `chezmoi managed` lists no
+files under that directory — no other retired theme files linger.
+
+The live file stays in place until the user syncs the chezmoi source and runs
+`chezmoi apply`; until then the smoke test
+"coding agents use terminal color palettes" remains red on this machine, which
+is expected.

--- a/docs/issues/2026-08-20-005-pane-inline-token-shipped-though-plan-defers-it.md
+++ b/docs/issues/2026-08-20-005-pane-inline-token-shipped-though-plan-defers-it.md
@@ -2,7 +2,8 @@
 title: pane_inline token is published on every pane although the plan defers it and nothing consumes it
 type: follow-up
 date: 2026-08-20
-status: open
+status: done
+closed: 2026-08-20
 parent-plan: docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
 ---
 
@@ -73,3 +74,36 @@ Direction B, keep it:
 - If A: whether the one-release `--clear-token pane_inline` window is worth the
   code, given that a pane's location eventually changes anyway and the token is
   invisible either way.
+
+## Resolution
+
+Direction A — removed, following the plan. Commit
+4b93f82f8d3cc302f3b09ab125eb6ebec6ab32f7.
+
+In `home/dot_local/bin/executable_herdr-task-sync`:
+
+- Deleted `pane_inline_label_for`.
+- Dropped `pane_inline` from the pane_rows jq token list and removed the
+  `pane_inline` / `current_pane_inline` / `_pane_inline` / `final_pane_inline`
+  slots from all positional `FIELD_SEPARATOR` records and every matching
+  `read -r` header; producers and consumers re-verified in lockstep
+  (pane_rows 15 fields, pane_intents 24, pane_presentations 27, final_tokens 6).
+- Deleted both pane_inline change-detection arms; the guarded block now only
+  covers the legacy `location_label` shed.
+
+On the sub-decision: kept one `--clear-token pane_inline` on both
+location-publish arms (single flag, cheap; sheds the stale token from panes
+labelled by the previous version whenever a location write fires). It can be
+dropped in a later release once no deployed version writes the token — same
+retirement path as `location_label`.
+
+Tests: the three `pane_inline` assertions in `tests/scripts.bats` now assert
+the token is absent, and the transient-identity test pre-seeds a stale
+`pane_inline` token to prove a location write clears it. Verified:
+`make lint` clean; `bats tests/scripts.bats` 187/189 (the two reds are
+pre-existing on unmodified main: the 1000ms coordinator-concurrency timing
+flake on this machine, and the Pi terminal-theme red tracked by
+`2026-08-20-003-pi-terminal-theme-hex-vars-red-test.md`);
+`bats tests/smoke.bats` 106/107 (the one red is the known
+`coding agents use terminal color palettes` leftover-file failure tracked
+separately). All published labels other than the removed token are unchanged.

--- a/docs/issues/2026-08-20-007-label-system-test-gaps-and-duplicated-icon-table.md
+++ b/docs/issues/2026-08-20-007-label-system-test-gaps-and-duplicated-icon-table.md
@@ -2,7 +2,8 @@
 title: Label-system test gaps and a hand-duplicated icon table in the bats suite
 type: follow-up
 date: 2026-08-20
-status: open
+status: done
+closed: 2026-08-20
 parent-plan: docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
 ---
 
@@ -79,3 +80,48 @@ as `docs/issues/2026-08-20-004-tab-repo-prefix-breaks-column-budget.md`.
   it describes the typical case rather than promising "no folder ever".
 - Whether a non-UTF-8 locale is worth testing, or whether the script should
   instead pin `LC_ALL` for its own width math so the question cannot arise.
+
+## Resolution
+
+**Icon table.** Already de-duplicated by commit 9e69d0b before this issue was
+picked up: `tests/scripts.bats` derives `HTS_ICON_*` through `hts_icon()`,
+which sed-extracts each octal sequence from the engine's own `ICON_*` table
+and re-expands it. A drift in the engine table now breaks the suite; no raw
+PUA glyph appears verbatim in either file.
+
+**Tests added** (all in `tests/scripts.bats`, existing `hts_*` helpers only):
+
+- `formatter renders a worktree whose folder equals its branch as icon plus
+  ref in sidebar and tab` — scenario matrix row 2 as one combined
+  sidebar-token + tab-label assertion.
+- `formatter keeps the folder qualifier on a main checkout in a
+  differently-named folder` — locks the implemented suppression rule where it
+  diverged from the plan's original decision 5 wording.
+- `formatter reads the workspace display name from the legacy name field when
+  label is absent` — exercises the `.name` half of `(.label // .name // "")`.
+- `formatter gives a detached HEAD inside a linked worktree the commit icon`
+  — commit place wins over worktree place; folder qualifier kept.
+- `formatter repo-qualifies every segment when three panes span two
+  repositories` — the ≥3-pane per-segment loop with
+  `first_repo`/`multiple_repos`/`segment_repo` tracking.
+- `location detached sha budget failure with no prior state renders no git
+  location and self-heals` — the second `--short=7` probe exceeds
+  `LOCATION_GIT_BUDGET` on a pane with no prior state: no git tokens that
+  pass, commit ref on the next. The test git stub gained a `block.short`
+  marker (mirror of `stdout.short`) so only the SHA probe stalls.
+- `width math counts codepoints even when the daemon inherits a non-UTF-8
+  locale` — the 80-column mixed-worktree label is byte-identical under
+  `LC_ALL=C`.
+
+**Open decision 1 (plan decision 5 vs implemented rule):** kept the engine
+behavior, reworded decision 5 in the plan to describe the typical case — a
+main checkout in a differently-named folder keeps its folder qualifier, which
+is real location information. Tested as-is (second test above).
+
+**Open decision 2 (non-UTF-8 locale):** pinned the locale in the engine
+instead of leaving the question open. `executable_herdr-task-sync` now
+resolves `TEXT_LOCALE` at start (inherited UTF-8 locale kept; otherwise the
+first UTF-8 locale from `locale -a`; `C` only when the system has none) and
+`text_length`/`text_prefix` run `wc -m`/`cut -c` under it. Labels under a
+UTF-8 environment are byte-identical to before; a `C`-locale daemon no longer
+charges each codicon three columns or cuts labels mid-codepoint.

--- a/docs/issues/2026-08-20-008-field-separator-positional-record-bus.md
+++ b/docs/issues/2026-08-20-008-field-separator-positional-record-bus.md
@@ -2,7 +2,8 @@
 title: FIELD_SEPARATOR pane records reached 29 positional fields across six read headers
 type: follow-up
 date: 2026-08-20
-status: open
+status: done
+closed: 2026-08-20
 parent-plan: docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
 ---
 
@@ -66,3 +67,30 @@ cross-model review leg.
   a cheap guard: a single assertion that each record's field count matches the
   expected width before the loop consumes it. That is far smaller and catches the
   exact failure mode, without restructuring the pass.
+
+## Resolution
+
+Took the third (narrow) option from Scope combined with the width guard from
+Open decisions; the base64-JSON rewrite was rejected for its per-row jq cost.
+
+- The six `current_*` baseline fields no longer ride the intermediate records.
+  They live in one keyed `pane_baselines` table (`pane_id` + 6 columns) built
+  once from `pane_rows` by awk, and are looked up per pane with the new
+  `table_row_for` (multi-column sibling of `table_value_for`): in the final
+  diff loop for the token comparison, and in the git_ref loop for the
+  transient worktree fallback.
+- New record widths: `pane_rows` 16 (unchanged), `pane_intents` 25 → 19,
+  `pane_presentations` 29 → 23, `tab_rows`/`tab_intents` 4 (unchanged),
+  `pane_baselines` 7 (new).
+- New `filter_records_of_width` guard: every record stream is passed through
+  an awk width check right where it is produced (`pane_rows`, `pane_intents`,
+  `pane_presentations`, `tab_rows`, `tab_intents`). A record whose field
+  count does not match the consumers' expected width is logged to stderr and
+  dropped, so a smuggled FIELD_SEPARATOR or a producer/consumer arity slip
+  surfaces as one skipped record instead of silently shifted labels.
+- New bats test: "presentation drops a malformed-width record and keeps
+  labeling the rest" (a pane label carrying U+001F is dropped; the sibling
+  pane and the tab still get labeled).
+- All producer/consumer arities re-verified by hand after the edit:
+  16/16/16, 7/7, 19/19/19, 23/23/23, 4/4, 3/3, 7/7.
+- Commit: 33adde5

--- a/docs/issues/2026-08-20-011-deferred-simplify-findings-herdr-task-sync.md
+++ b/docs/issues/2026-08-20-011-deferred-simplify-findings-herdr-task-sync.md
@@ -2,7 +2,8 @@
 title: Deferred se-simplify findings for herdr-task-sync (quadratic scans and micro-refactors)
 type: chore
 date: 2026-08-20
-status: open
+status: done
+closed: 2026-08-20
 parent-plan: docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
 ---
 
@@ -66,3 +67,24 @@ Deferred findings:
 - Whether items 1 and 3 are worth doing at all at the current scale. Measure a
   sweep with a realistic pane count before optimizing; close as wontfix if the
   pass stays well inside the 5-second interval.
+
+## Resolution
+
+Commit ad2f181. Labels stayed byte-identical:
+`tests/scripts.bats` 188/189 and `tests/smoke.bats` 106/107, `make lint`
+clean. The two reds are pre-existing and unrelated: the Pi terminal-theme
+palette check (red on clean main, `docs/issues/2026-08-20-003`) and the smoke
+palette test's live leftover file (`docs/issues/2026-08-20-001`).
+
+| Item | Outcome |
+| --- | --- |
+| 1. per-tab rescan in `compose_tab_intents` | Measured and declined. 5 tabs × 20 panes: **109 ms/call**, ~2% of the 5 s sweep interval. |
+| 2. stale-state cleanup rescan | Applied. The pane-id column is cut once into `presented_pane_ids`; the per-state-file scan is now one `list_contains_line` call. |
+| 3. `build_worktree_tokens` quadratic scans | Measured and declined. 10 roots, distinct basenames (the shape `agent-<hash>` naming produces): **48 ms/call**. Pairwise basename collisions resolved at two components: **384 ms/call**. Pathological worst case — all ten basenames identical with suffixes probing past the 18-char cap into the digest fallback: **0.7–1.3 s/call**, still inside the 5 s interval and requiring ten same-named checkouts open in panes at once. The cost is dominated by per-comparison subshell/awk spawns, not the scan order, so the `sort \| uniq -c` rewrite would not remove most of it. Revisit only with the record restructuring in `docs/issues/2026-08-20-008-field-separator-positional-record-bus.md`. |
+| 4. `count` reused for two meanings | Applied in the minimal form: renamed to `base_matches` and `suffix_components`; the function was not split — the rename alone reads fine. |
+| 5. first-value/divergence idiom duplicated | Applied. `track_first_value` (remember first non-empty value, flag a later distinct one) now serves both the repo and the checkout-root bookkeeping; `first_prefix` is captured just before the tracker fills `first_root`. |
+| 6. inline tab-segment prefix rule | Applied. `git_ref_segment_for` sits next to `git_ref_for` and names the rule once; the inline branch at the presentation loop is one call now. |
+
+Benchmarks synthesized the issue's own scales (~20 panes, ~10 worktree
+roots) against the merged code by sourcing the script's function definitions;
+numbers are per call on this machine, 10-iteration averages.

--- a/docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
+++ b/docs/plans/2026-08-20-001-feat-herdr-label-system-plan.md
@@ -112,7 +112,13 @@ Workspace is `my-mac-setup` unless stated. Icons shown as ⎇ (branch), ⑂ (wor
    the same icon.
 5. **Special cases** — detached HEAD → commit icon + short SHA; folder == branch →
    plain worktree case (the icon already says it); repo-root main checkout → branch
-   icon + branch, no folder ever.
+   icon + branch, with the folder qualifier suppressed in the typical case where the
+   checkout folder repeats the branch or the workspace name. A main checkout in a
+   differently-named folder keeps its folder qualifier — the same suppression rule
+   as every other checkout, no main-checkout special arm. (Reworded per
+   docs/issues/2026-08-20-007: the original "no folder ever" promised more than the
+   implemented and now-tested rule delivers, and the implemented rule is the better
+   one — a divergent folder name is real location information.)
 6. **One location policy or two** — two, deliberately. Agent panes read `pane.cwd`
    (stable during tool calls); command panes read `foreground_cwd`. Already
    implemented and tested — do not regress.

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -7,3 +7,7 @@
 
 # The herdr-only peer consult is deployed under its capability-specific name.
 .claude/skills/ask-agent
+
+# opencode moved to theme "system"; the retired forced theme otherwise lingers
+# live and breaks the smoke deployment contract (tests/smoke.bats).
+.config/opencode/themes/flexoki-light-forced.json

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -57,6 +57,21 @@ ICON_WORKTREE="$(printf '\356\261\276')" # nf-cod-worktree U+EC7E
 ICON_COMMIT="$(printf '\356\253\274')"   # nf-cod-git_commit U+EAFC
 ICON_FOLDER="$(printf '\356\252\203')"   # nf-cod-folder U+EA83
 ICON_STALE="$(printf '\356\252\202')"    # nf-cod-history U+EA82
+# The width math (text_length's `wc -m`, text_prefix's `cut -c`) must count
+# codepoints: under a non-UTF-8 locale both count bytes, so every three-byte
+# codicon is charged three columns and a cap can cut a label mid-codepoint.
+# The daemon inherits its locale from whatever hook spawned it, so it pins its
+# own: keep an inherited UTF-8 locale, otherwise take the first UTF-8 locale
+# the system offers; only a system without any falls back to byte counting.
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+  *[Uu][Tt][Ff]8 | *[Uu][Tt][Ff]-8)
+    TEXT_LOCALE="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
+    ;;
+  *)
+    TEXT_LOCALE="$(locale -a 2>/dev/null | grep -i -m1 '\.utf-*8$' || true)"
+    [ -n "$TEXT_LOCALE" ] || TEXT_LOCALE=C
+    ;;
+esac
 FIELD_SEPARATOR=$'\037'
 WORKTREE_TOKEN_MAX_LEN=18
 # A repo name qualifies a tab segment only when the tab spans several
@@ -570,12 +585,12 @@ cleanup_old_task_context() {
 }
 
 text_length() {
-  printf '%s' "$1" | wc -m | tr -d '[:space:]'
+  printf '%s' "$1" | LC_ALL="$TEXT_LOCALE" wc -m | tr -d '[:space:]'
 }
 
 text_prefix() {
   [ "$2" -gt 0 ] || return 0
-  printf '%s' "$1" | cut -c "1-$2"
+  printf '%s' "$1" | LC_ALL="$TEXT_LOCALE" cut -c "1-$2"
 }
 
 truncate_text() {

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -950,12 +950,6 @@ git_ref_for() {
   printf '%s' "$label"
 }
 
-pane_inline_label_for() {
-  local label="$1"
-  [ -n "$label" ] || return 0
-  printf '· %s' "$label"
-}
-
 native_session_matches_active() {
   local native_session="$1" active_session="$2" base stem
   [ -z "$native_session" ] && return 0
@@ -1149,7 +1143,7 @@ compose_tab_intents() {
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
   local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
   local _current_repo _current_worktree _current_branch _current_location_status
-  local _current_git_ref _current_pane_inline _git_ref _pane_inline _worktree_token _segment_prefix
+  local _current_git_ref _git_ref _worktree_token _segment_prefix
   tab_rows="$(printf '%s' "$snapshot" | jq -r '
     reduce .result.snapshot.tabs[]? as $t ({counts: {}, out: []};
       ($t.workspace_id // "") as $ws
@@ -1169,7 +1163,7 @@ compose_tab_intents() {
     multiple_roots=0
     first_repo=""
     multiple_repos=0
-    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline _git_ref _pane_inline _worktree_token _segment_prefix; do
+    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _git_ref _worktree_token _segment_prefix; do
       [ "$pane_tab" = "$tab_id" ] || continue
       [ -n "$pane_intended" ] || continue
       pane_count=$((pane_count + 1))
@@ -1251,18 +1245,18 @@ EOF
 reconcile_presentation_pass() {
   local pass="$1" snapshot pane_rows workspace_rows pane_intents="" pane_presentations="" tab_intents=""
   local id terminal tab_id workspace agent_of native_agent native_session current current_task
-  local current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline pane_json_encoded pane_json
+  local current_repo current_worktree current_branch current_location_status current_git_ref pane_json_encoded pane_json
   local intended slug metadata_seq control active_agent active_session generation committed task_file
   local saved_pane="$pane" saved_agent="$agent" saved_session="$session"
   local location_file location_result location_outcome checkout_root repository_anchor repo branch location_status is_linked sha
-  local roots root_tokens worktree_token git_ref pane_inline location_seq location_changed
+  local roots root_tokens worktree_token git_ref location_seq location_changed
   local _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
   local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
-  local _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline _worktree_token _git_ref _pane_inline
+  local _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _worktree_token _git_ref
   local _ref _place _folder _workspace_name _segment_prefix
   local final_payload final_label final_task final_tokens
-  local final_repo final_worktree final_branch final_location_status final_git_ref final_pane_inline
+  local final_repo final_worktree final_branch final_location_status final_git_ref
   local segment_prefix
   local state_file retained_pane found
   local location_pids="" location_results="" location_result_file location_pid
@@ -1287,8 +1281,7 @@ reconcile_presentation_pass() {
         (.workspace_id // ""), (.agent // ""), (.agent_session.agent // ""),
        (.agent_session.value // ""), (.label // ""), (.tokens.task // ""),
        (.tokens.repo // ""), (.tokens.worktree // ""), (.tokens.branch // ""),
-       (.tokens.location_status // ""), (.tokens.git_ref // ""),
-       (.tokens.pane_inline // ""), (@base64)]
+       (.tokens.location_status // ""), (.tokens.git_ref // ""), (@base64)]
     | join("\u001f")' 2>/dev/null)"
 
   # location_label is the retired predecessor of git_ref. It is deliberately
@@ -1314,7 +1307,7 @@ reconcile_presentation_pass() {
   # Location probes own no presentation state. Run one bounded probe per pane,
   # reap every child, then let the parent consume immutable results in the
   # snapshot's original order.
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_agent native_session current current_task current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline pane_json_encoded; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_agent native_session current current_task current_repo current_worktree current_branch current_location_status current_git_ref pane_json_encoded; do
     [ -n "$id" ] || continue
     pane_json="$(printf '%s' "$pane_json_encoded" | base64 -d 2>/dev/null)"
     location_file="$(location_state_file "$id")"
@@ -1385,7 +1378,7 @@ $location_results
 EOF
   [ "$location_child_failed" -eq 0 ] || return 1
 
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_agent native_session current current_task current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline pane_json_encoded; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_agent native_session current current_task current_repo current_worktree current_branch current_location_status current_git_ref pane_json_encoded; do
     [ -n "$id" ] || continue
     location_result="${location_probe_results%%$'\n'*}"
     [ -n "$location_result" ] || return 1
@@ -1464,7 +1457,7 @@ EOF
       [ -n "$intended" ] || intended="$IDLE_PANE_LABEL"
     fi
     pane_intents="${pane_intents}${pane_intents:+
-}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${location_status}${FIELD_SEPARATOR}${current_repo}${FIELD_SEPARATOR}${current_worktree}${FIELD_SEPARATOR}${current_branch}${FIELD_SEPARATOR}${current_location_status}${FIELD_SEPARATOR}${current_git_ref}${FIELD_SEPARATOR}${current_pane_inline}"
+}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${location_status}${FIELD_SEPARATOR}${current_repo}${FIELD_SEPARATOR}${current_worktree}${FIELD_SEPARATOR}${current_branch}${FIELD_SEPARATOR}${current_location_status}${FIELD_SEPARATOR}${current_git_ref}"
   done <<EOF
 $pane_rows
 EOF
@@ -1472,7 +1465,7 @@ EOF
   agent="$saved_agent"
   session="$saved_session"
 
-  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline; do
+  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref; do
     [ -z "$_checkout_root" ] || printf '%s\n' "$_checkout_root"
   done <<EOF
 $pane_intents
@@ -1480,7 +1473,7 @@ EOF
 )"
   roots="$(printf '%s\n' "$roots" | sed '/^$/d' | LC_ALL=C sort -u)"
   root_tokens="$(build_worktree_tokens "$roots")"
-  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline; do
+  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref; do
     [ -n "$_pane_id" ] || continue
     _worktree_token=""
     if [ -n "$_checkout_root" ]; then
@@ -1517,9 +1510,8 @@ EOF
     else
       _segment_prefix="$_git_ref"
     fi
-    _pane_inline="$(pane_inline_label_for "$pane_intended")"
     pane_presentations="${pane_presentations}${pane_presentations:+
-}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_current_repo}${FIELD_SEPARATOR}${_current_worktree}${FIELD_SEPARATOR}${_current_branch}${FIELD_SEPARATOR}${_current_location_status}${FIELD_SEPARATOR}${_current_git_ref}${FIELD_SEPARATOR}${_current_pane_inline}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_pane_inline}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_segment_prefix}"
+}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_current_repo}${FIELD_SEPARATOR}${_current_worktree}${FIELD_SEPARATOR}${_current_branch}${FIELD_SEPARATOR}${_current_location_status}${FIELD_SEPARATOR}${_current_git_ref}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_segment_prefix}"
   done <<EOF
 $pane_intents
 EOF
@@ -1544,7 +1536,7 @@ EOF
   # Herdr 0.8 has no rename compare-and-swap. A target can change after the
   # final get and briefly receive stale intent; the next pass repairs it.
   presentation_generation_valid "$pass" || return 2
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha location_status current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline git_ref pane_inline worktree_token segment_prefix; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha location_status current_repo current_worktree current_branch current_location_status current_git_ref git_ref worktree_token segment_prefix; do
     [ -n "$id" ] || continue
     if [ -n "$slug" ] && [ "$current_task" != "$slug" ]; then
       presentation_generation_valid "$pass" || return 2
@@ -1560,11 +1552,9 @@ EOF
     fi
     location_changed=0
     # A transient pass with no evidence publishes nothing: location tokens
-    # retain as-is, and pane_inline alone is not worth a metadata write.
+    # retain as-is. Same gate as the publish arms below, so such a pass also
+    # keeps the legacy token for now.
     if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
-      [ "$current_pane_inline" = "$pane_inline" ] || location_changed=1
-      # Same gate as the publish arms below: a transient pass with no evidence
-      # must keep retaining, so it also keeps the legacy token for now.
       ! list_contains_line "$id" "$legacy_label_panes" || location_changed=1
     fi
     if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
@@ -1586,16 +1576,14 @@ EOF
       final_tokens="$(printf '%s' "$final_payload" | jq -r '
         .result.pane.tokens
         | [(.repo // ""), (.worktree // ""), (.branch // ""),
-           (.location_status // ""), (.git_ref // ""), (.pane_inline // ""),
-           (.location_label // "")]
+           (.location_status // ""), (.git_ref // ""), (.location_label // "")]
         | join("\u001f")' 2>/dev/null)"
       IFS="$FIELD_SEPARATOR" read -r final_repo final_worktree final_branch \
-        final_location_status final_git_ref final_pane_inline final_location_label <<EOF
+        final_location_status final_git_ref final_location_label <<EOF
 $final_tokens
 EOF
       location_changed=0
       if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
-        [ "$final_pane_inline" = "$pane_inline" ] || location_changed=1
         [ -z "$final_location_label" ] || location_changed=1
       fi
       if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
@@ -1615,13 +1603,15 @@ EOF
         set -- herdr pane report-metadata "$id" --source "$LOCATION_SOURCE_ID" --seq "$location_seq"
         # location_label is the retired predecessor of git_ref: every write
         # path clears it so panes labeled by the old deployed version shed
-        # the legacy token instead of carrying it forever.
+        # the legacy token instead of carrying it forever. pane_inline shipped
+        # once despite being deferred by the plan; the clear can be dropped a
+        # release after no deployed version writes it anymore.
         if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
-          set -- "$@" --token "repo=$repo" --token "worktree=$worktree_token" --token "git_ref=$git_ref" --token "pane_inline=$pane_inline" --clear-token location_label
+          set -- "$@" --token "repo=$repo" --token "worktree=$worktree_token" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token location_label
           if [ -n "$branch" ]; then set -- "$@" --token "branch=$branch"; else set -- "$@" --clear-token branch; fi
           if [ -n "$location_status" ]; then set -- "$@" --token "location_status=$location_status"; else set -- "$@" --clear-token location_status; fi
         else
-          set -- "$@" --token "pane_inline=$pane_inline" --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token location_label
+          set -- "$@" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token location_label
         fi
         "$@" >/dev/null 2>&1 || continue
       fi

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -834,30 +834,30 @@ EOF
 }
 
 build_worktree_tokens() {
-  local roots="$1" mappings="" root other base candidate suffix components count unique
+  local roots="$1" mappings="" root other base candidate suffix components base_matches suffix_components unique
   local digest digest_len fragment_len ordinal=0 ordinal_hex
   while IFS= read -r root; do
     [ -n "$root" ] || continue
     ordinal=$((ordinal + 1))
     base="${root##*/}"
-    count=0
+    base_matches=0
     while IFS= read -r other; do
-      [ "${other##*/}" = "$base" ] && count=$((count + 1))
+      [ "${other##*/}" = "$base" ] && base_matches=$((base_matches + 1))
     done <<EOF
 $roots
 EOF
     candidate=""
-    if [ "$count" -eq 1 ] && [ "$(text_length "$base")" -le "$WORKTREE_TOKEN_MAX_LEN" ]; then
+    if [ "$base_matches" -eq 1 ] && [ "$(text_length "$base")" -le "$WORKTREE_TOKEN_MAX_LEN" ]; then
       candidate="$base"
-    elif [ "$count" -gt 1 ]; then
+    elif [ "$base_matches" -gt 1 ]; then
       components="$(printf '%s' "$root" | awk -F/ '{print NF}')"
-      count=2
-      while [ "$count" -le "$components" ]; do
-        suffix="$(path_suffix "$root" "$count")"
+      suffix_components=2
+      while [ "$suffix_components" -le "$components" ]; do
+        suffix="$(path_suffix "$root" "$suffix_components")"
         unique=1
         while IFS= read -r other; do
           [ "$other" = "$root" ] && continue
-          if [ "$(path_suffix "$other" "$count")" = "$suffix" ]; then
+          if [ "$(path_suffix "$other" "$suffix_components")" = "$suffix" ]; then
             unique=0
             break
           fi
@@ -868,7 +868,7 @@ EOF
           [ "$(text_length "$suffix")" -le "$WORKTREE_TOKEN_MAX_LEN" ] && candidate="$suffix"
           break
         fi
-        count=$((count + 1))
+        suffix_components=$((suffix_components + 1))
       done
     fi
     if [ -n "$candidate" ] && token_is_taken "$candidate" "$mappings"; then candidate=""; fi
@@ -912,6 +912,20 @@ EOF
   return 1
 }
 
+# Remember the first non-empty value seen in the variable named by $2 and set
+# the flag variable named by $3 to 1 when a later value disagrees. Serves
+# compose_tab_intents' "does this tab span one repo / one checkout?" question.
+track_first_value() {
+  local value="$1" first_var="$2" flag_var="$3" first
+  [ -n "$value" ] || return 0
+  eval "first=\"\$$first_var\""
+  if [ -z "$first" ]; then
+    eval "$first_var=\"\$value\""
+  elif [ "$first" != "$value" ]; then
+    eval "$flag_var=1"
+  fi
+}
+
 # Look up the value column of a FIELD_SEPARATOR-joined two-column table
 # (key␟value rows). Serves worktree tokens and workspace names alike.
 table_value_for() {
@@ -948,6 +962,20 @@ git_ref_for() {
   fi
   [ -z "$status" ] || label="$label $ICON_STALE"
   printf '%s' "$label"
+}
+
+# Tab segments stay compact: icon + capped ref only — the sidebar carries the
+# folder qualifier and the full ref. Ref-less evidence keeps its folder-icon
+# form (the full $git_ref, passed as $4). The cap keeps a long branch name
+# from eating the 80-column tab budget; the hoisted tab prefix reuses this
+# value too.
+git_ref_segment_for() {
+  local place="$1" ref="$2" status="$3" full_ref="$4"
+  if [ -n "$ref" ]; then
+    git_ref_for "$place" "$(truncate_text "$ref" "$WORKTREE_TOKEN_MAX_LEN")" "" "$status"
+  else
+    printf '%s' "$full_ref"
+  fi
 }
 
 pane_inline_label_for() {
@@ -1167,6 +1195,7 @@ compose_tab_intents() {
     first_root=""
     first_prefix=""
     multiple_roots=0
+    # shellcheck disable=SC2034 # first_repo is read via eval in track_first_value
     first_repo=""
     multiple_repos=0
     while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline _git_ref _pane_inline _worktree_token _segment_prefix; do
@@ -1177,21 +1206,13 @@ compose_tab_intents() {
       if [ -z "$parts" ]; then parts="$pane_intended"; else parts="$parts$LABEL_SEPARATOR$pane_intended"; fi
       segment_rows="${segment_rows}${segment_rows:+
 }${_repo}${FIELD_SEPARATOR}${_segment_prefix}${FIELD_SEPARATOR}${pane_intended}"
-      if [ -n "$_repo" ]; then
-        if [ -z "$first_repo" ]; then
-          first_repo="$_repo"
-        elif [ "$first_repo" != "$_repo" ]; then
-          multiple_repos=1
-        fi
-      fi
+      track_first_value "$_repo" first_repo multiple_repos
       if [ -n "$_checkout_root" ]; then
         all_non_git=0
-        if [ -z "$first_root" ]; then
-          first_root="$_checkout_root"
-          first_prefix="$_segment_prefix"
-        elif [ "$first_root" != "$_checkout_root" ]; then
-          multiple_roots=1
-        fi
+        # first_prefix rides with the first root: capture it before the
+        # tracker fills first_root.
+        [ -n "$first_root" ] || first_prefix="$_segment_prefix"
+        track_first_value "$_checkout_root" first_root multiple_roots
         [ -z "$_location_status" ] || all_fresh_git=0
       elif [ -n "$_worktree_token" ]; then
         # Token-only evidence cannot prove that two panes share one checkout.
@@ -1264,7 +1285,7 @@ reconcile_presentation_pass() {
   local final_payload final_label final_task final_tokens
   local final_repo final_worktree final_branch final_location_status final_git_ref final_pane_inline
   local segment_prefix
-  local state_file retained_pane found
+  local state_file retained_pane presented_pane_ids
   local location_pids="" location_results="" location_result_file location_pid
   local location_probe_results="" location_child_failed=0
   local legacy_label_panes final_location_label
@@ -1508,15 +1529,7 @@ EOF
       fi
     fi
     _git_ref="$(git_ref_for "$_place" "$_ref" "$_folder" "$_location_status")"
-    # Tab segments stay compact: icon + capped ref only — the sidebar carries
-    # the folder qualifier and the full ref. Ref-less evidence keeps its
-    # folder-icon form. The cap keeps a long branch name from eating the
-    # 80-column tab budget; the hoisted tab prefix reuses this value too.
-    if [ -n "$_ref" ]; then
-      _segment_prefix="$(git_ref_for "$_place" "$(truncate_text "$_ref" "$WORKTREE_TOKEN_MAX_LEN")" "" "$_location_status")"
-    else
-      _segment_prefix="$_git_ref"
-    fi
+    _segment_prefix="$(git_ref_segment_for "$_place" "$_ref" "$_location_status" "$_git_ref")"
     _pane_inline="$(pane_inline_label_for "$pane_intended")"
     pane_presentations="${pane_presentations}${pane_presentations:+
 }${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_current_repo}${FIELD_SEPARATOR}${_current_worktree}${FIELD_SEPARATOR}${_current_branch}${FIELD_SEPARATOR}${_current_location_status}${FIELD_SEPARATOR}${_current_git_ref}${FIELD_SEPARATOR}${_current_pane_inline}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_pane_inline}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_segment_prefix}"
@@ -1526,17 +1539,12 @@ EOF
 
   # A complete snapshot authoritatively deletes evidence for panes that no
   # longer exist. No label policy or applied-label copy is retained.
+  presented_pane_ids="$(printf '%s\n' "$pane_presentations" | cut -d "$FIELD_SEPARATOR" -f1)"
   for state_file in "$(namespace_dir)"/panes/*/location.state; do
     [ -f "$state_file" ] || continue
     retained_pane="$(read_state_field "$state_file" pane)"
     [ -n "$retained_pane" ] || continue
-    found=0
-    while IFS="$FIELD_SEPARATOR" read -r _pane_id _; do
-      [ "$_pane_id" != "$retained_pane" ] || { found=1; break; }
-    done <<EOF
-$pane_presentations
-EOF
-    [ "$found" -eq 1 ] || rm -f "$state_file" 2>/dev/null || true
+    list_contains_line "$retained_pane" "$presented_pane_ids" || rm -f "$state_file" 2>/dev/null || true
   done
 
   tab_intents="$(compose_tab_intents "$snapshot" "$pane_presentations")"

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -926,6 +926,34 @@ $table
 EOF
 }
 
+# Like table_value_for, but returns the whole value row: every column after
+# the key, still FIELD_SEPARATOR-joined. `read` leaves the remainder of the
+# line in its last variable, separators included.
+table_row_for() {
+  local wanted="$1" table="$2" key rest
+  while IFS="$FIELD_SEPARATOR" read -r key rest; do
+    if [ "$key" = "$wanted" ]; then
+      printf '%s' "$rest"
+      return 0
+    fi
+  done <<EOF
+$table
+EOF
+}
+
+# Positional record streams are only safe while every row carries exactly the
+# width its consumers expect. A field that smuggles in a FIELD_SEPARATOR or a
+# newline shifts every later field and surfaces as a wrong label, not as a
+# crash. Passing each stream through this filter drops such rows loudly
+# instead of letting a read header consume garbage.
+filter_records_of_width() {
+  awk -F "$FIELD_SEPARATOR" -v expected="$1" '
+    NF == 0 { next }
+    NF == expected { print; next }
+    { printf "herdr-task-sync: dropped %d-field record (expected %d)\n", NF, expected > "/dev/stderr" }
+  '
+}
+
 # One formatter for every surface:
 #   $git_ref = <place-icon> <ref> [<folder-icon> <folder>] [<stale-icon>]
 # place is "branch" (main checkout), "worktree" (linked worktree), or
@@ -1148,14 +1176,13 @@ compose_tab_intents() {
   local _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
   local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
-  local _current_repo _current_worktree _current_branch _current_location_status
-  local _current_git_ref _current_pane_inline _git_ref _pane_inline _worktree_token _segment_prefix
+  local _git_ref _pane_inline _worktree_token _segment_prefix
   tab_rows="$(printf '%s' "$snapshot" | jq -r '
     reduce .result.snapshot.tabs[]? as $t ({counts: {}, out: []};
       ($t.workspace_id // "") as $ws
       | .counts[$ws] = ((.counts[$ws] // 0) + 1)
       | .out += [[$t.tab_id, $ws, ($t.label // ""), (.counts[$ws] | tostring)]])
-    | .out[] | join("\u001f")' 2>/dev/null)"
+    | .out[] | join("\u001f")' 2>/dev/null | filter_records_of_width 4)"
   while IFS="$FIELD_SEPARATOR" read -r tab_id workspace current index; do
     [ -n "$tab_id" ] || continue
     parts=""
@@ -1169,7 +1196,7 @@ compose_tab_intents() {
     multiple_roots=0
     first_repo=""
     multiple_repos=0
-    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline _git_ref _pane_inline _worktree_token _segment_prefix; do
+    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _git_ref _pane_inline _worktree_token _segment_prefix; do
       [ "$pane_tab" = "$tab_id" ] || continue
       [ -n "$pane_intended" ] || continue
       pane_count=$((pane_count + 1))
@@ -1259,11 +1286,11 @@ reconcile_presentation_pass() {
   local _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
   local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
-  local _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline _worktree_token _git_ref _pane_inline
+  local _current_worktree _worktree_token _git_ref _pane_inline
   local _ref _place _folder _workspace_name _segment_prefix
   local final_payload final_label final_task final_tokens
   local final_repo final_worktree final_branch final_location_status final_git_ref final_pane_inline
-  local segment_prefix
+  local segment_prefix pane_baselines baseline_row
   local state_file retained_pane found
   local location_pids="" location_results="" location_result_file location_pid
   local location_probe_results="" location_child_failed=0
@@ -1289,7 +1316,15 @@ reconcile_presentation_pass() {
        (.tokens.repo // ""), (.tokens.worktree // ""), (.tokens.branch // ""),
        (.tokens.location_status // ""), (.tokens.git_ref // ""),
        (.tokens.pane_inline // ""), (@base64)]
-    | join("\u001f")' 2>/dev/null)"
+    | join("\u001f")' 2>/dev/null | filter_records_of_width 16)"
+
+  # The six current_* baseline tokens are consumed only where a pane's newly
+  # derived presentation is diffed against what the pane already shows: the
+  # final publish loop, plus the transient worktree fallback. Keeping them in
+  # one keyed table instead of threading them through every intermediate
+  # record keeps those records narrow.
+  pane_baselines="$(printf '%s\n' "$pane_rows" | awk -F "$FIELD_SEPARATOR" \
+    -v OFS="$FIELD_SEPARATOR" 'NF { print $1, $10, $11, $12, $13, $14, $15 }')"
 
   # location_label is the retired predecessor of git_ref. It is deliberately
   # absent from the presentation record, so a pane whose new tokens all match
@@ -1464,15 +1499,16 @@ EOF
       [ -n "$intended" ] || intended="$IDLE_PANE_LABEL"
     fi
     pane_intents="${pane_intents}${pane_intents:+
-}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${location_status}${FIELD_SEPARATOR}${current_repo}${FIELD_SEPARATOR}${current_worktree}${FIELD_SEPARATOR}${current_branch}${FIELD_SEPARATOR}${current_location_status}${FIELD_SEPARATOR}${current_git_ref}${FIELD_SEPARATOR}${current_pane_inline}"
+}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${location_status}"
   done <<EOF
 $pane_rows
 EOF
   pane="$saved_pane"
   agent="$saved_agent"
   session="$saved_session"
+  pane_intents="$(printf '%s\n' "$pane_intents" | filter_records_of_width 19)"
 
-  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline; do
+  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status; do
     [ -z "$_checkout_root" ] || printf '%s\n' "$_checkout_root"
   done <<EOF
 $pane_intents
@@ -1480,12 +1516,18 @@ EOF
 )"
   roots="$(printf '%s\n' "$roots" | sed '/^$/d' | LC_ALL=C sort -u)"
   root_tokens="$(build_worktree_tokens "$roots")"
-  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _current_repo _current_worktree _current_branch _current_location_status _current_git_ref _current_pane_inline; do
+  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status; do
     [ -n "$_pane_id" ] || continue
     _worktree_token=""
     if [ -n "$_checkout_root" ]; then
       _worktree_token="$(table_value_for "$_checkout_root" "$root_tokens")"
-    elif [ "$_location_outcome" = "transient" ] && [ -n "$_repo" ] && [ -n "$_current_worktree" ]; then
+    elif [ "$_location_outcome" = "transient" ] && [ -n "$_repo" ]; then
+      # Transient identity keeps the last published worktree token, looked up
+      # from the baseline table instead of being carried in the record.
+      baseline_row="$(table_row_for "$_pane_id" "$pane_baselines")"
+      IFS="$FIELD_SEPARATOR" read -r _ _current_worktree _ <<EOF
+$baseline_row
+EOF
       _worktree_token="$_current_worktree"
     fi
     # Branch is the primary ref; detached HEAD promotes the short SHA with
@@ -1519,10 +1561,11 @@ EOF
     fi
     _pane_inline="$(pane_inline_label_for "$pane_intended")"
     pane_presentations="${pane_presentations}${pane_presentations:+
-}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_current_repo}${FIELD_SEPARATOR}${_current_worktree}${FIELD_SEPARATOR}${_current_branch}${FIELD_SEPARATOR}${_current_location_status}${FIELD_SEPARATOR}${_current_git_ref}${FIELD_SEPARATOR}${_current_pane_inline}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_pane_inline}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_segment_prefix}"
+}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_pane_inline}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_segment_prefix}"
   done <<EOF
 $pane_intents
 EOF
+  pane_presentations="$(printf '%s\n' "$pane_presentations" | filter_records_of_width 23)"
 
   # A complete snapshot authoritatively deletes evidence for panes that no
   # longer exist. No label policy or applied-label copy is retained.
@@ -1539,13 +1582,19 @@ EOF
     [ "$found" -eq 1 ] || rm -f "$state_file" 2>/dev/null || true
   done
 
-  tab_intents="$(compose_tab_intents "$snapshot" "$pane_presentations")"
+  tab_intents="$(compose_tab_intents "$snapshot" "$pane_presentations" | filter_records_of_width 4)"
 
   # Herdr 0.8 has no rename compare-and-swap. A target can change after the
   # final get and briefly receive stale intent; the next pass repairs it.
   presentation_generation_valid "$pass" || return 2
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha location_status current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline git_ref pane_inline worktree_token segment_prefix; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha location_status git_ref pane_inline worktree_token segment_prefix; do
     [ -n "$id" ] || continue
+    # The published-token baseline this pane is diffed against lives in the
+    # keyed table, not in the record.
+    baseline_row="$(table_row_for "$id" "$pane_baselines")"
+    IFS="$FIELD_SEPARATOR" read -r current_repo current_worktree current_branch current_location_status current_git_ref current_pane_inline <<EOF
+$baseline_row
+EOF
     if [ -n "$slug" ] && [ "$current_task" != "$slug" ]; then
       presentation_generation_valid "$pass" || return 2
       final_payload="$(herdr pane get "$id" 2>/dev/null)" || continue

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1153,6 +1153,15 @@ if [ -d "$fixture" ]; then
   if [ -f "$fixture/block" ]; then
     while [ ! -f "$fixture/release" ]; do sleep 0.01; done
   fi
+  # block.short stalls only the second (--short=7) probe of a detached-HEAD
+  # resolve, so the first probe of the same fixture still answers in budget.
+  case "$command_args" in
+    *"--short=7"*)
+      if [ -f "$fixture/block.short" ]; then
+        while [ ! -f "$fixture/release" ]; do sleep 0.01; done
+      fi
+      ;;
+  esac
   : > "$fixture/completed"
   cat "$fixture/stderr" >&2
   out="$fixture/stdout"
@@ -3143,6 +3152,39 @@ EOF
   done
 }
 
+@test "herdr-task-sync location detached sha budget failure with no prior state renders no git location and self-heals" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git"
+  local detached="$root/detached" fixture state
+  mkdir -p "$detached" "$common" "$root/.git"
+  # given: real-git probe shape — the first call answers 3 lines in budget,
+  # and block.short stalls the second --short=7 call past LOCATION_GIT_BUDGET.
+  hts_git_fixture "$detached" "$(printf '%s\n%s\n%s' "$root" "$common" HEAD)"
+  fixture="$(hts_git_fixture_dir "$detached")"
+  printf 'e4f5a6b\n' > "$fixture/stdout.short"
+  : > "$fixture/block.short"
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$detached")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repo"}'
+  hts_set_process_label pane-1 worker
+  # when: the very first pass for this pane — no prior location state exists
+  HERDR_TASK_SYNC_GIT_BUDGET=0.075 hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  # then: the SHA probe fired, its budget failure discarded the freshly
+  # resolved root, and with nothing prior to retain the pane renders with no
+  # git location this pass — no half-built commit ref, no stale marker.
+  assert_equal "$(grep -c -- '--short=7' "$fixture/calls")" 1
+  run jq -e '.panes[0].tokens | (.repo == null and .worktree == null and .branch == null and .location_status == null and .git_ref == null)' "$state"
+  assert_success
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" worker
+  # when: the next sweep finds a responsive SHA probe
+  : > "$fixture/release"
+  hts_location_pass
+  # then: the pane self-heals to the commit ref without manual repair
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "$HTS_ICON_COMMIT e4f5a6b"
+}
+
 @test "herdr-task-sync location clears the retired location_label token on both publish and non-git clear paths" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
@@ -3446,6 +3488,85 @@ EOF
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_BRANCH main · task"
 }
 
+@test "herdr-task-sync formatter renders a worktree whose folder equals its branch as icon plus ref in sidebar and tab" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # Scenario matrix #2 (same plan doc): linked worktree in a folder named
+  # exactly like its branch. The worktree icon alone carries the place; a
+  # folder qualifier would only repeat the ref, so neither surface shows one.
+  local root="$HTS_WORK/feature" common="$HTS_WORK/repository/.git" state
+  mkdir -p "$root" "$common"
+  hts_mark_linked_worktree "$root" "$common/worktrees/feature"
+  hts_git_location_fixture "$root" "$root" "$common" refs/heads/feature
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"my-mac-setup"}'
+  hts_set_process_label pane-1 task
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE feature"
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_WORKTREE feature · task"
+}
+
+@test "herdr-task-sync formatter keeps the folder qualifier on a main checkout in a differently-named folder" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # Plan decision 5 describes the typical main checkout, whose folder repeats
+  # the branch or the workspace name. When the folder differs from BOTH it is
+  # real location information, so the sidebar qualifier stays — the same
+  # suppression rule as every other checkout, no main-checkout special case.
+  local root="$HTS_WORK/setup-copy" state
+  mkdir -p "$root/.git"
+  hts_git_location_fixture "$root" "$root" "$root/.git" refs/heads/main
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"my-mac-setup"}'
+  hts_set_process_label pane-1 task
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH main $HTS_ICON_FOLDER setup-copy"
+  # The tab segment stays compact: icon + ref only, folder in the sidebar.
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_BRANCH main · task"
+}
+
+@test "herdr-task-sync formatter reads the workspace display name from the legacy name field when label is absent" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # Older snapshot shapes carry the workspace display name as `name`; the
+  # (.label // .name // "") read must still suppress the folder qualifier when
+  # the worktree token merely repeats that name.
+  local root="$HTS_WORK/legacy-ws" state
+  mkdir -p "$root/.git"
+  hts_git_location_fixture "$root" "$root" "$root/.git" refs/heads/topic
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","name":"legacy-ws"}'
+  hts_set_process_label pane-1 task
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
+}
+
+@test "herdr-task-sync formatter gives a detached HEAD inside a linked worktree the commit icon" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # The commit place deliberately wins over the worktree place: the detached
+  # short SHA locates the pane more precisely than worktree-ness does, and the
+  # folder qualifier still names the linked worktree in the sidebar.
+  local root="$HTS_WORK/wt-detached" common="$HTS_WORK/repository/.git" state
+  mkdir -p "$root" "$common"
+  hts_mark_linked_worktree "$root" "$common/worktrees/wt-detached"
+  hts_git_location_fixture "$root" "$root" "$common" HEAD a1b2c3d
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repository"}'
+  hts_set_process_label pane-1 task
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_COMMIT a1b2c3d $HTS_ICON_FOLDER wt-detached"
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_COMMIT a1b2c3d · task"
+}
+
 @test "herdr-task-sync formatter qualifies a divergent worktree folder in the sidebar only and hoists the shared ref once" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
@@ -3500,6 +3621,30 @@ EOF
   hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-2 tab-1 "$outside")"
   hts_location_pass
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_BRANCH dev first · second"
+}
+
+@test "herdr-task-sync formatter repo-qualifies every segment when three panes span two repositories" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # The two-pane tab has its own composer; three or more panes walk the
+  # per-segment loop instead, where first_repo/multiple_repos tracking must
+  # still notice the second repository and repo-qualify every segment —
+  # including the two that share repository a.
+  local root_a="$HTS_WORK/a" root_b="$HTS_WORK/b" state
+  mkdir -p "$root_a/.git" "$root_b/.git"
+  hts_git_location_fixture "$root_a" "$root_a" "$root_a/.git" refs/heads/dev
+  hts_git_location_fixture "$root_b" "$root_b" "$root_b/.git" refs/heads/main
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root_a")"
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-2 tab-1 "$root_a")"
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-3 tab-1 "$root_b")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_process_label pane-1 one
+  hts_set_process_label pane-2 two
+  hts_set_process_label pane-3 three
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" \
+    "a $HTS_ICON_BRANCH dev one · a $HTS_ICON_BRANCH dev two · b $HTS_ICON_BRANCH main three"
 }
 
 @test "herdr-task-sync worktree tokens use shortest unique slash suffixes for basename collisions" {
@@ -3599,6 +3744,23 @@ EOF
     --arg two "$HTS_ICON_WORKTREE stuvwxyzabcdefghi" \
     '.tabs[0].label | capture("^" + $one + " (?<one>.+) · " + $two + " (?<two>.+)$") | (.one | length) >= 8 and (.two | length) >= 8' "$state"
   assert_success
+}
+
+@test "herdr-task-sync width math counts codepoints even when the daemon inherits a non-UTF-8 locale" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  local state label expected
+  hts_two_pane_mixed_worktrees abcdefghijklmnopqr stuvwxyzabcdefghi
+  # when: the whole pass runs under LC_ALL=C, the locale a hook spawned from a
+  # non-UTF-8 environment hands the daemon
+  LC_ALL=C HERDR_TASK_SYNC_LABEL_COLUMNS=80 hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  label="$(jq -r '.tabs[0].label' "$state")"
+  # then: byte-identical to the UTF-8 run — the pinned TEXT_LOCALE charged
+  # each three-byte codicon one column, so the budget still hands each pane
+  # text 18 columns instead of the shrunken byte-counted share.
+  expected="$HTS_ICON_WORKTREE abcdefghijklmnopqr first-process-nam… · $HTS_ICON_WORKTREE stuvwxyzabcdefghi second-process-na…"
+  assert_equal "$label" "$expected"
 }
 
 @test "herdr-task-sync two-pane mixed formatter caps long branch refs in tab prefixes while the sidebar keeps the full ref" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -3066,7 +3066,9 @@ EOF
   hts_set_pane_location "$HTS_DEFAULT_SOCKET" pane-1 "$nongit" "$nongit"
   HERDR_TASK_SYNC_TEST_NOW_SEQ=0 hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  assert_equal "$(jq -c '.panes[0].tokens' "$state")" '{"task":"kept-task","pane_inline":"· worker"}'
+  # pane_inline is deferred by the plan and never published; the non-Git arm
+  # clears any stale copy, so only the task token survives.
+  assert_equal "$(jq -c '.panes[0].tokens' "$state")" '{"task":"kept-task"}'
   [[ "$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)" -gt "$second_seq" ]]
 }
 
@@ -3343,7 +3345,7 @@ EOF
   hts_git_fixture "$outside" "" 1 ready 'fatal: not a git repository'
   hts_git_fixture "$unavailable" unavailable 127
   pane_one="$(hts_process_pane_json pane-1 tab-1 "$missing_one")"
-  pane_one="$(jq -c '.tokens = {repo:"live-repo",worktree:"live-token",branch:"topic-one"}' <<< "$pane_one")"
+  pane_one="$(jq -c '.tokens = {repo:"live-repo",worktree:"live-token",branch:"topic-one",pane_inline:"· one"}' <<< "$pane_one")"
   pane_two="$(hts_process_pane_json pane-2 tab-1 "$unavailable")"
   pane_two="$(jq -c '.tokens = {repo:"live-repo",worktree:"live-token",location_status:"current"}' <<< "$pane_two")"
   hts_set_pane "$HTS_DEFAULT_SOCKET" "$pane_one"
@@ -3365,8 +3367,8 @@ EOF
   run jq -e \
     --arg ref_one "$HTS_ICON_BRANCH topic-one $HTS_ICON_FOLDER live-token $HTS_ICON_STALE" \
     --arg ref_two "$HTS_ICON_FOLDER live-token $HTS_ICON_STALE" '
-    (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one,pane_inline:"· one"})
-    and (.panes[] | select(.pane_id == "pane-2") | .tokens == {repo:"live-repo",worktree:"live-token",location_status:"stale",git_ref:$ref_two,pane_inline:"· two"})
+    (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one})
+    and (.panes[] | select(.pane_id == "pane-2") | .tokens == {repo:"live-repo",worktree:"live-token",location_status:"stale",git_ref:$ref_two})
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_BRANCH topic-one $HTS_ICON_STALE one · $HTS_ICON_FOLDER live-token $HTS_ICON_STALE two · three"
@@ -3707,7 +3709,8 @@ EOF
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "$HTS_ICON_WORKTREE plain · plain-task"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE plain $HTS_ICON_FOLDER plain-worktree"
-  assert_equal "$(jq -r '.panes[0].tokens.pane_inline' "$state")" "· plain-task"
+  # pane_inline stays deferred per the label-system plan: no pass publishes it.
+  assert_equal "$(jq -r '.panes[0].tokens.pane_inline // ""' "$state")" ""
 }
 
 @test "herdr-task-sync plugin exposes only the approved pane and tab invalidations" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -2663,6 +2663,26 @@ SH
   assert_failure
 }
 
+@test "herdr-task-sync presentation drops a malformed-width record and keeps labeling the rest" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # A FIELD_SEPARATOR smuggled into a pane field would shift every later
+  # positional field and surface as a wrong label. The width guard must drop
+  # only that pane's record; the other pane and the tab still get labeled.
+  hts_set_pane "$HTS_DEFAULT_SOCKET" '{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","terminal_id":"term-1","agent":null,"label":"bad\u001flabel","tokens":{}}'
+  hts_set_pane "$HTS_DEFAULT_SOCKET" '{"pane_id":"pane-2","tab_id":"tab-1","workspace_id":"ws-1","terminal_id":"term-1","agent":null,"label":"old","tokens":{}}'
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":"old-tab"}'
+  hts_proc_info pane-2 '{"result":{"process_info":{"shell_pid":100,"foreground_process_group_id":200,"foreground_processes":[{"pid":200,"name":"btop","argv0":"btop","argv":["btop"]}]}}}'
+  hts_event_run
+  hts_wait_for_presentation_quiescence "$HTS_DEFAULT_SOCKET"
+  local state
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .label' "$state")" btop
+  run grep '^pane rename pane-1' "$HTS_LOG"
+  assert_failure
+  assert_file_contains "$HTS_LOG" '^tab rename tab-1 btop$'
+}
+
 @test "herdr-task-sync presentation skips pre-read deletion and repairs the post-read race next pass" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -240,3 +240,11 @@ render_with_source() {
 
   [[ -z "$conflicts" ]] || fail "listed in .chezmoiremove but still in the source tree:"$'\n'"$conflicts"
 }
+
+@test ".chezmoiremove deletes the retired opencode forced theme" {
+  # smoke.bats asserts the live file is gone; this entry is what makes
+  # `chezmoi apply` delete it on machines that deployed the old theme.
+  run grep -qx '.config/opencode/themes/flexoki-light-forced.json' \
+    "$SOURCE_ROOT/.chezmoiremove"
+  assert_success
+}


### PR DESCRIPTION
## Summary

Closes the six open `docs/issues/` findings left by the herdr label-system review cycle: the pane metadata bus is narrower and guarded, the dead `pane_inline` token is gone, the coverage gaps in the label test suite are filled, the safe deferred-simplify findings are applied, the retired opencode forced theme is now deleted declaratively, and the pre-label-system hardening issue is closed by audit. Each issue was fixed on its own branch and the six branches are merged here; every issue file carries a `## Resolution` and is set to `status: done`.

## What each issue got

- **`2026-08-20-008` record bus** — the six `current_*` baseline fields moved out of the positional `FIELD_SEPARATOR` records into one keyed `pane_baselines` table, and every record stream now passes through `filter_records_of_width`, which drops (and logs) a wrong-width record instead of consuming it shifted. A malformed record can no longer silently mislabel a pane.
- **`2026-08-20-005` pane_inline** — the plan defers the token and nothing rendered it; direction A from the issue: the formatter, all record slots, and both change-detection arms are removed. Location publishes carry a transitional `--clear-token pane_inline` so already-labelled panes shed the stale token; it can be dropped a release later.
- **`2026-08-20-007` test gaps** — seven new bats tests cover the untested paths (legacy `name` workspace fallback, three panes across two repos, detached HEAD in a linked worktree, SHA-probe budget failure with no prior state, scenario-matrix row 2, the folder-qualifier rule, non-UTF-8 locale). The engine now pins `TEXT_LOCALE` to a UTF-8 locale for its width math, so a C-locale daemon no longer cuts labels mid-codepoint. Plan decision 5 was reworded to match the implemented folder-qualifier rule.
- **`2026-08-20-011` deferred simplify** — items 2, 4, 5, 6 applied (`list_contains_line` cleanup sweep, counter renames, a shared `track_first_value` helper, `git_ref_segment_for`). The two quadratic-scan items were measured and declined: 109 ms per `compose_tab_intents` call at 5 tabs × 20 panes and 48–384 ms per `build_worktree_tokens` call at 10 roots, against a 5 s sweep interval; the numbers are recorded in the issue.
- **`2026-08-20-001` opencode theme leftover** — `home/.chezmoiremove` now deletes `.config/opencode/themes/flexoki-light-forced.json` on apply; a template test locks the entry. No other retired theme lingers.
- **`2026-08-18-025` harden task-sync** — closed by audit: every scope bullet was already shipped by the label-system merge, and the manual-ownership/reclaim scope was superseded by the plan's R7–R9 decisions. The issue's Resolution maps each bullet to the code that satisfies it.

## Merge notes

Branches 005, 008, and 011 all rewrite the record plumbing in `home/dot_local/bin/executable_herdr-task-sync`, so their merges were resolved by hand. The combined result is 008's narrow records minus 005's removed token: `pane_rows` 15 fields, `pane_intents` 19, `pane_presentations` 22, `pane_baselines` 1+5. Every producer/consumer pair was re-verified positionally after resolution, and the full suite passed at the riskiest intermediate state (after 005+008) as well as at the final merge.

## Verification

- `bats tests/scripts.bats` — 196/197. The one red, `Pi terminal theme uses only terminal palette colors`, is red on clean main and tracked in `docs/issues/2026-08-20-003-pi-terminal-theme-hex-vars-red-test.md`.
- `bats tests/smoke.bats` — 106/107. The one red asserts the live leftover theme file is absent; this PR's `.chezmoiremove` entry removes the file on the next `chezmoi apply`, which turns the test green.
- `make lint` — clean.
