### PR TITLE
fix(tests): resolve Pi updater import in Docker

### DIFF
--- a/docs/issues/2026-08-21-011-pi-brew-test-unresolvable-path-in-docker.md
+++ b/docs/issues/2026-08-21-011-pi-brew-test-unresolvable-path-in-docker.md
@@ -1,12 +1,13 @@
 ---
 title: "The Pi brew auto-updater test cannot resolve its import inside Docker, so make test-ubuntu is red"
-short_description: "Docker mounts `tests/` at `/home/testuser/tests` and `home/` at `/home/testuser/dotfiles`, so the test's `../home/...` import failed identically in sequential, parallel, and ten stability runs."
+short_description: "The focused Pi updater test now imports its subject through the cross-environment SOURCE_ROOT, so case 72 passes in Docker and direct checkout runs."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-08-22"
 ---
 
 ## Why this exists
@@ -70,3 +71,7 @@ resolution. The comment above that helper is worth reading first.
 - **Whether the Docker services should fail loudly on this today.** They already
   do -- the suite exits non-zero -- but nothing distinguishes this known failure
   from a new one, so in practice it is ignored rather than acted on.
+
+## Resolution
+
+Changed the runtime module load to resolve through SOURCE_ROOT with a direct-checkout fallback. Verified 13 focused Bun tests and the filtered Docker Bats case; the full Docker suite reaches and passes this case but remains red on the separately tracked focus-notify py_compile failure.

--- a/docs/issues/2026-08-22-001-the-focus-notify-compile-test-writes-bytecode-into-docker-s-read-only-source-mount.md
+++ b/docs/issues/2026-08-22-001-the-focus-notify-compile-test-writes-bytecode-into-docker-s-read-only-source-mount.md
@@ -1,0 +1,42 @@
+---
+title: "The focus-notify compile test writes bytecode into Docker's read-only source mount"
+short_description: "make test-ubuntu reaches case 32, where python3 -m py_compile tries to create __pycache__ under the read-only /home/testuser/dotfiles mount and exits with Errno 30."
+type: "bug"
+category: "testing-ci"
+tags: ["testing-ci","docker"]
+date: "2026-08-22"
+status: "open"
+priority: "high"
+---
+
+## Why this exists
+
+`make test-ubuntu` mounts `home/` at `/home/testuser/dotfiles:ro`. The smoke
+test at `tests/smoke.bats:560` runs:
+
+```sh
+python3 -m py_compile "$FOCUS_NOTIFY_DIR/notify.py"
+```
+
+Python tries to create `__pycache__` beside `notify.py`, so the test fails with:
+
+```
+[Errno 30] Read-only file system: '/home/testuser/dotfiles/private_dot_config/herdr/plugins/herdr-focus-notify/__pycache__'
+```
+
+The failure is independent of the Pi updater import fixed in
+`docs/issues/2026-08-21-011-pi-brew-test-unresolvable-path-in-docker.md`. The
+full Docker suite reaches and passes that focused test at case 72, but this
+earlier case 32 keeps the suite exit status red.
+
+## Scope
+
+- Make the compile assertion write bytecode under `BATS_TEST_TMPDIR`, or disable
+  bytecode output while preserving syntax validation.
+- Verify the focused smoke test inside Docker.
+- Run `make test-ubuntu` to confirm that the full suite passes this case.
+
+## Open decisions
+
+- Choose whether `py_compile` should use its explicit output-path API or whether
+  the test should use a syntax check that does not write beside the source.

--- a/tests/pi-brew-auto-update.test.ts
+++ b/tests/pi-brew-auto-update.test.ts
@@ -3,11 +3,15 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import registerBrewAutoUpdater, {
-  runBrewAutoUpdate,
-  type BrewAutoUpdateDependencies,
-  type UpdateUi,
+import type {
+  BrewAutoUpdateDependencies,
+  UpdateUi,
 } from "../home/dot_pi/agent/extensions/brew-auto-update/index.ts";
+
+const sourceRoot = process.env.SOURCE_ROOT ?? join(import.meta.dir, "../home");
+const { default: registerBrewAutoUpdater, runBrewAutoUpdate } = await import(
+  join(sourceRoot, "dot_pi/agent/extensions/brew-auto-update/index.ts"),
+);
 
 const cleanupPaths: string[] = [];
 


### PR DESCRIPTION
## Summary

The Pi updater's focused test now runs in Docker instead of failing before its first assertion. The test resolves the product source through the harness's cross-environment `SOURCE_ROOT`, while direct checkout runs retain their local fallback and static type imports.

The original repository issue is closed. The full suite exposed a separate read-only Python bytecode failure, now tracked as `2026-08-22-001` rather than being conflated with this fix.

## Validation

- `bun test tests/pi-brew-auto-update.test.ts` (13 passed)
- Docker-focused Bats case `Pi brew auto updater focused tests pass`
- `make test-issues` (33 passed)
- `make test-ubuntu` reaches and passes the Pi case at 72; the command remains red at unrelated case 32, tracked by `2026-08-22-001`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
