### PR TITLE
docs(issues): close 016 — plugin-doctor deliberately abandoned

### DIFF
--- a/docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md
+++ b/docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md
@@ -2,7 +2,8 @@
 title: plugin-doctor command exists only on the host, not reproducible from the repo
 type: bug
 date: 2026-08-21
-status: open
+status: wontfix
+closed: 2026-08-21
 ---
 
 ## Why this exists
@@ -26,3 +27,14 @@ Add a smoke test for whichever source is chosen.
 ## Open decisions
 
 - Which of the three options above; depends on whether a marketplace plugin-doctor provider exists and is trusted.
+
+## Resolution
+
+Closed as wontfix: the user confirmed the plugin-doctor capability is deliberately abandoned — option 3. The untracked host copy at `~/.claude/commands/plugin-doctor.md` was already deleted when resolution started (the directory holds only `checkpoint.md`, `end-day.md`, `start-day.md`), so no host cleanup remains; the repo state and the host now agree that the command does not exist.
+
+The other two options were ruled out on evidence, not skipped:
+
+- Option 2 (plugin provider) has no provider: none of the 8 enabled plugins in `home/private_dot_claude/private_settings.json.tmpl` (claude-md-management, compound-engineering, frontend-design, playground, playwright, plugin-dev, security-guidance, typescript-lsp) ships a plugin-doctor command, and `~/.claude/plugins/cache` contains none. Commit `d4e32f9`'s deletion message ("now provided by plugins") was factually wrong — but the deletion outcome is now the wanted one.
+- Option 1 (restore the tracked file) was built and offered as PR #30, and the user closed it unmerged as the explicit record of the not-taken alternative.
+
+If the capability is ever wanted again, the full command file remains recoverable verbatim from git history: `git show d4e32f9^:home/private_dot_claude/commands/plugin-doctor.md`.


### PR DESCRIPTION
Closes repo issue `docs/issues/2026-08-21-016-plugin-doctor-command-not-reproducible-from-repo.md` as **wontfix**: the `/plugin-doctor` Claude Code slash command is deliberately abandoned, and the issue file now records that decision with its evidence.

The issue tracked a reproducibility gap: commit d4e32f9 deleted the command from chezmoi management claiming it is "now provided by plugins", leaving it alive only as an untracked host file. Investigation established that no enabled plugin provides the command — none of the 8 plugins in `home/private_dot_claude/private_settings.json.tmpl` ships it, and the plugin cache contains none — and that the untracked host copy has meanwhile also been deleted.

The user confirmed the capability is not wanted. The alternative — restoring the tracked file — was offered as #30 and closed unmerged as the explicit record of the not-taken path. If the command is ever wanted again, it remains recoverable verbatim from git history: `git show d4e32f9^:home/private_dot_claude/commands/plugin-doctor.md`.

Docs-only change: `make lint` is clean; template and bats suites are unaffected (no template, script, or test file changed).
