### PR TITLE
fix(zsh): stop freezing the generating shell's PATH into the mise cache

### DIFF
--- a/docs/issues/2026-08-21-001-mise-cache-freezes-generating-shell-path.md
+++ b/docs/issues/2026-08-21-001-mise-cache-freezes-generating-shell-path.md
@@ -2,7 +2,8 @@
 title: The cached mise activate output freezes the generating shell's PATH into every later shell
 type: bug
 date: 2026-08-21
-status: open
+status: done
+closed: 2026-08-21
 ---
 
 ## Why this exists
@@ -58,3 +59,46 @@ fork per shell start, and that trade-off is not being reopened here.
 3. **Which test proves it.** A candidate: render `dot_zshenv.tmpl`, generate the
    cache under an unusual `PATH`, start a second shell with a normal `PATH`, and
    assert the second shell's `PATH` does not contain the marker entry.
+
+## Resolution
+
+Decision 1 went to the **strip** variant, kept the cache: the regeneration in
+`home/dot_zshenv.tmpl` now pipes `mise activate zsh` through
+`sed '1{/^export PATH=/d;}'` before writing the cache, and the mv/rm branch
+keys on `$pipestatus[1]` so a failed mise still discards the temp file.
+
+Why stripping is safe was verified on the host, not assumed: `mise activate
+zsh | head` confirmed the absolute `export PATH='...'` snapshot is exactly
+line 1 (and on this machine it did carry the Claude plugin `bin` dirs the
+issue describes), and the activate script *ends with a direct `_mise_hook`
+call*, which evals `mise hook-env -s zsh` at source time. So a fresh shell —
+including a non-interactive `zsh -f -c`, where precmd never fires — gets
+mise-managed tool dirs on `PATH` the moment the cache is sourced: sourcing the
+stripped output in a `zsh -f` with a minimal `PATH` resolved `node` to
+`~/.local/share/mise/installs/node/lts/bin/node`. No relative shims prepend
+was needed. The strip is scoped to line 1 so a legitimate runtime `PATH`
+mutation elsewhere in future mise output would survive.
+
+Decision 2 (regenerate on `PATH` change) became moot: with no `PATH` line in
+the cache, the cached content is `PATH`-independent, so `PATH`-based
+regeneration would add churn and guard nothing. Not implemented.
+
+Decision 3, tests (verified red on the unfixed template by mutation, then
+green):
+
+- `tests/templates.bats`: a behavioral test renders `dot_zshenv.tmpl`, points
+  it at a fake `mise` (function shim — the rendered file prepends the
+  homebrew dirs, so a PATH-based fake would be shadowed by the real mise)
+  whose activate output mimics the real shape, generates the cache in a
+  throwaway `HOME` with a marker dir on `PATH`, then starts a second zsh with
+  a normal `PATH`: the marker must be absent and the runtime mutation line
+  must still apply. Plus a render assertion pinning the sed strip. Never
+  touches the real `~/.cache` or `$HOME`.
+- `tests/smoke.bats`: guards for the `cached_init` consumers in
+  `home/dot_zshrc.tmpl` — `starship init zsh`, `zoxide init zsh --cmd cd`,
+  `rgrc --aliases` each must emit no `export PATH=` line (skip when the tool
+  is absent), so only mise ever had this shape and it stays that way.
+
+Verified: `bats tests/templates.bats` (41/41), `bats tests/smoke.bats` (all
+green incl. the three new guards), `make lint`, `make test-templates`.
+The fix is commit-ready but not live until `chezmoi apply` deploys it.

--- a/home/dot_zshenv.tmpl
+++ b/home/dot_zshenv.tmpl
@@ -45,8 +45,19 @@ if has mise; then
     # "zsh: command not found: " while sourcing them.
     # mktemp rather than "$_mise_cache.$$": zsh reports the parent shell's PID
     # in a subshell, so $$ does not separate concurrent writers.
+    #
+    # sed strips the absolute `export PATH='...'` snapshot mise emits as line
+    # 1: it captures THIS shell's PATH, and caching it froze that PATH into
+    # every later shell until the mise binary changed (a capture from a shell
+    # with an augmented PATH pinned those extra entries for weeks). The
+    # activate script ends by calling _mise_hook, which recomputes PATH via
+    # `mise hook-env` at source time, so dropping the snapshot loses nothing —
+    # each shell mutates its own PATH instead of inheriting a frozen one.
+    # Scoped to line 1 so a relative, runtime PATH mutation elsewhere in the
+    # output would survive.
     _mise_cache_tmp="$(mktemp "$_mise_cache.XXXXXX")"
-    if mise activate zsh > "$_mise_cache_tmp" 2>/dev/null; then
+    mise activate zsh 2>/dev/null | sed '1{/^export PATH=/d;}' > "$_mise_cache_tmp"
+    if [[ $pipestatus[1] -eq 0 ]]; then
       mv -f "$_mise_cache_tmp" "$_mise_cache"
     else
       rm -f "$_mise_cache_tmp"

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -1032,3 +1032,34 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$relink" 'herdr plugin link'
   assert_file_contains "$relink" 'herdr plugin enable seigi.pane-labels'
 }
+
+# ===========================================
+# zsh cached_init consumers (docs/issues/2026-08-21-001)
+#
+# ~/.zshrc caches the output of these tools via cached_init and sources the
+# cache in every later shell. An absolute `export PATH=...` line in any of
+# them would freeze the generating shell PATH into every shell that sources
+# the cache -- the exact bug mise activate had. As of 2026-08-21 none of them
+# emits one; these guards keep it that way across tool upgrades.
+# ===========================================
+
+@test "starship init output embeds no absolute PATH export" {
+  command_exists starship || skip "starship not installed"
+  run starship init zsh
+  assert_success
+  refute_line --regexp '^export PATH='
+}
+
+@test "zoxide init output embeds no absolute PATH export" {
+  command_exists zoxide || skip "zoxide not installed"
+  run zoxide init zsh --cmd cd
+  assert_success
+  refute_line --regexp '^export PATH='
+}
+
+@test "rgrc aliases output embeds no absolute PATH export" {
+  command_exists rgrc || skip "rgrc not installed"
+  run rgrc --aliases
+  assert_success
+  refute_line --regexp '^export PATH='
+}

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -108,6 +108,77 @@ teardown() {
   refute_output --partial 'mise activate zsh > "$_mise_cache"'
 }
 
+@test "zshenv strips the absolute PATH export when generating the mise cache" {
+  # Line 1 of `mise activate zsh` is an `export PATH='...'` snapshot of the
+  # generating shell. Cached, it froze that one shell's PATH into every later
+  # shell until the mise binary changed (docs/issues/2026-08-21-001). The
+  # activate script ends with a direct `_mise_hook` call that recomputes PATH
+  # via `mise hook-env` at source time, so the snapshot line is redundant.
+  run render_template "$SOURCE_ROOT/dot_zshenv.tmpl"
+  assert_success
+  assert_output --partial "sed '1{/^export PATH=/d;}'"
+}
+
+@test "zshenv mise cache does not freeze the generating shell's PATH into later shells" {
+  command_exists zsh || skip "zsh not installed"
+
+  local work="$BATS_TEST_TMPDIR/mise-freeze"
+  mkdir -p "$work/bin" "$work/home" "$work/marker" "$work/toolbin"
+
+  # A fake mise shaped like the real activate output: line 1 is an absolute
+  # snapshot of the generating shell's PATH; the second line mutates PATH at
+  # source time, standing in for the trailing `_mise_hook` call that real
+  # activate output performs via `mise hook-env`.
+  cat > "$work/bin/mise" <<MISE
+#!/bin/sh
+if [ "\$1" = "activate" ]; then
+  printf "export PATH='%s'\n" "\$PATH"
+  printf 'export PATH="%s/toolbin:\$PATH"\n' "$work"
+fi
+MISE
+  chmod +x "$work/bin/mise"
+
+  render_template "$SOURCE_ROOT/dot_zshenv.tmpl" > "$work/zshenv.rendered"
+
+  # The shim is a function, not a PATH entry, because the rendered zshenv
+  # prepends the homebrew dirs before the mise block: on a host with a real
+  # mise install, any PATH-based fake would be shadowed by it. zsh's
+  # `command -v` resolves functions, so `has mise` and the activate call both
+  # hit the fake, and the `-ot` regeneration probe against the nonexistent
+  # path "mise" is simply false.
+  # Shell 1 generates the cache while a marker directory is on its PATH.
+  cat > "$work/gen.zsh" <<GEN
+mise() { "$work/bin/mise" "\$@" }
+export HOME="$work/home"
+export PATH="$work/marker:/usr/bin:/bin"
+source "$work/zshenv.rendered"
+GEN
+  run zsh -f "$work/gen.zsh"
+  assert_success
+  assert_file_exists "$work/home/.cache/zsh/mise-activate.zsh"
+
+  # The generating shell's PATH (with the marker) must not be in the cache;
+  # the runtime PATH-mutation line must survive the strip.
+  run grep -F "$work/marker" "$work/home/.cache/zsh/mise-activate.zsh"
+  assert_failure
+  run grep -F "$work/toolbin" "$work/home/.cache/zsh/mise-activate.zsh"
+  assert_success
+
+  # Shell 2 starts with a normal PATH against the same cache: the marker must
+  # not leak in, while the runtime hook line must still mutate PATH.
+  cat > "$work/probe.zsh" <<PROBE
+mise() { "$work/bin/mise" "\$@" }
+export HOME="$work/home"
+export PATH="/usr/bin:/bin"
+source "$work/zshenv.rendered"
+print -r -- "\$PATH"
+PROBE
+  run zsh -f "$work/probe.zsh"
+  assert_success
+  refute_output --partial "$work/marker"
+  assert_output --partial "$work/toolbin"
+}
+
 @test "zshrc cached_init generates the cache through a temp file rename" {
   run render_template "$SOURCE_ROOT/dot_zshrc.tmpl"
   assert_success


### PR DESCRIPTION
`~/.zshenv` caches the output of `mise activate zsh` and sources it in every shell. Line 1 of that output is an absolute `export PATH='...'` snapshot of whichever shell happened to regenerate the cache, so that one shell's PATH — a real capture on this machine carried Claude Code plugin `bin` directories — was pinned into every later shell until the mise binary changed. Cache generation now strips that snapshot (scoped to line 1, so a relative runtime PATH mutation elsewhere in future mise output would survive), and keys the write on `$pipestatus[1]` so a failed mise still discards the temp file.

Nothing is lost by dropping the snapshot: mise's activate script ends with a direct `_mise_hook` call that recomputes PATH via `mise hook-env` at the moment the cache is sourced. Sourcing the stripped output in a fresh `zsh -f` with a minimal PATH still resolved `node` to the mise-managed install, so even non-interactive shells (where precmd never fires) get mise tools immediately.

Tests: a behavioral test in `tests/templates.bats` renders `dot_zshenv.tmpl`, generates the cache in a throwaway HOME with a marker directory on PATH, and asserts a second shell with a normal PATH never sees the marker while the runtime PATH-mutation line still applies — confirmed red against the unfixed template by mutation, then green. Three new guards in `tests/smoke.bats` keep the other cached zsh init outputs (`starship init zsh`, `zoxide init zsh --cmd cd`, `rgrc --aliases`) free of `export PATH=` lines, each skipping when the tool is absent.

Verified: `bats tests/templates.bats` (41/41), `bats tests/smoke.bats` (all green), `make lint`, `make test-templates` (Docker, green). The fix reaches live shells on the next `chezmoi apply`.

Closes the repo issue file `docs/issues/2026-08-21-001-mise-cache-freezes-generating-shell-path.md`; its Resolution section records the decision trail.
