### PR TITLE
fix(tests): align ubuntu docker service label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ build-docker: init-submodules
 	docker compose -f docker/docker-compose.yml build
 
 test-ubuntu: test-issues build-docker
-	docker compose -f docker/docker-compose.yml run --rm test-quick
+	docker compose -f docker/docker-compose.yml run --rm test-ubuntu
 
 test-templates: test-issues build-docker
-	docker compose -f docker/docker-compose.yml run --rm -T test-quick \
+	docker compose -f docker/docker-compose.yml run --rm -T test-ubuntu \
 		'set -e && (cd /home/testuser/dotfiles && cp -r . /home/testuser/.local/share/chezmoi/) && \
 		chezmoi init --source=/home/testuser/.local/share/chezmoi --promptString name="Test User" --promptString email="test@example.com" && \
 		bats tests/templates.bats'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # idempotency tests in tests/idempotent.bats run their real
       # `chezmoi apply`. Written literally in all three services, unlike
       # MMS_CI_MINIMAL above, which is read from the host and is deliberately
-      # absent from test-quick. tests/idempotent.bats hard-fails when
+      # absent from the test-ubuntu service. tests/idempotent.bats hard-fails when
       # /.dockerenv exists and this is missing.
       - MMS_DISPOSABLE_HOME=1
     tty: true
@@ -43,7 +43,7 @@ services:
       # cross-platform Brewfile (R5). Set it to compare skip counts between the
       # two renders:
       #   MMS_CI_MINIMAL=1 docker compose -f docker/docker-compose.yml run --rm test-full
-      # `test-quick` deliberately has no such entry, which is what keeps
+      # The `test-ubuntu` service deliberately has no such entry, which keeps
       # `make test-ubuntu` on the full render — see docs/issues/2026-08-20-014.
       - MMS_CI_MINIMAL=${MMS_CI_MINIMAL:-}
       # See the ubuntu service above for why this is written literally.
@@ -81,8 +81,8 @@ services:
 
         echo "=== All done! ==="
 
-  # Quick test (no package installation, just config files)
-  test-quick:
+  # Full Ubuntu test without the optional CI-minimal Brewfile render
+  test-ubuntu:
     build:
       context: ..
       dockerfile: docker/Dockerfile.ubuntu

--- a/docs/issues/2026-08-20-014-make-test-ubuntu-labeling-drift.md
+++ b/docs/issues/2026-08-20-014-make-test-ubuntu-labeling-drift.md
@@ -1,12 +1,13 @@
 ---
 title: "make test-ubuntu labeling drift — runs test-quick, docs say \"Full test\""
-short_description: "The `test-quick` and `test-full` services both perform a full `chezmoi apply` plus the suite, so the current names and documentation conceal that neither path skips package installation."
+short_description: "The full Ubuntu Docker service now uses the `test-ubuntu` name, so Make targets, Compose services, and disposable-home guard messages agree that the path runs the full apply suite."
 type: "chore"
 category: "testing-ci"
 tags: ["testing-ci","chore"]
 date: "2026-08-20"
-status: "open"
+status: "done"
 priority: "low"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -26,3 +27,7 @@ In practice `test-quick` and `test-full` run the same apply-plus-suite flow; the
 ## Open decisions
 
 - Merge `test-quick` into `test-full` vs. make `test-quick` genuinely quick. The parallel-bats plan's U4 measures via `make test-ubuntu`, so whichever service it maps to should match CI's apply-then-suite path.
+
+## Resolution
+
+Renamed the full Ubuntu Docker compose service from test-quick to test-ubuntu, updated Make targets and guard messages to use the clear service name, and added a regression test that prevents make test-ubuntu from routing through a misleading service name.

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -161,7 +161,7 @@ require_disposable_home() {
       return 0
       ;;
     misconfigured)
-      fail "MMS_DISPOSABLE_HOME is not 1, but this environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists). Declare the marker at the site that launched this suite, or these tests lose their coverage silently: .github/workflows/test-dotfiles.yml (top-level env: block), and docker/docker-compose.yml (services ubuntu, test-quick, test-full)."
+      fail "MMS_DISPOSABLE_HOME is not 1, but this environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists). Declare the marker at the site that launched this suite, or these tests lose their coverage silently: .github/workflows/test-dotfiles.yml (top-level env: block), and docker/docker-compose.yml (services ubuntu, test-ubuntu, test-full)."
       return 1
       ;;
     *)

--- a/tests/idempotent.bats
+++ b/tests/idempotent.bats
@@ -21,7 +21,7 @@ load 'helpers/common'
 # race, so this file stays sequential even when the suite runs with --jobs,
 # and all five invocation sites keep --no-parallelize-across-files: Makefile
 # `test-suite`, the two `Run post-apply tests` steps in
-# .github/workflows/test-dotfiles.yml, and the test-full and test-quick
+# .github/workflows/test-dotfiles.yml, and the test-full and test-ubuntu
 # services in docker/docker-compose.yml. It is 1.3 s of a 268 s suite, so
 # serializing it costs nothing measurable.
 BATS_NO_PARALLELIZE_WITHIN_FILE=true
@@ -142,7 +142,7 @@ predicate_verdict() {
   fi
 
   [[ "${MMS_DISPOSABLE_HOME:-}" == "1" ]] || \
-    fail "This environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists), but MMS_DISPOSABLE_HOME is '${MMS_DISPOSABLE_HOME:-<unset>}' instead of 1. The four idempotency tests in this file would skip here, removing that coverage without turning anything red. Declare the marker at the site that launched this suite: .github/workflows/test-dotfiles.yml (top-level env: block), or docker/docker-compose.yml (services ubuntu, test-quick, test-full)."
+    fail "This environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists), but MMS_DISPOSABLE_HOME is '${MMS_DISPOSABLE_HOME:-<unset>}' instead of 1. The four idempotency tests in this file would skip here, removing that coverage without turning anything red. Declare the marker at the site that launched this suite: .github/workflows/test-dotfiles.yml (top-level env: block), or docker/docker-compose.yml (services ubuntu, test-ubuntu, test-full)."
 }
 
 @test "guard: the marker's claim covers chezmoi's real destination" {

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import re
+import unittest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+MAKEFILE = REPOSITORY / "Makefile"
+COMPOSE = REPOSITORY / "docker" / "docker-compose.yml"
+
+
+class TestDockerContract(unittest.TestCase):
+    def test_make_test_ubuntu_uses_clearly_named_full_apply_service(self):
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        compose = COMPOSE.read_text(encoding="utf-8")
+
+        target = re.search(r"^test-ubuntu:.*\n\t(?P<command>[^\n]+)", makefile, re.MULTILINE)
+        self.assertIsNotNone(target, "Makefile must define the test-ubuntu target")
+        self.assertIn(
+            "docker compose -f docker/docker-compose.yml run --rm test-ubuntu",
+            target.group("command"),
+            "make test-ubuntu must not route through a misleading service name",
+        )
+
+        self.assertRegex(compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
+        self.assertNotRegex(compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
+        self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", compose)
+        self.assertIn("tests/idempotent.bats", compose)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Rename the full Ubuntu Docker Compose service from `test-quick` to `test-ubuntu`.
- Update `make test-ubuntu`, `make test-templates`, and disposable-home guard messages to use the clear service name.
- Close repository issue `docs/issues/2026-08-20-014-make-test-ubuntu-labeling-drift.md` with a resolution entry.

## Why

`make test-ubuntu` runs the full disposable apply-and-suite path. It should not route through a service named `test-quick`, because that name made the Docker path look lighter than it is.

## Verification

- `python3 -m unittest tests/test_docker_contract.py`
- `make test-issues`
- `make -n test-ubuntu`
- `make -n test-templates`
- `docker compose -f docker/docker-compose.yml config --services`
- `git diff --check`

## Known Residuals

None.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
