### PR TITLE
feat(pi): load local project instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates lint clean build-docker shell-ubuntu init-submodules
+.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local lint clean build-docker shell-ubuntu init-submodules
 
 help:
 	@echo "Chezmoi Dotfiles - Available commands:"
@@ -7,6 +7,7 @@ help:
 	@echo "  make test-ubuntu      Run tests in Ubuntu Docker container"
 	@echo "  make test-suite       Run the post-apply suite in parallel (host-safe files)"
 	@echo "  make test-templates   Run template tests only (fast, no apply)"
+	@echo "  make test-pi-agents-local  Run focused Pi local-instructions extension tests"
 	@echo "  make test-local       Run chezmoi diff on current machine (dry-run)"
 	@echo "  make test-docker      Build and run full Docker test suite"
 	@echo "  make lint             Run shellcheck on all scripts"
@@ -35,6 +36,9 @@ test-templates: test-issues build-docker
 		'set -e && (cd /home/testuser/dotfiles && cp -r . /home/testuser/.local/share/chezmoi/) && \
 		chezmoi init --source=/home/testuser/.local/share/chezmoi --promptString name="Test User" --promptString email="test@example.com" && \
 		bats tests/templates.bats'
+
+test-pi-agents-local:
+	bun test tests/pi-agents-local-extension.test.ts
 
 shell-ubuntu: build-docker
 	docker compose -f docker/docker-compose.yml run --rm ubuntu /bin/zsh

--- a/home/dot_pi/agent/extensions/agents-local.ts
+++ b/home/dot_pi/agent/extensions/agents-local.ts
@@ -1,0 +1,240 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { lstat, readFile, realpath, stat } from "node:fs/promises";
+import { isAbsolute, join, relative } from "node:path";
+
+export const LOCAL_INSTRUCTION_FILE_NAMES = ["AGENTS.local.md", "CLAUDE.local.md"] as const;
+export const MAX_LOCAL_INSTRUCTIONS_BYTES = 50 * 1024;
+
+type LocalInstructionFileName = (typeof LOCAL_INSTRUCTION_FILE_NAMES)[number];
+type DiagnosticStatus =
+  | "missing"
+  | "candidate"
+  | "selected"
+  | "skipped-preferred-agents"
+  | "skipped-not-file"
+  | "skipped-broken-symlink"
+  | "skipped-outside-project"
+  | "skipped-too-large"
+  | "skipped-unreadable";
+
+export interface LocalInstructionDiagnostic {
+  name: LocalInstructionFileName;
+  path: string;
+  realPath?: string;
+  size?: number;
+  status: DiagnosticStatus;
+}
+
+export interface LocalInstructionCandidate extends LocalInstructionDiagnostic {
+  status: "candidate";
+  realPath: string;
+  size: number;
+}
+
+export interface LocalInstructionSelection {
+  selected?: LocalInstructionCandidate;
+  diagnostics: LocalInstructionDiagnostic[];
+  warnings: string[];
+}
+
+const warnedKeys = new Set<string>();
+
+function isMissing(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function notifyWarningsOnce(ctx: ExtensionContext, warnings: string[]): void {
+  if (!ctx.hasUI) return;
+  for (const warning of warnings) {
+    const key = `${ctx.cwd}:${warning}`;
+    if (warnedKeys.has(key)) continue;
+    warnedKeys.add(key);
+    ctx.ui.notify(warning, "warning");
+  }
+}
+
+function isWithinProject(projectRealPath: string, targetRealPath: string): boolean {
+  const projectRelativePath = relative(projectRealPath, targetRealPath);
+  return projectRelativePath === "" || (!projectRelativePath.startsWith("..") && !isAbsolute(projectRelativePath));
+}
+
+async function inspectCandidate(
+  cwd: string,
+  cwdRealPath: string | undefined,
+  name: LocalInstructionFileName,
+): Promise<{ diagnostic: LocalInstructionDiagnostic; warning?: string }> {
+  const path = join(cwd, name);
+  let linkStat;
+  try {
+    linkStat = await lstat(path);
+  } catch (error) {
+    if (isMissing(error)) {
+      return {
+        diagnostic: {
+          name,
+          path,
+          status: "missing",
+        },
+      };
+    }
+    const warning = `Could not inspect ${path}; skipping local instructions from ${name}.`;
+    return {
+      diagnostic: {
+        name,
+        path,
+        status: "skipped-unreadable",
+      },
+      warning,
+    };
+  }
+
+  const isSymlink = linkStat.isSymbolicLink();
+  let targetStat;
+  let targetRealPath;
+  try {
+    [targetStat, targetRealPath] = await Promise.all([stat(path), realpath(path)]);
+  } catch (error) {
+    const status = isSymlink && isMissing(error) ? "skipped-broken-symlink" : "skipped-unreadable";
+    const warning =
+      status === "skipped-broken-symlink"
+        ? `${path} is a broken symlink; skipping local instructions from ${name}.`
+        : `Could not read ${path}; skipping local instructions from ${name}.`;
+    return {
+      diagnostic: {
+        name,
+        path,
+        status,
+      },
+      warning,
+    };
+  }
+
+  if (!targetStat.isFile()) {
+    return {
+      diagnostic: {
+        name,
+        path,
+        realPath: targetRealPath,
+        status: "skipped-not-file",
+      },
+    };
+  }
+
+  if (cwdRealPath && !isWithinProject(cwdRealPath, targetRealPath)) {
+    const warning = `${path} resolves outside the project to ${targetRealPath}; skipping local instructions from ${name}.`;
+    return {
+      diagnostic: {
+        name,
+        path,
+        realPath: targetRealPath,
+        size: targetStat.size,
+        status: "skipped-outside-project",
+      },
+      warning,
+    };
+  }
+
+  if (targetStat.size > MAX_LOCAL_INSTRUCTIONS_BYTES) {
+    const warning = `${path} is ${targetStat.size} bytes, above the ${MAX_LOCAL_INSTRUCTIONS_BYTES} byte limit; skipping local instructions from ${name}.`;
+    return {
+      diagnostic: {
+        name,
+        path,
+        realPath: targetRealPath,
+        size: targetStat.size,
+        status: "skipped-too-large",
+      },
+      warning,
+    };
+  }
+
+  return {
+    diagnostic: {
+      name,
+      path,
+      realPath: targetRealPath,
+      size: targetStat.size,
+      status: "candidate",
+    },
+  };
+}
+
+function selectPreferredCandidate(candidates: LocalInstructionCandidate[]): LocalInstructionCandidate | undefined {
+  return candidates.find((candidate) => candidate.name === "AGENTS.local.md") ?? candidates[0];
+}
+
+function markSelection(
+  diagnostics: LocalInstructionDiagnostic[],
+  selected?: LocalInstructionCandidate,
+): LocalInstructionDiagnostic[] {
+  if (!selected) return diagnostics;
+  return diagnostics.map((diagnostic) => {
+    if (diagnostic.status !== "candidate") return diagnostic;
+    if (diagnostic.path === selected.path) {
+      return { ...diagnostic, status: "selected" };
+    }
+    return {
+      ...diagnostic,
+      status: "skipped-preferred-agents",
+    };
+  });
+}
+
+export async function inspectLocalInstructions(cwd: string): Promise<LocalInstructionSelection> {
+  let cwdRealPath: string | undefined;
+  try {
+    cwdRealPath = await realpath(cwd);
+  } catch {
+    cwdRealPath = undefined;
+  }
+
+  const inspected = await Promise.all(
+    LOCAL_INSTRUCTION_FILE_NAMES.map((name) => inspectCandidate(cwd, cwdRealPath, name)),
+  );
+  const diagnostics = inspected.map(({ diagnostic }) => diagnostic);
+  const warnings = inspected.flatMap(({ warning }) => (warning ? [warning] : []));
+  const candidates = diagnostics.filter(
+    (diagnostic): diagnostic is LocalInstructionCandidate => diagnostic.status === "candidate",
+  );
+  const selected = selectPreferredCandidate(candidates);
+
+  return {
+    selected,
+    diagnostics: markSelection(diagnostics, selected),
+    warnings,
+  };
+}
+
+export function formatLocalInstructions(selected: LocalInstructionCandidate, contents: string): string {
+  return `
+
+## Local Private Project Instructions
+
+Loaded from ${selected.realPath}. These instructions are private and local. Follow them in addition to repository instructions.
+
+### ${selected.name}
+
+${contents}`;
+}
+
+export default function agentsLocalExtension(pi: ExtensionAPI): void {
+  pi.on("before_agent_start", async (event, ctx) => {
+    const selection = await inspectLocalInstructions(ctx.cwd);
+    notifyWarningsOnce(ctx, selection.warnings);
+    if (!selection.selected) return undefined;
+
+    let contents;
+    try {
+      contents = await readFile(selection.selected.realPath, "utf8");
+    } catch {
+      const warning = `Could not read ${selection.selected.realPath}; skipping local instructions from ${selection.selected.name}.`;
+      notifyWarningsOnce(ctx, [warning]);
+      return undefined;
+    }
+
+    return {
+      systemPrompt: event.systemPrompt + formatLocalInstructions(selection.selected, contents),
+    };
+  });
+}

--- a/home/private_dot_claude/skills/markdown-new/scripts/deepwiki-read.sh
+++ b/home/private_dot_claude/skills/markdown-new/scripts/deepwiki-read.sh
@@ -21,5 +21,5 @@ case "$target" in
     ;;
 esac
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 "$script_dir/jina-read.sh" "$url"

--- a/tests/pi-agents-local-extension.test.ts
+++ b/tests/pi-agents-local-extension.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const extensionPath =
+  process.env.PI_AGENTS_LOCAL_EXTENSION_PATH ?? join(import.meta.dir, "../home/dot_pi/agent/extensions/agents-local.ts");
+const {
+  default: registerAgentsLocalExtension,
+  formatLocalInstructions,
+  inspectLocalInstructions,
+  MAX_LOCAL_INSTRUCTIONS_BYTES,
+} = await import(extensionPath);
+
+const cleanupPaths: string[] = [];
+
+async function temporaryProject(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pi-agents-local-test-"));
+  cleanupPaths.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  for (const path of cleanupPaths.splice(0)) {
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function fakePi() {
+  const handlers: Record<string, Function> = {};
+  const pi = {
+    on: (event: string, handler: Function) => {
+      handlers[event] = handler;
+    },
+  };
+  registerAgentsLocalExtension(pi as never);
+  return { handlers };
+}
+
+function fakeContext(cwd: string) {
+  const notifications: Array<{ message: string; level: string }> = [];
+  return {
+    ctx: {
+      cwd,
+      hasUI: true,
+      ui: {
+        notify: (message: string, level: string) => notifications.push({ message, level }),
+      },
+    },
+    notifications,
+  };
+}
+
+describe("Pi AGENTS.local.md extension selection", () => {
+  test("loads AGENTS.local.md when only AGENTS.local.md exists", async () => {
+    const root = await temporaryProject();
+    await writeFile(join(root, "AGENTS.local.md"), "Use the local AGENTS file.\n");
+
+    const selection = await inspectLocalInstructions(root);
+
+    expect(selection.selected?.name).toBe("AGENTS.local.md");
+    expect(selection.diagnostics.map((diagnostic) => [diagnostic.name, diagnostic.status])).toEqual([
+      ["AGENTS.local.md", "selected"],
+      ["CLAUDE.local.md", "missing"],
+    ]);
+  });
+
+  test("prefers AGENTS.local.md when both local files resolve to different files", async () => {
+    const root = await temporaryProject();
+    await writeFile(join(root, "AGENTS.local.md"), "Use AGENTS.\n");
+    await writeFile(join(root, "CLAUDE.local.md"), "Use CLAUDE.\n");
+
+    const selection = await inspectLocalInstructions(root);
+
+    expect(selection.selected?.name).toBe("AGENTS.local.md");
+    expect(selection.diagnostics.map((diagnostic) => [diagnostic.name, diagnostic.status])).toEqual([
+      ["AGENTS.local.md", "selected"],
+      ["CLAUDE.local.md", "skipped-preferred-agents"],
+    ]);
+  });
+
+  test("skips a broken symlink and warns once per session", async () => {
+    const root = await temporaryProject();
+    await symlink("missing-target.md", join(root, "AGENTS.local.md"));
+    await writeFile(join(root, "CLAUDE.local.md"), "Fallback instructions.\n");
+    const { handlers } = fakePi();
+    const { ctx, notifications } = fakeContext(root);
+
+    await handlers.before_agent_start({ systemPrompt: "Base prompt" }, ctx);
+    await handlers.before_agent_start({ systemPrompt: "Base prompt" }, ctx);
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].level).toBe("warning");
+    expect(notifications[0].message).toContain("broken symlink");
+  });
+
+  test("skips a too-large file and falls back to the other local file", async () => {
+    const root = await temporaryProject();
+    await writeFile(join(root, "AGENTS.local.md"), "A".repeat(MAX_LOCAL_INSTRUCTIONS_BYTES + 1));
+    await writeFile(join(root, "CLAUDE.local.md"), "Fallback instructions.\n");
+
+    const selection = await inspectLocalInstructions(root);
+
+    expect(selection.selected?.name).toBe("CLAUDE.local.md");
+    expect(selection.diagnostics.map((diagnostic) => [diagnostic.name, diagnostic.status])).toEqual([
+      ["AGENTS.local.md", "skipped-too-large"],
+      ["CLAUDE.local.md", "selected"],
+    ]);
+    expect(selection.warnings[0]).toContain("above the 51200 byte limit");
+  });
+
+  test("skips an outside-project symlink and falls back to the other local file", async () => {
+    const root = await temporaryProject();
+    const outsideRoot = await temporaryProject();
+    const outsideInstructions = join(outsideRoot, "outside.md");
+    await writeFile(outsideInstructions, "Do not load outside instructions.\n");
+    await symlink(outsideInstructions, join(root, "AGENTS.local.md"));
+    await writeFile(join(root, "CLAUDE.local.md"), "Fallback instructions.\n");
+
+    const selection = await inspectLocalInstructions(root);
+
+    expect(selection.selected?.name).toBe("CLAUDE.local.md");
+    expect(selection.diagnostics.map((diagnostic) => [diagnostic.name, diagnostic.status])).toEqual([
+      ["AGENTS.local.md", "skipped-outside-project"],
+      ["CLAUDE.local.md", "selected"],
+    ]);
+    expect(selection.warnings[0]).toContain("resolves outside the project");
+  });
+
+  test("skips a directory without warning", async () => {
+    const root = await temporaryProject();
+    await mkdir(join(root, "AGENTS.local.md"));
+
+    const selection = await inspectLocalInstructions(root);
+
+    expect(selection.selected).toBeUndefined();
+    expect(selection.warnings).toEqual([]);
+    expect(selection.diagnostics[0].status).toBe("skipped-not-file");
+  });
+});
+
+describe("Pi AGENTS.local.md extension hooks", () => {
+  test("appends one local instruction block before the agent starts", async () => {
+    const root = await temporaryProject();
+    await writeFile(join(root, "AGENTS.local.md"), "Use only AGENTS.\n");
+    await writeFile(join(root, "CLAUDE.local.md"), "Do not load this file.\n");
+    const { handlers } = fakePi();
+    const { ctx } = fakeContext(root);
+
+    const result = await handlers.before_agent_start({ systemPrompt: "Base prompt" }, ctx);
+
+    expect(result.systemPrompt).toStartWith("Base prompt");
+    expect(result.systemPrompt).toContain("## Local Private Project Instructions");
+    expect(result.systemPrompt).toContain("Use only AGENTS.");
+    expect(result.systemPrompt).not.toContain("Do not load this file.");
+  });
+
+  test("formatLocalInstructions names the real loaded path", async () => {
+    const root = await temporaryProject();
+    await writeFile(join(root, "AGENTS.local.md"), "Use formatted instructions.\n");
+    const selection = await inspectLocalInstructions(root);
+    const content = await readFile(selection.selected!.realPath, "utf8");
+
+    const promptBlock = formatLocalInstructions(selection.selected!, content);
+
+    expect(promptBlock).toContain(`Loaded from ${selection.selected!.realPath}`);
+    expect(promptBlock).toContain("Use formatted instructions.");
+  });
+});

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -47,6 +47,7 @@ load 'helpers/common'
     .config/yazi
     .claude
     .claude/CLAUDE.md
+    .pi/agent/extensions/agents-local.ts
     .config/herdr/config.toml
     .config/herdr/plugins/command-palette/herdr-plugin.toml
     .config/herdr/plugins/command-palette/open.py
@@ -950,6 +951,12 @@ PY
   assert_file_contains "$ext" 'before_agent_start'
   assert_file_contains "$ext" 'session_start'
   assert_file_contains "$ext" 'getSessionName'
+}
+
+@test "Pi local private instructions focused tests pass" {
+  run env PI_AGENTS_LOCAL_EXTENSION_PATH="$HOME/.pi/agent/extensions/agents-local.ts" \
+    bun test "$BATS_TEST_DIRNAME/pi-agents-local-extension.test.ts"
+  assert_success
 }
 
 @test "Pi brew auto updater is deployed with startup and manual entry points" {


### PR DESCRIPTION
## Summary

Pi now loads `AGENTS.local.md` or `CLAUDE.local.md` from the active project before each agent turn. This moves private local instruction loading into the Pi bootstrap path instead of relying on the model to remember to check for those files.

## Details

- Prefers `AGENTS.local.md`, then falls back to `CLAUDE.local.md`.
- Skips missing, broken, directory, oversized, unreadable, and outside-project symlink targets.
- Adds focused Bun coverage, including smoke coverage against the deployed extension file.

## Validation

- `git diff --check`
- `make test-pi-agents-local`
- `HOME=<temp home> SOURCE_ROOT=$PWD/home CHEZMOI_SOURCE=$PWD/home bats --filter 'Pi local private instructions' tests/smoke.bats`

Not run: `make test-ubuntu`.
