### PR TITLE
fix(tests): split the nested-Bats wall-clock budget into a hang guard and an exit assertion

### DIFF
--- a/docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md
+++ b/docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md
@@ -21,6 +21,7 @@ diagnosed from scratch.
 | 75 ms git probe | `HERDR_TASK_SYNC_GIT_BUDGET` | `kill -9` on healthy probes |
 | 2 s fail-open | four assertions in `tests/scripts.bats` | Red with no regression behind it |
 | 5 s engine watchdog | `HTS_TIMEOUT` default | `kill -9` mid-call; the invocation then committed nothing, and the ordering tests waiting on that commit timed out and looked like a coordinator bug (`docs/issues/2026-08-20-010`) |
+| 90 s nested-Bats budget | `HTS_INNER_BATS_TIMEOUT` | Red on the macOS CI job with no regression behind it; the budget covered a nested Bats run whose cost is dominated by parsing 196 unrelated tests, leaving a 1.5x margin against ordinary run-to-run variance (`docs/issues/2026-08-21-020`) |
 
 One shape: a wall-clock number chosen on an idle machine, correct there, and
 falsified the moment real concurrency exists. The failure is expensive to read
@@ -61,8 +62,34 @@ fail rather than pass. Where that move is available it removes the whole class.
   scoped to external agent subprocesses. Same principle, different domain, and
   the pair is more useful than either alone.
 
+## Instance five, 2026-08-21: the split was applied, not the causal remedy
+
+`docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md` is the
+fifth instance, and it is the first one fixed by **splitting the number rather
+than raising it** — which is what the first rule above asks for. The single 90 s
+budget became a 600 s hang guard over the load-elastic part and a 30 s assertion
+over the part that actually carries the property. Measured margins moved from 1.5x
+to ~750x, because the assertion no longer covers the expensive work.
+
+Two things that instance adds to this document's eventual write-up:
+
+- **The preferred causal remedy is not always available, and that is worth saying
+  out loud in the fix.** There, the property is "a detached descendant is not
+  holding an inherited descriptor" — and a held pipe differs from a released one
+  only in elapsed time, with no marker a test can block on. When the causal form
+  is unavailable, the split is the fallback, and the comment should say why so the
+  next reader does not read it as an unnoticed exception to this rule.
+- **A non-vacuity guard needs to watch the process whose blocking is the premise.**
+  The first implementation there checked a *parent* of the blocking process for
+  liveness. The parent outlives the child's give-up, so the check passed on a run
+  that proved nothing — and it was caught only because the fix was rehearsed
+  against a deliberately-pinned-low ceiling. The working form records the give-up
+  as a durable marker rather than racing a liveness poll.
+
 ## Open decisions
 
 - Whether the shared-`/tmp`-path lesson belongs in the same document or its own.
   It is a different mechanism (collision, not timing) that happened to surface in
   the same work.
+- Whether the write-up should carry the two additions from instance five above as
+  their own rules, or fold them into the existing two.

--- a/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
+++ b/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
@@ -118,7 +118,9 @@ Three supporting changes came out of implementing it:
 - **The driver waits for exit *and* pipe EOF, never exit alone**, and the nested
   run keeps receiving pipes rather than temp files. A worker holding a file
   descriptor blocks nothing, so redirecting to files would have made the test
-  pass unconditionally.
+  pass unconditionally. In practice the leak trips the process wait first (see
+  the note under the status table), but both are checked because both are the
+  same fault.
 - **Both pipes are drained from launch by reader threads.** Leaving them unread
   through the progress phase would deadlock a chatty nested run against a full
   pipe buffer — reachable on the nested-test-failure path, where Bats echoes the
@@ -135,13 +137,27 @@ Each failure mode now exits with its own status and names itself:
 | Status | Meaning |
 |---|---|
 | 124 | never reached its completion signal (hang guard) |
-| 125 | completed, then held its pipes open — the guarded regression |
+| 125 | completed, then failed to finish — the guarded regression |
 | 3 | ended before completing its test |
 | 4 | the fixture gave up; nothing was being held |
 | 5 | detached worker outlived its release |
+| 7 | the nested test failed on its own terms |
 
 126 and 127 are deliberately avoided: the shell reserves them, and bats reports a
-misleading `BW01` warning when a `run` command exits with either.
+misleading `BW01` warning when a `run` command exits with either. The nested run's
+own status is carried in the message rather than forwarded as the driver's exit
+code, so it cannot coincide with one of these and claim a failure mode that did
+not happen.
+
+**A held descriptor stops the whole nested invocation, not just the pipes.** The
+first implementation split status 125 into "Bats never exited" and "Bats exited
+but its pipes stayed open", on the assumption that a leaked descriptor only
+affects the latter. Rehearsal disproved it: Bats' own formatter reads its pipeline
+to EOF, so a descendant holding the write end stops the top-level Bats process
+from finishing at all — the process wait times out, not the reader join. The split
+would have filed the real regression under "Bats is stuck, which is not the
+descriptor bug". The two symptoms are one condition; the message names whichever
+was observed.
 
 ### Measured margins
 
@@ -162,9 +178,8 @@ Both were run and reverted; neither is committed.
 - **Regression.** With `close_inherited_descriptors` neutered in
   `home/dot_local/bin/executable_herdr-task-sync` — the checkout copy the harness
   runs via `HTS_ENGINE`, not the deployed `~/.local/bin` copy — the test fails
-  with status 125: `inner Bats did not exit and close its output pipes within 30
-  seconds of its test completing -- a detached descendant is holding an inherited
-  descriptor open`.
+  with status 125: `the Bats process never exited within 30 seconds of its test
+  completing -- a detached descendant is holding an inherited descriptor open`.
 - **Vacuity.** With `HTS_BLOCKED_HERDR_POLLS=1` the test fails with status 4:
   `the blocked herdr stub hit HTS_BLOCKED_HERDR_CEILING_SECONDS and gave up, so
   nothing held a descriptor while the inner Bats exited -- this run proved

--- a/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
+++ b/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
@@ -1,0 +1,185 @@
+---
+title: The nested-Bats wall-clock budget flaked the macOS CI job
+type: bug
+date: 2026-08-21
+status: open
+---
+
+## Why this exists
+
+`herdr-task-sync bounded Bats invocation exits after detached work`
+(`tests/scripts.bats`) failed on the `test-macos` job of CI run
+[32454626507](https://github.com/Seigiard/my-mac-setup/actions/runs/32454626507),
+on `main` at `9f539b5`. The `test-ubuntu` and `lint` jobs passed. The failure was
+load, not a regression.
+
+```
+not ok 130 herdr-task-sync bounded Bats invocation exits after detached work
+#   `assert_success' failed
+# status : 124
+# output (2 lines):
+#   inner Bats invocation exceeded 90 seconds
+#   1..1
+```
+
+### The causal chain
+
+1. The test spawns a nested Bats invocation of its own file —
+   `bats tests/scripts.bats --filter '^herdr-task-sync descriptor child probe$'` —
+   inside a Python heredoc, and capped the whole nested run with one fixed
+   wall-clock budget, `HTS_INNER_BATS_TIMEOUT`, default 90 seconds.
+2. Most of that nested run is work unrelated to the property under test: Bats
+   parses and gathers all 196 tests of the 5105-line file before running the one
+   test that survives `--filter`. Measured on a 10-core macOS host,
+   `bats --count tests/scripts.bats` costs 1.9 s of CPU out of a 3.9 s nested run
+   and a 6.9 s outer test.
+3. On the 3-core `macos-latest` runner the same nested run costs about ten times
+   more. In the last green macOS run (32453886866) test 130 printed 64.0 s after
+   test 129; in the red run that gap was 95.0 s while the nested run is known to
+   have hit its 90 s cap. So gap ≈ duration + 5 s, putting the green nested run at
+   ≈59 s against a 90 s budget — a 1.5x margin.
+4. The red run was ~1.36x slower overall than that green run (suite wall time
+   371 s vs 272 s). A 1.36x-slower run against a 1.5x margin exceeds 90 s,
+   `subprocess.run(..., timeout=90)` raises `TimeoutExpired`, and the outer
+   `assert_success` fails.
+
+### Why this was load and not the regression the test guards
+
+Exit status 124 alone cannot separate the two causes. `subprocess.run` reads to
+end-of-file, and a missing EOF is exactly the signature of the regression this
+test guards — a detached descendant holding an inherited descriptor open. Both
+causes produce the same exit code.
+
+The discriminator is whether the nested run reached its own completion signal
+before the expiry, and it is visible in the captured output:
+
+| Cause | Captured stdout |
+|---|---|
+| Load (what happened) | 2 lines: the driver's message and `1..1` |
+| Leaked descriptor | 3 lines: the same two plus `ok 1 herdr-task-sync descriptor child probe` |
+
+The red run printed two lines with no `ok 1`, so the nested test body had not
+finished — the expiry landed before completion and the leaked-pipe branch did not
+fire.
+
+That table is not inference. It was produced by rehearsal: neutering
+`close_inherited_descriptors` (`home/dot_local/bin/executable_herdr-task-sync`)
+and running the test yields the three-line form with `ok 1` present, every time.
+
+### Prior handling
+
+`docs/issues/2026-08-20-010-two-herdr-task-sync-tests-flake-under-full-suite-load.md`
+named this same test as a co-failure under `--jobs 12`, but attributed the pair to
+the 5 s engine watchdog it fixed. That fix did not touch this budget. Its closing
+note asked for exactly this: a fresh issue when a new load-sensitive flake appears
+in this file.
+
+This is the fifth instance of the pattern
+`docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md`
+tracks — a wall-clock number calibrated on an idle machine, correct there, and
+falsified the moment real concurrency exists. `HTS_INNER_BATS_TIMEOUT` had already
+been recalibrated once, from 12 s to 90 s, with a comment recording that 12 s "was
+calibrated on an idle machine and timed out under parallel load".
+
+## Scope
+
+- `tests/scripts.bats` — the outer test, its Python driver, the blocking `herdr`
+  stub, and the harness timing-constants block.
+- `home/dot_local/bin/executable_herdr-task-sync` is **not** in scope. The
+  production script is correct; only the test's bound was wrong. It is edited
+  during the rehearsal and reverted.
+
+## Open decisions
+
+- None outstanding. The confirmation criterion below is the remaining work.
+
+## The fix
+
+The single whole-run budget is replaced by two separately named bounds, applying
+the rule `2026-08-21-015` states: a hang guard and a performance assertion must
+not share a number.
+
+- `HTS_INNER_BATS_PROGRESS_SECONDS` (600 s) is the hang guard. It covers the
+  nested run up to the probe writing its pid file, absorbing the whole
+  load-elastic parse. It never fires in a healthy run or in the regression.
+  Bounded on both ends: far above the ≈59 s observed cost, and far below the
+  macOS job's `timeout-minutes: 25` so a genuine hang prints the guard's own
+  message instead of the job being killed with none.
+- `HTS_INNER_BATS_EXIT_SECONDS` (30 s) is the assertion, and the only bound that
+  can fire on a healthy run. It covers Bats teardown and exit alone.
+
+The causal remedy `2026-08-21-015` prefers was unavailable: a held pipe and a
+released pipe differ only in elapsed time, with no marker a test could block on.
+So the split is the fallback, applied deliberately rather than as an unnoticed
+exception.
+
+Three supporting changes came out of implementing it:
+
+- **The driver waits for exit *and* pipe EOF, never exit alone**, and the nested
+  run keeps receiving pipes rather than temp files. A worker holding a file
+  descriptor blocks nothing, so redirecting to files would have made the test
+  pass unconditionally.
+- **Both pipes are drained from launch by reader threads.** Leaving them unread
+  through the progress phase would deadlock a chatty nested run against a full
+  pipe buffer — reachable on the nested-test-failure path, where Bats echoes the
+  failed test's captured output.
+- **Non-vacuity is asserted, not assumed.** The blocking stub records a durable
+  give-up marker when it hits `HTS_BLOCKED_HERDR_CEILING_SECONDS`, and the driver
+  refuses to pass when that marker exists. This was found by rehearsal: the first
+  implementation checked the presentation coordinator's liveness instead, and the
+  coordinator is the stub's *parent* — it outlives the stub's give-up, so the
+  check passed on a run that proved nothing.
+
+Each failure mode now exits with its own status and names itself:
+
+| Status | Meaning |
+|---|---|
+| 124 | never reached its completion signal (hang guard) |
+| 125 | completed, then held its pipes open — the guarded regression |
+| 3 | ended before completing its test |
+| 4 | the fixture gave up; nothing was being held |
+| 5 | detached worker outlived its release |
+
+126 and 127 are deliberately avoided: the shell reserves them, and bats reports a
+misleading `BW01` warning when a `run` command exits with either.
+
+### Measured margins
+
+| Phase | Idle | Under 16 CPU hogs | Bound | Margin |
+|---|---|---|---|---|
+| Exit (the assertion) | 0.011 s | 0.040 s | 30 s | ~750x |
+| Whole run (the old budget) | 6.9 s | 16.0 s | 90 s | 1.5x on CI |
+
+The driver prints the exit-phase duration on every run, passing runs included, and
+the test forwards it to bats' console descriptor — so a green CI run carries the
+number the bound gets recalibrated against, instead of it being reconstructed from
+TAP print-order gaps.
+
+### Rehearsals
+
+Both were run and reverted; neither is committed.
+
+- **Regression.** With `close_inherited_descriptors` neutered in
+  `home/dot_local/bin/executable_herdr-task-sync` — the checkout copy the harness
+  runs via `HTS_ENGINE`, not the deployed `~/.local/bin` copy — the test fails
+  with status 125: `inner Bats did not exit and close its output pipes within 30
+  seconds of its test completing -- a detached descendant is holding an inherited
+  descriptor open`.
+- **Vacuity.** With `HTS_BLOCKED_HERDR_POLLS=1` the test fails with status 4:
+  `the blocked herdr stub hit HTS_BLOCKED_HERDR_CEILING_SECONDS and gave up, so
+  nothing held a descriptor while the inner Bats exited -- this run proved
+  nothing`.
+
+## Confirmation criterion
+
+**This issue stays open until three consecutive green `test-macos` runs of the
+post-apply suite.** Every piece of evidence above was gathered on a 10-core host,
+which cannot produce the 3-core profile where this reproduces, and a flake that
+has fired twice in CI is not shown fixed by a passing local run. Landing the PR
+does not close it.
+
+**Reopen trigger.** Any `test-macos` failure of this test at status 125 (the exit
+bound) after the criterion is met. That would mean either a genuine
+`close_inherited_descriptors` regression or that 30 s is not the margin the
+measurements above suggest — the printed exit-phase duration in the same CI log
+distinguishes them.

--- a/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
+++ b/docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md
@@ -1,8 +1,12 @@
 ---
-title: The nested-Bats wall-clock budget flaked the macOS CI job
-type: bug
-date: 2026-08-21
-status: open
+title: "The nested-Bats wall-clock budget flaked the macOS CI job"
+short_description: "One 90-second budget covered a nested Bats run whose cost is dominated by parsing 196 unrelated tests, leaving a 1.5x margin that ordinary CI variance exceeded; it is split into a hang guard plus an exit assertion and stays open until three consecutive green test-macos runs."
+type: "bug"
+category: "testing-ci"
+tags: ["testing-ci","herdr","bug"]
+date: "2026-08-21"
+status: "open"
+priority: "high"
 ---
 
 ## Why this exists

--- a/docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md
+++ b/docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md
@@ -1,0 +1,72 @@
+---
+title: The nested Bats run parses all 196 tests to execute one
+type: follow-up
+date: 2026-08-21
+status: open
+parent-plan: docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
+---
+
+## Why this exists
+
+`herdr-task-sync bounded Bats invocation exits after detached work`
+(`tests/scripts.bats`) spawns a nested Bats invocation of **its own file** to run a
+single test:
+
+```
+bats tests/scripts.bats --filter '^herdr-task-sync descriptor child probe$'
+```
+
+Bats parses and gathers all 196 tests of the 5105-line file before running the one
+test that survives the filter. That parse is the dominant cost and it has nothing
+to do with the property under test.
+
+Measured on a 10-core macOS host:
+
+| What | Cost |
+|---|---|
+| `bats --count tests/scripts.bats` (parse alone) | 1.9 s |
+| The whole nested run | 3.9 s |
+| The outer test | 6.9 s |
+
+So roughly half the nested run is parsing tests it will not execute. On the 3-core
+`macos-latest` CI runner the same nested run costs about ten times more — an
+inferred ≈59 s in a green run.
+
+That cost is why the test needed a large bound at all, and it is what made the
+previous single 90-second budget flake:
+`docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md`. That issue
+is fixed by splitting the budget into a hang guard and an exit assertion, which
+removes the load sensitivity without touching the cost. This issue is the cost.
+
+## Why it lands after `020`, not before
+
+A hang guard and an exit assertion have to be separate numbers at any nested-run
+cost, so this work shrinks the hang guard's sizing problem but does not remove the
+need for the split. Doing it first would have delayed the flake fix behind a
+harness refactor.
+
+It would, however, retire the weakest input in `020`'s analysis: the ≈59 s figure
+is inferred from TAP print-order gaps in two CI logs rather than instrumented on
+the runner, because under `--jobs 8` output is emitted in plan order rather than
+completion order. A nested run that parsed one small file would be fast enough
+that the inference stops mattering.
+
+## Scope
+
+- Move the `hts_*` harness out of `tests/scripts.bats` into a helper file under
+  `tests/helpers/`, so the nested invocation can target a small dedicated file
+  containing only the descriptor probe.
+- The probe itself (`herdr-task-sync descriptor child probe`) and its
+  `HTS_DESCRIPTOR_PID_FILE` skip guard move with it.
+- Re-measure the nested run afterwards and resize
+  `HTS_INNER_BATS_PROGRESS_SECONDS` against the new cost.
+
+## Open decisions
+
+- Whether to extract the whole `hts_*` harness or only the subset the probe needs.
+  Extracting only a subset risks the two copies drifting; extracting the whole
+  harness is a large, mostly mechanical move across a 5105-line file that many
+  other tests depend on.
+- Whether the extraction is worth doing on its own, or only as part of a broader
+  split of `tests/scripts.bats` — the file's size is the underlying condition, and
+  this test is one symptom of it.

--- a/docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md
+++ b/docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md
@@ -1,9 +1,12 @@
 ---
-title: The nested Bats run parses all 196 tests to execute one
-type: follow-up
-date: 2026-08-21
-status: open
-parent-plan: docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
+title: "The nested Bats run parses all 196 tests to execute one"
+short_description: "The descriptor test spawns a nested Bats invocation of its own 5105-line file to run one filtered test, so roughly half that run is parsing tests it will never execute -- which is why the bound around it had to be large at all."
+type: "follow-up"
+category: "testing-ci"
+tags: ["testing-ci","herdr","follow-up"]
+date: "2026-08-21"
+status: "open"
+priority: "low"
 ---
 
 ## Why this exists

--- a/docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
+++ b/docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
@@ -557,3 +557,32 @@ harness constants block, and the issue records.
   both.
 - **Not part of this plan's done, but its closing condition:** `020` flips to `done` after three
   consecutive green `test-macos` runs. Landing the PR does not close it.
+
+---
+
+## Post-implementation corrections
+
+Three things this plan asserts turned out to be wrong. They are recorded here rather than edited in
+place, because the reasoning that produced them is the useful part — each was caught by running the
+thing, not by reading it.
+
+**KTD4's stated mechanism was wrong; its decision was not.** The plan says the liveness check reads
+"the right process" because the recorded PID is the presentation claim's owner, which is the blocked
+stub's parent. That is true and irrelevant: the parent *outlives* the stub's give-up, so checking it
+passes on exactly the vacuous run the check exists to catch. The vacuity rehearsal proved it by
+passing when it should have failed. The shipped form has the stub record a durable give-up marker,
+which is a fact rather than a race. KTD4's decision — assert non-vacuity rather than assume it —
+stands unchanged; only the mechanism moved.
+
+**KTD3 understates what a leaked descriptor does.** The plan frames the property as "pipes reach EOF"
+on the theory that Bats itself exits normally and only the pipes stay open. Rehearsal shows the
+opposite: Bats' own formatter reads its pipeline to EOF, so a descendant holding the write end stops
+the top-level Bats process from finishing at all. A later attempt to split those into two separately
+reported faults was reverted for this reason — it would have filed the real regression under "Bats is
+stuck, which is not the descriptor bug". Both symptoms are checked; both report as one condition.
+
+**U3's index step no longer applies.** `docs/issues/_open-issues.md` was a hand-maintained index when
+this plan was written. `main` has since replaced it with guidance that explicitly says not to keep a
+second snapshot there — issues are listed through `python3 scripts/issues list`, and a validator
+(`make test-issues`) now enforces a richer frontmatter schema. The rebase dropped the index rows this
+plan asked for, and issues `020` and `021` were written to the new schema instead.

--- a/docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
+++ b/docs/plans/2026-08-21-0901-fix-inner-bats-wallclock-flake-plan.md
@@ -1,0 +1,559 @@
+---
+title: "fix: Split the inner-Bats wall-clock budget into a hang guard and a causal exit assertion"
+type: fix
+date: 2026-08-21
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# fix: Split the inner-Bats wall-clock budget into a hang guard and a causal exit assertion
+
+## Summary
+
+`tests/scripts.bats` contains one test that spawns a nested Bats invocation and caps the whole
+nested run with a single 90-second wall-clock budget. On the 3-core `macos-latest` CI runner that
+nested run already costs about 59 seconds in a green run, so the margin is roughly 1.5x. A CI run
+that is 1.36x slower than green — ordinary variance — lands past the budget and the job goes red
+with no regression behind it.
+
+This plan replaces the one budget with two separately named bounds: a generous hang guard covering
+the nested run up to its own completion signal, and a short bound on the property the test actually
+exists to prove. It also closes a latent vacuity in the same test, where the blocked fixture can
+release itself and let the test pass without proving anything.
+
+Scope is the test harness in `tests/scripts.bats` plus the issue records the repo convention
+requires. `home/dot_local/bin/executable_herdr-task-sync` does not change.
+
+---
+
+## Problem Frame
+
+The test `herdr-task-sync bounded Bats invocation exits after detached work`
+(`tests/scripts.bats:1873`) is a regression guard for `close_inherited_descriptors`
+(`home/dot_local/bin/executable_herdr-task-sync:327`). That function closes descriptors above
+stderr in a detached descendant, so a detached worker cannot keep the parent's output pipes alive
+after the test process that spawned it has finished.
+
+The test proves this by running a nested Bats invocation whose single test leaves a deliberately
+blocked detached worker behind, then requiring that nested invocation to complete. Today it
+expresses "complete" as one fixed number.
+
+**The failure.** CI run 32454626507, job `test-macos`:
+`not ok 130 herdr-task-sync bounded Bats invocation exits after detached work`, failing at
+`assert_success` (`tests/scripts.bats:1927`) with status 124 and output
+`inner Bats invocation exceeded 90 seconds`. The `test-ubuntu` and `lint` jobs passed.
+
+**Why it fired.**
+
+1. The nested run is `bats tests/scripts.bats --filter '^herdr-task-sync descriptor child probe$'`
+   (`tests/scripts.bats:1889-1894`), capped by `HTS_INNER_BATS_TIMEOUT`, default 90 seconds
+   (`tests/scripts.bats:1899`).
+2. Most of that nested run is work unrelated to the property under test: Bats parses and gathers
+   all 196 tests of the 5105-line file before running the one test that survives `--filter`.
+   Measured on a 10-core macOS host, `bats --count tests/scripts.bats` costs 1.9 s of CPU out of a
+   3.9 s nested run and a 6.9 s outer test.
+3. On the 3-core runner the same nested run costs about ten times more. In the last green macOS run
+   (32453886866) test 130 printed 64.0 s after test 129; in the red run that gap was 95.0 s while
+   the nested run is known to have hit its 90 s cap, so gap ≈ duration + 5 s. The green nested run
+   was therefore ≈59 s against a 90 s budget.
+4. The red run was ~1.36x slower overall than that green run (suite wall time 371 s vs 272 s). A
+   1.36x-slower run against a 1.5x margin exceeds 90 s, `subprocess.run(..., timeout=90)` raises
+   `TimeoutExpired`, the handler exits 124, and `assert_success` fails.
+
+**It is slowness, not the guarded deadlock — and one observation separates them.** Status 124 alone
+cannot tell the two causes apart: `subprocess.run` reads to EOF, and KTD3 below establishes that a
+missing EOF is exactly the guarded regression's signature, so both causes produce the same exit code.
+The discriminator is whether the nested run reached its own completion signal before the expiry. It
+did not. The red run's captured output was exactly two lines — the driver's own message and the TAP
+plan line `1..1` — with no `ok 1 herdr-task-sync descriptor child probe`. The nested test body had not
+finished, so the expiry landed *before* completion and the leaked-pipe branch did not fire.
+
+Two weaker observations agree with that reading: the cost scales smoothly with CPU pressure rather
+than hanging (the outer test ran 6.9 s idle and 16.0 s under 24 busy loops on 10 cores, passing both
+times), and the same test took 16 s in the Ubuntu job of the red run. Neither is decisive on its own,
+because neither runs the 3-core macOS profile under `bats --jobs 8 --no-parallelize-across-files`
+(`.github/workflows/test-dotfiles.yml:311`) where this reproduces. The absent `ok 1` line is the
+evidence that carries the verdict.
+
+**If that line is ever present in a future occurrence, this premise is wrong** and the leaked-pipe
+branch fired — in which case the split below makes CI go red sooner rather than less often, and the
+design needs rework before U1.
+
+**This is the fifth instance of a pattern this repo has already named.** The comment at
+`tests/scripts.bats:1895-1898` records that the previous value, 12 s, "was calibrated on an idle
+machine and timed out under parallel load" — 90 s is the second calibration of the same number, made
+before `--jobs 8` shipped in CI (commit `543ca9e`).
+`docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md` (status: open) lists four
+prior instances and states the two rules this one breaks: a hang guard and a performance assertion
+must not share a number, and assert the property causally rather than temporally. The same rule pair
+is recorded from a different domain in
+`docs/solutions/design-patterns/external-review-legs-as-unreliable-subprocesses.md` ("Give legs
+liveness detection AND generous wall-clock — they are different budgets"), including the calibration
+rule that thresholds come from healthy runs rather than the one pathological sample.
+
+---
+
+## Requirements
+
+- **R1.** The test must stop failing on ordinary run-to-run slowness of the macOS CI job. No
+  remaining bound may sit within a small multiple of the nested run's observed healthy cost.
+- **R2.** The test must still fail if `close_inherited_descriptors` regresses. The fix must not make
+  the guard vacuous, weaker, or conditional.
+- **R3.** A failure must name which bound fired, so a reader can tell a genuine regression from a
+  slow run without reconstructing the mechanism.
+- **R4.** No blocked fixture worker may be left running after any path through the test, including
+  every failure path.
+- **R5.** The test must fail loudly rather than pass, if the fixture releases itself before the
+  property is observed (non-vacuity).
+- **R6.** Findings not fixed here are recorded as issue files under `docs/issues/`, per the
+  convention in `CLAUDE.md`.
+
+### Success Criteria
+
+- The test passes idle, and passes under CPU saturation with a wide margin on every remaining bound.
+- With `close_inherited_descriptors` temporarily neutered, the test fails, and its message names the
+  exit bound rather than a generic timeout.
+- `bats tests/scripts.bats` is green, and the parallel post-apply suite is green.
+
+---
+
+## Key Technical Decisions
+
+### KTD1. Two named bounds replace the single whole-run budget
+
+*(session-settled: user-approved — chosen over raising 90 s to a larger number such as 300 s: 90 s
+is already the second calibration of the same idle-machine number, and the repo's own rule is that a
+hang guard and a performance assertion must not share a number.)*
+
+- **Phase A, progress.** Wait for the nested run to reach its own completion signal. The bound here
+  is a hang guard: generous, out of load's reach, and it never fires in either the healthy or the
+  regression case. It is bounded on both ends — far above the nested run's observed cost, and far
+  enough below the macOS job's `timeout-minutes: 25` (`.github/workflows/test-dotfiles.yml:203`)
+  that a genuine hang prints the guard's own message instead of the job being killed with none.
+- **Phase B, the property.** Once that signal has arrived, require the nested invocation to finish
+  within a short, separately named bound. This is the only window the guarded regression breaks.
+
+Phase B is tight because it covers only Bats teardown and exit, not the file parse that dominates
+the nested run. That is what removes the load sensitivity: the expensive, load-elastic work now sits
+under the guard, and only the cheap, load-insensitive work sits under the assertion.
+
+**Phase B is sized from measurement, not intuition.** It is the only bound that can fire on a healthy
+run, so R1's margin rule applies to it and to nothing else. The driver prints Phase B's elapsed time
+on every run, including passing ones, and the bound is set as a large multiple of the value observed
+under contention. Sizing it by feel on a fast local host would reproduce the exact defect this plan
+diagnoses, at a smaller number.
+
+**Why the remedy is a split and not a causal assertion.** `docs/issues/2026-08-21-015` prefers
+replacing a wall-clock bound with a causal one, as the R8 test did. That remedy is unavailable here:
+a held pipe and a released pipe are distinguishable only by elapsed time, and there is no marker a
+test could block on. So the split into a guard and an assertion is the available fallback, applied
+deliberately rather than as an unnoticed exception to the rule this plan invokes.
+
+### KTD2. The completion signal is the PID file the probe already writes
+
+The nested test `herdr-task-sync descriptor child probe` (`tests/scripts.bats:1851`) writes
+`HTS_DESCRIPTOR_PID_FILE` as its final statement (`tests/scripts.bats:1868-1870`). Its appearance
+proves the nested test body finished — in the healthy case and in the regression case alike, since
+the regression manifests after the body, at exit. No new signal is needed.
+
+### KTD3. Phase B waits for output-pipe EOF, not merely for process exit
+
+This is the decision most likely to be got wrong, and getting it wrong silently guts the test.
+
+The regression is a detached worker holding the parent's **pipes** open. Today's
+`subprocess.run(..., capture_output=True)` detects it because `run()` reads to EOF, and EOF arrives
+only when every writer has closed — including the leaked descriptor. So the property is "the
+nested invocation's output pipes reach EOF", which is strictly stronger than "the process exited".
+
+Three consequences bind the implementation:
+
+- Phase B must wait for process exit **and** EOF, never for process exit alone.
+- The nested invocation must keep receiving **pipes**. Redirecting its output to temp files instead
+  would remove the blocking behavior entirely — a worker holding a file descriptor blocks nothing —
+  and the test would pass unconditionally.
+- Both pipes must be drained from the moment the nested process launches, by a reader thread each,
+  rather than left unread until Phase B. Today `subprocess.run` drains concurrently; a design that
+  polls the filesystem through Phase A with both pipes unread can deadlock a chatty nested run
+  against a full pipe buffer. That is reachable on the failing-nested-test path, where Bats echoes
+  the failed test's captured output as TAP comments — the failure would then surface as a Phase A
+  hang-guard expiry minutes later instead of an immediate report of the nested failure. Phase B
+  becomes a bounded join on those readers plus the process exit, which is the same exit-and-EOF
+  property, drained safely.
+
+### KTD4. Non-vacuity is asserted, not assumed
+
+*(session-settled: user-approved — chosen over releasing the blocked worker as soon as the nested
+body signals completion: releasing early would let the worker exit before the nested invocation
+does, destroying the very condition the test exists to prove.)*
+
+`HTS_DESCRIPTOR_RELEASE_FILE` stays untouched until the nested invocation has finished, on every
+path where the nested run got that far.
+
+The blocked `herdr` stub gives up on its own after 3000 poll iterations of `sleep 0.01`
+(`tests/scripts.bats:998-1008`), roughly 30 s plus loop overhead. If that ceiling were ever reached
+before the release, the worker would exit by itself, the liveness check in the driver would find it
+already gone, and the test would pass having proved nothing. Two changes close that hole: the stub's
+ceiling covers the whole window it must outlast (below), and the driver asserts the worker is still
+alive immediately before releasing it.
+
+**The window the ceiling must outlast is not Phase B.** The stub starts blocking inside the nested
+test body — it writes `herdr-blocked` at `tests/scripts.bats:1002`, and the probe waits for that file
+at `:1867` before writing the PID file at `:1868-1870`. So the countdown begins *before* the
+completion signal, and the window runs from there through the tail of Phase A, all of Phase B, and
+the liveness check. Sizing the ceiling as "just above Phase B" would let a healthy-but-slow run trip
+it, which is the same load-sensitive false red this plan exists to remove. The ceiling gets a stated
+multiple of that whole window, not a direction.
+
+**The liveness check reads the right process.** The PID the probe records is the presentation
+claim's owner (`run_presentation_coordinator`, `home/dot_local/bin/executable_herdr-task-sync:1720-1723`),
+and that coordinator is the process that shells out to the blocked `herdr` stub — the stub is its
+child. So while the stub blocks, the owner is alive and the check is meaningful. The one window where
+it could pass on a vacuous run is between the stub giving up and the owner exiting, which is exactly
+what the ceiling above prevents from being reached at all.
+
+### KTD5. The new bounds live in the harness constants block, with the file's existing convention
+
+`tests/scripts.bats:1405-1437` already holds named `HTS_*_SECONDS` knobs, each with a comment
+stating its value, whether it is a hang guard or a budget, and how it was calibrated.
+`HTS_INNER_BATS_TIMEOUT` is the odd one out — it is read from the environment inside the Python
+heredoc with an inline default. Both new bounds are declared in that block, overridable from the
+environment like their neighbours.
+
+---
+
+## High-Level Technical Design
+
+Directional guidance for the driver's control flow, not implementation specification.
+
+```mermaid
+flowchart TD
+    S[Launch nested Bats with pipes<br/>start a reader thread on each] --> A{PID file appeared?}
+    A -- "no, process still alive" --> A
+    A -- "no, process exited" --> RC{PID file present on re-read?}
+    RC -- no --> E1[Fail: nested run ended before its test completed<br/>report status and output]
+    RC -- yes --> B
+    A -- "no, hang guard elapsed" --> E2[Fail: nested run never reached its completion signal]
+    A -- yes --> B{"Exit and pipe EOF within the exit bound?"}
+    B -- "no" --> E3[Fail: nested run left its output pipes open<br/>after its test completed — the guarded regression]
+    B -- yes --> L{Detached worker still alive?}
+    L -- no --> E4[Fail: fixture released itself — the test would be vacuous]
+    L -- yes --> R[Release the worker]
+    R --> W{Worker exits?}
+    W -- no --> E5[Fail: detached worker did not exit after release]
+    W -- yes --> ST{Nested exit status zero?}
+    ST -- no --> E6[Fail: propagate the nested status and output]
+    ST -- yes --> P[Pass: assert the nested ok line]
+    E1 --> C[Release the worker, reap the process]
+    E2 --> C
+    E3 --> C
+    E4 --> C
+```
+
+Every failure path that could still leave a blocked worker or an unreaped process — E1 through E4 —
+passes through the same cleanup: touch the release file, then reap the nested process. E5 and E6 are
+reached only after the release and the reap have already happened, so they need no cleanup of their
+own.
+
+Two branches exist to avoid misdiagnosis. The re-read after an observed exit is there because the
+guarded regression also exits — only its pipes stay open — so "process exited" and "PID file present"
+are both true in the regression case, separated by however long teardown takes; without the re-read,
+the regression would be reported as an early exit. And the status check sits *after* the release
+rather than before it, so a nested run that fails after writing its completion signal is reported
+with its own status instead of leaving a blocked worker behind.
+
+---
+
+## Implementation Units
+
+### U1. Declare the two bounds and rewrite the driver around them
+
+**Goal.** Replace the single whole-run budget in the outer test with the Phase A hang guard and the
+Phase B exit assertion, each separately named and separately reported.
+
+**Requirements.** R1, R2, R3, R4.
+
+**Dependencies.** None.
+
+**Files.**
+- `tests/scripts.bats` — the constants block at `1405-1437`, and the test at `1873-1929`.
+
+**Approach.**
+
+1. In the constants block, declare two knobs beside the existing ones, each with a comment in the
+   established style — value, whether it is a hang guard or an assertion, and what calibrated it:
+   - a hang-guard bound for Phase A, bounded on both ends. Above: a large multiple of the nested
+     run's ≈59 s cost on the 3-core CI runner, not a small one. Below: small enough that the guard
+     fires well inside the macOS job's `timeout-minutes: 25`
+     (`.github/workflows/test-dotfiles.yml:203`), so a real hang prints the guard's message rather
+     than the job being killed with none. 600 s satisfies both. State both ends in the comment.
+   - a short bound for Phase B, covering only Bats teardown and exit, sized as a large multiple of
+     the Phase B duration step 8 prints under contention. It must stay below the blocked stub's
+     ceiling from U2 by the margin KTD4 states — record that coupling in both comments, expressed
+     in the same unit on both sides (see U2 step 2).
+   - Retire `HTS_INNER_BATS_TIMEOUT`; nothing else reads it (`grep` before deleting).
+2. Rewrite the Python driver in the test to launch the nested invocation without a whole-run
+   timeout, keeping `stdout` and `stderr` as **pipes**, and start a reader thread on each at launch
+   so no phase ever leaves a pipe unread (KTD3).
+3. Phase A: poll for the PID file. Exit the loop three ways — the file appears; the hang guard
+   elapses; or the nested process is observed to have exited, in which case **re-read the PID file
+   once** and take the Phase B branch if it is now present, reporting the early-exit failure with
+   the nested status and output only when it is still absent.
+4. Phase B: once the PID file exists, wait for process exit plus reader-thread EOF within the exit
+   bound. A timeout here is the guarded regression; say so in the message.
+5. Every failure path in Phase A and Phase B touches `HTS_DESCRIPTOR_RELEASE_FILE` and reaps the
+   nested process before raising, so no blocked worker and no zombie survives.
+6. Keep the existing post-release check that the detached worker exits. Then, **after** the release
+   and that check, propagate a non-zero nested exit status with its captured output as the driver's
+   own failure — today that check sits before the release, which would strand a blocked worker.
+7. Keep the outer assertions `assert_success` and
+   `assert_output --partial "ok 1 herdr-task-sync descriptor child probe"`.
+8. Print Phase B's elapsed time on every run, passing runs included, so the next recalibration reads
+   a number out of CI instead of reconstructing one from print-order gaps.
+9. Replace the block comment at `1895-1898` with one that explains the two bounds, why they are two,
+   and why the causal remedy `docs/issues/2026-08-21-015` prefers is unavailable here (KTD1) —
+   rather than the history of a single recalibrated number.
+
+**Execution note.** Read the PID file defensively. The probe writes it with `>` from a command
+substitution, so the shell creates the file empty before any content lands, and a failed write leaves
+it empty permanently — poll until the contents parse as an integer, and keep that poll inside the
+Phase A loop so it retains the hang-guard and process-exit escapes rather than becoming a second
+unbounded wait after them.
+
+**Patterns to follow.**
+- The constants block at `tests/scripts.bats:1405-1437` for knob naming, environment override shape,
+  and comment content.
+- The R8 test's comment at `tests/scripts.bats:4258-4262` for the house framing: "The property is
+  causal, not temporal, so assert it causally."
+
+**Test scenarios.** This unit's subject *is* a test; the scenarios below are the states its driver
+must handle, exercised through the rehearsals in U3.
+
+- Healthy run: the PID file appears, exit and EOF arrive inside the exit bound, the worker is alive
+  at release and exits after it, and the outer assertions pass.
+- Guarded regression (rehearsed in U3): the PID file appears, exit and EOF do not both arrive inside
+  the exit bound, and the failure message names the exit bound and the leaked-pipe condition — not a
+  generic timeout, and not the early-exit message.
+- Nested test fails before writing the PID file: the driver reports the nested run's exit status and
+  captured output, and does not wait out the Phase A hang guard.
+- Nested test fails after writing the PID file: the driver releases the worker, confirms it exits,
+  then reports the nested status — no blocked worker survives.
+- Any failure path: the release file exists afterwards, and no nested Bats process survives.
+- Under CPU saturation the healthy run still passes, with both bounds far from firing.
+
+**Verification.** `bats tests/scripts.bats --filter '^herdr-task-sync bounded Bats invocation exits after detached work$'`
+passes idle and under CPU saturation. Both printed durations are recorded: the nested run's total
+sits far below the Phase A guard, and Phase B's measured value under contention is the number the
+Phase B bound is sized against.
+
+---
+
+### U2. Close the fixture's self-release hole
+
+**Goal.** Make it impossible for the test to pass because the blocked fixture gave up rather than
+because the property held.
+
+**Requirements.** R2, R5.
+
+**Dependencies.** U1 (the Phase B bound this ceiling must exceed).
+
+**Files.**
+- `tests/scripts.bats` — the harness constants block at `1405-1437` (the new derived, exported
+  ceiling) and the blocking branch of the `herdr` stub at `996-1010`.
+
+**Approach.**
+
+1. Replace the literal `3000` poll ceiling in the stub's blocking loop with a value derived from a
+   named seconds constant, in the same way `HTS_WAIT_POLLS`, `HTS_WAIT_SLOW_POLLS`, and
+   `HTS_WAIT_MATCH_POLLS` derive from `HTS_WAIT_CEILING_SECONDS` (`tests/scripts.bats:1431-1433`).
+   Give it its own constant rather than reusing `HTS_WAIT_CEILING_SECONDS`, whose 60 s is unrelated
+   to this window and would couple two things that should move independently. The stub is written
+   from a quoted heredoc and runs as its own process, so the value must be exported to reach it —
+   follow the `export HTS_WAIT_POLLS` precedent at `1437`.
+2. Size the ceiling against the whole window KTD4 names — from the stub blocking, through the tail of
+   Phase A, through Phase B, to the liveness check — at a stated multiple of it, not merely "greater
+   than Phase B". Declare the constant in seconds on both sides of the coupling so the two comments
+   compare like with like; a poll count at an assumed 0.01 s per iteration stretches under contention
+   and would state a figure the stub does not actually enforce.
+3. In the driver, immediately before touching the release file, assert the recorded worker PID is
+   still alive. If it is gone, fail with a message saying the fixture released itself and the run
+   proved nothing — do not pass.
+
+**Patterns to follow.** `tests/scripts.bats:1431-1437` for deriving poll counts from a named ceiling
+and exporting the one the stub reads.
+
+**Test scenarios.**
+
+- Healthy run: the worker is alive at the liveness check, and the run proceeds to release it.
+- Simulated self-release (rehearsed in U3 by pinning the stub's ceiling low): the driver fails at
+  the liveness check with the vacuity message, rather than passing.
+- The other two tests that use the same blocking stub (`tests/scripts.bats:2677`, `:2702`) still
+  pass, since the ceiling only grew.
+
+**Verification.** `bats tests/scripts.bats` is green, and the vacuity rehearsal fails loudly with
+the expected message.
+
+---
+
+### U3. Prove the guard still catches the regression, then record the follow-ups
+
+**Goal.** Show the rewritten test still fails for the reason it exists, and leave the repo's issue
+record consistent with what was found.
+
+**Requirements.** R2, R3, R6.
+
+**Dependencies.** U1, U2.
+
+**Files.**
+- `home/dot_local/bin/executable_herdr-task-sync` — temporarily edited by the rehearsal in step 1
+  and reverted; nothing from this unit is committed to it.
+- `docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md` — new.
+- `docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md` — new.
+- `docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md` — append.
+- `docs/issues/_open-issues.md` — add rows for the new issues.
+
+**Approach.**
+
+1. **Regression rehearsal (not committed).** Temporarily neuter `close_inherited_descriptors` — make
+   its body a no-op — in `home/dot_local/bin/executable_herdr-task-sync`, the checkout copy the
+   harness actually executes (`HTS_ENGINE`, `tests/scripts.bats:878`, resolved through `SOURCE_ROOT`
+   in `tests/helpers/common.bash:43-57`). Do **not** edit the deployed `~/.local/bin` copy: the
+   harness never runs it, so the test would stay green and read as a vacuous guard, and the edit
+   would sit outside git where the `git status` check below cannot see it. Confirm the test fails,
+   that it fails at the Phase B bound, and that the message names the leaked-pipe condition rather
+   than the early-exit condition. Restore the file and confirm green again. Record the observed
+   failure message in the flake issue. Check `git status` before committing.
+2. **Vacuity rehearsal (not committed).** Run the test with the stub ceiling pinned aggressively low
+   — far below the Phase B bound, not marginally — and confirm the liveness check from U2 fails
+   loudly. A marginal pin can leave the worker still alive at the check, and the rehearsal would go
+   green while proving nothing.
+3. **File the flake issue** (`020`) with the frontmatter and body sections `CLAUDE.md` requires
+   (`title`, `type: bug`, `date`, `status: open`; `## Why this exists`, `## Scope`,
+   `## Open decisions`). Keep it self-contained: the causal chain with the CI run IDs, the absent
+   `ok 1` line that rules out the leaked-pipe branch, the two measured gaps, the two-bound fix, and
+   both rehearsal results. **File it open, not closed.** Every piece of local evidence runs on a host
+   that cannot produce the 3-core profile, and a flake that has fired twice in CI is not shown fixed
+   by a passing local run. Give it a named confirmation criterion — three consecutive green
+   `test-macos` runs of the post-apply suite — and a reopen trigger for any Phase B firing in CI,
+   then flip it to `done` with a `## Resolution` once the criterion is met. This mirrors how
+   `docs/issues/2026-08-20-010-two-herdr-task-sync-tests-flake-under-full-suite-load.md` recorded a
+   reopen trigger and closed against confirming repetitions. Note in `020` that `010` named this same
+   test as a co-failure under `--jobs 12` but attributed it to the engine watchdog it fixed — that
+   fix did not touch this budget — and that its closing note asked for exactly this: a fresh issue
+   for a new load-sensitive flake in this file.
+4. **File the follow-up issue** (`021`, `type: follow-up`, `status: open`): the nested run parses all
+   196 tests of the 5105-line file to run one, which is what makes it expensive enough to have
+   needed a large bound at all. Cutting it at the source means moving the `hts_*` harness into a
+   helper file so the nested run can target a small dedicated file. Record the measurement (1.9 s of
+   the 3.9 s idle nested run) so the issue carries its own evidence. Note why it lands after this
+   plan rather than before it: a hang guard and an exit assertion have to be separate numbers at any
+   nested-run cost, so `021` shrinks the Phase A sizing problem but does not remove the need for the
+   split.
+5. **Append instance five** to `docs/issues/2026-08-21-015-...`: add the row to its table and one
+   line noting that this instance was fixed by splitting the number rather than raising it, which is
+   the remedy that issue already recommends.
+6. Add rows for both new issues to `docs/issues/_open-issues.md`, following the addendum style
+   already used there. That file documents itself as a partial derived index, so this is an append,
+   not a regeneration.
+
+**Test scenarios.** `Test expectation: none — this unit is a verification rehearsal plus
+documentation.` The rehearsals are the evidence; they produce no committed test.
+
+**Verification.** Both rehearsals produced the expected failures and were reverted. `git status`
+shows no stray edits to `home/`. The full file passes: `bats tests/scripts.bats`. The parallel suite
+passes: `make test-suite`.
+
+---
+
+## Verification Contract
+
+Run in this order:
+
+1. `bats tests/scripts.bats --filter '^herdr-task-sync bounded Bats invocation exits after detached work$'`
+   — the changed test, idle.
+2. The same command under CPU saturation, capturing **both** printed durations. The Phase B value
+   under contention is the number the Phase B bound is sized against — a large multiple of it, per
+   KTD1. Record both in the flake issue so the next recalibration starts from data.
+3. The two rehearsals in U3 — the neutered `close_inherited_descriptors` and the aggressively pinned
+   stub ceiling — each expected to fail, each reverted afterwards.
+4. `bats tests/scripts.bats` — the whole file, for the two other users of the blocking stub.
+5. `make test-suite` — the parallel post-apply suite, host-safe files.
+
+CI is the last gate: the macOS job is the one this fix targets, and it is the only place the 3-core
+profile exists. One green run is necessary but not sufficient — the flake's own confirmation
+criterion is three consecutive green `test-macos` runs, which is why the flake issue ships open
+(U3 step 3).
+
+---
+
+## Scope Boundaries
+
+**In scope.** The outer test and its Python driver, the blocking branch of the `herdr` stub, the
+harness constants block, and the issue records.
+
+**Out of scope.**
+
+- `home/dot_local/bin/executable_herdr-task-sync`. The production script is correct; only the test's
+  bound was wrong. It is touched during the U3 rehearsal and restored.
+- The CI workflow. `--jobs 8` is not the defect; a bound with a 1.5x margin is.
+- Other load-sensitive bounds in `tests/scripts.bats`. The instances found so far are enumerated in
+  `docs/issues/2026-08-21-015`, which this plan appends instance five to.
+
+### Deferred to Follow-Up Work
+
+- Cutting the nested run's cost at its source by extracting the `hts_*` harness into a helper file,
+  so the nested invocation can target a small dedicated file instead of re-parsing the whole suite.
+  Filed as issue `021` in U3.
+- Writing `docs/solutions/design-patterns/idle-machine-wall-clock-bounds-are-latent-flakes.md`.
+  `docs/issues/2026-08-21-015` already owns that work; this plan adds an instance to it rather than
+  writing the pattern document.
+
+---
+
+## Assumptions
+
+- The nested run's ≈59 s cost on the CI runner is inferred from print-order gaps in two CI logs
+  (green 64.0 s, red 95.0 s with a known 90 s cap), not from an instrumented measurement on the
+  runner. Under `--jobs 8` output is emitted in plan order rather than completion order, so a gap
+  between consecutive TAP lines is an upper bound on the test's duration, not the duration itself.
+  That makes the margin arithmetic suggestive rather than demonstrative. It is load-bearing only for
+  sizing the Phase A guard, which is deliberately oversized in either direction; the Phase B bound —
+  the one that can actually fire — is sized from the measurement U1 step 8 prints, not from this
+  inference. U3's follow-up issue (`021`) would retire the inference entirely by shrinking the
+  nested run.
+- The reader threads required by KTD3 make the pipe-buffer question moot, since no phase leaves a
+  pipe unread. Were they ever removed, the relevant figure is macOS's 16 KB initial pipe buffer —
+  not Linux's 64 KB default — because macOS is the only platform this fix targets.
+
+---
+
+## Risks
+
+- **Making the guard vacuous.** The dominant risk, and the reason KTD3 and KTD4 exist. Mitigated by
+  the two rehearsals in U3: a test that cannot be made to fail is not a guard.
+- **Leaving the rehearsal edit committed.** U3 temporarily neuters production code, in the checkout
+  copy. Mitigated by an explicit `git status` check before committing — which works only because the
+  edit is in the tracked copy, the reason U3 step 1 names that path rather than the deployed one.
+- **Inverting the stub-ceiling coupling later.** The Phase B bound must stay below the stub's ceiling
+  by the margin KTD4 states. Mitigated by stating the coupling at both ends, in the same unit, with
+  the window it covers named rather than implied.
+
+---
+
+## Definition of Done
+
+- The single whole-run budget is gone; two named, separately-reported bounds replace it, declared in
+  the harness constants block, each with both ends of its sizing stated in its comment.
+- The driver prints both phase durations on every run, and the Phase B bound is a large multiple of
+  the Phase B value measured under contention.
+- The test passes idle and under CPU saturation, with both bounds far from firing.
+- With `close_inherited_descriptors` neutered in the checkout copy, the test fails and names the exit
+  bound and the leaked-pipe condition — verified, then reverted, with `git status` clean.
+- With the stub ceiling pinned low, the test fails on the vacuity check — verified, then reverted.
+- `bats tests/scripts.bats` and `make test-suite` are green.
+- Issues `020` (the flake, open with its confirmation criterion and reopen trigger) and `021` (the
+  follow-up, open) exist, `2026-08-21-015` carries instance five, and `_open-issues.md` has rows for
+  both.
+- **Not part of this plan's done, but its closing condition:** `020` flips to `done` after three
+  consecutive green `test-macos` runs. Landing the PR does not close it.

--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -10,6 +10,7 @@
     "commit": "",
     "pr": ""
   },
+  "autoCompactWindow": 400000,
   "autoCompactEnabled": false,
   "autoUpdatesChannel": "stable",
   "cleanupPeriodDays": 365,
@@ -27,9 +28,6 @@
     "plugin-dev@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true
-  },
-  "env": {
-    "CLAUDE_CODE_NO_FLICKER": "1"
   },
   "extraKnownMarketplaces": {
     "compound-engineering-plugin": {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1987,11 +1987,12 @@ exit_budget = int(os.environ.get("HTS_INNER_BATS_EXIT_SECONDS", "30"))
 # bound fired without reading the message. Avoid 126 and 127: the shell reserves
 # them for "not executable" and "not found", and bats reports a misleading BW01
 # warning when a `run` command exits with either.
-EXIT_HANG_GUARD = 124   # never reached its completion signal
-EXIT_REGRESSION = 125   # completed, then held its pipes open -- the guarded bug
-EXIT_EARLY = 3          # ended before completing its test
-EXIT_VACUOUS = 4        # the fixture gave up; nothing was being held
-EXIT_WORKER_STUCK = 5   # detached worker outlived its release
+EXIT_HANG_GUARD = 124     # never reached its completion signal
+EXIT_REGRESSION = 125     # exited, then held its pipes open -- the guarded bug
+EXIT_EARLY = 3            # ended before completing its test
+EXIT_VACUOUS = 4          # the fixture gave up; nothing was being held
+EXIT_WORKER_STUCK = 5     # detached worker outlived its release
+EXIT_NESTED_FAILED = 7    # the nested test failed on its own terms
 
 release_file = Path(os.environ["HTS_DESCRIPTOR_RELEASE_FILE"])
 pid_file = Path(os.environ["HTS_DESCRIPTOR_PID_FILE"])
@@ -2065,6 +2066,22 @@ def worker_pid():
 # statement. Its arrival proves the nested test body finished -- in the healthy
 # case and in the regression case alike, since a leaked descriptor only shows up
 # afterwards, at exit.
+# Back the poll off rather than holding 10 ms for the whole phase. The signal is
+# tens of seconds away -- the nested run has a whole file to parse first -- so a
+# fixed 10 ms interval spends thousands of wakeups and file reads waiting for
+# something that cannot arrive yet, and it spends them competing with the seven
+# other tests this suite runs alongside under --jobs.
+#
+# The cap is low on purpose, and it is a trade rather than a free win. Noticing
+# late inflates the exit-phase measurement below by up to one interval, because
+# the pipes may already have closed by the time we look -- and that measurement
+# is what HTS_INNER_BATS_EXIT_SECONDS gets recalibrated against. 50 ms keeps the
+# distortion smaller than the values being measured while still cutting the
+# wakeup count roughly fivefold. Raising it trades measurement sharpness for
+# CPU that Bats' own parsing dwarfs anyway.
+poll_interval = 0.01
+poll_interval_cap = 0.05
+
 progress_deadline = time.monotonic() + progress_budget
 pid = None
 while pid is None:
@@ -2094,26 +2111,54 @@ while pid is None:
             f"{progress_budget} seconds (hang guard)",
             EXIT_HANG_GUARD,
         )
-    time.sleep(0.01)
+    time.sleep(poll_interval)
+    poll_interval = min(poll_interval * 1.5, poll_interval_cap)
 
 # Phase 2: the property. Exit and EOF must both arrive, and quickly -- only
-# teardown remains. A timeout here is the regression this test exists to catch.
+# teardown remains.
+#
+# Both are one condition, not two. A leaked descriptor does not merely keep the
+# pipes open after Bats exits: Bats' own formatter reads that pipeline to EOF, so
+# a descendant holding the write end stops the whole nested invocation from
+# finishing. Rehearsal confirms it -- with close_inherited_descriptors neutered,
+# it is the process wait that times out, not the reader join. Splitting these
+# into separate faults would file the real regression under "Bats is stuck, which
+# is not the descriptor bug" and send the next reader after the wrong thing. The
+# message names whichever symptom was observed; the cause is the same.
 exit_started = time.monotonic()
+# Enforce the budget from here -- monotonic, immune to clock skew -- but measure
+# from when the probe actually wrote its signal. The backoff above means we can
+# notice up to one poll interval late, and by then the pipes may already have
+# closed; measuring from detection would report our own latency as the exit cost
+# and quietly render the recalibration number meaningless.
+try:
+    completed_at = pid_file.stat().st_mtime
+except OSError:
+    completed_at = None
+
+symptom = None
 try:
     proc.wait(timeout=exit_budget)
+except subprocess.TimeoutExpired:
+    symptom = "the Bats process never exited"
+
+if symptom is None:
     for reader in readers:
         remaining = exit_budget - (time.monotonic() - exit_started)
         reader.join(timeout=max(remaining, 0))
     if any(reader.is_alive() for reader in readers):
-        raise subprocess.TimeoutExpired(proc.args, exit_budget)
-except subprocess.TimeoutExpired:
+        symptom = "Bats exited but its output pipes never reached EOF"
+
+if symptom is not None:
     report(
-        f"inner Bats did not exit and close its output pipes within "
-        f"{exit_budget} seconds of its test completing -- a detached descendant "
-        "is holding an inherited descriptor open",
+        f"{symptom} within {exit_budget} seconds of its test completing -- a "
+        "detached descendant is holding an inherited descriptor open",
         EXIT_REGRESSION,
     )
-exit_elapsed = time.monotonic() - exit_started
+if completed_at is None:
+    exit_elapsed = time.monotonic() - exit_started
+else:
+    exit_elapsed = max(time.time() - completed_at, 0.0)
 
 sys.stdout.write(captured.get("stdout") or "")
 sys.stderr.write(captured.get("stderr") or "")
@@ -2169,8 +2214,11 @@ else:
 # Last, so a nested failure after the completion signal is still reported -- but
 # only once the worker above has been released and reaped.
 if proc.returncode != 0:
+    # Carry the nested status in the message rather than as our own exit code:
+    # forwarding it raw could coincide with one of the codes above and claim a
+    # failure mode that did not happen.
     print(f"inner Bats exited with status {proc.returncode}", file=sys.stderr)
-    raise SystemExit(proc.returncode)
+    raise SystemExit(EXIT_NESTED_FAILED)
 PY
   unset HTS_DESCRIPTOR_RELEASE_FILE HTS_DESCRIPTOR_PID_FILE
   # `run` captures the driver's measurement into $output, which bats discards on

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1014,9 +1014,11 @@ if [ -f "$HTS_WORK/block-herdr" ]; then
   if [ -n "${HTS_DESCRIPTOR_BLOCKED_PID_FILE:-}" ]; then
     printf '%s\n' "$$" > "$HTS_DESCRIPTOR_BLOCKED_PID_FILE"
   fi
+  # The 3000-poll default (~30 s) is what every other user of this stub gets.
+  # Only the descriptor test raises it, and it exports the raised value itself.
   while [ ! -f "$release_file" ]; do
     block_attempts=$((block_attempts + 1))
-    if [ "$block_attempts" -ge "${HTS_BLOCKED_HERDR_POLLS:-30000}" ]; then
+    if [ "$block_attempts" -ge "${HTS_BLOCKED_HERDR_POLLS:-3000}" ]; then
       # Record the give-up durably. A caller cannot detect it by polling this
       # process for liveness -- that is a race it will usually lose -- and a
       # give-up silently invalidates any conclusion drawn about what was holding
@@ -1486,25 +1488,37 @@ HTS_INNER_BATS_PROGRESS_SECONDS="${HTS_INNER_BATS_PROGRESS_SECONDS:-600}"
 # HTS_BLOCKED_HERDR_CEILING_SECONDS below, which is stated in the same unit so
 # the two can be compared; see that comment for the window it has to clear.
 HTS_INNER_BATS_EXIT_SECONDS="${HTS_INNER_BATS_EXIT_SECONDS:-30}"
+# The driver runs as its own process, so both bounds have to be exported to
+# reach it -- like HTS_WAIT_POLLS above. Without this the driver silently falls
+# back to its own literals and editing the values here changes nothing, which is
+# the same two-sources-of-truth failure this whole change is about.
+export HTS_INNER_BATS_PROGRESS_SECONDS HTS_INNER_BATS_EXIT_SECONDS
 
 # How long the blocked herdr stub waits for its release before giving up. This
 # is a non-vacuity guard, not a budget. If the stub gives up first, the detached
-# worker exits on its own, the driver's liveness check finds it already gone, and
-# the test would have passed having proved nothing -- so the ceiling has to
-# outlast the whole window the worker must survive, which is NOT just the exit
-# bound above. The stub starts blocking inside the nested test body (it writes
-# herdr-blocked before the probe writes its pid file), so the window runs from
-# there through the tail of the progress phase, all of the exit bound, and the
-# liveness check. 300 s is 10x HTS_INNER_BATS_EXIT_SECONDS, which clears that
-# window with room for contention. Stated in seconds like its counterpart above:
-# the stub polls at 0.01 s, and under --jobs contention each iteration costs more
-# than that, so the poll count derived below is a floor on the real wall clock,
-# never a cap. Keep this strictly above HTS_INNER_BATS_EXIT_SECONDS.
-HTS_BLOCKED_HERDR_CEILING_SECONDS="${HTS_BLOCKED_HERDR_CEILING_SECONDS:-300}"
-# The stub is written from a quoted heredoc and runs as its own process, so like
-# HTS_WAIT_POLLS above it reads its ceiling from the environment.
+# worker exits on its own, nothing is holding a descriptor when the driver looks,
+# and the test would have passed having proved nothing.
+#
+# So the ceiling has to outlast the entire window the stub must stay blocked for,
+# which is NOT just the exit bound. The stub starts blocking inside the nested
+# test body -- it writes herdr-blocked before the probe writes its pid file -- so
+# the window runs from there through the rest of the progress phase, all of the
+# exit bound, and the liveness check. Derived rather than hardcoded so that
+# relation holds by construction: a hand-picked number silently inverts the first
+# time either bound above moves, and the failure it produces is a misdiagnosis
+# (the run reports "the fixture gave up" when what actually happened is the hang
+# guard's case).
+#
+# Stated in seconds like its counterparts: the stub polls at 0.01 s, and under
+# --jobs contention each iteration costs more than that, so the poll count
+# derived below is a floor on the real wall clock, never a cap.
+HTS_BLOCKED_HERDR_CEILING_SECONDS="${HTS_BLOCKED_HERDR_CEILING_SECONDS:-$((HTS_INNER_BATS_PROGRESS_SECONDS + HTS_INNER_BATS_EXIT_SECONDS + 60))}"
 HTS_BLOCKED_HERDR_POLLS="${HTS_BLOCKED_HERDR_POLLS:-$((HTS_BLOCKED_HERDR_CEILING_SECONDS * 100))}" # sleep 0.01
-export HTS_BLOCKED_HERDR_POLLS
+# Deliberately NOT exported at file scope. Two other tests use the same blocking
+# stub (search block-herdr) and release it promptly; handing them a ceiling two
+# orders of magnitude larger only slows down their failure paths, where the stub
+# would otherwise give up quickly inside an already-deleted work dir. The one
+# test that needs the raised ceiling exports it for itself.
 
 
 
@@ -1957,9 +1971,13 @@ hts_wait_for_task_slug() {
   export HTS_DESCRIPTOR_RELEASE_FILE="$release_file"
   export HTS_DESCRIPTOR_PID_FILE="$pid_file"
   export HTS_DESCRIPTOR_BLOCKED_PID_FILE="$blocked_pid_file"
+  # This is the only test whose stub must stay blocked across a whole nested Bats
+  # run, so it is the only one that gets the raised ceiling.
+  export HTS_BLOCKED_HERDR_POLLS
   run python3 - "$bats_bin" "$BATS_TEST_FILENAME" <<'PY'
 import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
 import threading
@@ -2199,6 +2217,11 @@ except ProcessLookupError:
         "a give-up; nothing held a descriptor while the inner Bats exited",
         EXIT_VACUOUS,
     )
+except PermissionError:
+    # Alive, just not ours to signal. Treated as alive on purpose: raising here
+    # would abort with a traceback whose status matches no EXIT_* code, so the
+    # failure block could not say which bound fired.
+    pass
 
 release_file.touch()
 for _ in range(500):
@@ -2208,6 +2231,13 @@ for _ in range(500):
         break
     time.sleep(0.01)
 else:
+    # Kill it before reporting. This is the one path that names a still-running
+    # process, and leaving it behind would strand a detached worker past the end
+    # of the test -- the same thing every other failure path here cleans up.
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
     print(f"detached worker {pid} did not exit after release", file=sys.stderr)
     raise SystemExit(EXIT_WORKER_STUCK)
 
@@ -2229,6 +2259,36 @@ PY
   printf '%s\n' "$output" | grep -F 'inner Bats exit phase took' >&3 || true
   assert_success
   assert_output --partial "ok 1 herdr-task-sync descriptor child probe"
+}
+
+# Guards the guard. The test above can only prove anything while the herdr stub
+# is still blocked -- if the stub gives up first, nothing holds a descriptor and
+# a green run means nothing. That was not a hypothetical: the first version of
+# the non-vacuity check watched the stub's parent, which outlives the give-up, so
+# it passed on exactly the vacuous run it was written to catch.
+#
+# Pinning the stub to give up immediately must therefore turn the test red. This
+# costs one extra nested Bats run, which is the expensive thing in this file
+# (docs/issues/2026-08-21-021), and it buys the one property no other test here
+# can assert: that the guard above still fails when it should.
+@test "herdr-task-sync bounded Bats invocation refuses a vacuous run" {
+  local bats_bin release_file="$BATS_TEST_TMPDIR/release-herdr"
+  local pid_file="$BATS_TEST_TMPDIR/descriptor-worker.pid"
+  local blocked_pid_file="$BATS_TEST_TMPDIR/blocked-herdr.pid"
+  bats_bin="$(command -v bats)"
+  export HTS_DESCRIPTOR_RELEASE_FILE="$release_file"
+  export HTS_DESCRIPTOR_PID_FILE="$pid_file"
+  export HTS_DESCRIPTOR_BLOCKED_PID_FILE="$blocked_pid_file"
+  # One poll: the stub records its give-up before the driver ever looks.
+  export HTS_BLOCKED_HERDR_POLLS=1
+
+  run bats "$BATS_TEST_FILENAME" \
+    --filter '^herdr-task-sync bounded Bats invocation exits after detached work$'
+
+  unset HTS_DESCRIPTOR_RELEASE_FILE HTS_DESCRIPTOR_PID_FILE
+  unset HTS_DESCRIPTOR_BLOCKED_PID_FILE HTS_BLOCKED_HERDR_POLLS
+  assert_failure
+  assert_output --partial "this run proved nothing"
 }
 
 @test "herdr-task-sync harness fresh reads follow pane and tab mutations" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1008,9 +1008,24 @@ if [ -f "$HTS_WORK/block-herdr" ]; then
   block_attempts=0
   release_file="${HTS_DESCRIPTOR_RELEASE_FILE:-$HTS_WORK/release-herdr}"
   : > "$HTS_WORK/herdr-blocked"
+  # Publish the blocking process itself, so a caller can prove it was still
+  # blocked rather than inferring it from an ancestor that outlives the give-up
+  # below. Only the descriptor test sets this.
+  if [ -n "${HTS_DESCRIPTOR_BLOCKED_PID_FILE:-}" ]; then
+    printf '%s\n' "$$" > "$HTS_DESCRIPTOR_BLOCKED_PID_FILE"
+  fi
   while [ ! -f "$release_file" ]; do
     block_attempts=$((block_attempts + 1))
-    [ "$block_attempts" -lt 3000 ] || exit 124
+    if [ "$block_attempts" -ge "${HTS_BLOCKED_HERDR_POLLS:-30000}" ]; then
+      # Record the give-up durably. A caller cannot detect it by polling this
+      # process for liveness -- that is a race it will usually lose -- and a
+      # give-up silently invalidates any conclusion drawn about what was holding
+      # a descriptor while it was supposed to be blocked.
+      if [ -n "${HTS_DESCRIPTOR_BLOCKED_PID_FILE:-}" ]; then
+        : > "$HTS_DESCRIPTOR_BLOCKED_PID_FILE.gave-up"
+      fi
+      exit 124
+    fi
     sleep 0.01
   done
 fi
@@ -1443,6 +1458,53 @@ HTS_WAIT_MATCH_POLLS="${HTS_WAIT_MATCH_POLLS:-$((HTS_WAIT_CEILING_SECONDS * 40))
 # so it reads its ceiling from the environment rather than from file scope. The
 # other two are only ever read by functions in this file.
 export HTS_WAIT_POLLS
+
+# The two bounds around the nested Bats run in "bounded Bats invocation exits
+# after detached work". They are deliberately two numbers, not one, because a
+# hang guard and an assertion are different budgets: the old single 90 s budget
+# covered the whole nested run, most of which is Bats parsing all ~196 tests of
+# this 5105-line file to reach the one the filter selects. On the 3-core macOS CI
+# runner that parse alone put a green run at ~59 s against the 90 s cap, and an
+# ordinary 1.36x-slower run then went red with no regression behind it.
+#
+# The causal remedy docs/issues/2026-08-21-015 prefers is unavailable here: a
+# held pipe and a released one differ only in elapsed time, with no marker a test
+# could block on. So the split is the fallback, applied deliberately.
+#
+# PROGRESS is the hang guard. It covers the nested run up to the probe writing
+# its pid file, so it absorbs the whole load-elastic parse. It never fires in a
+# healthy run or in the guarded regression -- only a genuine hang reaches it.
+# Sized between two anchors: far above the ~59 s observed cost, and far enough
+# below the macOS job's timeout-minutes: 25 that it prints its own message
+# instead of the job being killed with none.
+HTS_INNER_BATS_PROGRESS_SECONDS="${HTS_INNER_BATS_PROGRESS_SECONDS:-600}"
+# EXIT is the assertion, and the only bound here that can fire on a healthy run.
+# It covers Bats teardown and exit alone -- not the parse -- which is what takes
+# the load sensitivity out. Sized from measurement, not intuition: the driver
+# prints its elapsed value on every run, and this is a large multiple of the
+# ~0.2 s observed under CPU saturation on a 10-core host. Must stay below
+# HTS_BLOCKED_HERDR_CEILING_SECONDS below, which is stated in the same unit so
+# the two can be compared; see that comment for the window it has to clear.
+HTS_INNER_BATS_EXIT_SECONDS="${HTS_INNER_BATS_EXIT_SECONDS:-30}"
+
+# How long the blocked herdr stub waits for its release before giving up. This
+# is a non-vacuity guard, not a budget. If the stub gives up first, the detached
+# worker exits on its own, the driver's liveness check finds it already gone, and
+# the test would have passed having proved nothing -- so the ceiling has to
+# outlast the whole window the worker must survive, which is NOT just the exit
+# bound above. The stub starts blocking inside the nested test body (it writes
+# herdr-blocked before the probe writes its pid file), so the window runs from
+# there through the tail of the progress phase, all of the exit bound, and the
+# liveness check. 300 s is 10x HTS_INNER_BATS_EXIT_SECONDS, which clears that
+# window with room for contention. Stated in seconds like its counterpart above:
+# the stub polls at 0.01 s, and under --jobs contention each iteration costs more
+# than that, so the poll count derived below is a floor on the real wall clock,
+# never a cap. Keep this strictly above HTS_INNER_BATS_EXIT_SECONDS.
+HTS_BLOCKED_HERDR_CEILING_SECONDS="${HTS_BLOCKED_HERDR_CEILING_SECONDS:-300}"
+# The stub is written from a quoted heredoc and runs as its own process, so like
+# HTS_WAIT_POLLS above it reads its ceiling from the environment.
+HTS_BLOCKED_HERDR_POLLS="${HTS_BLOCKED_HERDR_POLLS:-$((HTS_BLOCKED_HERDR_CEILING_SECONDS * 100))}" # sleep 0.01
+export HTS_BLOCKED_HERDR_POLLS
 
 
 
@@ -1890,43 +1952,210 @@ hts_wait_for_task_slug() {
   # docs/issues/2026-08-20-013-se-blocks-test-hard-fails-without-deps.md.
   local bats_bin release_file="$BATS_TEST_TMPDIR/release-herdr"
   local pid_file="$BATS_TEST_TMPDIR/descriptor-worker.pid"
+  local blocked_pid_file="$BATS_TEST_TMPDIR/blocked-herdr.pid"
   bats_bin="$(command -v bats)"
   export HTS_DESCRIPTOR_RELEASE_FILE="$release_file"
   export HTS_DESCRIPTOR_PID_FILE="$pid_file"
+  export HTS_DESCRIPTOR_BLOCKED_PID_FILE="$blocked_pid_file"
   run python3 - "$bats_bin" "$BATS_TEST_FILENAME" <<'PY'
 import os
 from pathlib import Path
 import subprocess
 import sys
+import threading
 import time
 
-command = [
-    sys.argv[1],
-    sys.argv[2],
-    "--filter",
-    "^herdr-task-sync descriptor child probe$",
+# Two bounds, not one, and they measure different things. See the
+# HTS_INNER_BATS_* comments in this file's constants block for why the single
+# budget this replaced was a latent flake.
+#
+# PROGRESS covers the nested run up to the probe writing its pid file -- the
+# load-elastic part, dominated by Bats parsing this whole file to reach one
+# filtered test. It is a hang guard and should never fire.
+#
+# EXIT covers what happens after that signal: the nested Bats must exit AND its
+# output pipes must reach end-of-file. That pair is the property under test.
+# Waiting on process exit alone would not detect the regression -- a detached
+# worker that inherited the pipes keeps them open after Bats itself is gone, so
+# EOF, not exit, is what a leaked descriptor withholds. The pipes are also why
+# the nested run must never be given temp files instead: a worker holding a file
+# descriptor blocks nothing, and the test would pass unconditionally.
+progress_budget = int(os.environ.get("HTS_INNER_BATS_PROGRESS_SECONDS", "600"))
+exit_budget = int(os.environ.get("HTS_INNER_BATS_EXIT_SECONDS", "30"))
+
+# Distinct status per failure mode, so the outer test's failure block names which
+# bound fired without reading the message. Avoid 126 and 127: the shell reserves
+# them for "not executable" and "not found", and bats reports a misleading BW01
+# warning when a `run` command exits with either.
+EXIT_HANG_GUARD = 124   # never reached its completion signal
+EXIT_REGRESSION = 125   # completed, then held its pipes open -- the guarded bug
+EXIT_EARLY = 3          # ended before completing its test
+EXIT_VACUOUS = 4        # the fixture gave up; nothing was being held
+EXIT_WORKER_STUCK = 5   # detached worker outlived its release
+
+release_file = Path(os.environ["HTS_DESCRIPTOR_RELEASE_FILE"])
+pid_file = Path(os.environ["HTS_DESCRIPTOR_PID_FILE"])
+blocked_pid_file = Path(os.environ["HTS_DESCRIPTOR_BLOCKED_PID_FILE"])
+gave_up_file = Path(str(blocked_pid_file) + ".gave-up")
+
+
+def fixture_gave_up():
+    """The blocked herdr stub hit its ceiling and stopped holding its descriptor.
+    Whatever else this run observed, it did not observe the property under test."""
+    return gave_up_file.exists()
+
+
+VACUOUS = (
+    "the blocked herdr stub hit HTS_BLOCKED_HERDR_CEILING_SECONDS and gave up, so "
+    "nothing held a descriptor while the inner Bats exited -- this run proved nothing"
+)
+
+proc = subprocess.Popen(
+    [sys.argv[1], sys.argv[2], "--filter", "^herdr-task-sync descriptor child probe$"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+
+# Drain both pipes from launch in their own threads. Nothing may leave a pipe
+# unread: the nested run blocks on a full pipe buffer otherwise, and on the
+# nested-test-failure path Bats echoes the failed test's captured output, which
+# is exactly when that output is largest. An unread pipe there would stall the
+# pid file forever and report a plain test failure as a progress-phase hang.
+captured = {}
+
+
+def drain(name, stream):
+    captured[name] = stream.read()
+    stream.close()
+
+
+readers = [
+    threading.Thread(target=drain, args=("stdout", proc.stdout), daemon=True),
+    threading.Thread(target=drain, args=("stderr", proc.stderr), daemon=True),
 ]
-# This bound exists to catch a genuine hang, not to measure speed. It has to
-# clear the worst case of an inner Bats run competing with every other test in
-# a --jobs run, so it is generous rather than tight; 12s was calibrated on an
-# idle machine and timed out under parallel load.
-budget = int(os.environ.get("HTS_INNER_BATS_TIMEOUT", "90"))
+for reader in readers:
+    reader.start()
+
+
+def report(message, code):
+    """Fail without stranding a blocked worker or an unreaped process."""
+    release_file.touch()
+    if proc.poll() is None:
+        proc.kill()
+    proc.wait()
+    for reader in readers:
+        reader.join(timeout=5)
+    sys.stdout.write(captured.get("stdout") or "")
+    sys.stderr.write(captured.get("stderr") or "")
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def worker_pid():
+    """The probe writes this with a shell redirect, so the file exists empty
+    before its contents land -- and stays empty if the write failed."""
+    try:
+        return int(pid_file.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+# Phase 1: wait for the probe's completion signal, which it writes as its last
+# statement. Its arrival proves the nested test body finished -- in the healthy
+# case and in the regression case alike, since a leaked descriptor only shows up
+# afterwards, at exit.
+progress_deadline = time.monotonic() + progress_budget
+pid = None
+while pid is None:
+    pid = worker_pid()
+    if pid is not None:
+        break
+    if proc.poll() is not None:
+        # The nested run ended. Re-read once before calling this an early exit:
+        # the regression exits too, and only its pipes stay open, so "exited"
+        # and "signal present" are both true there, separated by teardown.
+        pid = worker_pid()
+        if pid is None:
+            # A give-up collapses the fixture too -- the coordinator's pass fails
+            # and releases its claim, so the probe records no owner pid. Name that
+            # cause rather than reporting it as an unexplained early exit.
+            if fixture_gave_up():
+                report(VACUOUS, EXIT_VACUOUS)
+            report(
+                f"inner Bats exited with status {proc.returncode} before its test "
+                "completed; it never wrote the descriptor pid file",
+                EXIT_EARLY,
+            )
+        break
+    if time.monotonic() > progress_deadline:
+        report(
+            f"inner Bats did not reach its completion signal within "
+            f"{progress_budget} seconds (hang guard)",
+            EXIT_HANG_GUARD,
+        )
+    time.sleep(0.01)
+
+# Phase 2: the property. Exit and EOF must both arrive, and quickly -- only
+# teardown remains. A timeout here is the regression this test exists to catch.
+exit_started = time.monotonic()
 try:
-    result = subprocess.run(command, capture_output=True, text=True, timeout=budget)
-except subprocess.TimeoutExpired as error:
-    Path(os.environ["HTS_DESCRIPTOR_RELEASE_FILE"]).touch()
-    if error.stdout:
-        sys.stdout.write(error.stdout if isinstance(error.stdout, str) else error.stdout.decode())
-    print(f"inner Bats invocation exceeded {budget} seconds", file=sys.stderr)
-    raise SystemExit(124)
+    proc.wait(timeout=exit_budget)
+    for reader in readers:
+        remaining = exit_budget - (time.monotonic() - exit_started)
+        reader.join(timeout=max(remaining, 0))
+    if any(reader.is_alive() for reader in readers):
+        raise subprocess.TimeoutExpired(proc.args, exit_budget)
+except subprocess.TimeoutExpired:
+    report(
+        f"inner Bats did not exit and close its output pipes within "
+        f"{exit_budget} seconds of its test completing -- a detached descendant "
+        "is holding an inherited descriptor open",
+        EXIT_REGRESSION,
+    )
+exit_elapsed = time.monotonic() - exit_started
 
-sys.stdout.write(result.stdout)
-sys.stderr.write(result.stderr)
-if result.returncode != 0:
-    raise SystemExit(result.returncode)
+sys.stdout.write(captured.get("stdout") or "")
+sys.stderr.write(captured.get("stderr") or "")
+# Printed on every run, passing runs included, so the next recalibration of
+# HTS_INNER_BATS_EXIT_SECONDS reads a number out of CI instead of reconstructing
+# one from TAP print-order gaps.
+print(f"inner Bats exit phase took {exit_elapsed:.3f}s", file=sys.stderr)
 
-Path(os.environ["HTS_DESCRIPTOR_RELEASE_FILE"]).touch()
-pid = int(Path(os.environ["HTS_DESCRIPTOR_PID_FILE"]).read_text())
+# Non-vacuity: the herdr stub must STILL be blocked right now. Everything above
+# only proves the nested Bats exited and closed its pipes -- which is unremarkable
+# if nothing was holding a descriptor at the time. The stub gives up on its own
+# after HTS_BLOCKED_HERDR_CEILING_SECONDS, and if it did, this run proved nothing.
+#
+# Check the stub's own pid, not the detached worker's. The worker is the stub's
+# parent and outlives its give-up, so a live worker does not imply a blocked
+# stub -- checking the worker here passes on exactly the vacuous run this guard
+# exists to catch.
+if fixture_gave_up():
+    report(VACUOUS, EXIT_VACUOUS)
+
+# Backstop for a stub that vanished without recording a give-up (killed, crashed).
+# The durable marker above is the primary signal; polling liveness is a race this
+# would usually lose on its own.
+try:
+    blocked_pid = int(blocked_pid_file.read_text().strip())
+except (FileNotFoundError, ValueError):
+    report(
+        "the blocked herdr stub never published its pid; this run cannot show "
+        "anything was holding a descriptor",
+        EXIT_VACUOUS,
+    )
+
+try:
+    os.kill(blocked_pid, 0)
+except ProcessLookupError:
+    report(
+        f"blocked herdr stub {blocked_pid} was gone before release without recording "
+        "a give-up; nothing held a descriptor while the inner Bats exited",
+        EXIT_VACUOUS,
+    )
+
+release_file.touch()
 for _ in range(500):
     try:
         os.kill(pid, 0)
@@ -1935,9 +2164,21 @@ for _ in range(500):
     time.sleep(0.01)
 else:
     print(f"detached worker {pid} did not exit after release", file=sys.stderr)
-    raise SystemExit(125)
+    raise SystemExit(EXIT_WORKER_STUCK)
+
+# Last, so a nested failure after the completion signal is still reported -- but
+# only once the worker above has been released and reaped.
+if proc.returncode != 0:
+    print(f"inner Bats exited with status {proc.returncode}", file=sys.stderr)
+    raise SystemExit(proc.returncode)
 PY
   unset HTS_DESCRIPTOR_RELEASE_FILE HTS_DESCRIPTOR_PID_FILE
+  # `run` captures the driver's measurement into $output, which bats discards on
+  # a passing test -- so forward it to the console descriptor. The number is only
+  # useful if a green CI run carries it: it is what
+  # HTS_INNER_BATS_EXIT_SECONDS gets recalibrated against, and reconstructing it
+  # from TAP print-order gaps is what made the previous bound guesswork.
+  printf '%s\n' "$output" | grep -F 'inner Bats exit phase took' >&3 || true
   assert_success
   assert_output --partial "ok 1 herdr-task-sync descriptor child probe"
 }


### PR DESCRIPTION
## What broke

`herdr-task-sync bounded Bats invocation exits after detached work` in `tests/scripts.bats` went red on the `test-macos` job of [run 32454626507](https://github.com/Seigiard/my-mac-setup/actions/runs/32454626507). There was no regression behind it — the test timed out because it was slow, not because the thing it guards broke.

That test spawns a **nested** Bats invocation of its own file to run a single filtered test, and capped the whole nested run with one fixed 90-second budget. Most of that run is Bats parsing all 196 tests of a 5105-line file to reach the one the filter selects. On the 3-core macOS runner the nested run already costs about 59 s in a *green* run, so the margin was roughly 1.5x — and the red run was about 1.36x slower than the green one it followed. Ordinary variance was enough.

## Why it was slowness and not the regression

Exit status 124 cannot tell the two apart on its own: `subprocess.run` reads to end-of-file, and a missing EOF is exactly what a leaked descriptor causes. Both produce 124.

The discriminator is whether the nested run reached its own completion signal before the expiry, and it is visible in the captured output:

| Cause | Captured stdout |
|---|---|
| Load (what happened) | 2 lines: the driver's message and `1..1` |
| Leaked descriptor | 3 lines: those two plus `ok 1 herdr-task-sync descriptor child probe` |

The red run printed two lines with no `ok 1`. That table is not inference — it was produced by rehearsal, neutering `close_inherited_descriptors` and observing the three-line form.

## The fix

One budget becomes two separately named bounds, which is the rule [`docs/issues/2026-08-21-015`](docs/issues/2026-08-21-015-capture-the-idle-machine-wall-clock-pattern.md) already states: a hang guard and a performance assertion must not share a number.

- **`HTS_INNER_BATS_PROGRESS_SECONDS`** (600 s) is the hang guard, covering the nested run up to its completion signal — the whole load-elastic parse. It never fires in a healthy run or in the regression. It is bounded on both ends: far above the observed cost, and far enough below the job's `timeout-minutes: 25` that a real hang prints its own message instead of the job being killed with none.
- **`HTS_INNER_BATS_EXIT_SECONDS`** (30 s) is the assertion, and the only bound that can fire on a healthy run. It covers Bats teardown and exit alone.

| Phase | Idle | 16 CPU hogs | `--jobs 8` | Bound | Margin |
|---|---|---|---|---|---|
| Exit (the assertion) | 0.011 s | 0.040 s | 0.083 s | 30 s | ~360x |
| Whole run (the old budget) | 6.9 s | 16.0 s | — | 90 s | 1.5x on CI |

The driver prints the exit-phase duration on every run, passing ones included, and the test forwards it to Bats' console descriptor — so a green CI run now carries the number the bound gets recalibrated against, instead of it being reconstructed from TAP print-order gaps.

The causal remedy `2026-08-21-015` prefers was not available here: a held pipe and a released pipe differ only in elapsed time, with no marker a test can block on. The split is the fallback, and the code says so.

## Three things the implementation found that the plan had wrong

Each was caught by running the thing, not by reading it. All three are recorded in the plan's `Post-implementation corrections` section rather than edited away, because the wrong reasoning is the useful part.

**A held descriptor stops the whole nested invocation, not just its pipes.** Bats' own formatter reads its pipeline to EOF, so a descendant holding the write end prevents the top-level Bats process from finishing at all. An attempt to split "Bats never exited" and "pipes stayed open" into separate faults was reverted — it would have filed the real regression under *"Bats is stuck, which is not the descriptor bug"*.

**The first non-vacuity check could not detect a vacuous run.** It watched the presentation coordinator, which is the blocked stub's **parent** and outlives its give-up. The rehearsal passed when it should have failed. The stub now records a durable give-up marker; the driver refuses to pass when it exists.

**The two new bounds were never exported.** They were assigned at file scope, so the driver — a separate process — fell back to its own literals. The values matched by coincidence, so nothing broke and no test could notice, but editing either constant changed nothing.

## Guarding the guard

Both proofs that this test still works were manual rehearsals: run once, reverted, recorded in prose. The vacuity half needs no production mutation, so it is now a committed test — pin the fixture to give up immediately and the guard must go red. Verified it is not itself vacuous by disabling the give-up marker, which turns the new test red as intended.

This costs one extra nested Bats run, which is the expensive thing in this file. That cost is filed as [`docs/issues/2026-08-21-021`](docs/issues/2026-08-21-021-nested-bats-run-parses-the-whole-suite.md): the nested run parses 196 tests to execute one, and cutting it means moving the `hts_*` harness into a helper file.

The regression half stays manual — committing it would mean mutating and restoring production source from inside a test.

## Verification

- `bats tests/scripts.bats` — 197 pass, 0 fail
- `make lint` — clean
- `make test-issues` — passes (the two new issues conform to the schema `main` introduced)
- Regression rehearsal — with `close_inherited_descriptors` neutered, fails at status 125 naming the held descriptor. Reverted.
- Vacuity rehearsal — with the fixture pinned to give up, fails at status 4 naming the vacuous run. Now also a committed test.

`make test-suite` reports one **unrelated** failure: `critical managed files are deployed and still managed` wants two `herdr-focus-notify` files from `6e6749c` that are not applied to this machine's `$HOME`. That target asserts against the deployed home by design; CI applies the checkout first.

## The flake issue stays open

[`docs/issues/2026-08-21-020`](docs/issues/2026-08-21-020-inner-bats-budget-flaked-the-macos-job.md) is filed **open**, not closed. Every measurement above was taken on a 10-core host, which cannot produce the 3-core profile where this reproduces, and a flake that has fired twice in CI is not shown fixed by a passing local run. It closes after three consecutive green `test-macos` runs. Merging this does not close it.

## Also in this PR

`1fac4ef Update private_settings.json.tmpl` is an unrelated Claude Code settings change (adds `autoCompactWindow`, drops `CLAUDE_CODE_NO_FLICKER`) that was already on this branch. Included deliberately rather than rewritten out.
