### PR TITLE
fix(issues): remove terminal priority icons

### DIFF
--- a/scripts/issues
+++ b/scripts/issues
@@ -30,7 +30,6 @@ CATEGORIES = {"testing-ci", "se-pipeline", "herdr", "command-palette", "agent-pl
 PRIORITIES = {"critical", "high", "medium", "low"}
 PRIORITY_LABELS = {"critical": "crit", "high": "high", "medium": "med", "low": "low"}
 PRIORITY_COLORS = {"critical": "\033[1;31m", "high": "\033[31m", "medium": "\033[33m", "low": "\033[34m"}
-PRIORITY_ICONS = {"critical": "", "high": "", "medium": "", "low": ""}
 DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -264,7 +263,7 @@ def format_issue_summary(value: Dict[str, Any], color: bool = False) -> str:
     title = value["title"]
     description = value["short_description"]
     if color:
-        label = "%s %s[%s]\033[0m" % (PRIORITY_ICONS[priority], PRIORITY_COLORS[priority], label)
+        label = "%s[%s]\033[0m" % (PRIORITY_COLORS[priority], label)
         compact_id = "\033[36m%s\033[0m" % compact_id
         title = "\033[1m%s\033[0m" % title
         description = "\033[2m%s\033[0m" % description

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -185,9 +185,9 @@ class ReadTests(IssueFixtures):
 
     def test_formats_terminal_priority_id_title_and_description_styles(self):
         value = {"id": "2026-08-21-002-high", "priority": "high", "short_description": "High desc", "title": "High"}
-        self.assertEqual(" \x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
+        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
         value["short_description"] = "High"
-        self.assertEqual(" \x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
+        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
 
     def test_searches_title_description_and_arbitrary_body_in_stable_order(self):
         self.write_issue("2026-08-21-002-body.md", issue_text(title="Other", short_description="Nothing") + b"\xffNeedle in body.\xfe\n")


### PR DESCRIPTION
Remove Nerd Font icons from terminal issue priorities because they add visual noise. Colored `[low|med|high|crit]` labels, cyan IDs, bold titles, muted descriptions, plain redirected output, and JSON behavior remain unchanged.

Validation: `make test-issues` passes all 33 tests.
