### PR TITLE
fix(ci): skip Linuxbrew on minimal Ubuntu runs

### DIFF
--- a/docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md
+++ b/docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md
@@ -1,73 +1,71 @@
 ---
-title: "The test-ubuntu CI job installs 37 brew packages it can never reach, because Linuxbrew's prefix is never put on PATH"
-short_description: "The Ubuntu job spends 177.9 seconds installing 37 Homebrew formulae but never exports `/home/linuxbrew/.linuxbrew/bin`, leaving every installed binary unreachable to tests."
+title: "Ubuntu push and PR runs bootstrap Linuxbrew for unreachable duplicate tools"
+short_description: "Push and pull-request runs spend about 60 seconds bootstrapping Linuxbrew and installing node, bun, and jq, although later steps use runner-provided copies because the Linuxbrew prefix never reaches PATH."
 type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","bug"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "medium"
 parent-plan: "docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md"
+closed: "2026-08-22"
 ---
 
 ## Why this exists
 
-The `test-ubuntu` job in `.github/workflows/test-dotfiles.yml` spends **177.9 s** — 82.5% of
-its whole `Apply dotfiles` step — running `brew bundle` for 37 formulae, and then no test can
-invoke any of them. Every one of those installs is dead weight.
+The CI-minimal plan has changed the size and purpose of the install, but it has not removed the
+waste on ordinary Ubuntu runs. Push and pull-request events now render only three formulae:
+`node`, `oven-sh/bun/bun`, and `jq`. The `test-ubuntu` job still bootstraps Linuxbrew to install
+those formulae even though no later step can resolve them from Linuxbrew.
 
-The chain, each link verifiable:
+The current chain is verifiable in push run `32553980667`, job `96985167596`:
 
-1. Homebrew is **not** preinstalled on the `ubuntu-latest` runner image.
-   `home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl:16-26` therefore
-   installs it from scratch on every run, at a further 26.4 s cost.
-2. That script puts brew on `PATH` with `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"`
-   at line 24 — but that export lives and dies inside the script's own process.
-3. The workflow adds only `$HOME/.local/bin` to `$GITHUB_PATH`
-   (`.github/workflows/test-dotfiles.yml:48-49`). Nothing ever adds
-   `/home/linuxbrew/.linuxbrew/bin`.
-4. The Homebrew installer says so out loud in the job log:
-   `Warning: /home/linuxbrew/.linuxbrew/bin is not in your PATH.`
-   (run 32429787123, job 96618922151, `Apply dotfiles` step.)
-5. The installer's own "Next steps" only offers to append to `~/.bashrc`, which GitHub's
-   non-interactive `bash -e {0}` step shell never reads.
+1. The workflow selected the minimal render: `no Brewfile change; the minimal install stands`.
+2. `home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl` installed Homebrew,
+   `node`, `bun`, and `jq`. Homebrew reported four dependencies because the Brewfile also has the
+   `oven-sh/bun` tap.
+3. The installer repeated `Warning: /home/linuxbrew/.linuxbrew/bin is not in your PATH.`
+4. The script's `brew shellenv` export affected only that script process. The workflow added only
+   `$HOME/.local/bin` to `$GITHUB_PATH`, so later steps still could not reach Linuxbrew.
+5. The workflow had already installed bun through `oven-sh/setup-bun@v2`. The Ubuntu runner image
+   supplied node and jq independently. The post-apply suite had no missing-node, missing-bun, or
+   missing-jq skips despite Linuxbrew remaining unreachable.
 
-Corroboration from the other direction: the ubuntu post-apply run's complete skip list is
-`8 × "Not on macOS"`, `1 × "Only relevant on macOS"`, `1 × "internal descriptor probe"`.
-There is not one `jq not available`, `bun not available`, `sqlite3 is required`, or
-`zsh not installed` skip — because `jq`, `python3`, `git`, `sqlite3`, and `perl` all come from
-the runner image, `zsh` and `bats` from apt, `fzf` from the upstream tarball, and `bun` from
-`oven-sh/setup-bun@v2`. The suite never needed Linuxbrew on this job.
+The `Apply dotfiles` step ran from `05:18:44` to `05:19:49`. Homebrew bootstrap and `brew bundle`
+occupied about 60 seconds of that 65-second step. This is smaller than the original 177.9-second
+full install, but it remains avoidable work on every ordinary push and pull request.
 
-The workflow already documents one instance of this without generalising it: the comment at
-`.github/workflows/test-dotfiles.yml:67-73` explains that the Brewfile's `bun` lands in
-Linuxbrew's prefix "which this job never puts on PATH", and adds a `setup-bun` step to work
-around it. That is true of all 37 entries, not just `bun`.
+Full-set runs are different. Scheduled and manually dispatched runs, plus a push or pull request
+that changes a Brewfile, intentionally install the complete Brewfile as an installability gate.
+Scheduled run `32551513158`, job `96978924101`, installed 39 Brewfile dependencies and completed
+successfully. Those binaries also remain outside later steps' PATH, but installation itself is the
+assertion, so that work is not dead weight.
 
 ## Scope
 
-Two mutually exclusive directions, and they mean opposite things:
+- Skip the Homebrew bootstrap and `brew bundle` on Linux when the CI-minimal render is selected.
+- Keep the current full install for scheduled runs, manual runs, and Brewfile-changing diffs. These
+  runs prove that the cross-platform Brewfile still installs.
+- Keep macOS behavior separate. The shared `MMS_CI_MINIMAL` switch does not prove that the macOS
+  job can skip the same formulae or the Homebrew invocation.
+- Do not add Linuxbrew to `$GITHUB_PATH` only to justify the minimal install. The Ubuntu job already
+  provisions each required test tool outside Linuxbrew, and the workflow declares push and pull
+  requests as the fast path.
+- Preserve template-render coverage for both minimal and full Brewfiles in
+  `tests/templates.bats`.
 
-- **Treat the install as waste and stop doing it.** The apply on this job would skip
-  `brew bundle` entirely, saving 177.9 s plus the 26.4 s Homebrew bootstrap. This makes the
-  ubuntu job a config-and-template test rather than an install test, which is arguably what it
-  already is.
-- **Treat it as a broken environment and fix PATH.** Add
-  `/home/linuxbrew/.linuxbrew/bin` to `$GITHUB_PATH` after the apply. This makes the ubuntu job
-  genuinely exercise the Brewfile for the first time — and would very likely surface tests that
-  have been silently skipping, plus new failures, since no run has ever had these binaries.
-
-Related but separate: the sibling CI-minimal plan
-(`docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md`) reduces the install to five
-entries on push/PR. That shrinks the waste; it does not resolve which of the two directions
-above is correct, and the nightly full run still pays the whole cost.
+The Docker path remains the end-to-end Linux environment where Linuxbrew is on PATH. Its separate
+Brewfile-baking work does not remove this GitHub Actions waste.
 
 ## Open decisions
 
-- Which direction? They imply different answers to "what is the `test-ubuntu` job for" —
-  a fast config gate, or a Linux installability check.
-- If PATH is fixed: how much currently-skipped surface does that turn on, and is the job
-  prepared to be red while that is sorted out?
-- Does the Docker path (`make test-ubuntu`), which *does* put Linuxbrew on PATH
-  (`docker/Dockerfile.ubuntu:37`) and does exercise the Brewfile, already cover the
-  installability question well enough that the CI job does not need to?
+- Should the package script branch directly on Linux plus `ci_minimal`, or should the workflow pass
+  a dedicated variable that skips package installation? The first option reuses existing state;
+  the second makes the workflow policy explicit but adds another switch.
+- What assertion should prove that an Ubuntu minimal run did not install Homebrew? A focused log or
+  filesystem assertion would prevent the optimization from silently regressing while the suite
+  remains green.
+
+## Resolution
+
+Skipped Homebrew bootstrap and brew bundle only for CI-minimal Linux renders, preserved full Linux and all non-Linux package installs, and verified the behavior with focused render tests plus the full Ubuntu Docker suite.

--- a/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
@@ -18,6 +18,9 @@ set -e
 
 BREWFILES_DIR="$HOME/.config/brewfiles"
 
+# Linux push and pull-request CI already provisions every required test tool
+# outside Linuxbrew. Full Linux runs and every macOS run still verify Brewfiles.
+# # {{ if not (and (get . "is_linux") (get . "ci_minimal")) }}
 # Check if Homebrew is installed
 if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew..."
@@ -43,6 +46,7 @@ brew bundle --file="$BREWFILES_DIR/Brewfile.macos"
 # # {{ end }}
 
 echo "=== Package installation complete! ==="
+# # {{ end }}
 
 # Install Oh My Zsh if not present
 if [[ ! -d "$HOME/.oh-my-zsh" ]]; then

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -59,8 +59,51 @@ teardown() {
 # different in a git worktree, and the mismatch surfaced the moment the
 # Brewfiles were renamed in one tree and not the other.
 render_install_packages() {
-  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" --source "$SOURCE_ROOT" execute-template \
+  local config_args=()
+  if [[ -n "${1:-}" ]]; then
+    config_args=(--config "$1")
+  fi
+  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" "${config_args[@]}" \
+    --source "$SOURCE_ROOT" execute-template \
     < "$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl"
+}
+
+@test "CI-minimal Linux render skips Homebrew but keeps the remaining setup" {
+  skip_if_no_chezmoi
+  local cfg="$BATS_TEST_TMPDIR/minimal-linux.yaml"
+  MMS_CI_MINIMAL=1 write_test_config "$cfg"
+  sed -i.bak 's/^  is_linux: .*/  is_linux: true/' "$cfg"
+
+  run render_install_packages "$cfg"
+  assert_success
+  refute_output --partial 'Installing Homebrew'
+  refute_output --partial 'brew bundle --file='
+  assert_output --partial 'Installing Oh My Zsh'
+  assert_output --partial 'Installing fff-mcp'
+}
+
+@test "full Linux render keeps Homebrew package installation" {
+  skip_if_no_chezmoi
+  local cfg="$BATS_TEST_TMPDIR/full-linux.yaml"
+  MMS_CI_MINIMAL="" write_test_config "$cfg"
+  sed -i.bak 's/^  is_linux: .*/  is_linux: true/' "$cfg"
+
+  run render_install_packages "$cfg"
+  assert_success
+  assert_output --partial 'Installing Homebrew'
+  assert_output --partial 'brew bundle --file="$BREWFILES_DIR/Brewfile"'
+}
+
+@test "CI-minimal non-Linux render keeps Homebrew package installation" {
+  skip_if_no_chezmoi
+  local cfg="$BATS_TEST_TMPDIR/minimal-non-linux.yaml"
+  MMS_CI_MINIMAL=1 write_test_config "$cfg"
+  sed -i.bak 's/^  is_linux: .*/  is_linux: false/' "$cfg"
+
+  run render_install_packages "$cfg"
+  assert_success
+  assert_output --partial 'Installing Homebrew'
+  assert_output --partial 'brew bundle --file="$BREWFILES_DIR/Brewfile"'
 }
 
 @test "install-packages script renders as valid bash" {


### PR DESCRIPTION
## Summary

Ordinary Ubuntu push and pull-request runs no longer spend about 60 seconds bootstrapping Linuxbrew for tools they cannot reach. Full Linux installability runs and all macOS runs keep their existing Homebrew behavior.

The package script reuses the existing CI-minimal and Linux data keys. It skips only the Homebrew block, so Oh My Zsh, plugins, mise, and fff-mcp setup still run.

## Validation

- `make test-ubuntu` passed all 360 Ubuntu Docker tests.
- `bats tests/scripts.bats` passed all 200 tests.
- `bats tests/templates.bats` passed all 41 tests.
- `make lint` passed.
- Focused render tests cover minimal Linux, full Linux, and minimal non-Linux behavior.

## Related

Related: `docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
