### PR TITLE
feat(issues): make active issue lists scannable

### DIFF
--- a/.claude/skills/repository-issues/SKILL.md
+++ b/.claude/skills/repository-issues/SKILL.md
@@ -13,8 +13,8 @@ Each issue is `docs/issues/YYYY-MM-DD-NNN-slug.md`. Its frontmatter has these re
 
 | Field | Values or format |
 |---|---|
-| `title` | Non-empty text |
-| `short_description` | Non-empty text |
+| `title` | Concise, stable label for the issue |
+| `short_description` | One self-contained sentence that explains the issue beyond the title |
 | `type` | `bug`, `follow-up`, `idea`, or `chore` |
 | `category` | A category in the table below |
 | `tags` | JSON array of unique kebab-case tags |
@@ -23,6 +23,27 @@ Each issue is `docs/issues/YYYY-MM-DD-NNN-slug.md`. Its frontmatter has these re
 | `priority` | `critical`, `high`, `medium`, or `low` |
 
 `parent-plan` is optional. Terminal issues also require `closed` and a `## Resolution` section. Active issues require `## Why this exists`, `## Scope`, and `## Open decisions`.
+
+### Writing titles and short descriptions
+
+Keep `title` concise and stable so lists remain scannable. Use `short_description` for the current, information-dense summary of the issue.
+
+A good `short_description`:
+
+- is one self-contained sentence;
+- adds concrete mechanism, impact, evidence, constraint, or intended outcome beyond the title;
+- keeps useful commands, paths, measurements, and known blockers when they explain why the issue matters;
+- describes the current understanding, not only the state when the issue was created;
+- does not repeat or lightly paraphrase the title.
+
+When investigation changes the diagnosis, impact, scope, blocker, or intended outcome, update `short_description` in the same lifecycle operation. Before finishing `start`, `edit`, `close`, or `wontfix` work, compare the description with the current issue body and revise stale wording through `scripts/issues edit`.
+
+Example:
+
+```yaml
+title: "macOS suite misses wall-time gate"
+short_description: "The parallel post-apply suite reaches 67% of the serial baseline against a 60% target; stable runs show a deferred optimization gap rather than a regression."
+```
 
 ## Classification
 

--- a/docs/issues/2026-08-14-008-doc-review-path-has-no-live-coverage.md
+++ b/docs/issues/2026-08-14-008-doc-review-path-has-no-live-coverage.md
@@ -1,6 +1,6 @@
 ---
 title: "The verify-doc waive path has no live coverage since it was rewritten"
-short_description: "The verify-doc waive path has no live coverage since it was rewritten"
+short_description: "A $2.72 live run verified stripped advisory delivery and payload-based review status, but only a deliberately triggered P0 can prove that the rewritten waive path persists findings without the raw `SEVERITY:` line."
 type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]

--- a/docs/issues/2026-08-14-015-run-budgets.md
+++ b/docs/issues/2026-08-14-015-run-budgets.md
@@ -1,6 +1,6 @@
 ---
 title: "Decide what a run budget is for, and give se pipeline one"
-short_description: "Decide what a run budget is for, and give se pipeline one"
+short_description: "Unlike `se flow`, `se pipeline` has no whole-run spending ceiling or pre-launch estimate, so two failed work-stage runs consumed $16 without warning or control."
 type: "idea"
 category: "se-pipeline"
 tags: ["se-pipeline","idea"]

--- a/docs/issues/2026-08-14-020-pipeline-launch-surface.md
+++ b/docs/issues/2026-08-14-020-pipeline-launch-surface.md
@@ -1,6 +1,6 @@
 ---
 title: "Decide what a pipeline launch should ask the operator for, and delete the rest"
-short_description: "Decide what a pipeline launch should ask the operator for, and delete the rest"
+short_description: "The pipeline schema exposes eleven inputs while operators reliably know only the plan, fails to elicit setup controls that prevent fresh-worktree failures, and advertises `--until=pr` although gate 0 always refuses it."
 type: "idea"
 category: "se-pipeline"
 tags: ["se-pipeline","idea"]

--- a/docs/issues/2026-08-15-005-se-flow-has-no-main-checkout-escape-diagnosis.md
+++ b/docs/issues/2026-08-15-005-se-flow-has-no-main-checkout-escape-diagnosis.md
@@ -1,6 +1,6 @@
 ---
 title: "An se-flow run that writes into the main checkout reports \"no content change\", not the cause"
-short_description: "An se-flow run that writes into the main checkout reports \"no content change\", not the cause"
+short_description: "Because `se-flow` records no main-checkout digest, its KTD14 tree-hash failure reports \"no content change\" when escaped edits may exist in the main checkout, although the known escape doorway is now closed."
 type: "follow-up"
 category: "se-pipeline"
 tags: ["se-pipeline","follow-up"]

--- a/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
+++ b/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
@@ -1,6 +1,6 @@
 ---
 title: "A supervisor process that subscribes to herdr agent-status events"
-short_description: "A supervisor process that subscribes to herdr agent-status events"
+short_description: "Run a long-lived socket subscriber for `pane_agent_status_changed` so a parent receives terminal or blocked child status after crashes or missed callbacks, while timeout-based hang detection remains unresolved."
 type: "idea"
 category: "herdr"
 tags: ["herdr","idea"]

--- a/docs/issues/2026-08-18-001-launch-time-permission-mode-for-child-agents.md
+++ b/docs/issues/2026-08-18-001-launch-time-permission-mode-for-child-agents.md
@@ -1,6 +1,6 @@
 ---
 title: "Set a child agent's permission mode at launch instead of inheriting bypassPermissions"
-short_description: "Set a child agent's permission mode at launch instead of inheriting bypassPermissions"
+short_description: "A read-only Claude child inherits `bypassPermissions` and can write through its shell, so launch-time controls must restrict tools while preserving the mandatory `herdr agent prompt` return channel."
 type: "idea"
 category: "agent-platform"
 tags: ["agent-platform","idea"]

--- a/docs/issues/2026-08-18-002-sandbox-a-child-agents-filesystem-access.md
+++ b/docs/issues/2026-08-18-002-sandbox-a-child-agents-filesystem-access.md
@@ -1,6 +1,6 @@
 ---
 title: "Sandbox a child agent's filesystem access"
-short_description: "Sandbox a child agent's filesystem access"
+short_description: "Contain child processes because OpenCode's shared `permission.external_directory` value of `\"*\": \"allow\"` exposes credential-bearing host paths to every session, while isolated children must retain their parent return channel."
 type: "idea"
 category: "agent-platform"
 tags: ["agent-platform","idea"]

--- a/docs/issues/2026-08-18-003-headless-peer-consult-outside-herdr.md
+++ b/docs/issues/2026-08-18-003-headless-peer-consult-outside-herdr.md
@@ -1,6 +1,6 @@
 ---
 title: "Consulting a peer agent from outside herdr"
-short_description: "Consulting a peer agent from outside herdr"
+short_description: "Restore peer consultation outside Herdr without duplicating per-agent option mappings, preferably through Smithers while retaining the stronger headless posture that denies shell access."
 type: "follow-up"
 category: "herdr"
 tags: ["herdr","follow-up"]

--- a/docs/issues/2026-08-18-004-palette-frecency-ranking.md
+++ b/docs/issues/2026-08-18-004-palette-frecency-ranking.md
@@ -1,6 +1,6 @@
 ---
 title: "Rank the command palette's resting list by frecency"
-short_description: "Rank the command palette's resting list by frecency"
+short_description: "Persist an atomically written selection history and apply zoxide-style frecency only to empty-query results, so learned ordering never competes with fuzzy search."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-005-palette-alias-tier.md
+++ b/docs/issues/2026-08-18-005-palette-alias-tier.md
@@ -1,6 +1,6 @@
 ---
 title: "Give command palette commands aliases that match by strict prefix, never fuzzy"
-short_description: "Give command palette commands aliases that match by strict prefix, never fuzzy"
+short_description: "Define how case-insensitive prefix shortcuts collide across global and project commands, because the implemented group-order tie-break lets projects silently shadow familiar shortcuts."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-006-palette-preview-pane.md
+++ b/docs/issues/2026-08-18-006-palette-preview-pane.md
@@ -1,6 +1,6 @@
 ---
 title: "Show a preview of the selected pane's contents in the command palette"
-short_description: "Show a preview of the selected pane's contents in the command palette"
+short_description: "Render selected pane contents through `herdr pane read --format ansi`, with a 70 ms debounce and 1.5 s cache to keep terminal input responsive."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-007-palette-pane-and-tab-switcher.md
+++ b/docs/issues/2026-08-18-007-palette-pane-and-tab-switcher.md
@@ -1,6 +1,6 @@
 ---
 title: "Add a pane switcher and a tab switcher to the command palette"
-short_description: "Add a pane switcher and a tab switcher to the command palette"
+short_description: "Build searchable pane and tab rows from `session.snapshot`, using the socket-only `pane.focus` method because the CLI cannot focus arbitrary non-agent panes by ID."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-008-palette-dynamic-plugin-action-source.md
+++ b/docs/issues/2026-08-18-008-palette-dynamic-plugin-action-source.md
@@ -1,6 +1,6 @@
 ---
 title: "Surface every installed herdr plugin's actions in the command palette"
-short_description: "Surface every installed herdr plugin's actions in the command palette"
+short_description: "Load installed actions from `herdr plugin action list`, exclude the palette itself, and label their origin so plugin capabilities no longer require manual TOML duplication."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-009-palette-select-options-from-command.md
+++ b/docs/issues/2026-08-18-009-palette-select-options-from-command.md
@@ -1,6 +1,6 @@
 ---
 title: "Let a command palette select command generate its options from a shell command"
-short_description: "Let a command palette select command generate its options from a shell command"
+short_description: "Add `choices_command` output as dynamic select options while distinguishing command failure from zero results and preserving the originating pane's working-directory context."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-010-palette-herdr-builtin-command-catalog.md
+++ b/docs/issues/2026-08-18-010-palette-herdr-builtin-command-catalog.md
@@ -1,6 +1,6 @@
 ---
 title: "Ship a catalog of herdr's built-in operations in the command palette"
-short_description: "Ship a catalog of herdr's built-in operations in the command palette"
+short_description: "Import a verified catalog of roughly 30 Herdr operations with exact argv and compatibility checks, after destructive entries gain confirmation and list growth gains ranking controls."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-011-palette-query-field-filters.md
+++ b/docs/issues/2026-08-18-011-palette-query-field-filters.md
@@ -1,6 +1,6 @@
 ---
 title: "Support field filters in the command palette's query string"
-short_description: "Support field filters in the command palette's query string"
+short_description: "Parse filters such as `group:git` and `origin:project` before fuzzy scoring, with quoted values, negation, and fail-closed diagnostics for unknown fields."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-012-palette-jump-back-workspace.md
+++ b/docs/issues/2026-08-18-012-palette-jump-back-workspace.md
@@ -1,6 +1,6 @@
 ---
 title: "Jump back to the previous workspace from the command palette"
-short_description: "Jump back to the previous workspace from the command palette"
+short_description: "Persist a depth-one previous-workspace ID only after real transitions, clear stale targets, and capture non-palette focus events so the record remains accurate."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-013-palette-confirm-destructive-commands.md
+++ b/docs/issues/2026-08-18-013-palette-confirm-destructive-commands.md
@@ -1,6 +1,6 @@
 ---
 title: "Confirm destructive command palette commands, with the cursor starting on No"
-short_description: "Confirm destructive command palette commands, with the cursor starting on No"
+short_description: "Require destructive commands to confirm their resolved target with the cursor on No, while preventing key repeat from dismissing the prompt immediately."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-014-palette-percentage-popup-sizing.md
+++ b/docs/issues/2026-08-18-014-palette-percentage-popup-sizing.md
@@ -1,6 +1,6 @@
 ---
 title: "Size the command palette popup in percentages instead of fixed cells"
-short_description: "Size the command palette popup in percentages instead of fixed cells"
+short_description: "Move the hardcoded 104×34 geometry into percentage-based manifest settings after verifying whether undocumented `popup` placement differs from the declared `overlay` behavior."
 type: "chore"
 category: "command-palette"
 tags: ["command-palette","chore"]

--- a/docs/issues/2026-08-18-015-palette-verify-dispatched-plugin-action.md
+++ b/docs/issues/2026-08-18-015-palette-verify-dispatched-plugin-action.md
@@ -1,6 +1,6 @@
 ---
 title: "Verify that a dispatched plugin action reached a terminal state"
-short_description: "Verify that a dispatched plugin action reached a terminal state"
+short_description: "Use the invoke response's `log_id` and `plugin_id` to poll `herdr plugin log list`, because a zero invoke exit code proves acceptance rather than action success."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-016-palette-command-bundles.md
+++ b/docs/issues/2026-08-18-016-palette-command-bundles.md
@@ -1,6 +1,6 @@
 ---
 title: "Let a command palette command ship with its own scripts as a bundle"
-short_description: "Let a command palette command ship with its own scripts as a bundle"
+short_description: "Let each command directory carry TOML and colocated scripts referenced through a relocatable command-directory variable, so project workflows travel and delete as one unit."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-017-evaluate-herdr-omnisearch-plugin.md
+++ b/docs/issues/2026-08-18-017-evaluate-herdr-omnisearch-plugin.md
@@ -1,6 +1,6 @@
 ---
 title: "Evaluate herdr-omnisearch as a sibling plugin for searching pane contents"
-short_description: "Evaluate herdr-omnisearch as a sibling plugin for searching pane contents"
+short_description: "Evaluate the SQLite FTS5 pane-search plugin only after reproducing its reported live-pane scrolling and deciding whether archived conversation indexing creates an acceptable privacy surface."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-018-run-smithers-pipeline-agents-in-microsandbox.md
+++ b/docs/issues/2026-08-18-018-run-smithers-pipeline-agents-in-microsandbox.md
@@ -1,6 +1,6 @@
 ---
 title: "Run Smithers pipeline agents in Microsandbox with Herdr visibility"
-short_description: "Run Smithers pipeline agents in Microsandbox with Herdr visibility"
+short_description: "Upgrade `smithers-orchestrator@0.32.0` to pinned `smthrs@0.35.x` and prove that Microsandbox isolates worktrees and credentials while returning validated output, diffs, durable state, and Herdr events."
 type: "follow-up"
 category: "agent-platform"
 tags: ["agent-platform","follow-up"]

--- a/docs/issues/2026-08-18-019-add-manual-agentbox-sessions-to-herdr.md
+++ b/docs/issues/2026-08-18-019-add-manual-agentbox-sessions-to-herdr.md
@@ -1,6 +1,6 @@
 ---
 title: "Add manual AgentBox sessions to Herdr without requiring a pipeline"
-short_description: "Add manual AgentBox sessions to Herdr without requiring a pipeline"
+short_description: "Manage AgentBox and its Herdr plugin through chezmoi so interactive isolated sessions expose lifecycle state and inspectable branches without installer-driven config drift or undocumented host credentials."
 type: "follow-up"
 category: "herdr"
 tags: ["herdr","follow-up"]

--- a/docs/issues/2026-08-18-021-harden-child-agent-ownership-and-launch-cleanup.md
+++ b/docs/issues/2026-08-18-021-harden-child-agent-ownership-and-launch-cleanup.md
@@ -1,6 +1,6 @@
 ---
 title: "Harden child-agent ownership and launch cleanup"
-short_description: "Harden child-agent ownership and launch cleanup"
+short_description: "Add parent-scoped launch ownership because `herdr-child` can target an unrelated live agent, while malformed successful split responses can hide the new pane ID and leave an orphan."
 type: "follow-up"
 category: "agent-platform"
 tags: ["agent-platform","follow-up"]

--- a/docs/issues/2026-08-18-023-palette-keyboard-layout-folding.md
+++ b/docs/issues/2026-08-18-023-palette-keyboard-layout-folding.md
@@ -1,6 +1,6 @@
 ---
 title: "Match command palette queries typed in the wrong keyboard layout"
-short_description: "Match command palette queries typed in the wrong keyboard layout"
+short_description: "Apply a ЙЦУКЕН-to-QWERTY positional mapping as a Cyrillic-query search pass, eliminating per-command Cyrillic shortcuts without changing normal Latin matching."
 type: "idea"
 category: "command-palette"
 tags: ["command-palette","idea"]

--- a/docs/issues/2026-08-18-024-palette-focus-sleeps-live-trial.md
+++ b/docs/issues/2026-08-18-024-palette-focus-sleeps-live-trial.md
@@ -1,6 +1,6 @@
 ---
 title: "Remove the command palette's three sleep-based focus workarounds"
-short_description: "Remove the command palette's three sleep-based focus workarounds"
+short_description: "Replace three 0.2–0.4 second focus delays only after user-run `chezmoi apply` trials establish whether popup teardown races on a loaded Herdr 0.8.0 session."
 type: "bug"
 category: "command-palette"
 tags: ["command-palette","bug"]

--- a/docs/issues/2026-08-18-026-preserve-verification-command-working-directories.md
+++ b/docs/issues/2026-08-18-026-preserve-verification-command-working-directories.md
@@ -1,6 +1,6 @@
 ---
 title: "Preserve each Verification Contract command's working directory in the se-work gate"
-short_description: "Preserve each Verification Contract command's working directory in the se-work gate"
+short_description: "The fallback parser drops package working directories, causing run-1787064382632 to fail after a paid work leg even though all six verification rows passed from their declared directories."
 type: "bug"
 category: "se-pipeline"
 tags: ["se-pipeline","bug"]

--- a/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
+++ b/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
@@ -1,6 +1,6 @@
 ---
 title: "make test-ubuntu fails two tests on main because the Docker harness lacks two setup steps GitHub CI has"
-short_description: "make test-ubuntu fails two tests on main because the Docker harness lacks two setup steps GitHub CI has"
+short_description: "Docker mounts `tests/` and `home/` apart and read-only, breaking the Pi updater import and preventing Smithers dependency installation, while GitHub CI keeps the trees resolvable and runs `bun install`."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]

--- a/docs/issues/2026-08-20-009-se-simplify-apply-timeout-budget.md
+++ b/docs/issues/2026-08-20-009-se-simplify-apply-timeout-budget.md
@@ -1,6 +1,6 @@
 ---
 title: "se-simplify apply leg dies on APPLY_TIMEOUT_MS in repos with a slow test suite"
-short_description: "se-simplify apply leg dies on APPLY_TIMEOUT_MS in repos with a slow test suite"
+short_description: "Run 85e40697-1cb3-4b25-b4f6-61e17dd2d677 spent 12.5 minutes on redundant baseline tests before the fixed 20-minute timeout killed the apply leg and reverted every edit."
 type: "bug"
 category: "se-pipeline"
 tags: ["se-pipeline","bug"]

--- a/docs/issues/2026-08-20-012-same-name-repos-defeat-tab-repo-qualification.md
+++ b/docs/issues/2026-08-20-012-same-name-repos-defeat-tab-repo-qualification.md
@@ -1,6 +1,6 @@
 ---
 title: "Two repositories with the same folder name defeat the multi-repo tab qualifier"
-short_description: "Two repositories with the same folder name defeat the multi-repo tab qualifier"
+short_description: "Repository identity currently uses folder basenames and 12-character display tokens, so same-named or shared-prefix repositories produce missing or identical tab qualifiers."
 type: "bug"
 category: "repository-maintenance"
 tags: ["repository-maintenance","bug"]

--- a/docs/issues/2026-08-20-014-make-test-ubuntu-labeling-drift.md
+++ b/docs/issues/2026-08-20-014-make-test-ubuntu-labeling-drift.md
@@ -1,6 +1,6 @@
 ---
 title: "make test-ubuntu labeling drift — runs test-quick, docs say \"Full test\""
-short_description: "make test-ubuntu labeling drift — runs test-quick, docs say \"Full test\""
+short_description: "The `test-quick` and `test-full` services both perform a full `chezmoi apply` plus the suite, so the current names and documentation conceal that neither path skips package installation."
 type: "chore"
 category: "testing-ci"
 tags: ["testing-ci","chore"]

--- a/docs/issues/2026-08-21-005-post-apply-suite-invocation-duplicated.md
+++ b/docs/issues/2026-08-21-005-post-apply-suite-invocation-duplicated.md
@@ -1,6 +1,6 @@
 ---
 title: "The post-apply suite invocation is duplicated across five sites and drift degrades silently to sequential"
-short_description: "The post-apply suite invocation is duplicated across five sites and drift degrades silently to sequential"
+short_description: "Five independent bats invocations can silently lose parallel flags or new test files, while any shared definition must preserve the host-safe subset that excludes `tests/idempotent.bats`."
 type: "follow-up"
 category: "repository-maintenance"
 tags: ["repository-maintenance","follow-up"]

--- a/docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md
+++ b/docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md
@@ -1,6 +1,6 @@
 ---
 title: "Sharding the post-apply suite across CI jobs was never evaluated against within-file parallelism"
-short_description: "Sharding the post-apply suite across CI jobs was never evaluated against within-file parallelism"
+short_description: "Runner-level sharding would isolate each `$HOME` but repeat the dominant `chezmoi apply`, while `tests/scripts.bats` holds 85% of the Ubuntu baseline and must be split before a file matrix can reduce wall time materially."
 type: "idea"
 category: "testing-ci"
 tags: ["testing-ci","idea"]

--- a/docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md
+++ b/docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md
@@ -1,6 +1,6 @@
 ---
 title: "The test-ubuntu CI job installs 37 brew packages it can never reach, because Linuxbrew's prefix is never put on PATH"
-short_description: "The test-ubuntu CI job installs 37 brew packages it can never reach, because Linuxbrew's prefix is never put on PATH"
+short_description: "The Ubuntu job spends 177.9 seconds installing 37 Homebrew formulae but never exports `/home/linuxbrew/.linuxbrew/bin`, leaving every installed binary unreachable to tests."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]

--- a/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
+++ b/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
@@ -1,6 +1,6 @@
 ---
 title: "Revisit the CI timeout-minutes downward once two weeks of minimal-install runs exist"
-short_description: "Revisit the CI timeout-minutes downward once two weeks of minimal-install runs exist"
+short_description: "After two weeks of minimal-install data, the 15-minute Ubuntu and 25-minute macOS ceilings should use observed slow-tail durations while remaining high enough for scheduled full-Brewfile runs."
 type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]

--- a/docs/issues/2026-08-21-011-pi-brew-test-unresolvable-path-in-docker.md
+++ b/docs/issues/2026-08-21-011-pi-brew-test-unresolvable-path-in-docker.md
@@ -1,6 +1,6 @@
 ---
 title: "The Pi brew auto-updater test cannot resolve its import inside Docker, so make test-ubuntu is red"
-short_description: "The Pi brew auto-updater test cannot resolve its import inside Docker, so make test-ubuntu is red"
+short_description: "Docker mounts `tests/` at `/home/testuser/tests` and `home/` at `/home/testuser/dotfiles`, so the test's `../home/...` import failed identically in sequential, parallel, and ten stability runs."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]

--- a/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
+++ b/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
@@ -1,6 +1,6 @@
 ---
 title: "The macOS post-apply suite misses the 60% wall-time gate at --jobs 8"
-short_description: "The macOS post-apply suite misses the 60% wall-time gate at --jobs 8"
+short_description: "At `--jobs 8`, macOS reached 283 seconds or 66.9% of its 423-second baseline, with bats-core's one-second `shlock` polling as the leading unmeasured cause of the 29-second target gap."
 type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]

--- a/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
+++ b/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
@@ -1,6 +1,6 @@
 ---
 title: "The fail-open assertions widened to 20s and no longer catch a slow fail-open"
-short_description: "The fail-open assertions widened to 20s and no longer catch a slow fail-open"
+short_description: "Three assertions now allow 20 seconds to tolerate scheduler contention, so regressions that delay normally sub-second fail-open paths by 3–18 seconds remain green."
 type: "bug"
 category: "repository-maintenance"
 tags: ["repository-maintenance","bug"]

--- a/docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md
+++ b/docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md
@@ -1,6 +1,6 @@
 ---
 title: "Capture the idle-machine wall-clock bound as a documented pattern"
-short_description: "Capture the idle-machine wall-clock bound as a documented pattern"
+short_description: "Four load-sensitive failures were independently misdiagnosed because idle-machine deadlines conflated hang guards with performance assertions, so the causal-testing pattern needs a durable `docs/solutions` entry."
 type: "follow-up"
 category: "repository-maintenance"
 tags: ["repository-maintenance","follow-up"]

--- a/docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md
+++ b/docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md
@@ -1,6 +1,6 @@
 ---
 title: "The CI-minimal Docker apply has no automated gate, so a base-image downgrade would break it silently"
-short_description: "The CI-minimal Docker apply has no automated gate, so a base-image downgrade would break it silently"
+short_description: "Only a manual `MMS_CI_MINIMAL=1 docker compose -f docker/docker-compose.yml run --rm test-full` verifies that Ubuntu supplies Git 2.35 or newer for `merge.conflictStyle = zdiff3` and still includes Python 3."
 type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]

--- a/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
+++ b/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
@@ -1,6 +1,6 @@
 ---
 title: "The python3 version floor is stated in two places with nothing checking they agree"
-short_description: "The python3 version floor is stated in two places with nothing checking they agree"
+short_description: "The enforced Python 3.9 floor in `tests/helpers/common.bash` can silently diverge from `README.md`, unlike the existing `FZF_MIN_VERSION` test that reads its authoritative source."
 type: "follow-up"
 category: "repository-maintenance"
 tags: ["repository-maintenance","follow-up"]

--- a/docs/issues/2026-08-21-020-pi-skills-and-agents-inventory-drift.md
+++ b/docs/issues/2026-08-21-020-pi-skills-and-agents-inventory-drift.md
@@ -1,6 +1,6 @@
 ---
 title: "Pi skills and agents in the inventory doc do not match disk"
-short_description: "Pi skills and agents in the inventory doc do not match disk"
+short_description: "Decide whether to recover nine authored Pi agents marked \"keep\" or update `docs/agent-setup-inventory.md`, because the agents directory and listed `web-research` skill no longer exist."
 type: "follow-up"
 category: "agent-platform"
 tags: ["agent-platform","follow-up"]

--- a/docs/issues/2026-08-21-022-brew-auto-update-failures-are-invisible.md
+++ b/docs/issues/2026-08-21-022-brew-auto-update-failures-are-invisible.md
@@ -1,6 +1,6 @@
 ---
 title: "The Pi brew auto-updater never surfaces a failure, even on manual invocation"
-short_description: "The Pi brew auto-updater never surfaces a failure, even on manual invocation"
+short_description: "Both Pi updater entry points discard `{ status: \"failed\", message }`, so Homebrew or extension-update failures remain invisible even after an explicit `/brew-auto-update-now` invocation."
 type: "follow-up"
 category: "agent-platform"
 tags: ["agent-platform","follow-up"]

--- a/docs/issues/2026-08-21-023-no-test-observes-which-toml-parser-the-palette-used.md
+++ b/docs/issues/2026-08-21-023-no-test-observes-which-toml-parser-the-palette-used.md
@@ -1,6 +1,6 @@
 ---
 title: "No test observes which TOML parser the command palette actually used"
-short_description: "No test observes which TOML parser the command palette actually used"
+short_description: "Add an ambient-interpreter test that reports Python's version and fails if palette parsing silently switches from `tomllib` to the fallback parser."
 type: "follow-up"
 category: "command-palette"
 tags: ["command-palette","follow-up"]

--- a/docs/issues/2026-08-21-025-automatically-load-local-agent-instructions-into-opencode-and-pi-system-prompts.md
+++ b/docs/issues/2026-08-21-025-automatically-load-local-agent-instructions-into-opencode-and-pi-system-prompts.md
@@ -1,6 +1,6 @@
 ---
 title: "Automatically load local agent instructions into OpenCode and Pi system prompts"
-short_description: "Configure OpenCode and Pi to discover CLAUDE.local.md and AGENTS.local.md automatically and append them to the system prompt, without conditional instructions inside shared agent guidance."
+short_description: "Use each client's native settings, hooks, or plugin API to discover applicable `CLAUDE.local.md` and `AGENTS.local.md` files and append ordered, deduplicated instructions before request processing."
 type: "idea"
 category: "agent-platform"
 tags: ["local-instructions","system-prompt","opencode","pi"]

--- a/scripts/issues
+++ b/scripts/issues
@@ -28,6 +28,8 @@ TYPES = {"bug", "follow-up", "idea", "chore"}
 STATUSES = {"open", "in-progress", "done", "wontfix"}
 CATEGORIES = {"testing-ci", "se-pipeline", "herdr", "command-palette", "agent-platform", "dotfiles", "repository-maintenance"}
 PRIORITIES = {"critical", "high", "medium", "low"}
+PRIORITY_LABELS = {"critical": "crit", "high": "high", "medium": "med", "low": "low"}
+PRIORITY_COLORS = {"critical": "\033[1;31m", "high": "\033[31m", "medium": "\033[33m", "low": "\033[34m"}
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -255,14 +257,19 @@ def summary(document: Document) -> Dict[str, Any]:
 
 
 def format_issue_summary(value: Dict[str, Any], color: bool = False) -> str:
+    priority = value["priority"]
+    label = PRIORITY_LABELS[priority]
     compact_id = value["id"][:14]
-    heading = "%s - [%s] %s" % (compact_id, value["priority"], value["title"])
+    title = value["title"]
     description = value["short_description"]
-    if description == value["title"]:
-        return heading
     if color:
+        label = "%s[%s]\033[0m" % (PRIORITY_COLORS[priority], label)
+        compact_id = "\033[36m%s\033[0m" % compact_id
+        title = "\033[1m%s\033[0m" % title
         description = "\033[2m%s\033[0m" % description
-    return "%s\n  %s" % (heading, description)
+    else:
+        label = "[%s]" % label
+    return "%s %s - %s\n%s" % (label, compact_id, title, description)
 
 
 def issue_directory(root: Path, create: bool = False) -> Path:

--- a/scripts/issues
+++ b/scripts/issues
@@ -30,6 +30,7 @@ CATEGORIES = {"testing-ci", "se-pipeline", "herdr", "command-palette", "agent-pl
 PRIORITIES = {"critical", "high", "medium", "low"}
 PRIORITY_LABELS = {"critical": "crit", "high": "high", "medium": "med", "low": "low"}
 PRIORITY_COLORS = {"critical": "\033[1;31m", "high": "\033[31m", "medium": "\033[33m", "low": "\033[34m"}
+PRIORITY_ICONS = {"critical": "", "high": "", "medium": "", "low": ""}
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -263,7 +264,7 @@ def format_issue_summary(value: Dict[str, Any], color: bool = False) -> str:
     title = value["title"]
     description = value["short_description"]
     if color:
-        label = "%s[%s]\033[0m" % (PRIORITY_COLORS[priority], label)
+        label = "%s %s[%s]\033[0m" % (PRIORITY_ICONS[priority], PRIORITY_COLORS[priority], label)
         compact_id = "\033[36m%s\033[0m" % compact_id
         title = "\033[1m%s\033[0m" % title
         description = "\033[2m%s\033[0m" % description

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -185,9 +185,9 @@ class ReadTests(IssueFixtures):
 
     def test_formats_terminal_priority_id_title_and_description_styles(self):
         value = {"id": "2026-08-21-002-high", "priority": "high", "short_description": "High desc", "title": "High"}
-        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
+        self.assertEqual(" \x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
         value["short_description"] = "High"
-        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
+        self.assertEqual(" \x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
 
     def test_searches_title_description_and_arbitrary_body_in_stable_order(self):
         self.write_issue("2026-08-21-002-body.md", issue_text(title="Other", short_description="Nothing") + b"\xffNeedle in body.\xfe\n")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -154,21 +154,21 @@ class ReadTests(IssueFixtures):
         lines = result.stdout.splitlines()
         self.assertEqual([
             "[herdr]",
-            "2026-08-21-002 - [high] High",
-            "  High desc",
+            "[high] 2026-08-21-002 - High",
+            "High desc",
             "",
-            "2026-08-21-005 - [high] Later high",
-            "  Later high desc",
+            "[high] 2026-08-21-005 - Later high",
+            "Later high desc",
             "",
-            "2026-08-21-003 - [low] Low",
-            "  Low desc",
+            "[low] 2026-08-21-003 - Low",
+            "Low desc",
             "",
             "[testing-ci]",
-            "2026-08-21-004 - [critical] Critical",
-            "  Critical desc",
+            "[crit] 2026-08-21-004 - Critical",
+            "Critical desc",
             "",
-            "2026-08-21-006 - [medium] Medium",
-            "  Medium desc",
+            "[med] 2026-08-21-006 - Medium",
+            "Medium desc",
             "",
         ], lines)
         self.assertNotIn("\x1b[", result.stdout)
@@ -181,13 +181,13 @@ class ReadTests(IssueFixtures):
         result = self.run_issues("list", "--tag", "missing", "--json")
         self.assertEqual({"issues": []}, json.loads(result.stdout))
         result = self.run_issues("list", "--category", "herdr", "--priority", "high", "--type", "bug", "--tag", "focus")
-        self.assertIn("2026-08-21-002 - [high] High", result.stdout)
+        self.assertIn("[high] 2026-08-21-002 - High", result.stdout)
 
-    def test_formats_description_as_muted_text_for_a_terminal(self):
+    def test_formats_terminal_priority_id_title_and_description_styles(self):
         value = {"id": "2026-08-21-002-high", "priority": "high", "short_description": "High desc", "title": "High"}
-        self.assertEqual("2026-08-21-002 - [high] High\n  \x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
+        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
         value["short_description"] = "High"
-        self.assertEqual("2026-08-21-002 - [high] High", self.module().format_issue_summary(value, color=True))
+        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
 
     def test_searches_title_description_and_arbitrary_body_in_stable_order(self):
         self.write_issue("2026-08-21-002-body.md", issue_text(title="Other", short_description="Nothing") + b"\xffNeedle in body.\xfe\n")
@@ -195,7 +195,9 @@ class ReadTests(IssueFixtures):
         self.write_issue("2026-08-21-003-description.md", issue_text(title="Other", short_description="Needle summary"))
         text = self.run_issues("search", "needle")
         self.assertEqual(0, text.returncode, text.stderr)
-        self.assertEqual(["[testing-ci]", "2026-08-21-001", "2026-08-21-002", "2026-08-21-003"], [line.split()[0] for line in text.stdout.splitlines() if line and not line.startswith("  ")])
+        lines = text.stdout.splitlines()
+        self.assertEqual("[testing-ci]", lines[0])
+        self.assertEqual(["2026-08-21-001", "2026-08-21-002", "2026-08-21-003"], [line.split()[1] for line in lines if line.startswith(("[low] ", "[med] ", "[high] ", "[crit] "))])
         payload = json.loads(self.run_issues("search", "NEEDLE", "--json").stdout)
         self.assertEqual(["2026-08-21-001-title", "2026-08-21-002-body", "2026-08-21-003-description"], [item["id"] for item in payload["issues"]])
 


### PR DESCRIPTION
## Summary

Active issue lists are now scannable without losing the context needed to choose work. Terminal output uses compact priority labels, semantic colors, Nerd Font icons, cyan IDs, bold titles, and unindented muted descriptions; redirected output remains plain text and JSON remains unchanged.

All 46 active issues now have information-dense descriptions instead of title duplicates. The repository-issues skill also requires agents to keep those descriptions aligned with changes in diagnosis, impact, scope, blockers, and intended outcomes.

## Validation

- `make test-issues` — 33 tests passed
- `git diff --check` — passed
