### PR TITLE
fix(tests): stabilize task sync and Pi settings checks

### DIFF
--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1730,8 +1730,13 @@ PY
   namespace_two="$(hts_namespace "$socket_two")"
   [[ "$namespace_one" != "$namespace_two" ]]
 
-  hts_run_for_socket "$socket_one" --agent pi --session same --set socket-one < /dev/null
-  hts_run_for_socket "$socket_two" --agent pi --session same --set socket-two < /dev/null
+  # This test owns task namespace isolation only. A successful task commit normally
+  # starts a detached presentation pass, and that pass legitimately advances the
+  # location high-water before this task-only assertion can read it under load.
+  HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1 \
+    hts_run_for_socket "$socket_one" --agent pi --session same --set socket-one < /dev/null
+  HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1 \
+    hts_run_for_socket "$socket_two" --agent pi --session same --set socket-two < /dev/null
   task_one="$(hts_task_file "$socket_one" pi pane-1 same)"
   task_two="$(hts_task_file "$socket_two" pi pane-1 same)"
   hts_wait_for_task_slug "$task_one" socket-one
@@ -1744,6 +1749,8 @@ PY
   assert_equal "$(hts_record_text "$namespace_two/socket.state" socket_path)" "$socket_two"
   [[ "$(hts_record_number "$namespace_one/reconcile.state" task_metadata_high_water)" -gt 0 ]]
   assert_equal "$(hts_record_number "$namespace_one/reconcile.state" location_metadata_high_water)" 0
+  [[ "$(hts_record_number "$namespace_two/reconcile.state" task_metadata_high_water)" -gt 0 ]]
+  assert_equal "$(hts_record_number "$namespace_two/reconcile.state" location_metadata_high_water)" 0
   grep -q '^checkout_root=' "$namespace_one/reconcile.state"
   grep -q '^repository_anchor=' "$namespace_one/reconcile.state"
 }

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -514,7 +514,7 @@ class ClientDiscoveryTests(unittest.TestCase):
         self.assertEqual(skill, opencode_skill.resolve() / "SKILL.md")
 
         pi_settings = REPOSITORY / ".pi" / "settings.json"
-        self.assertEqual({"skills": ["../.claude/skills"]}, json.loads(pi_settings.read_text()))
+        self.assertEqual({"skills": ["~/.claude/skills", "../.claude/skills"]}, json.loads(pi_settings.read_text()))
 
         agents = REPOSITORY / "AGENTS.md"
         self.assertTrue(agents.is_symlink())


### PR DESCRIPTION
## Summary

The socket namespace collision test now exercises task namespace isolation without racing the detached presentation coordinator. The presentation path can legitimately advance `location_metadata_high_water`, so the test disables presentation before it asserts task-only state.

The repository-issues client discovery test now matches the committed Pi settings file. CI was already receiving both managed Pi skill paths, but the test still expected only the repository-local path.

Related: `docs/issues/2026-08-22-002-herdr-task-sync-socket-namespace-test-lets-location-metadata-advance.md`

## Validation

- `bats tests/scripts.bats --filter '^herdr-task-sync exact socket namespaces survive legacy sanitized-name collisions$'`
- `bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats` — 360 tests, 0 failures, workstation-only `chezmoi apply` tests skipped by their guard.
- `make test-issues`
- `make lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
