### PR TITLE
fix(tests): keep focus-notify bytecode writable

### DIFF
--- a/docs/issues/2026-08-22-001-the-focus-notify-compile-test-writes-bytecode-into-docker-s-read-only-source-mount.md
+++ b/docs/issues/2026-08-22-001-the-focus-notify-compile-test-writes-bytecode-into-docker-s-read-only-source-mount.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["testing-ci","docker"]
 date: "2026-08-22"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -40,3 +41,7 @@ earlier case 32 keeps the suite exit status red.
 
 - Choose whether `py_compile` should use its explicit output-path API or whether
   the test should use a syntax check that does not write beside the source.
+
+## Resolution
+
+Updated tests/smoke.bats so the focus-notify py_compile assertion writes bytecode under BATS_TEST_TMPDIR via PYTHONPYCACHEPREFIX. Verified the focused Docker smoke test and make test-ubuntu.

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -562,7 +562,8 @@ SH
 }
 
 @test "focus-notify plugin compiles and declares no build step or extra backend" {
-  run python3 -m py_compile "$FOCUS_NOTIFY_DIR/notify.py"
+  run env PYTHONPYCACHEPREFIX="$BATS_TEST_TMPDIR/pycache" \
+    python3 -m py_compile "$FOCUS_NOTIFY_DIR/notify.py"
   assert_success
 
   # The whole point of this local plugin: no compile-at-install step and no


### PR DESCRIPTION
## Summary

The focus-notify smoke test can now compile its Python source in Docker while `home/` stays mounted read-only. The test redirects Python bytecode into the writable Bats temp directory instead of creating `__pycache__` beside the source file.

## Validation

- `docker compose -f docker/docker-compose.yml run --rm -T test-quick 'bats --filter "focus-notify plugin compiles" /home/testuser/tests/smoke.bats'`
- `make test-ubuntu`
- `make test-issues`
- `git diff --check`

## Related

Issue record: `docs/issues/2026-08-22-001-the-focus-notify-compile-test-writes-bytecode-into-docker-s-read-only-source-mount.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
