### PR TITLE
fix(brewfiles): deploy an empty Brewfile.macos instead of none, and move Docker to ubuntu:24.04

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,4 +1,9 @@
-FROM ubuntu:22.04
+# 24.04 rather than 22.04 for git: the deployed .gitconfig sets
+# merge.conflictStyle = zdiff3, which needs git 2.35 or newer. 22.04 ships
+# 2.34.1 and aborts the apply's Oh My Zsh clone with "unknown style 'zdiff3'"
+# unless a newer git comes from Homebrew — which is why `git` had to stay in the
+# CI-minimal Brewfile set. 24.04 ships 2.43.0 and accepts it.
+FROM ubuntu:24.04
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
@@ -11,7 +11,7 @@
 # here, since every environment that toggles the guard re-inits from scratch.
 # # {{ include "private_dot_config/brewfiles/Brewfile.tmpl" | sha256sum }}
 # # {{ if eq .chezmoi.os "darwin" }}
-# # {{ include "private_dot_config/brewfiles/Brewfile.macos.tmpl" | sha256sum }}
+# # {{ include "private_dot_config/brewfiles/empty_Brewfile.macos.tmpl" | sha256sum }}
 # # {{ end }}
 
 set -e

--- a/home/private_dot_config/brewfiles/empty_Brewfile.macos.tmpl
+++ b/home/private_dot_config/brewfiles/empty_Brewfile.macos.tmpl
@@ -2,7 +2,7 @@
 {{- /*                                                                                                */ -}}
 {{- /* The guard covers the whole file: no test in tests/ references any cask                         */ -}}
 {{- /* here, nor elio, rgrc, terminal-notifier or linear. On push/PR CI this                          */ -}}
-{{- /* renders empty, which `brew bundle` accepts. The casks are 291 s of the                         */ -}}
+{{- /* renders to zero bytes; see the note below. The casks are 291 s of the                         */ -}}
 {{- /* 400 s macOS apply step, so this file is where nearly all of the saving is.                     */ -}}
 {{- /*                                                                                                */ -}}
 {{- /* Guarding the 1password-cli cask has a second effect worth knowing: it                          */ -}}
@@ -11,6 +11,15 @@
 {{- /*                                                                                                */ -}}
 {{- /* See Brewfile.tmpl for why the flag is read with `get` rather than as                           */ -}}
 {{- /* `.ci_minimal`, and for why every comment here is a template comment.                           */ -}}
+{{- /*                                                                                                */ -}}
+{{- /* The `empty_` prefix on this file's name is load-bearing, not decoration.                       */ -}}
+{{- /* chezmoi deletes a file whose template renders to nothing unless the source                     */ -}}
+{{- /* name carries that attribute, and the minimal render here is exactly zero                       */ -}}
+{{- /* bytes. `brew bundle` is perfectly happy with an empty file — the problem                       */ -}}
+{{- /* is that without the attribute there is no file at all, so the apply dies                       */ -}}
+{{- /* on the next line of run_onchange_after_1 with "No Brewfile found".                             */ -}}
+{{- /* chezmoi strips the attribute from the target path, so the deployed name                        */ -}}
+{{- /* stays ~/.config/brewfiles/Brewfile.macos.                                                      */ -}}
 {{- $full := not (get . "ci_minimal") -}}
 {{ if $full -}}
 # macOS-specific packages

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -326,7 +326,7 @@ render_with_source() {
 # ===========================================
 # CI-minimal Brewfile render guard
 # private_dot_config/brewfiles/Brewfile.tmpl
-# private_dot_config/brewfiles/Brewfile.macos.tmpl
+# private_dot_config/brewfiles/empty_Brewfile.macos.tmpl
 #
 # The guard is driven by the chezmoi data key `ci_minimal`, which
 # .chezmoi.yaml.tmpl reads from the MMS_CI_MINIMAL environment variable. It
@@ -338,7 +338,7 @@ render_with_source() {
 # ===========================================
 
 BREWFILE_TMPL="private_dot_config/brewfiles/Brewfile.tmpl"
-BREWFILE_MACOS_TMPL="private_dot_config/brewfiles/Brewfile.macos.tmpl"
+BREWFILE_MACOS_TMPL="private_dot_config/brewfiles/empty_Brewfile.macos.tmpl"
 
 # The entries the suite actually needs from the brew prefix: jq directly, grc
 # for the python3 that gates all of palette.bats, node for the sqlite3 that
@@ -500,7 +500,7 @@ assert_minimal_brewfile() {
 
   run grep -F 'include "private_dot_config/brewfiles/Brewfile.tmpl"' "$script"
   assert_success
-  run grep -F 'include "private_dot_config/brewfiles/Brewfile.macos.tmpl"' "$script"
+  run grep -F 'include "private_dot_config/brewfiles/empty_Brewfile.macos.tmpl"' "$script"
   assert_success
 
   # The deployed paths in the same file must NOT gain the suffix.
@@ -528,4 +528,37 @@ assert_minimal_brewfile() {
     assert_success
     assert_output --regexp '^[0-9a-f]{64}$'
   done <<< "$paths"
+}
+
+@test "the minimal render deploys Brewfile.macos empty rather than not at all" {
+  # This is the gap that let a green suite ship a broken apply. Every other test
+  # in this section checks what `chezmoi execute-template` prints, and for the
+  # minimal macOS render that is correctly nothing. What rendering cannot show is
+  # that chezmoi *deletes* a file whose template renders to zero bytes, unless the
+  # source name carries the `empty_` attribute. Without it the deployed
+  # ~/.config/brewfiles/Brewfile.macos never appeared, and the apply died on the
+  # next line of run_onchange_after_1 with "No Brewfile found" — on macOS only,
+  # because Brewfile.macos is brew-bundled solely under darwin.
+  #
+  # So this one applies for real. It is safe and stays within the repo's rule
+  # against applying on a host: the apply is scoped to .config/brewfiles, which
+  # contains no run_ scripts, and --destination points at a throwaway directory,
+  # so $HOME is never a target.
+  local cfg="$BATS_TEST_TMPDIR/deploy.yaml"
+  local dest="$BATS_TEST_TMPDIR/dest"
+  MMS_CI_MINIMAL=1 write_test_config "$cfg"
+  # chezmoi does not create ancestor directories for a scoped apply.
+  mkdir -p "$dest/.config"
+
+  run env PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" apply \
+    --source "$SOURCE_ROOT" --destination "$dest" --config "$cfg" \
+    "$dest/.config/brewfiles"
+  assert_success
+
+  assert_file_exists "$dest/.config/brewfiles/Brewfile"
+  assert_file_exists "$dest/.config/brewfiles/Brewfile.macos"
+  # Empty is the intended state — the entries are guarded out, the file remains.
+  [[ ! -s "$dest/.config/brewfiles/Brewfile.macos" ]] \
+    || fail "Brewfile.macos should be empty in minimal mode"
+  assert_file_contains "$dest/.config/brewfiles/Brewfile" '^brew "jq"'
 }


### PR DESCRIPTION
## Summary

Fixes the macOS apply failure on `main`. The CI-minimal guard blanks the whole of `Brewfile.macos`, so its template renders to zero bytes — and chezmoi **deletes** a file that renders to nothing unless the source name carries the `empty_` attribute. The deployed `~/.config/brewfiles/Brewfile.macos` never appeared, and the install script then ran `brew bundle` against a path with no file behind it.

```
--- Installing macOS packages ---
##[error]No Brewfile found
chezmoi: .chezmoiscripts/1-install-packages.sh: exit status 1
```

Only macOS was affected: `Brewfile.macos` is brew-bundled solely under `eq .chezmoi.os "darwin"`, so Linux never reads it and its apply passed. `brew bundle` is perfectly happy with an *empty* Brewfile — it was the *missing* file that broke it.

Also moves the Docker test image to `ubuntu:24.04`, which removes the reason `git` is in the minimal set. That removal is deliberately **not** done here; see below.

## Why rendering tests could not catch this

Every existing test in that section asserts on what `chezmoi execute-template` prints, and for the minimal macOS render that output is correctly nothing. The deletion happens later, at deploy time, where no test looked.

Proven in an isolated sandbox — same template content, two source names:

| Source name | Renders to | Deployed |
|---|---|---|
| `plain.tmpl` | 0 bytes | **absent** |
| `empty_kept.tmpl` | 0 bytes | present, 0 bytes |

The new test closes that gap by applying for real. It is scoped to `.config/brewfiles`, which contains no `run_` scripts, and points `--destination` at a throwaway directory, so no host path is ever a target — it stays inside the repo's rule against applying on a host. Verified by mutation: dropping the attribute reddens it on the missing file, restoring it turns it green.

The attribute is stripped from the target path, so the deployed name is unchanged, `chezmoi managed` still lists `.config/brewfiles/Brewfile.macos`, and the full render is byte-identical to what `main` deploys today.

## The image bump, and what it deliberately leaves alone

`ubuntu:22.04` ships git 2.34.1, which rejects `merge.conflictStyle = zdiff3` — the setting `home/dot_gitconfig.tmpl` deploys. That is what killed the first parity run at 57 seconds, and why `git` had to be folded back into the minimal set: Homebrew's newer git was the only thing satisfying that config inside the image. `ubuntu:24.04` ships **2.43.0** and accepts it.

`git` still stays in the minimal set in this PR. Removing it is a separate change with its own proof, and landing both at once would make any failure unattributable. It is worth doing next — see the measurements below.

Verified on the rebuilt image: `os 24.04.4`, `apt git 2.43.0`, brew/bats/fzf/bun all still resolve, and the full-render suite reports **the same 15 skips** and the same single pre-existing Docker-harness failure (`docs/issues/2026-08-19-001`) as on 22.04.

Two 24.04 differences worth knowing: the base image ships a stock user at uid 1000, so `testuser` lands on 1001 — nothing in the suite depends on the value. And `python3` is still absent, so `grc` remains the image's only python3 supplier and `docs/issues/2026-08-21-010` is unaffected by this bump.

## Measured: the speed target is currently missed

The first real minimal-install run (`048e33f`, the push whose diff touched no Brewfile, so the override correctly did not fire) gives the number the original change could not measure — its own run installed the full set by design.

| Job | Baseline | Now | Cut | Target | |
|---|---|---|---|---|---|
| `test-ubuntu` | 177.9 s | **53.5 s** | 69.9% | ≤ 35.6 s | **missed** |
| `test-macos` | 383.8 s | 27.8 s* | — | ≤ 76.8 s | unproven |

\* cross-platform file only; the run died entering the macOS bundle, which is the bug this PR fixes.

Where the 53.5 s goes on Ubuntu:

| | |
|---|---|
| `grc` + `bun` | 18.4 s |
| `git` | 15.1 s |
| `node` | 7.9 s |
| `jq` | 1.1 s |
| index fetch + tap | ~10.9 s |

The two entries kept for indirect reasons are the whole overrun. `git` is 15.1 s paid in CI to satisfy one environment's old git — which this PR's image bump removes the need for. `grc` is 18.4 s for a package nothing calls, kept only because it drags in `python@3.14` (`docs/issues/2026-08-21-010`). Removing both would land around 20 s, comfortably under target.

## Verification

`bats tests/templates.bats` gives 39 ok, one new. `make lint` clean. Full-render Docker suite on the new image: 368 ok, 15 skipped, 1 pre-existing failure — skip count unchanged from 22.04, which is what proves the bump changed no coverage.
