### PR TITLE
feat(herdr): clickable agent notifications without a Rust build

### DIFF
--- a/docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md
+++ b/docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md
@@ -2,7 +2,8 @@
 title: Add clickable Herdr focus notifications without a Rust build dependency
 type: follow-up
 date: 2026-08-18
-status: open
+status: done
+closed: 2026-08-21
 ---
 
 ## Why this exists
@@ -51,3 +52,30 @@ that verifies notification display, click activation, pane focus, duplicate repl
   binding learned from `pane.focused` events.
 - Which upstream behaviors are required for the first version: duplicate suppression, automatic
   removal after pane focus, agent icons, timeout configuration, and debug logs.
+
+## Resolution
+
+Option 2 implemented: a local plugin, no Rust build, no `alerter`.
+
+- Plugin: `home/private_dot_config/herdr/plugins/herdr-focus-notify/` — `herdr-plugin.toml`
+  (id `seigi.focus-notify`, macOS-only) plus a single Python script `notify.py` over the
+  `terminal-notifier` formula already in `Brewfile.macos`. The event contract
+  (`pane.agent_status_changed` payload in `HERDR_PLUGIN_EVENT_JSON` with `data.pane_id`,
+  `data.agent_status`, `data.agent`, `data.display_agent`) was confirmed against the upstream
+  `yankewei/herdr-focus-notify` source, not guessed.
+- Notifies only for `blocked` and `done`. `-group herdr-<pane-id>` gives per-pane duplicate
+  replacement. Click runs `-execute "<herdr> agent focus <pane-id>"` with both halves
+  `shlex.quote`d, and `-activate` brings the terminal forward (default
+  `com.mitchellh.ghostty` — this repo's ghostty auto-launches herdr — overridable via a
+  one-line `terminal-bundle-id` file in the plugin config dir).
+- Deployment: tolerant link-and-enable script
+  `home/.chezmoiscripts/run_onchange_after_8-link-herdr-focus-notify.sh.tmpl` (mirrors the
+  caffeinate/pane-labels scripts), darwin-only ignore rules in `home/.chezmoiignore`.
+- Tests in `tests/smoke.bats`: deployment manifest entries, py_compile + no-cargo/no-alerter
+  policy, safe-quoting unit test against a fake notifier with a hostile pane id, quiet on
+  non-actionable statuses, stable group id, link-script guard checks.
+- Not implemented in v1 (per the "ambiguous focus must notify" rule, always-notify was chosen):
+  focus suppression, terminal learning from `pane.focused`, auto-removal on focus, agent
+  icons, sounds, timeout config. State directory unused. The open decision on
+  `terminal-notifier -execute` click reliability on current macOS remains a manual check —
+  posting and `-remove` were verified live; click handling needs a human.

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -22,6 +22,8 @@ Library/**
 .chezmoiscripts/darwin/**
 .config/herdr/plugins/herdr-caffeinate
 .config/herdr/plugins/herdr-caffeinate/**
+.config/herdr/plugins/herdr-focus-notify
+.config/herdr/plugins/herdr-focus-notify/**
 {{ end }}
 
 # Python bytecode caches. Running any managed .py script (the herdr

--- a/home/.chezmoiscripts/run_onchange_after_8-link-herdr-focus-notify.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_8-link-herdr-focus-notify.sh.tmpl
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# chezmoi:template:left-delimiter="# {{" right-delimiter="}}"
+# Link and enable the local Herdr focus-notify plugin after the managed files change.
+#
+# Hash triggers:
+# # {{ if eq .chezmoi.os "darwin" }}
+# # {{ include "private_dot_config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml" | sha256sum }}
+# # {{ include "private_dot_config/herdr/plugins/herdr-focus-notify/notify.py" | sha256sum }}
+# # {{ end }}
+
+# Keep this tolerant: missing Herdr or a stopped server should not make chezmoi apply fail.
+set -u
+
+plugin_dir="$HOME/.config/herdr/plugins/herdr-focus-notify"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if ! command -v herdr >/dev/null 2>&1; then
+  echo "herdr not found; skipping focus-notify plugin link"
+  exit 0
+fi
+
+if [[ ! -f "$plugin_dir/herdr-plugin.toml" ]]; then
+  echo "Herdr focus-notify plugin manifest not found at $plugin_dir; skipping"
+  exit 0
+fi
+
+if herdr plugin link "$plugin_dir" >/dev/null 2>&1; then
+  echo "Linked Herdr focus-notify plugin"
+  if herdr plugin enable seigi.focus-notify >/dev/null 2>&1; then
+    echo "Enabled seigi.focus-notify"
+  else
+    echo "Warning: linked but failed to enable; run manually: herdr plugin enable seigi.focus-notify" >&2
+  fi
+  if herdr server reload-config >/dev/null 2>&1; then
+    echo "Reloaded Herdr config"
+  else
+    echo "Warning: failed to reload Herdr config; restart Herdr or run: herdr server reload-config" >&2
+  fi
+else
+  echo "Warning: failed to link Herdr focus-notify plugin. Run manually: herdr plugin link $plugin_dir" >&2
+fi

--- a/home/private_dot_config/herdr/plugins/herdr-focus-notify/README.md
+++ b/home/private_dot_config/herdr/plugins/herdr-focus-notify/README.md
@@ -1,0 +1,58 @@
+# herdr-focus-notify
+
+Clickable macOS notification when a herdr agent goes `blocked` or `done`.
+Clicking the toast activates the terminal that runs herdr and runs
+`herdr agent focus <pane-id>`.
+
+Local reimplementation of the core of
+[yankewei/herdr-focus-notify](https://github.com/yankewei/herdr-focus-notify)
+without its Rust build step or third-party notifier backend: one Python script
+plus the `terminal-notifier` formula this repo already installs.
+
+## How it works
+
+- Subscribes to `pane.agent_status_changed`; herdr delivers the payload in
+  `HERDR_PLUGIN_EVENT_JSON`.
+- Notifies only for `agent_status` `blocked` or `done`.
+- `-group herdr-<pane-id>` keeps one toast per pane: a newer status replaces
+  the older notification instead of stacking.
+- The click command is built with `shlex.quote` on both the herdr binary path
+  and the pane id, so no event value is ever interpreted as shell syntax.
+
+## Configuration
+
+The terminal activated on click defaults to ghostty
+(`com.mitchellh.ghostty`), because this repo's ghostty config auto-launches
+herdr. To activate another terminal, write its bundle identifier as the single
+line of:
+
+```
+$(herdr plugin config-dir seigi.focus-notify)/terminal-bundle-id
+```
+
+For example `net.kovidgoyal.kitty`.
+
+## v1 limitations (deliberate)
+
+- No focus suppression: a notification is sent even when the pane may already
+  be visible. Ambiguous focus state must notify, and always-notify is the
+  simplest correct version of that rule.
+- No terminal learning from `pane.focused` and no state files.
+- No auto-removal of a toast once the pane gets focused; `-group` replacement
+  and manual dismissal cover cleanup.
+- No agent icons, sounds, or timeout configuration.
+
+## Manual verification (needs a live macOS session)
+
+1. `herdr plugin list` shows `seigi.focus-notify` linked and enabled.
+2. `herdr plugin action invoke seigi.focus-notify test` (or the palette action
+   "Focus notify: send test notification") shows a toast titled
+   "Focus notify test needs your input".
+3. Let an agent in some pane reach `blocked` or `done` while another app is
+   frontmost: a toast appears naming the agent and the pane.
+4. Click the toast: the terminal comes to the front and the matching pane
+   gets focused (`herdr agent focus` ran).
+5. Duplicate replacement: trigger two status changes for the same pane; the
+   second toast replaces the first instead of stacking in Notification Center.
+6. Cleanup: dismissed toasts leave nothing behind (`herdr plugin log
+   seigi.focus-notify` shows no errors; the plugin writes no state files).

--- a/home/private_dot_config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml
+++ b/home/private_dot_config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml
@@ -1,0 +1,21 @@
+id = "seigi.focus-notify"
+name = "Focus Notify"
+version = "0.1.0"
+min_herdr_version = "0.8.0"
+description = "Clickable macOS notification when an agent goes blocked or done; click focuses the pane."
+platforms = ["macos"]
+
+# Local reimplementation of the useful core of yankewei/herdr-focus-notify.
+# The upstream plugin compiles a Rust binary during install and needs an extra
+# notification backend from a third-party tap; this one is a single Python
+# script over the terminal-notifier formula this repo already installs.
+
+[[events]]
+on = "pane.agent_status_changed"
+command = ["python3", "notify.py"]
+
+[[actions]]
+id = "test"
+title = "Focus notify: send test notification"
+contexts = ["workspace"]
+command = ["python3", "notify.py", "--test"]

--- a/home/private_dot_config/herdr/plugins/herdr-focus-notify/notify.py
+++ b/home/private_dot_config/herdr/plugins/herdr-focus-notify/notify.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Clickable macOS notification when a herdr agent goes blocked or done.
+
+Event hook for `pane.agent_status_changed`. Herdr passes the event payload in
+the HERDR_PLUGIN_EVENT_JSON environment variable; the fields read here
+(data.pane_id, data.agent_status, data.agent, data.display_agent) match what
+the upstream herdr-focus-notify plugin consumes. Only `blocked` and `done`
+notify -- they are the two statuses that need the user's action.
+
+The toast goes through terminal-notifier:
+  -group    one notification per pane; a newer status replaces the older toast
+  -activate brings the terminal that runs herdr to the front on click
+  -execute  runs `herdr agent focus <pane-id>` on click
+
+v1 always notifies: it builds no focus-suppression heuristics, learns no
+terminal binding from pane.focused, and does not auto-remove a toast when the
+pane gets focused. Ambiguous focus state must produce a notification, and
+"always" is the simplest correct reading of that rule.
+
+Fail open: any failure exits 0 so this hook can never break herdr event
+dispatch. Errors go to stderr, which `herdr plugin log` captures.
+"""
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+# The terminal this repo binds herdr to: ghostty's config auto-launches herdr
+# (home/private_dot_config/ghostty/config). Override per machine with the
+# one-line config file read by terminal_bundle_id().
+DEFAULT_TERMINAL_BUNDLE_ID = "com.mitchellh.ghostty"
+
+ACTIONABLE_STATUSES = ("blocked", "done")
+
+NOTIFIER_CANDIDATES = (
+    "/opt/homebrew/bin/terminal-notifier",
+    "/usr/local/bin/terminal-notifier",
+)
+
+
+def parse_event(raw: str) -> Optional[Tuple[str, str, str]]:
+    """(pane_id, status, agent_label) from event JSON, or None to stay quiet."""
+    try:
+        event = json.loads(raw)
+    except ValueError:
+        return None
+    data = event.get("data") if isinstance(event, dict) else None
+    if not isinstance(data, dict):
+        return None
+
+    status = str(data.get("agent_status") or "").strip().lower()
+    pane_id = str(data.get("pane_id") or "").strip()
+    if not pane_id or status not in ACTIONABLE_STATUSES:
+        return None
+
+    agent = ""
+    for key in ("display_agent", "agent"):
+        value = str(data.get(key) or "").strip()
+        if value:
+            agent = value
+            break
+    return pane_id, status, agent or "Agent"
+
+
+def find_notifier() -> Optional[str]:
+    override = os.environ.get("HERDR_FOCUS_NOTIFY_NOTIFIER_BIN")
+    if override:
+        return override if os.access(override, os.X_OK) else None
+    found = shutil.which("terminal-notifier")
+    if found:
+        return found
+    for candidate in NOTIFIER_CANDIDATES:
+        if os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def resolve_herdr() -> str:
+    # HERDR_BIN_PATH is set by herdr for plugin commands. The click command
+    # runs later in a bare `sh` with no such environment, so resolve to an
+    # absolute path now while the answer is still known.
+    configured = os.environ.get("HERDR_BIN_PATH") or "herdr"
+    if os.sep in configured:
+        return configured
+    return shutil.which(configured) or "/opt/homebrew/bin/herdr"
+
+
+def terminal_bundle_id() -> str:
+    override = os.environ.get("HERDR_FOCUS_NOTIFY_ACTIVATE")
+    if override:
+        return override
+    config_dir = os.environ.get("HERDR_PLUGIN_CONFIG_DIR")
+    if config_dir:
+        path = os.path.join(config_dir, "terminal-bundle-id")
+        try:
+            with open(path, encoding="utf-8") as handle:
+                value = handle.readline().strip()
+            if value:
+                return value
+        except OSError:
+            pass
+    return DEFAULT_TERMINAL_BUNDLE_ID
+
+
+def group_id(pane_id: str) -> str:
+    """Stable per-pane group so a newer toast replaces the older one."""
+    return "herdr-" + re.sub(r"[^A-Za-z0-9]+", "-", pane_id)
+
+
+def notification_copy(status: str, agent: str) -> Tuple[str, str]:
+    if status == "blocked":
+        return f"{agent} needs your input", "Open the pane to review and respond."
+    return f"{agent} finished", "Open the pane to review the result."
+
+
+def build_argv(
+    notifier: str, pane_id: str, title: str, body: str, herdr_bin: str
+) -> List[str]:
+    # The -execute value is the one string terminal-notifier hands to `sh`.
+    # Both halves are shlex-quoted, so a pane id (or an unusual herdr path)
+    # can never be interpreted as shell syntax.
+    click_command = "{} agent focus {}".format(
+        shlex.quote(herdr_bin), shlex.quote(pane_id)
+    )
+    return [
+        notifier,
+        "-title",
+        title,
+        "-subtitle",
+        f"pane {pane_id}",
+        "-message",
+        body,
+        "-group",
+        group_id(pane_id),
+        "-activate",
+        terminal_bundle_id(),
+        "-execute",
+        click_command,
+    ]
+
+
+def main() -> int:
+    if "--test" in sys.argv[1:]:
+        pane_id = (
+            os.environ.get("HERDR_ACTIVE_PANE_ID")
+            or os.environ.get("HERDR_PANE_ID")
+            or "test-pane"
+        )
+        parsed = (pane_id, "blocked", "Focus notify test")
+    else:
+        raw = os.environ.get("HERDR_PLUGIN_EVENT_JSON")
+        if not raw:
+            return 0
+        parsed = parse_event(raw)
+        if parsed is None:
+            return 0
+
+    pane_id, status, agent = parsed
+    notifier = find_notifier()
+    if notifier is None:
+        print(
+            "herdr-focus-notify: terminal-notifier not found; skipping notification",
+            file=sys.stderr,
+        )
+        return 0
+
+    title, body = notification_copy(status, agent)
+    argv = build_argv(notifier, pane_id, title, body, resolve_herdr())
+    try:
+        subprocess.run(
+            argv,
+            check=False,
+            timeout=15,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError) as err:
+        print(f"herdr-focus-notify: notifier failed: {err}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -53,6 +53,8 @@ load 'helpers/common'
       .config/herdr/plugins/herdr-caffeinate/lib.sh
       .config/herdr/plugins/herdr-caffeinate/actions.sh
       .config/herdr/plugins/herdr-caffeinate/config.example.sh
+      .config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml
+      .config/herdr/plugins/herdr-focus-notify/notify.py
     )
   fi
 
@@ -514,6 +516,104 @@ PY
     run sh -n "$HOME/.config/herdr/plugins/herdr-caffeinate/$f"
     [ "$status" -eq 0 ]
   done
+}
+
+# ===========================================
+# herdr focus-notify plugin (source tree)
+# ===========================================
+
+FOCUS_NOTIFY_DIR="$SOURCE_ROOT/private_dot_config/herdr/plugins/herdr-focus-notify"
+
+# Runs notify.py against a fake notifier that records its argv one line per
+# argument, so tests can assert the exact command terminal-notifier would get.
+# $1: event JSON. Extra env for the run comes via focus_notify_env array.
+run_focus_notify() {
+  local event_json="$1"
+  local fake_bin="$BATS_TEST_TMPDIR/fake-notifier"
+  FOCUS_NOTIFY_ARGV="$BATS_TEST_TMPDIR/notifier.argv"
+  cat > "$fake_bin" <<SH
+#!/bin/sh
+printf '%s\n' "\$@" > "$FOCUS_NOTIFY_ARGV"
+SH
+  chmod +x "$fake_bin"
+  HERDR_PLUGIN_EVENT_JSON="$event_json" \
+    HERDR_FOCUS_NOTIFY_NOTIFIER_BIN="$fake_bin" \
+    HERDR_BIN_PATH="$BATS_TEST_TMPDIR/dir with space/herdr" \
+    run python3 "$FOCUS_NOTIFY_DIR/notify.py"
+}
+
+@test "focus-notify plugin compiles and declares no build step or extra backend" {
+  run python3 -m py_compile "$FOCUS_NOTIFY_DIR/notify.py"
+  assert_success
+
+  # The whole point of this local plugin: no compile-at-install step and no
+  # notifier backend beyond the terminal-notifier formula the repo installs.
+  run grep -Ei 'cargo|alerter|\[\[build\]\]' \
+    "$FOCUS_NOTIFY_DIR/herdr-plugin.toml" "$FOCUS_NOTIFY_DIR/notify.py"
+  assert_failure
+
+  # The manifest wires the status event and the interpreter as argv arrays.
+  assert_file_contains "$FOCUS_NOTIFY_DIR/herdr-plugin.toml" \
+    '^on = "pane.agent_status_changed"$'
+  assert_file_contains "$FOCUS_NOTIFY_DIR/herdr-plugin.toml" \
+    '^command = \["python3", "notify.py"\]$'
+}
+
+@test "focus-notify builds a safely quoted click command" {
+  # A hostile pane id proves the quoting: nothing here may reach sh as syntax.
+  run_focus_notify '{"event":"pane.agent_status_changed","data":{"pane_id":"w1:p3; $(boom) &","agent_status":"blocked","agent":"codex","display_agent":"Codex"}}'
+  assert_success
+  assert_file_exists "$FOCUS_NOTIFY_ARGV"
+
+  run python3 - "$FOCUS_NOTIFY_ARGV" "$BATS_TEST_TMPDIR/dir with space/herdr" <<'PY'
+import shlex, sys
+argv = open(sys.argv[1], encoding="utf-8").read().split("\n")
+execute = argv[argv.index("-execute") + 1]
+# shlex.split proves the string survives sh word-splitting as exactly the
+# intended four tokens -- binary, agent, focus, pane id -- nothing executed.
+assert shlex.split(execute) == [sys.argv[2], "agent", "focus", "w1:p3; $(boom) &"], execute
+assert argv[argv.index("-group") + 1] == "herdr-w1-p3-boom-", argv
+assert argv[argv.index("-title") + 1] == "Codex needs your input", argv
+assert "-activate" in argv, argv
+PY
+  assert_success
+}
+
+@test "focus-notify stays quiet for non-actionable statuses and missing pane id" {
+  run_focus_notify '{"data":{"pane_id":"w1:p1","agent_status":"working","agent":"codex"}}'
+  assert_success
+  assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
+
+  run_focus_notify '{"data":{"agent_status":"blocked","agent":"codex"}}'
+  assert_success
+  assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
+}
+
+@test "focus-notify uses one notification group per pane for duplicate replacement" {
+  run_focus_notify '{"data":{"pane_id":"w1:p3","agent_status":"done","agent":"claude"}}'
+  assert_success
+
+  run python3 - "$FOCUS_NOTIFY_ARGV" <<'PY'
+import sys
+argv = open(sys.argv[1], encoding="utf-8").read().split("\n")
+assert argv[argv.index("-group") + 1] == "herdr-w1-p3", argv
+assert argv[argv.index("-title") + 1] == "claude finished", argv
+PY
+  assert_success
+}
+
+@test "focus-notify plugin is linked by a tolerant darwin-guarded script" {
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_8-link-herdr-focus-notify.sh.tmpl"
+
+  assert_file_exists "$script"
+  assert_file_contains "$script" 'herdr plugin link "\$plugin_dir"'
+  assert_file_contains "$script" 'herdr plugin enable seigi.focus-notify'
+
+  run grep -Fq '[[ "$(uname -s)" != "Darwin" ]]' "$script"
+  assert_success
+
+  run bash -n "$script"
+  assert_success
 }
 
 # ===========================================


### PR DESCRIPTION
## Summary

Herdr agents can now raise a clickable macOS notification when they go `blocked` or `done`; clicking it brings the terminal forward and focuses the matching pane. This lands the behavior of the upstream `yankewei/herdr-focus-notify` plugin without its costs: no `cargo build --release` at install time and no `alerter` from a third-party tap — one Python script over the `terminal-notifier` formula this repo already installs.

Resolves `docs/issues/2026-08-18-027-add-herdr-focus-notifications-without-rust-runtime.md` (closed in this PR), which asked to evaluate installing upstream unchanged versus a small local plugin. Local won: the useful core is ~180 lines of Python, while upstream would add a Rust toolchain and an extra notification backend to clean-machine setup for one integration.

## Design decisions

- **Event contract confirmed, not guessed.** The payload shape (`HERDR_PLUGIN_EVENT_JSON` env var with `data.pane_id`, `data.agent_status`, `data.agent`, `data.display_agent`) was read from the upstream plugin's source, and the manifest conventions from the two local plugins already running on herdr 0.8.2.
- **v1 always notifies.** The issue requires that ambiguous focus state produce a notification. Upstream's focus-suppression machinery (terminal learning from `pane.focused`, visibility monitors, state files) is deliberately not implemented; always-notify is the simplest version that satisfies the rule. Also excluded: auto-removal on pane focus, agent icons, sounds, timeout config.
- **Injection-safe click command.** `terminal-notifier -execute` takes one string that a shell later evaluates. Both halves — the herdr binary path and the pane id — go through `shlex.quote`, and a smoke test drives a hostile pane id (`w1:p3; $(boom) &`) through a fake notifier and proves the string splits back into exactly four argv tokens.
- **Duplicate replacement via `-group`.** One stable group id per pane, so a newer status replaces the older toast instead of stacking.
- **Click activation targets ghostty by default** (`com.mitchellh.ghostty`) because this repo's ghostty config auto-launches herdr; a one-line `terminal-bundle-id` file in the plugin config dir overrides it (e.g. for kitty).
- **Deployment mirrors the existing local plugins**: tolerant darwin-guarded link-and-enable chezmoi script (`run_onchange_after_8-...`), darwin-only `.chezmoiignore` rules, macOS-only manifest.

## Verification

- `bats tests/smoke.bats -f focus-notify` — 5/5: py_compile + no-cargo/no-alerter/no-build-step policy, safe quoting against the hostile pane id, silence for non-actionable statuses and missing pane id, stable group id, link-script guard checks.
- `bats tests/templates.bats` (39/39), `bats tests/scripts.bats` (196/196), `make lint` — clean. The new run script renders with resolving hash triggers via `chezmoi execute-template`.
- Live on this machine: `notify.py --test` exits 0 through the real `terminal-notifier`, and a direct run with the exact flag set (`-group`/`-activate`/`-execute`) posted a notification that `-remove <group>` then found and removed — so posting and group cleanup are proven.
- Full `bats tests/smoke.bats` has one expected local failure: the deployment manifest asserts against the applied `~/`, and this change is not applied on the host (applying there is forbidden). CI applies the checkout before running the suite on both ubuntu and macos, so the manifest entries are exercised there.

### Manual verification still needed (I cannot click a notification)

1. After `chezmoi apply`, `herdr plugin list` shows `seigi.focus-notify` linked and enabled.
2. The palette action "Focus notify: send test notification" shows a toast.
3. An agent reaching `blocked`/`done` while another app is frontmost raises a toast naming the agent and pane.
4. Clicking it activates the terminal and focuses the pane (`terminal-notifier -execute` click reliability on current macOS is the issue's open question — this is the step that answers it).
5. Two status changes for one pane replace the toast instead of stacking.
6. `herdr plugin log seigi.focus-notify` shows no errors; no state files appear.

## New concepts

**Consuming herdr event payloads via `HERDR_PLUGIN_EVENT_JSON`.** The two local plugins that already subscribe to `pane.agent_status_changed` ignore the event's content and re-query `herdr agent list` to re-derive truth. This plugin is the repo's first to read the payload itself: herdr puts the event JSON in the `HERDR_PLUGIN_EVENT_JSON` environment variable (event name in `HERDR_PLUGIN_EVENT`), with the changed pane under `data`:

```json
{"event": "pane.agent_status_changed",
 "data": {"pane_id": "w1:p3", "agent_status": "blocked",
          "agent": "codex", "display_agent": "Codex"}}
```

Use the payload when the event's *subject* matters (which pane changed, to what status); keep the re-query pattern when only the *aggregate* matters (caffeinate: "is any agent working?") — a payload snapshot can be stale by the time the hook runs, but the pane id it names is stable.
