### PR TITLE
fix(tests): flaky herdr-task-sync atomic-records test

### DIFF
--- a/docs/issues/2026-08-21-021-atomic-records-test-asserts-delivery-the-inbox-does-not-promise.md
+++ b/docs/issues/2026-08-21-021-atomic-records-test-asserts-delivery-the-inbox-does-not-promise.md
@@ -1,0 +1,78 @@
+---
+title: The atomic-records test asserts one-shot delivery the fail-open inbox does not promise
+type: bug
+date: 2026-08-21
+status: done
+closed: 2026-08-21
+---
+
+## Why this exists
+
+`herdr-task-sync atomic records never expose truncation or mixed fields`
+(`tests/scripts.bats`) failed on three CI runs within minutes on 2026-08-21 —
+`test-ubuntu` on run `32468923311` and `test-macos` on runs `32468558665` and
+`32468832954` — on three branches whose diffs touch no herdr-task-sync code. All
+three show the same signature: `hts_wait_for_task_slug "$task" atomic-40` runs
+to its ceiling, no error and no kill anywhere before it, then post-teardown
+ENOENT noise from paths inside the already-deleted `$HTS_WORK`
+(`bad-reader: No such file or directory`).
+
+Two defects combined:
+
+1. **The primary failure.** The engine's inbox is fail-open by design: both the
+   enqueue and the worker commit take `control.lock` with a bounded
+   `acquire_claim` (`INBOX_LOCK_ATTEMPTS`, default 20) and drop the request
+   silently on exhaustion (`acquire_claim ... || exit 0` in the enqueue path of
+   `home/dot_local/bin/executable_herdr-task-sync`; `|| return 1` →
+   `abort_worker` in `commit_task_result`). The test fires 40 rapid sequential
+   `--set` enqueues — exactly the load that provokes those drops — and then
+   asserts one-shot delivery of the final `atomic-40`. On a `--jobs 8` CI runner
+   the sentinel (or its commit) can lose its whole lock window; the slug then
+   never arrives and the wait times out. Proven deterministically on the host:
+   an enqueue issued while `control.lock` is held by a live owner exits 0 and
+   leaves `generation` unchanged — the set vanishes without a trace; the next
+   enqueue after release lands.
+2. **The misleading noise.** On any assertion failure the test's backgrounded
+   reader loop is never stopped: the `: > "$stop"` / `wait "$reader"` pair sits
+   after the failing line. Teardown's `rm -rf "$HTS_WORK"` then races the still
+   running loop — which can never terminate once its stop file's directory is
+   gone — leaving an orphan spinning at 5 ms intervals for the rest of the job
+   and burying the real failure under ENOENT spray.
+
+This is the flake family `docs/issues/2026-08-20-010` predicted:
+within-file parallelism exposing an assumption calibrated on an idle machine —
+here a delivery assumption rather than a wall-clock one
+(`docs/issues/2026-08-21-015` names the pattern).
+
+## Scope
+
+- `tests/scripts.bats` — the atomic-records test and `teardown()`.
+
+## Resolution
+
+Fixed in the same change that files this issue.
+
+- The 40-set burst stays untouched as the load generator, and the atomicity
+  assertions the reader collects stay as strict as before. Only sentinel
+  delivery is made deterministic: after the burst the test re-enqueues
+  `--set atomic-40` (up to 10 times, short poll between attempts) until the
+  slug commits, then keeps the original full-ceiling wait as the final
+  assertion. A re-enqueue also drains a pending generation whose own worker
+  aborted, so both drop modes recover.
+- `teardown()` now reaps `$HTS_READER_PID` (set by the test, cleared after its
+  own `wait`) before deleting `$HTS_WORK`, so a failed run kills the reader
+  instead of orphaning it, and the real failure output stays readable.
+
+Verification: the drop mechanism reproduced deterministically at the engine
+level (held `control.lock` → enqueue exits 0, `generation` unchanged); the
+fixed test passed 15/15 focused repetitions and two full
+`bats --jobs 8 --no-parallelize-across-files tests/scripts.bats` runs
+(196 ok, 0 failures each); `make lint` clean. The CI race itself did not
+reproduce on an idle 10-core host (5 starved-lock runs, 4 runs under 12 busy
+loops with `HERDR_TASK_SYNC_LOCK_ATTEMPTS=1` — all green), consistent with
+2026-08-20-010's finding that CPU pressure alone is the wrong contention
+profile; the deterministic engine-level proof is the evidence the fix rests on.
+
+The engine's fail-open inbox is deliberate and stays as shipped: in production
+a dropped request costs one pane-label refresh and the next event repairs it.
+The defect was the test demanding a stronger contract than the engine offers.

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -8,6 +8,14 @@ setup() {
 }
 
 teardown() {
+  # Reap a background reader a failed test left running BEFORE deleting its
+  # HTS_WORK: the loop only stops via a file inside HTS_WORK, so once that
+  # directory is gone the orphan spins forever and its ENOENT stderr lands on
+  # top of the real failure output.
+  if [[ -n "${HTS_READER_PID:-}" ]]; then
+    kill "$HTS_READER_PID" 2>/dev/null || true
+    wait "$HTS_READER_PID" 2>/dev/null || true
+  fi
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
   [[ -n "${HTS_WORK:-}" ]] && rm -rf "$HTS_WORK" || true
   [[ -n "${CHILD_STUB:-}" ]] && rm -rf "$CHILD_STUB" || true
@@ -2227,7 +2235,7 @@ PY
 
 @test "herdr-task-sync atomic records never expose truncation or mixed fields" {
   hts_setup
-  local task control reconcile stop="$HTS_WORK/stop-reader" bad="$HTS_WORK/bad-reader" reader i
+  local task control reconcile stop="$HTS_WORK/stop-reader" bad="$HTS_WORK/bad-reader" reader i poll
   task="$(hts_task_file "$HTS_DEFAULT_SOCKET" pi pane-1 atomic-s)"
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
   reconcile="$(hts_namespace "$HTS_DEFAULT_SOCKET")/reconcile.state"
@@ -2256,12 +2264,34 @@ PY
     done
   ) &
   reader=$!
+  # Teardown owns the reader from here: a failed assertion below would skip the
+  # stop/wait pair, and the orphaned loop then races teardown's rm -rf of
+  # HTS_WORK forever (its stop file can no longer be created), spraying
+  # misleading ENOENT noise over the real failure.
+  HTS_READER_PID=$reader
   for i in $(seq 1 40); do
     hts_run --agent pi --session atomic-s --set "atomic-$i" < /dev/null
+  done
+  # The engine's inbox is fail-open by design: an enqueue or a worker commit
+  # that loses its bounded control.lock window (INBOX_LOCK_ATTEMPTS) drops the
+  # request silently rather than stall the callback. The 40-set burst above is
+  # exactly the load that provokes those drops, so delivery of the final set is
+  # not guaranteed in one shot — under CI --jobs contention the sentinel
+  # vanished and this wait ran to its ceiling. Re-enqueue the sentinel until it
+  # commits; every re-enqueue spawns a fresh worker, which also drains a
+  # pending generation whose own worker aborted. The atomicity assertions the
+  # reader collects stay as strict as before.
+  for i in $(seq 1 10); do
+    for poll in $(seq 1 200); do
+      [[ "$(hts_record_text "$task" slug 2>/dev/null || true)" = atomic-40 ]] && break 2
+      sleep 0.01
+    done
+    hts_run --agent pi --session atomic-s --set atomic-40 < /dev/null
   done
   hts_wait_for_task_slug "$task" atomic-40
   : > "$stop"
   wait "$reader"
+  unset HTS_READER_PID
   assert_file_not_exists "$bad"
 }
 


### PR DESCRIPTION
The flaky `herdr-task-sync atomic records never expose truncation or mixed fields` test no longer asserts a delivery guarantee the engine deliberately does not provide. It went red on three CI runs across three unrelated branches on 2026-08-21 (runs 32468923311 ubuntu, 32468558665 and 32468832954 macos), always the same way: `hts_wait_for_task_slug "$task" atomic-40` ran to its ceiling with no error before it.

Root cause: the herdr-task-sync inbox is fail-open by design — both the enqueue and the worker commit take `control.lock` through a bounded `acquire_claim` and silently drop the request when the window is exhausted. The test fires 40 rapid sequential `--set` enqueues (exactly the load that provokes drops) and then asserted one-shot delivery of the final `atomic-40`. Under `--jobs 8` CI contention the sentinel — or its commit — loses the lock window, and the slug can never arrive. Reproduced deterministically on the host: an enqueue issued while `control.lock` is held by a live owner exits 0 and leaves `generation` unchanged; the next enqueue after release lands.

The fix keeps the 40-set burst as the load generator and keeps every atomicity assertion the background reader collects exactly as strict as before. Only sentinel delivery changes: the test now re-enqueues `--set atomic-40` (bounded, short poll between attempts) until it commits — each re-enqueue spawns a fresh worker, which also drains a pending generation whose own worker aborted — then the original full-ceiling wait remains as the final assertion. This is not a blanket retry of the test: a torn or mixed record still fails immediately.

Second defect fixed alongside: on any assertion failure the backgrounded reader was never stopped, so teardown's `rm -rf "$HTS_WORK"` raced it and left an unstoppable 5 ms spin loop whose ENOENT output (`bad-reader: No such file or directory` in the CI logs) buried the real failure. `teardown()` now reaps the reader before deleting its work directory.

Validation: the fixed test passed 15/15 focused repetitions and two full `bats --jobs 8 --no-parallelize-across-files tests/scripts.bats` runs (196 ok, 0 failures each); `make lint` clean. The CI race itself does not reproduce on an idle 10-core host (starved-lock and busy-loop attempts stayed green), so the deterministic engine-level drop proof is the evidence the fix rests on. Full write-up: `docs/issues/2026-08-21-021-atomic-records-test-asserts-delivery-the-inbox-does-not-promise.md`.
