### PR TITLE
docs: reconcile the Pi package inventory with the managed state

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -106,18 +106,15 @@ Local plugins kept in repo: `herdr-agent-state.js`.
 
 ### Packages (`~/.pi/agent/settings.json` → `packages[]`) — `pi install <source>`
 
+Every package is enforced by `home/dot_pi/agent/modify_settings.json`; no Pi
+package is manual.
+
 | Package                      | Source                                                    | Managed |
 | ---------------------------- | --------------------------------------------------------- | ------- |
 | compound-engineering-plugin  | `git:github.com/EveryInc/compound-engineering-plugin`     | repo    |
-| pi-theme-flexoki             | `git:github.com/markacianfrani/pi-theme-flexoki`          | manual  |
 | pi-web-access                | `npm:pi-web-access`                                       | repo    |
 | pi-context-view              | `npm:pi-context-view`                                     | repo    |
 | pi-fff                       | `npm:@ff-labs/pi-fff`                                     | repo    |
-| pi-codex-conversion          | `npm:@howaboua/pi-codex-conversion`                       | manual  |
-| pi-agents                    | `npm:pi-agents`                                           | manual  |
-| pi-subagents                 | `npm:pi-subagents`                                        | manual  |
-| pi-intercom                  | `npm:pi-intercom`                                         | manual  |
-| pi-agent-browser-native      | `npm:pi-agent-browser-native`                             | manual  |
 | pi-ask-user                  | `npm:pi-ask-user`                                         | repo    |
 | pi-subagentura               | `npm:pi-subagentura`                                      | repo    |
 | pi-loop                      | `npm:@trevonistrevon/pi-loop`                             | repo    |

--- a/docs/issues/2026-08-19-001-pi-package-inventory-drift.md
+++ b/docs/issues/2026-08-19-001-pi-package-inventory-drift.md
@@ -2,7 +2,8 @@
 title: Pi package inventory does not match current managed settings
 type: follow-up
 date: 2026-08-19
-status: open
+status: done
+closed: 2026-08-21
 ---
 
 ## Why this exists
@@ -22,3 +23,37 @@ Decide which documented Pi packages remain useful. Add selected packages to `hom
 ## Progress
 
 Chezmoi now manages `pi-web-access`, `pi-context-view`, and `npm:@ff-labs/pi-fff`. The broader manual-package inventory audit remains open.
+
+## Resolution
+
+Audit completed 2026-08-21 against three states: `pi list`, the live
+`~/.pi/agent/settings.json`, and the managed set in
+`home/dot_pi/agent/modify_settings.json`. All three agree exactly — every
+installed package is chezmoi-managed, so `modify_settings.json` and the smoke
+tests needed no change; only the doc did.
+
+| Package (doc entry)         | Verdict          | Evidence                                                              |
+| --------------------------- | ---------------- | --------------------------------------------------------------------- |
+| compound-engineering-plugin | keep, managed    | in `pi list`, settings.json, modify_settings.json                     |
+| pi-web-access               | keep, managed    | same three                                                            |
+| pi-context-view             | keep, managed    | same three                                                            |
+| pi-fff (`@ff-labs`)         | keep, managed    | same three                                                            |
+| pi-ask-user                 | keep, managed    | same three                                                            |
+| pi-subagentura              | keep, managed    | same three (pinning question stays with issue 2026-08-21-017)         |
+| pi-loop (`@trevonistrevon`) | keep, managed    | same three                                                            |
+| pi-theme-flexoki            | removed from doc | not in `pi list`; `~/.pi/agent/git/github.com/` has only `EveryInc`   |
+| pi-codex-conversion         | removed from doc | `@howaboua` absent from `~/.pi/agent/npm/node_modules/`               |
+| pi-agents                   | removed from doc | absent from node_modules                                              |
+| pi-subagents                | removed from doc | absent from node_modules (superseded in practice by `pi-subagentura`) |
+| pi-intercom                 | removed from doc | absent from node_modules                                              |
+| pi-agent-browser-native     | removed from doc | absent from node_modules                                              |
+
+Doc change: the Pi packages table in `docs/agent-setup-inventory.md` now lists
+the seven managed packages, all `repo`, with a note that
+`home/dot_pi/agent/modify_settings.json` enforces the set. No package stays
+consciously manual — the six `manual` rows described packages that are not
+installed anywhere.
+
+Side finding filed separately: the doc's Pi Skills and Agents subsections also
+drifted (skill `web-research` gone, `~/.pi/agent/agents/` gone) — see issue
+`2026-08-21-020-pi-skills-and-agents-inventory-drift`.

--- a/docs/issues/2026-08-21-020-pi-skills-and-agents-inventory-drift.md
+++ b/docs/issues/2026-08-21-020-pi-skills-and-agents-inventory-drift.md
@@ -1,0 +1,37 @@
+---
+title: Pi skills and agents in the inventory doc do not match disk
+type: follow-up
+date: 2026-08-21
+status: open
+---
+
+## Why this exists
+
+The Pi packages audit (issue `2026-08-19-001-pi-package-inventory-drift`)
+reconciled the packages table in `docs/agent-setup-inventory.md`, but the two
+neighboring Pi subsections also drifted and were out of that audit's scope:
+
+- **Skills**: the doc lists `web-research` under `~/.pi/agent/skills/`. On disk
+  that directory contains only `smithers`; `web-research` is gone.
+- **Agents**: the doc lists nine authored agents (`ask-claude`, `ask-external`,
+  `ask-opencode`, `ask-pi`, `brainstorm-doc-reviewer`, `reviewer`,
+  `se-plan-review`, `se-report-writer`, `synthes-agent`) as "authored, keep"
+  under `~/.pi/agent/agents/`. That directory does not exist, and none of the
+  nine are tracked anywhere in this repo (`rg` finds them only in the inventory
+  doc itself).
+
+The agents were marked "keep", so the doc entry may be the only remaining record
+of them — removing the lines without a decision could lose that intent.
+
+## Scope
+
+Decide per subsection: resurrect the content (recover the agents from Pi
+session history or another machine, then track them in `home/dot_pi/agent/`),
+or accept the loss and update `docs/agent-setup-inventory.md` to the actual
+state (`smithers` skill; no agents directory).
+
+## Open decisions
+
+- Are the nine authored Pi agents still wanted, and does a copy survive
+  anywhere recoverable?
+- Is the `smithers` skill worth listing (and managing) in the inventory?


### PR DESCRIPTION
The Pi packages table in `docs/agent-setup-inventory.md` again describes what a fresh machine actually gets. An audit against three sources — `pi list`, the live `~/.pi/agent/settings.json`, and the managed set in `home/dot_pi/agent/modify_settings.json` — shows all three agree exactly: seven packages, every one enforced by chezmoi, so no code, template, or test change was needed.

The six table entries marked `manual` (`pi-theme-flexoki`, `pi-codex-conversion`, `pi-agents`, `pi-subagents`, `pi-intercom`, `pi-agent-browser-native`) are installed nowhere — absent from `pi list`, the settings file, and `~/.pi/agent/npm/node_modules/` — and are removed as obsolete; no Pi package remains consciously manual. The tracking issue `docs/issues/2026-08-19-001-pi-package-inventory-drift.md` closes with the full audit table as its resolution.

The same check surfaced separate drift in the doc's Pi Skills and Agents subsections: the `web-research` skill and the nine authored agents no longer exist on disk or in the repo. Because the doc may be the only remaining record of those agents, that is filed as a new issue (`docs/issues/2026-08-21-020-pi-skills-and-agents-inventory-drift.md`) instead of being silently rewritten here.

Verified with `make test-templates` (39 ok) and `make lint` (clean).
