### PR TITLE
fix(tests): align Docker harness with CI

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,8 +52,15 @@ services:
     command:
       - |
         set -e
+        echo "=== Staging writable test worktree ==="
+        mkdir -p /home/testuser/worktree
+        cp -r /home/testuser/dotfiles /home/testuser/worktree/home
+        cp -r /home/testuser/tests /home/testuser/worktree/tests
+        rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
+        cd /home/testuser/worktree
+
         echo "=== Copying dotfiles to chezmoi source ==="
-        (cd /home/testuser/dotfiles && cp -r . /home/testuser/.local/share/chezmoi/)
+        (cd home && cp -r . /home/testuser/.local/share/chezmoi/)
 
         echo "=== Initializing chezmoi ==="
         chezmoi init --source=/home/testuser/.local/share/chezmoi \
@@ -65,6 +72,9 @@ services:
 
         echo "=== Applying dotfiles (with package installation) ==="
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
+
+        echo "=== Installing smithers dependencies in the source tree ==="
+        bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
 
         echo "=== Running post-apply tests ==="
         bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats
@@ -90,10 +100,16 @@ services:
     command:
       - |
         set -e
-        (cd /home/testuser/dotfiles && cp -r . /home/testuser/.local/share/chezmoi/)
+        mkdir -p /home/testuser/worktree
+        cp -r /home/testuser/dotfiles /home/testuser/worktree/home
+        cp -r /home/testuser/tests /home/testuser/worktree/tests
+        rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
+        cd /home/testuser/worktree
+        (cd home && cp -r . /home/testuser/.local/share/chezmoi/)
         chezmoi init --source=/home/testuser/.local/share/chezmoi \
           --promptString name="Test User" \
           --promptString email="test@example.com"
         bats tests/templates.bats
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
+        bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
         bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats

--- a/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
+++ b/docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md
@@ -1,12 +1,13 @@
 ---
 title: "make test-ubuntu fails two tests on main because the Docker harness lacks two setup steps GitHub CI has"
-short_description: "Docker mounts `tests/` and `home/` apart and read-only, breaking the Pi updater import and preventing Smithers dependency installation, while GitHub CI keeps the trees resolvable and runs `bun install`."
+short_description: "Docker now stages writable sibling home/tests copies and installs Smithers in a clean source copy, matching CI without depending on ignored host artifacts."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]
 date: "2026-08-19"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-08-22"
 ---
 
 ## Why this exists
@@ -93,3 +94,7 @@ regression.
   the smithers dependencies must be installed into the chezmoi source copy instead.
 - Whether `make test-ubuntu` should be gated in CI too, so this drift is caught automatically rather
   than by a developer running it locally.
+
+## Resolution
+
+Updated both Docker test services to copy the read-only home and tests mounts into a writable checkout-shaped worktree, remove copied Smithers node_modules, and run bun install --frozen-lockfile in that source tree before post-apply tests. This restores the sibling path required by the Pi TypeScript import, permits Python bytecode compilation, and prevents ignored host dependencies from masking missing Docker setup. The original Smithers failure had since gained a local-checkout skip, but the Docker harness still lacked CI source dependency provisioning. Verified all 356 Docker tests with the CI-minimal package render; two exact full-package retries were blocked before tests by transient ghcr.io Homebrew download failures.


### PR DESCRIPTION
Local Docker test runs now use a writable checkout-shaped worktree, so repository-relative imports and Python compilation behave like GitHub Actions while host mounts stay read-only. The harness also installs Smithers dependencies from a clean source copy instead of depending on ignored host `node_modules`.

Validation: the continuous-integration minimal package render passed all 356 Docker tests; `make test-issues` passed 33 tests; and the focused Pi suite passed 17 tests. Two exact `make test-ubuntu` retries were blocked before the suite by external Homebrew downloads from `ghcr.io`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
