### PR TITLE
perf(docker): bake Brewfile dependencies into the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the build context limited to Docker inputs. Do not unignore all of home:
+# it can contain untracked dependencies and encrypted chezmoi source files.
+*
+!docker
+!home/private_dot_config/brewfiles

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -73,4 +73,13 @@ RUN brew install fzf
 # image, so installing the formula is enough.
 RUN brew install oven-sh/bun/bun
 
+# Bake the full cross-platform Brewfile so apply-time brew bundle only verifies
+# installed formulae. The assertion guards the implicit full render selected by
+# the intentionally absent ci_minimal template value.
+COPY --chown=testuser home/private_dot_config/brewfiles/Brewfile.tmpl /tmp/Brewfile.tmpl
+RUN chezmoi execute-template --file /tmp/Brewfile.tmpl > /tmp/Brewfile && \
+    grep -Fq 'brew "lazywalker/tap/rgrc"' /tmp/Brewfile && \
+    brew bundle --file=/tmp/Brewfile && \
+    rm -rf "$(brew --cache)"
+
 CMD ["/bin/zsh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   # Interactive shell for debugging
   ubuntu:
     build:
-      context: .
-      dockerfile: Dockerfile.ubuntu
+      context: ..
+      dockerfile: docker/Dockerfile.ubuntu
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
@@ -28,8 +28,8 @@ services:
   # Full test with package installation
   test-full:
     build:
-      context: .
-      dockerfile: Dockerfile.ubuntu
+      context: ..
+      dockerfile: docker/Dockerfile.ubuntu
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
@@ -84,14 +84,16 @@ services:
   # Quick test (no package installation, just config files)
   test-quick:
     build:
-      context: .
-      dockerfile: Dockerfile.ubuntu
+      context: ..
+      dockerfile: docker/Dockerfile.ubuntu
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
     environment:
       - CHEZMOI_NAME=Test User
       - CHEZMOI_EMAIL=test@example.com
+      - HOMEBREW_NO_AUTO_UPDATE=1
+      - HOMEBREW_NO_INSTALL_CLEANUP=1
       # See the ubuntu service above for why this is written literally. Note
       # that MMS_CI_MINIMAL stays absent here on purpose (docs/issues/
       # 2026-08-20-014); only the disposable-$HOME marker is shared.


### PR DESCRIPTION
## Summary

Repeated Docker test runs now reuse all 39 rendered Brewfile dependencies from the image instead of reinstalling formulae during every `chezmoi apply`. The image keeps the full Linux Brewfile coverage while a narrow build-context allowlist prevents unrelated repository changes from invalidating the layer.

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| Warm `make test-ubuntu`, run 1 | 223 s | 100.26 s | 55.0% faster |
| Warm `make test-ubuntu`, run 2 | 235 s | 100.55 s | 57.2% faster |
| Apply-time `brew bundle` | 119-133 s | 2 s | Formula installs eliminated |

The first build of the baked layer took 122.8 seconds and produced a 2.93 GB image. A Brewfile content change correctly rebuilt the layer and made `make test-templates` take 132.85 seconds; an edit to the macOS-only Brewfile left every image layer cached. The transferred build context was 3.94 kB.

## Validation

- `make test-ubuntu` passed twice from a warm image with 40 `Using` lines and no formula `Installing` lines.
- `make test-docker` passed before and after rebasing onto the latest `origin/main`.
- `make test-templates` passed all 41 template tests after a Brewfile cache invalidation.
- `make shell-ubuntu` opened an interactive Zsh shell.
- `brew bundle check --file=/tmp/Brewfile` reported all dependencies satisfied.
- `make lint` passed.
- Cache probes confirmed that only `Brewfile.tmpl` content invalidates the bundle layer, and all scratch edits were restored.

## Post-Deploy Monitoring & Validation

No production monitoring is required because this change affects only the local Docker test image. During the first two local Docker runs after merge, the maintainer should confirm that build logs show a context below 1 MB and apply logs show `Using` rather than formula `Installing` lines. A repeated run near 100 seconds is healthy; repeated formula installs, an unexpectedly large context, or a failed Brewfile build requires reverting the Dockerfile, Compose, and `.dockerignore` changes together.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
