### PR TITLE
fix(claude): restore the plugin-doctor command to chezmoi management

### DIFF
--- a/docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md
+++ b/docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md
@@ -2,7 +2,8 @@
 title: plugin-doctor command exists only on the host, not reproducible from the repo
 type: bug
 date: 2026-08-21
-status: open
+status: done
+closed: 2026-08-21
 ---
 
 ## Why this exists
@@ -26,3 +27,15 @@ Add a smoke test for whichever source is chosen.
 ## Open decisions
 
 - Which of the three options above; depends on whether a marketplace plugin-doctor provider exists and is trusted.
+
+## Resolution
+
+Option 1 taken: the command file is restored under chezmoi management at `home/private_dot_claude/commands/plugin-doctor.md`, recovered verbatim (66 lines) from git history via `git show d4e32f9^:home/private_dot_claude/commands/plugin-doctor.md` — the parent commit of the deletion. A smoke test in `tests/smoke.bats` asserts the source file is tracked and the deployed `~/.claude/commands/plugin-doctor.md` exists after apply.
+
+Evidence behind the choice:
+
+- The deletion reason in `d4e32f9` ("now provided by plugins") is factually wrong: none of the 8 enabled plugins in `home/private_dot_claude/private_settings.json.tmpl` (claude-md-management, compound-engineering, frontend-design, playground, playwright, plugin-dev, security-guidance, typescript-lsp) provides a plugin-doctor command, and `~/.claude/plugins/cache` contains no such command either — so option 2 had no provider to enable.
+- During resolution the untracked host copy at `~/.claude/commands/plugin-doctor.md` turned out to be already gone (the directory holds only `checkpoint.md`, `end-day.md`, `start-day.md`), so the capability was lost on this machine too, not just on a clean rebuild.
+- If that host deletion was a deliberate abandonment of the capability (option 3), the restoring PR is the review gate: closing it unmerged records that choice.
+
+Neither `home/.chezmoiignore` nor `home/.chezmoiexternal.toml` touches `.claude/commands`, so single-source management holds. The deployed copy returns only after the user runs `chezmoi apply`; until then the new smoke-test assertion on the deployed path is red on the host (green in Docker CI, which applies the checkout first). Commit: the commit that carries this Resolution.

--- a/home/private_dot_claude/commands/plugin-doctor.md
+++ b/home/private_dot_claude/commands/plugin-doctor.md
@@ -1,0 +1,66 @@
+---
+allowed-tools: Bash(jq:*), Bash(test:*), Bash(claude plugin:*), Bash(echo:*), Bash(cat:*), Bash(ls:*)
+description: Check and repair broken Claude Code plugins
+---
+
+<command>
+
+<context>
+- Plugin status from CLI: !`claude plugin list --json 2>/dev/null || echo '[]'`
+</context>
+
+<task>
+You are a plugin health checker. Analyze plugin status and cache integrity.
+
+<process>
+1. Parse the JSON array from context. Each entry has: `id`, `version`, `scope`, `enabled`, `installPath`, optionally `projectPath`.
+
+2. For each plugin, run TWO checks:
+   a. **Enabled check**: is `"enabled": true`?
+   b. **Cache check**: does `installPath` directory exist AND contain at least one subdirectory (commands/, skills/, agents/, hooks/, .claude-plugin/)?
+      Run: `test -d "<installPath>" && ls "<installPath>/" | head -5`
+
+3. Classify results:
+   - **HEALTHY**: enabled=true AND cache has content
+   - **DISABLED**: enabled=false (just report, don't fix — user may have disabled intentionally)
+   - **BROKEN**: enabled=true BUT cache is empty/missing → needs reinstall
+   - **GHOST**: enabled=false AND cache is empty/missing → stale entry, suggest removal
+
+4. For each BROKEN plugin with user scope:
+   - Run: `claude plugin uninstall -s user "<id>"`
+   - Then: `claude plugin install -s user "<id>"`
+   - Verify fix: re-run cache check
+   - If install fails, report the error and continue to next plugin
+
+5. For each BROKEN plugin with project/local scope:
+   - Output a warning with the exact copy-paste command:
+     `cd <projectPath> && claude plugin uninstall -s <scope> "<id>" && claude plugin install -s <scope> "<id>"`
+
+6. Print a summary report:
+```
+Plugin Doctor Report
+────────────────────
+HEALTHY   <N> plugins OK
+DISABLED  <N> plugins disabled (intentional)
+FIXED     <N> plugins reinstalled
+FAILED    <N> plugins failed to reinstall
+WARNING   <N> plugins need manual fix (project/local scope):
+  → <copy-paste command for each>
+GHOST     <N> stale entries (disabled + no cache):
+  → claude plugin uninstall -s <scope> "<id>"
+```
+
+Omit sections with 0 count (except HEALTHY).
+</process>
+
+<rules>
+- Do NOT modify installed_plugins.json directly — use `claude plugin` CLI only
+- Process ALL plugins, do not stop on first error
+- Run uninstall before install to clear stale state
+- Use the `id` field as-is for plugin commands (format: name@marketplace)
+- DISABLED plugins are NOT broken — do not attempt to fix them
+</rules>
+
+</task>
+
+</command>

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -400,6 +400,18 @@ PY
   assert_dir_not_exists "$HOME/.claude/skills/ask-in-herdr/scripts/agents"
 }
 
+# plugin-doctor was deleted from the source tree in d4e32f9 on the false
+# premise that a plugin provides it (none of the enabled plugins does), which
+# left the command existing only as an untracked host file — and later not even
+# that (docs/issues/2026-08-21-016). Both copies are asserted: the source
+# assertion catches the file being dropped from management again; the deployed
+# assertion is red on a host that has not run `chezmoi apply` since the
+# restore, and green in Docker CI, which applies the checkout first.
+@test "plugin-doctor command is tracked in the source tree and deployed" {
+  assert_file_exists "$SOURCE_ROOT/private_dot_claude/commands/plugin-doctor.md"
+  assert_file_exists "$HOME/.claude/commands/plugin-doctor.md"
+}
+
 @test "every skill description survives YAML parsing" {
   # An unquoted YAML scalar ends at " #" (comment) and cannot contain ": ".
   # Both truncate or invalidate the description, which is how the agent finds


### PR DESCRIPTION
## Summary

A clean machine rebuild gets the `/plugin-doctor` Claude Code slash command back: the command file is chezmoi-managed again at `home/private_dot_claude/commands/plugin-doctor.md`, restored byte-for-byte from git history (`git show d4e32f9^:home/private_dot_claude/commands/plugin-doctor.md`).

Commit d4e32f9 deleted it with the message that the command is "now provided by plugins". That premise is factually wrong: none of the 8 enabled plugins in `home/private_dot_claude/private_settings.json.tmpl` (claude-md-management, compound-engineering, frontend-design, playground, playwright, plugin-dev, security-guidance, typescript-lsp) provides a plugin-doctor command, and `~/.claude/plugins/cache` contains none. The capability survived only as an untracked host file at `~/.claude/commands/plugin-doctor.md` — which has meanwhile also disappeared — so today nothing provides the command anywhere.

If the host deletion of ~/.claude/commands/plugin-doctor.md was a deliberate abandonment of the capability, close this PR unmerged — that records the choice explicitly.

A new smoke test guards both copies: the source-tree assertion catches the file being dropped from management again; the deployed assertion confirms the live command after `chezmoi apply`. The tracked issue `docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md` is closed in this PR with the full evidence trail.

## Verification

- `make test-templates` — 39/39 ok
- `make lint` — clean
- `bats tests/smoke.bats` — 71/72 ok. The single failure is the new test's assertion on the deployed `~/.claude/commands/plugin-doctor.md`: expected red on a host that has not run `chezmoi apply` since this change. The source-tree assertion in the same test passes, and Docker CI goes green because it applies the checkout before testing. After merge, the host goes green on the next `chezmoi apply`.
- Neither `home/.chezmoiignore` nor `home/.chezmoiexternal.toml` touches `.claude/commands`, so restoring the file introduces no duplicate management ("inconsistent state").
