### PR TITLE
fix: declare python3 as a requirement, drop git from the minimal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/).
 
+## Requirements
+
+Check that `python3` is on your `PATH` and reports at least **3.9**. It is the
+interpreter of the herdr command palette, and `chezmoi apply` shells out to it
+while it runs — this repo does not install it, so a machine without one is
+broken rather than merely missing a convenience.
+
+- **macOS** — `/usr/bin/python3` ships behind the Xcode Command Line Tools that
+  Homebrew already requires. It is 3.9.6, the oldest interpreter any supported
+  environment provides, which is where the 3.9 floor comes from.
+- **Linux** — Ubuntu and Debian ship `python3` in the base install.
+
 ## Quick Start (new machine)
 
 ### 1. Install Homebrew

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ broken rather than merely missing a convenience.
 - **macOS** — `/usr/bin/python3` ships behind the Xcode Command Line Tools that
   Homebrew already requires. It is 3.9.6, the oldest interpreter any supported
   environment provides, which is where the 3.9 floor comes from.
-- **Linux** — Ubuntu and Debian ship `python3` in the base install.
+- **Linux** — Ubuntu and Debian ship `python3` in a normal install. Minimal
+  container images often do not: this repo's own `docker/Dockerfile.ubuntu`
+  has to `apt-get install -y python3` for exactly that reason.
 
 ## Quick Start (new machine)
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -9,7 +9,11 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-# Install base dependencies for Linuxbrew
+# Install base dependencies for Linuxbrew, plus python3. python3 is not a
+# Linuxbrew dependency: it is the herdr command palette's interpreter, and the
+# apply itself shells out to it. The image would otherwise get an interpreter
+# only as a transitive dependency of `brew "grc"`, a package nothing calls and
+# docs/issues/2026-08-21-010 removes.
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -20,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     procps \
     file \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up locale

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,8 +1,11 @@
 # 24.04 rather than 22.04 for git: the deployed .gitconfig sets
 # merge.conflictStyle = zdiff3, which needs git 2.35 or newer. 22.04 ships
 # 2.34.1 and aborts the apply's Oh My Zsh clone with "unknown style 'zdiff3'"
-# unless a newer git comes from Homebrew — which is why `git` had to stay in the
-# CI-minimal Brewfile set. 24.04 ships 2.43.0 and accepts it.
+# before any test runs. 24.04 ships 2.43.0 and accepts it, which is what lets
+# the CI-minimal Brewfile set install no git of its own.
+#
+# Do not move this base image back. The failure names zdiff3, not git, and it
+# happens during the apply, so nothing points at the base image that caused it.
 FROM ubuntu:24.04
 
 # Avoid interactive prompts during package installation

--- a/docs/issues/2026-08-21-010-grc-is-vestigial-and-rgrc-was-never-moved-cross-platform.md
+++ b/docs/issues/2026-08-21-010-grc-is-vestigial-and-rgrc-was-never-moved-cross-platform.md
@@ -37,6 +37,10 @@ sudo, zsh, locales, ca-certificates, build-essential, procps, file. So `grc` is 
 the sole supplier of the `python3` that `tests/palette.bats` needs. That is why the
 CI-minimal set keeps it, and the Brewfile carries a comment saying so.
 
+That last paragraph describes the state that created this issue and is no longer current:
+step 1 of Scope has landed, so the image installs its own `python3` and the Brewfile comment
+no longer credits `grc` with supplying it. `grc` is now held in the file by this issue alone.
+
 The cost is not theoretical: the timing measurement recorded in
 `docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md` puts `grc` at **21 s** of
 the Ubuntu install, against a minimal-set target of ≤ 35.6 s. A package nothing uses is
@@ -50,19 +54,39 @@ evidence of replacement: a named successor wired into the shell.
 
 ## Scope
 
-1. Put `python3` in the Docker image by an honest route — `apt-get install -y python3` in
-   `docker/Dockerfile.ubuntu`. It is a system tool, not a dotfile package. The CI runners
-   already ship `python3`, and the `test-ubuntu` job cannot reach Linuxbrew at all
-   (`docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md`), so this
-   is the only environment that needs the change.
+1. **Done.** `docker/Dockerfile.ubuntu` installs `python3` in its apt layer, landed by
+   `docs/plans/2026-08-21-0337-fix-python3-declared-dependency-plan.md` (R2/U1) rather than
+   by the Dockerfile plan named under Sequencing below. `python3` is also now a stated
+   system requirement in `README.md` with a 3.9 floor, and the bats suite asserts it instead
+   of skipping on it. Measured in the rebuilt image before any `chezmoi apply`:
+   `/usr/bin/python3` is **Python 3.12.3**, and the palette's own `--validate` exits 0 on it.
+   This step is the precondition for step 2 — do not remove `grc` from a checkout where it
+   is not present.
 2. Delete `brew "grc"` from `Brewfile.tmpl`, along with the comment explaining why it was
    kept and the `grc` assertions in `tests/templates.bats`.
 3. Decide `rgrc`'s home (below) and move it if the answer is cross-platform.
 
-**Ordering.** Step 1 must land before step 2, or `python3` disappears from the Docker image
-and 56 tests in `tests/palette.bats` start skipping silently — see
-`docs/issues/2026-08-21-009-python3-is-both-required-and-optional-in-the-test-suite.md`,
-which is the reason that failure would be confusing rather than obvious.
+**Ordering.** Step 1 must land before step 2. It now has — but verify that before removing
+`grc`, because the consequence changed rather than disappeared. The old failure mode was
+silent: `python3` vanished and 56 tests in `tests/palette.bats` skipped without saying why.
+That skip guard is gone (see
+`docs/issues/2026-08-21-009-python3-is-both-required-and-optional-in-the-test-suite.md`), so
+on a checkout without step 1 the same mistake now produces a named assertion failure naming
+`python3` and pointing at the `README.md` requirements section. Loud instead of silent, but
+still a broken image.
+
+**Which interpreter the palette ends up on.** Removing `grc` removes `python@3.14` from the
+image, so the palette drops from Homebrew's 3.14 to the apt interpreter that step 1
+installs. Measured on the current `ubuntu:24.04` base, that is **3.12.3**, which still ships
+`tomllib` in the standard library (stdlib since 3.11), so the palette keeps taking the
+`tomllib` branch at
+`home/private_dot_config/herdr/plugins/command-palette/palette.py:156-171` rather than its
+own fallback parser. An earlier reading of this — 3.10.6, taking the fallback — was measured
+against `ubuntu:22.04` and is stale: the base image moved to 24.04 in commit `f83e95d`.
+What remains true either way is that **no test observes which parser ran**. The only
+`tomllib` test forces the fallback by monkeypatching `builtins.__import__`, so an
+interpreter change here is silent, and a future base-image move to something older than 3.11
+would flip the branch with nothing reporting it.
 
 **Sequencing against the plans.** `docker/Dockerfile.ubuntu` is owned by
 `docs/plans/2026-08-20-2217-perf-docker-baked-brewfile-plan.md`, the next plan in the
@@ -80,6 +104,9 @@ change to what a host installs. Existing machines keep their installed `grc` eit
   placement is correct after all.
 - If `rgrc` does move, does it belong in the CI-minimal set? Almost certainly not — no test
   references it, and the shell init is guarded by `has rgrc`.
+- Should a test observe which TOML parser the palette actually used, rather than only that
+  the forced fallback works? Currently nothing does, so an interpreter change is invisible.
+  Tracked here because `grc`'s removal is the change that makes it matter.
 - Worth a broader inventory pass? The sweep that found this also showed several entries with
   no textual reference whose real consumer is yazi. A one-off audit could confirm each of
   those is genuinely reachable, but absence of a reference is weak evidence and the audit

--- a/docs/issues/2026-08-21-011-ci-minimal-docker-apply-has-no-automated-gate.md
+++ b/docs/issues/2026-08-21-011-ci-minimal-docker-apply-has-no-automated-gate.md
@@ -1,0 +1,70 @@
+---
+title: The CI-minimal Docker apply has no automated gate, so a base-image downgrade would break it silently
+type: follow-up
+date: 2026-08-21
+status: open
+parent-plan: docs/plans/2026-08-21-0337-fix-python3-declared-dependency-plan.md
+---
+
+## Why this exists
+
+`brew "git"` left the CI-minimal Brewfile render because the Docker test image moved to
+`ubuntu:24.04`, whose apt git is 2.43.0 and therefore accepts the
+`merge.conflictStyle = zdiff3` that `home/dot_gitconfig.tmpl:27` deploys. Ubuntu 22.04's
+apt git 2.34.1 rejects it and aborts the apply's Oh My Zsh clone before any test runs.
+
+That dependency is real but nothing enforces it. It is held up by two comments —
+`docker/Dockerfile.ubuntu:1-8` and the rationale block above `assert_minimal_brewfile()` in
+`tests/templates.bats` — and by one command a person has to remember to type:
+
+```
+MMS_CI_MINIMAL=1 docker compose -f docker/docker-compose.yml run --rm test-full
+```
+
+No job in `.github/workflows/test-dotfiles.yml` runs it. `make test-ubuntu` cannot
+substitute: it runs the `test-quick` service, which sets no `MMS_CI_MINIMAL`
+(`docker/docker-compose.yml:67` deliberately omits the entry — see
+`docs/issues/2026-08-20-014`), so its apply installs the full Brewfile including
+Homebrew's git and stays green.
+
+So a future change to `FROM ubuntu:24.04` breaks the minimal apply while every automated
+check keeps passing. When it does surface, the error names `zdiff3`, not `git`, and it
+happens mid-apply — nothing points at the base image that caused it.
+
+The template tests do not close this. `tests/templates.bats` inspects rendered lines; it
+cannot observe which git the image actually has.
+
+A second, narrower version of the same gap: nothing asserts the Docker image's apt layer
+still contains `python3`. `docker/Dockerfile.ubuntu` installing it is the load-bearing half
+of the `python3` work, and the only thing that would catch its removal is a post-apply
+assertion failing minutes later inside a built image, not the fast pre-apply gate.
+
+Raised by the independent cross-model adversarial pass and by the correctness reviewer
+during the code review of the plan named in `parent-plan`.
+
+## Scope
+
+1. Add a build-time assertion to `docker/Dockerfile.ubuntu` that the installed git is at
+   least 2.35, so a base-image downgrade fails at `make build-docker` naming the version,
+   rather than mid-apply naming `zdiff3`. Consider the same for `python3` presence.
+2. Decide whether the CI-minimal apply becomes an automated gate. The candidates:
+   - a scheduled or `workflow_dispatch` job that runs the `MMS_CI_MINIMAL=1 test-full`
+     command above, accepting that it needs Docker on the runner;
+   - or leaving it manual and accepting the comments as the only guard.
+   Note that `docs/issues/2026-08-21-003` established that the Actions-billing premise
+   behind some of this work was void, so cost is a live input to this decision rather than
+   an assumed blocker.
+3. Whatever is chosen, the skip-set parity check between the minimal and full renders is
+   currently done by hand and compared by eye. It matched at 13 skips each on
+   2026-08-21. Any future comparison must be taken against a post-change baseline, because
+   removing the `python3` skip guards removed up to 56 potential skips.
+
+## Open decisions
+
+- Is a Docker-building CI job worth its runtime, given that the thing it protects — the
+  minimal render — only runs on push and pull_request events where the runner already
+  supplies its own git? The failure this guards against is a developer running the Docker
+  suite locally, not a CI break.
+- Should the build-time git assertion live in the Dockerfile or in a bats test that runs
+  inside the image? The Dockerfile catches it earlier; a bats test keeps the assertion
+  beside the other tool-presence checks.

--- a/docs/issues/2026-08-21-012-python3-floor-is-stated-in-two-places-with-no-cross-check.md
+++ b/docs/issues/2026-08-21-012-python3-floor-is-stated-in-two-places-with-no-cross-check.md
@@ -1,0 +1,58 @@
+---
+title: The python3 version floor is stated in two places with nothing checking they agree
+type: follow-up
+date: 2026-08-21
+status: open
+parent-plan: docs/plans/2026-08-21-0337-fix-python3-declared-dependency-plan.md
+---
+
+## Why this exists
+
+The minimum supported `python3` version is written down twice:
+
+- `tests/helpers/common.bash` — `PYTHON3_MIN_VERSION="3.9"`, the value the test assertion
+  enforces.
+- `README.md`, the `## Requirements` section — the value a person setting up a machine
+  reads, and the one the assertion's own failure message points them at.
+
+Nothing checks the two agree. Bump one and the other goes stale silently: the suite would
+enforce a floor the documentation does not state, or the documentation would promise a
+floor the suite does not enforce. The failure message makes this worse than ordinary
+drift, because it directs the reader to `README.md` for the authoritative number while
+having tested a different one.
+
+The same shape already has precedent in this repo, solved the other way. The fzf floor is
+read from `palette.py`'s own `FZF_MIN_VERSION` by `tests/smoke.bats:527` specifically so
+the two cannot drift — the test comment says so outright. `python3` has no equivalent
+single source.
+
+A related, smaller gap: the "python3 is absent from PATH entirely" branch of
+`assert_python3_available` has no committed test. The below-floor and malformed-output
+branches are covered by `a python3 below the floor, or one answering with junk, is
+rejected` in `tests/palette.bats`, which stubs an interpreter on `PATH`. The absent case is
+harder to stub, because emptying `PATH` far enough to hide `python3` also breaks bats
+itself.
+
+Raised by the testing reviewer during the code review of the plan named in `parent-plan`.
+
+## Scope
+
+1. Pick one source of truth for the floor and derive the other from it. Options:
+   - keep the constant in `tests/helpers/common.bash` and add a test that greps `README.md`
+     for the same number — cheap, and it fails loudly on drift;
+   - or move the floor into a file both can read, mirroring how `FZF_MIN_VERSION` lives in
+     `palette.py` and is read by the test.
+2. Decide whether the absent-interpreter branch is worth a committed test, given the
+   stubbing difficulty. It is currently proven only by an ad-hoc harness run, not by
+   anything in the repo.
+
+## Open decisions
+
+- Is `README.md` the right home for a machine-readable constant at all? It is the file a
+  human reads, which is why the assertion points there. A grep-based test couples the test
+  suite to prose formatting, which is its own fragility — a heading rename or a reworded
+  sentence would break it for no real reason.
+- The floor is 3.9 because that is what macOS ships at `/usr/bin/python3` (3.9.6,
+  measured). If macOS ever ships newer, the floor could rise — but the decision of when to
+  raise it belongs with whoever checks that all four command-palette sources still compile
+  under the new floor, not with a drift check.

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -32,9 +32,8 @@ brew "starship"
 brew "grc"          # generic colouriser
 
 # Git tools
-{{/* git is kept, folded back after the minimal render failed the Docker suite: the deployed .gitconfig sets merge.conflictStyle = zdiff3, which needs git >= 2.35, and Ubuntu 22.04's apt git is 2.34.1 — the apply's Oh My Zsh clone aborts on it before any test runs */ -}}
-brew "git"
 {{ if $full -}}
+brew "git"
 brew "gh"
 brew "delta"
 brew "lazygit"

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -28,7 +28,7 @@ tap "oven-sh/bun", trusted: true
 brew "zsh"
 brew "starship"
 {{ end -}}
-{{/* grc is kept: it is the only source of python3 in the Docker image, and tests/palette.bats guards the whole file on python3 */ -}}
+{{/* grc is kept only until docs/issues/2026-08-21-010 removes it. It used to be the Docker image's only source of python3; docker/Dockerfile.ubuntu installs python3 itself now, and nothing in the repo calls grc */ -}}
 brew "grc"          # generic colouriser
 
 # Git tools

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -71,6 +71,44 @@ command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
+# python3 is a declared system requirement of this repository, not an optional
+# tool: it is the herdr command palette's interpreter and `chezmoi apply` shells
+# out to it. So the files that depend on it assert instead of skipping -- a
+# deliberate exception to the skip convention in
+# docs/issues/2026-08-20-013-se-blocks-test-hard-fails-without-deps.md.
+# The floor is what macOS ships at /usr/bin/python3, the oldest interpreter any
+# supported environment provides.
+PYTHON3_MIN_VERSION="3.9"
+
+# Each check returns explicitly: bats-support's fail() prints and returns 1, it
+# does not abort the function, so falling through would emit a second message
+# derived from the state the first one just reported as broken.
+assert_python3_available() {
+  local readme="the Requirements section of README.md"
+  local bin found major minor min_major min_minor
+
+  if ! command_exists python3; then
+    fail "python3 is not on PATH. It is the herdr command palette's interpreter and a declared requirement of this repository -- see $readme. Every supported OS ships one, so this repository does not install it."
+    return 1
+  fi
+
+  bin="$(command -v python3)"
+  found="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null)" || found=""
+  if [[ -z "$found" ]]; then
+    fail "python3 at $bin did not report a version, so it cannot be checked against the $PYTHON3_MIN_VERSION floor stated in $readme."
+    return 1
+  fi
+
+  major="${found%%.*}"
+  minor="${found#*.}"
+  min_major="${PYTHON3_MIN_VERSION%%.*}"
+  min_minor="${PYTHON3_MIN_VERSION#*.}"
+  if (( major < min_major || (major == min_major && minor < min_minor) )); then
+    fail "python3 at $bin is $found, older than the $PYTHON3_MIN_VERSION this repository requires -- see $readme. The palette's sources are kept compiling on $PYTHON3_MIN_VERSION because that is what macOS ships at /usr/bin/python3."
+    return 1
+  fi
+}
+
 get_os() {
   case "$(uname -s)" in
     Darwin) echo "darwin" ;;

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -94,8 +94,12 @@ assert_python3_available() {
 
   bin="$(command -v python3)"
   found="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null)" || found=""
-  if [[ -z "$found" ]]; then
-    fail "python3 at $bin did not report a version, so it cannot be checked against the $PYTHON3_MIN_VERSION floor stated in $readme."
+  # Validate the shape before any arithmetic. Anything else -- a wrapper that
+  # prints "3.8.1", a banner, whitespace, nothing at all -- would reach (( ))
+  # as a non-numeric token, and a (( )) syntax error returns non-zero, which
+  # reads as "not below the floor" and lets a bad interpreter through.
+  if [[ ! "$found" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    fail "python3 at $bin answered the version probe with '$found' instead of a major.minor number, so it cannot be checked against the $PYTHON3_MIN_VERSION floor stated in $readme. A wrapper or stub shadowing the real interpreter on PATH looks like this."
     return 1
   fi
 
@@ -103,7 +107,9 @@ assert_python3_available() {
   minor="${found#*.}"
   min_major="${PYTHON3_MIN_VERSION%%.*}"
   min_minor="${PYTHON3_MIN_VERSION#*.}"
-  if (( major < min_major || (major == min_major && minor < min_minor) )); then
+  # 10# forces base 10: the pattern above admits a leading zero, which bash
+  # would otherwise read as an invalid octal literal and error on.
+  if (( 10#$major < 10#$min_major || (10#$major == 10#$min_major && 10#$minor < 10#$min_minor) )); then
     fail "python3 at $bin is $found, older than the $PYTHON3_MIN_VERSION this repository requires -- see $readme. The palette's sources are kept compiling on $PYTHON3_MIN_VERSION because that is what macOS ships at /usr/bin/python3."
     return 1
   fi

--- a/tests/palette.bats
+++ b/tests/palette.bats
@@ -41,6 +41,42 @@ teardown() {
   assert_python3_available
 }
 
+# The gate has to reject, not fall through. Before the shape check in
+# assert_python3_available, a stub printing "3.8.1" made the minor component
+# "8.1", which is an arithmetic syntax error -- (( )) returned non-zero, the
+# too-old branch was skipped, and a Python 3.8 stub passed the 3.9 floor.
+# Stubbed on PATH the same way the missing-fzf test further down this file does.
+@test "a python3 below the floor, or one answering with junk, is rejected" {
+  local stub="$PALETTE_WORK/badpy" saved="$PATH"
+  mkdir -p "$stub"
+
+  # Well-formed but too old: the ordinary floor rejection.
+  printf '#!/bin/sh\necho "3.8"\nexit 0\n' > "$stub/python3"
+  chmod +x "$stub/python3"
+  PATH="$stub:$saved"
+  run assert_python3_available
+  PATH="$saved"
+  assert_failure
+  assert_output --partial "3.8"
+  assert_output --partial "3.9"
+
+  # Three components: the shape that used to pass.
+  printf '#!/bin/sh\necho "3.8.1"\nexit 0\n' > "$stub/python3"
+  PATH="$stub:$saved"
+  run assert_python3_available
+  PATH="$saved"
+  assert_failure
+  assert_output --partial "3.8.1"
+
+  # Not a version at all.
+  printf '#!/bin/sh\necho "Python 3.9.6 (stub)"\nexit 0\n' > "$stub/python3"
+  PATH="$stub:$saved"
+  run assert_python3_available
+  PATH="$saved"
+  assert_failure
+  assert_output --partial "python3"
+}
+
 # ===========================================
 # U1 -- the source-tree seam itself
 # ===========================================

--- a/tests/palette.bats
+++ b/tests/palette.bats
@@ -12,7 +12,11 @@ PALETTE_DIR="$SOURCE_ROOT/private_dot_config/herdr/plugins/command-palette"
 REAL_COMMANDS="$SOURCE_ROOT/private_dot_config/herdr/command-palette/commands.toml"
 
 setup() {
-  command_exists python3 || skip "python3 not installed"
+  # No `command_exists python3 || skip` here. python3 is a declared requirement
+  # (README.md, Requirements), so its absence must fail rather than silence all
+  # 56 tests in this file from inside setup(). Deliberate exception to the skip
+  # convention in docs/issues/2026-08-20-013-se-blocks-test-hard-fails-without-deps.md;
+  # the first test below is what names the cause.
   export PALETTE_PY="$PALETTE_DIR/palette.py"
   export PALETTE_OPEN_PY="$PALETTE_DIR/open.py"
   export OPEN_IN_ZED_PY="$PALETTE_DIR/open_in_zed.py"
@@ -25,6 +29,16 @@ setup() {
 
 teardown() {
   [[ -n "${PALETTE_WORK:-}" ]] && rm -rf "$PALETTE_WORK" || true
+}
+
+# ===========================================
+# python3 -- the declared interpreter
+# ===========================================
+
+# First, so a missing or too-old interpreter states its own cause instead of
+# leaving a wall of identical `python3: command not found` failures below.
+@test "python3 is present and at least 3.9, the floor README.md declares" {
+  assert_python3_available
 }
 
 # ===========================================

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -14,6 +14,16 @@ teardown() {
 }
 
 # ===========================================
+# python3 -- the declared interpreter
+# ===========================================
+
+# First, so a missing or too-old interpreter states its own cause instead of
+# leaving the bare `python3` call sites below to fail without naming it.
+@test "python3 is present and at least 3.9, the floor README.md declares" {
+  assert_python3_available
+}
+
+# ===========================================
 # Repository linting
 # ===========================================
 
@@ -1786,7 +1796,9 @@ hts_wait_for_task_slug() {
 }
 
 @test "herdr-task-sync bounded Bats invocation exits after detached work" {
-  command -v python3 >/dev/null || skip "python3 not available"
+  # No python3 skip guard: it is a declared requirement (README.md,
+  # Requirements), a deliberate exception to the skip convention in
+  # docs/issues/2026-08-20-013-se-blocks-test-hard-fails-without-deps.md.
   local bats_bin release_file="$BATS_TEST_TMPDIR/release-herdr"
   local pid_file="$BATS_TEST_TMPDIR/descriptor-worker.pid"
   bats_bin="$(command -v bats)"

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -3,6 +3,17 @@
 load 'helpers/common'
 
 # ===========================================
+# python3 -- the declared interpreter
+# ===========================================
+
+# This file loses no skip guard, but it holds eight of the nine bare `run
+# python3` call sites, so a contributor running it alone still needs the cause
+# named rather than inferred from the failures.
+@test "python3 is present and at least 3.9, the floor README.md declares" {
+  assert_python3_available
+}
+
+# ===========================================
 # Chezmoi-managed files exist
 # ===========================================
 

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -408,6 +408,10 @@ assert_minimal_brewfile() {
   assert_line 'brew "ffmpeg"'
   assert_line 'brew "shellcheck"'
   assert_line 'brew "jq"'
+  # git is refuted in the minimal render, so it needs pinning here too, or
+  # deleting it from the template outright would satisfy every assertion in
+  # this file while real hosts silently stop getting it.
+  assert_line 'brew "git"'
 
   run render_with_config "$cfg" "$SOURCE_ROOT/$BREWFILE_MACOS_TMPL"
   assert_success
@@ -425,6 +429,7 @@ assert_minimal_brewfile() {
   run render_with_config "$cfg" "$SOURCE_ROOT/$BREWFILE_TMPL"
   assert_success
   assert_line 'brew "ffmpeg"'
+  assert_line 'brew "git"'
 
   run render_with_config "$cfg" "$SOURCE_ROOT/$BREWFILE_MACOS_TMPL"
   assert_success

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -340,13 +340,17 @@ render_with_source() {
 BREWFILE_TMPL="private_dot_config/brewfiles/Brewfile.tmpl"
 BREWFILE_MACOS_TMPL="private_dot_config/brewfiles/empty_Brewfile.macos.tmpl"
 
-# The entries the suite actually needs from the brew prefix: jq directly, grc
-# for the python3 that gates all of palette.bats, node for the sqlite3 that
-# gates seven tests, bun because the macOS job's setup-bun step runs after the
-# apply, and git because the deployed .gitconfig sets merge.conflictStyle =
-# zdiff3, which apt's git 2.34.1 rejects outright.
+# The entries the suite actually needs from the brew prefix: jq directly, node
+# for the sqlite3 that gates seven tests, bun because the macOS job's setup-bun
+# step runs after the apply, and git because the deployed .gitconfig sets
+# merge.conflictStyle = zdiff3, which apt's git 2.34.1 rejects outright.
 #
-# Every one of these is here because removing it broke something observable.
+# grc is the exception, asserted below only to pin the entry until
+# docs/issues/2026-08-21-010 removes it. It supplied the image's python3 until
+# docker/Dockerfile.ubuntu started installing python3 itself; nothing calls grc,
+# and no test needs it now.
+#
+# Every other entry is here because removing it broke something observable.
 # Anything added without that evidence is install time the CI runs pay for
 # nothing — the point of the guard is that this list stays honest.
 assert_minimal_brewfile() {

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -341,9 +341,15 @@ BREWFILE_TMPL="private_dot_config/brewfiles/Brewfile.tmpl"
 BREWFILE_MACOS_TMPL="private_dot_config/brewfiles/empty_Brewfile.macos.tmpl"
 
 # The entries the suite actually needs from the brew prefix: jq directly, node
-# for the sqlite3 that gates seven tests, bun because the macOS job's setup-bun
-# step runs after the apply, and git because the deployed .gitconfig sets
-# merge.conflictStyle = zdiff3, which apt's git 2.34.1 rejects outright.
+# for the sqlite3 that gates seven tests, and bun because the macOS job's
+# setup-bun step runs after the apply.
+#
+# git was on that list and is not any more. The deployed .gitconfig sets
+# merge.conflictStyle = zdiff3, which needs git >= 2.35, and Ubuntu 22.04's apt
+# git was 2.34.1 — so Homebrew's git was the only one that could read the config
+# inside the image. docker/Dockerfile.ubuntu now builds on 24.04, whose apt git
+# is 2.43.0, so the claim no longer holds. It is refuted below rather than left
+# unasserted, or a later fold-back passes silently.
 #
 # grc is the exception, asserted below only to pin the entry until
 # docs/issues/2026-08-21-010 removes it. It supplied the image's python3 until
@@ -356,11 +362,11 @@ BREWFILE_MACOS_TMPL="private_dot_config/brewfiles/empty_Brewfile.macos.tmpl"
 assert_minimal_brewfile() {
   assert_line 'tap "oven-sh/bun", trusted: true'
   assert_line --partial 'brew "grc"'
-  assert_line 'brew "git"'
   assert_line 'brew "node"'
   assert_line --partial 'brew "oven-sh/bun/bun"'
   assert_line 'brew "jq"'
 
+  refute_line 'brew "git"'
   refute_line 'brew "ffmpeg"'
   refute_line 'brew "poppler"'
   refute_line 'brew "imagemagick"'


### PR DESCRIPTION
## Summary

A machine without `python3` now says so, loudly and by name, instead of quietly running fewer tests. `python3` is the interpreter of the herdr command palette and `chezmoi apply` shells out to it, so its absence is a broken machine — but the repo never declared it anywhere, and the suite could not decide whether it was required.

`tests/palette.bats` skipped on a missing `python3` from inside `setup()`. bats runs `setup()` before every test, so that one line silenced all 56 tests in the file while nine other sites called `python3` bare and failed. A reader saw a handful of red tests and a quietly shortened suite, with nothing connecting the two.

The interpreter is now a stated system requirement with a measured 3.9 floor, the Docker test image installs it via apt instead of inheriting it by accident, and both skip guards are replaced by one shared assertion whose failure message names the interpreter, the version it found, and where the requirement is written down.

The same change drops `brew "git"` from the CI-minimal Homebrew set. That entry existed for exactly one reason, and the reason is gone.

## Why `git` was in the minimal set, and why it isn't now

The deployed `.gitconfig` sets `merge.conflictStyle = zdiff3`, which needs git 2.35 or newer. The Docker test image ran Ubuntu 22.04, whose apt git is 2.34.1 — it rejects the setting and aborts the apply's Oh My Zsh clone before any test runs. Homebrew's git was the only one in that image that could read the config, so `git` was folded back into the minimal set to keep the suite alive.

The image moved to `ubuntu:24.04` in `f83e95d`. Its apt git is 2.43.0 and accepts the setting, so a push or pull-request CI run no longer pays to install a git it already has. Both GitHub runner images also ship a current git.

Verified on the rebuilt image rather than assumed: the minimal apply installs `grc`, `node` and `jq` only — no git — and the Oh My Zsh clone completes against the `zdiff3` config that used to abort it.

## Do not read this as the speed target being met

| | Baseline | Measured | After removing `git` | Target |
|---|---|---|---|---|
| `test-ubuntu` install | 177.9 s | 53.5 s | ~38.4 s | ≤ 35.6 s |

`git` accounted for 15.1 s of the 53.5 s. Removing it lands around 38.4 s — a real cut, still roughly 3 s short. The rest of the overrun sits in `grc`, a package nothing calls that survives only as a transitive dependency (`docs/issues/2026-08-21-010`). That figure is arithmetic from a prior CI measurement, not a number this branch produced; the real one becomes observable when CI runs here.

## What review caught, and why it matters more than the feature

The first version of the new assertion **could pass an interpreter it exists to reject**. A `python3` printing a three-component version made the minor component `8.1`; that is a bash arithmetic syntax error, `(( ))` returns non-zero on it, which reads as "not below the floor", and the function fell through to success. Reproduced: a stub reporting **3.8.1 passed the 3.9 gate**. Two more faults fell out of reproducing it — a non-numeric banner raised `unbound variable` instead of a named failure, and whitespace produced the message `is  , older than`.

That is the exact defect class this change exists to eliminate, living inside the fix. The version string is now shape-checked before any arithmetic, and a regression test pins it — mutation-proved by reverting the check and watching the test go red.

The full render's `brew "git"` was also left unasserted, so deleting the entry outright would have satisfied every test in the file while real hosts silently stopped receiving git. Both full-render tests now pin it.

## Deliberately not done here

- `brew "grc"` stays. Its justification is about `python3` and stays live until this lands; removing it is `docs/issues/2026-08-21-010`, which now records the handover.
- The roughly 98 other tool guards (`jq`, `bun`, `sqlite3`, `zsh`) keep their skips. The discriminator is not "declared" — those tools are declared too. It is that this repo does **not** install `python3` and a shipped feature invokes it during the apply itself.
- The `jq`/`python3`/`node` JSON-parser fallback is untouched; it picks among interchangeable parsers and states no policy.

Two review findings are filed rather than fixed: no automated job runs the CI-minimal Docker apply, so a base-image downgrade would break it while every check stays green (`docs/issues/2026-08-21-011`); and the 3.9 floor is written in both the test helper and `README.md` with nothing checking they agree (`docs/issues/2026-08-21-012`).

## Verification

Host: `tests/palette.bats` 58, `tests/templates.bats` 39, `tests/smoke.bats` 71, `tests/scripts.bats` 195 — zero failures, and no skip in any file names `python3`. `make lint` clean.

Docker, all three services on the rebuilt image: **372 ok, 13 skipped, 1 failure** each, and the minimal and full renders produce **identical skip sets** — the parity this removal needed. Against the last recorded measurement on this image (368 ok, 15 skipped) the delta is fully accounted for: +4 new assertions, −2 JSON-shape tests that used to skip with `no JSON parser available` and now take the `python3` branch.

The full Brewfile render is **byte-identical** to before at 1060 bytes; the minimal render differs by exactly one line, the removed `brew "git"`. Confirmed independently during review.

`python3 --version` in the built image before any apply reports **3.12.3** at `/usr/bin/python3`, and the palette's own `--validate` exits 0 on it. Note that 3.12.3 ships `tomllib`, so the parser switch that removing `grc` was expected to cause will not happen — the earlier 3.10.6 reading was measured against Ubuntu 22.04 and is stale.

**One item is not met.** `make test-ubuntu` exits 2, on the pre-existing `Pi brew auto updater focused tests pass` failure documented in `docs/issues/2026-08-19-001`: `tests/pi-brew-auto-update.test.ts` imports `../home/...`, and Compose mounts `home/` and `tests/` apart, so that path does not exist in the container. Present on `main` before this branch; not caused by it.

Session-settled decisions carried from planning: `python3` is a dependency this repo owns rather than an optional tool (user-directed, over adding guards to the nine bare call sites); this change owns the `docker/Dockerfile.ubuntu` edit rather than deferring it to the Dockerfile plan (user-directed, over folding it in); a missing interpreter is announced by a named assertion (user-directed, over relying on roughly sixty-five identical `command not found` failures); and `git` leaves the minimal set here rather than in a change of its own (user-directed, over filing it separately).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
