### PR TITLE
ci: cancel superseded workflow runs per ref and event type

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# A newer commit on the same ref makes the running check obsolete, so cancel it
+# and free the macOS runner slot for the verdict someone will actually read.
+# `main` is included deliberately: it carries no branch protection, so a
+# cancelled run blocks no required check. The group carries `event_name`
+# because a scheduled run executes on `refs/heads/main` too — without it, a
+# morning push would silently cancel the nightly run, which sends no failure
+# notification when cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CHEZMOI_NAME: "Test User"
   CHEZMOI_EMAIL: "test@example.com"


### PR DESCRIPTION
## Summary

A CI run no longer keeps going after a newer commit supersedes it. On 2026-08-20, 5 of 16 runs on `main` were still in flight when the next push arrived, so the newest commit's verdict queued behind a run nobody would read and macOS runner slots stayed held. `.github/workflows/test-dotfiles.yml` gains a top-level `concurrency` block; nothing else in the workflow changed. The added comment explains why the group key carries the event name and why `main` runs are cancelled too.

This is the first unit of `docs/plans/2026-08-20-2217-chore-ci-workflow-hygiene-plan.md`, and the first of four CI plans whose landing order that plan settles. Its second unit — an `actions/cache` step for the Homebrew download directories — is deliberately not here. It lands last, after the CI-minimal-brew-install and Docker-baked-Brewfile plans cut most of the download volume the cache exists to hold; the plan states "Do not land U1 and U2 together."

Session-settled decisions carried from planning: cancel `main` runs rather than exempt them (user-approved); defer the Homebrew download cache behind the two sibling plans rather than delete it (user-approved, over dropping it once the Actions-minutes premise proved void on a public repository).

### Verification

`make lint` is clean and the workflow parses, with `concurrency` resolving to `cancel-in-progress: true` and the intended group. The comment's load-bearing claim was checked live: `gh api repos/Seigiard/my-mac-setup/branches/main/protection` returns 404 and `gh api repos/Seigiard/my-mac-setup/rulesets` returns `[]`, so a cancelled run blocks no required check.

Cancellation itself is not verified — it can only be observed on live runs. It needs two quick pushes to this PR, then two quick pushes to `main`, each checked with `gh run list` for the first run showing `cancelled`. The event-name split cannot be exercised at all until a `schedule` trigger exists; the plan records that as a hand-off to the CI-minimal-brew-install plan.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
