### PR TITLE
fix(tests): flaky herdr-task-sync sweep location-repair test

### DIFF
--- a/docs/issues/2026-08-21-024-sweep-location-test-runs-the-75ms-production-git-budget.md
+++ b/docs/issues/2026-08-21-024-sweep-location-test-runs-the-75ms-production-git-budget.md
@@ -1,0 +1,67 @@
+---
+title: The sweep location-repair test ran its git probes on the 75 ms production budget
+type: bug
+date: 2026-08-21
+status: done
+closed: 2026-08-21
+---
+
+## Why this exists
+
+`herdr-task-sync sweep repairs process and CWD changes through the presentation
+coordinator` (`tests/scripts.bats`) failed twice on CI macos jobs on 2026-08-21,
+at two different assertions with one signature — the process-label repair
+succeeded while the **worktree location token** did not:
+
+- run `32469269551` (09:49): first-pass assertion, `tokens.worktree` expected
+  `old`, actual `null`;
+- run `32473218810` attempt 1 (10:46, PR #33 whose diff is Brewfiles and docs):
+  post-sweep assertion, expected `new-worktree`, actual `old` — while the
+  `cargo test` label assert on the line above passed.
+
+Root cause: the engine's git location probe runs under
+`LOCATION_GIT_BUDGET="${HERDR_TASK_SYNC_GIT_BUDGET:-0.075}"` with a `kill -9`
+watchdog (`home/dot_local/bin/executable_herdr-task-sync`,
+`run_budgeted_command`). A probe that loses the 75 ms race is killed and the
+pane degrades to `location_status=stale` — by design, the next pass repairs it.
+The harness knows this: `HTS_GIT_BUDGET` (2 s) exists exactly to keep stub
+probes inside the budget, and `hts_location_pass` applies it to every location
+test. But this test called bare `hts_event_run` for its first pass and
+`hts_sweep_run` for its second, and neither carried the calibrated budget — so
+both passes ran a forked bash-stub git (awk over a registry plus marker writes)
+against the 75 ms production bound. On a loaded `--jobs 8` CI runner the stub
+loses that race; on an idle host it never does, which is why the flake is
+CI-only.
+
+This is the third missed call site of the wall-clock pattern
+`docs/issues/2026-08-21-015` names: the first two 75 ms/5 s idle-calibrated
+bounds were fixed in `543ca9e` and `7f675e1`; the sweep path kept the
+production budget.
+
+## Scope
+
+- `tests/scripts.bats` — `hts_sweep_run` and the sweep location-repair test.
+
+## Resolution
+
+Fixed in the same change that files this issue.
+
+- `hts_sweep_run` now defaults `HERDR_TASK_SYNC_GIT_BUDGET` to `HTS_GIT_BUDGET`
+  the same way `hts_location_pass` does; an explicit env override still wins,
+  so the deliberate stale-path tests keep their knob.
+- The test's first pass uses `hts_location_pass` instead of bare
+  `hts_event_run` + quiescence wait — identical semantics plus the budget.
+- Assertions are unchanged and as strict as before; no retries, no skips.
+
+This is a budget correction, not a timeout widen-to-hide: the root cause
+genuinely is a too-tight bound — a UI-latency budget calibrated against real
+git on an idle machine, applied to a test stub under CI load.
+
+Verification: the CI failure reproduced **verbatim** on the pre-fix file by
+starving the budget (`HERDR_TASK_SYNC_GIT_BUDGET=0.0001` → `expected: old,
+actual: null`, byte-identical to run 32469269551's block), proving killed
+probe → missing/stale worktree token; the fixed test passes 15/15 focused
+repetitions and two full `bats --jobs 8 --no-parallelize-across-files
+tests/scripts.bats` runs (196 ok, 0 failures each); the override knob still
+reaches the engine (starved budget still fails, as the stale-path tests
+require); `make lint` clean.

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1625,11 +1625,17 @@ hts_crash_run() {
 }
 
 # The sweep modes carry no agent and no pane, so they run the script directly
-# rather than through hts_run.
+# rather than through hts_run. The git budget mirrors hts_location_pass: the
+# shipped 75 ms SIGKILL bound is a UI-latency budget calibrated against real
+# git on an idle machine, and a forked bash-stub probe under --jobs load loses
+# that race, degrades the pane to location_status=stale, and flakes any
+# location assertion (the pattern docs/issues/2026-08-21-015 names; this was
+# its third missed call site after 543ca9e and 7f675e1).
 hts_sweep_run() {
   env PATH="$HTS_STUB:/usr/bin:/bin" \
     HERDR_TASK_SYNC_STATE_DIR="$HTS_STATE" \
     HERDR_TASK_SYNC_SWEEP_INTERVAL="${HTS_SWEEP_INTERVAL:-1}" \
+    HERDR_TASK_SYNC_GIT_BUDGET="${HERDR_TASK_SYNC_GIT_BUDGET:-$HTS_GIT_BUDGET}" \
     bash "$HTS_ENGINE" "$@"
 }
 
@@ -4146,8 +4152,10 @@ socket_path=$(printf '%s' "$HTS_DEFAULT_SOCKET" | base64 | tr -d '\n')"
   hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
   hts_git_location_fixture "$old" "$old" "$common" refs/heads/old
   hts_set_process_label pane-1 btop
-  hts_event_run
-  hts_wait_for_presentation_quiescence "$HTS_DEFAULT_SOCKET"
+  # hts_location_pass, not bare hts_event_run: this pass asserts a worktree
+  # token, so its git probe needs the calibrated HTS_GIT_BUDGET instead of the
+  # shipped 75 ms bound (killed probe -> tokens.worktree null under load).
+  hts_location_pass
   assert_equal "$(jq -r '.panes[0].label' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" btop
   assert_equal "$(jq -r '.panes[0].tokens.worktree' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" old
 


### PR DESCRIPTION
The flaky `herdr-task-sync sweep repairs process and CWD changes through the presentation coordinator` test no longer runs its git probes against the shipped 75 ms production budget. It failed on two CI macos jobs today (runs 32469269551 and 32473218810) with one signature at two assertions: the process-label repair succeeded while the worktree location token did not — `null` after the first pass in one run, stale `old` after the sweep in the other. The failing branches' diffs do not touch this code.

Root cause: the engine kills any git location probe that exceeds `LOCATION_GIT_BUDGET` (shipped default 0.075 s, `kill -9`) and degrades the pane to `location_status=stale` — deliberately, because the next sweep repairs it. The test harness already compensates for this: `HTS_GIT_BUDGET` (2 s) exists precisely so a forked bash-stub probe survives CI load, and `hts_location_pass` applies it to every location test. This test was the missed call site — it drove its first pass through bare `hts_event_run` and its second through `hts_sweep_run`, neither of which carried the calibrated budget, so both passes raced a bash stub (awk over a registry plus marker writes) against 75 ms. Idle hosts always win that race, which is why the flake is CI-only. This is the third instance of the idle-calibrated wall-clock pattern documented in `docs/issues/2026-08-21-015`; the first two bounds were fixed in 543ca9e and 7f675e1.

The fix is a budget correction, not a widen-to-hide: the first pass now goes through `hts_location_pass`, and `hts_sweep_run` defaults `HERDR_TASK_SYNC_GIT_BUDGET` to `HTS_GIT_BUDGET` the same way — an explicit env override still wins, so the tests that deliberately exercise the stale path keep their knob. Every assertion is unchanged and as strict as before; no retries, no skips.

Validation: the CI failure reproduces verbatim on the pre-fix file by starving the budget (`HERDR_TASK_SYNC_GIT_BUDGET=0.0001` yields `expected: old / actual: null`, byte-identical to run 32469269551's failure block), which pins the mechanism as killed probe → missing or stale worktree token. The fixed test passed 15/15 focused repetitions and two full `bats --jobs 8 --no-parallelize-across-files tests/scripts.bats` runs (196 ok, 0 failures each); the starved-budget override still fails as the stale-path tests require; `make lint` is clean. Write-up: `docs/issues/2026-08-21-024-sweep-location-test-runs-the-75ms-production-git-budget.md`.
