### PR TITLE
fix(docker): gate minimal image git version

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -29,6 +29,24 @@ RUN apt-get update && apt-get install -y \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 
+# Fail at image build time if the apt layer no longer supplies the tools that a
+# CI-minimal apply depends on before Homebrew can install anything. The git floor
+# is not arbitrary: home/dot_gitconfig.tmpl deploys merge.conflictStyle=zdiff3,
+# and git older than 2.35 rejects that value during the Oh My Zsh clone.
+RUN set -eu; \
+    assert_git_version_at_least() { \
+      required="$1.$2"; \
+      found="$(git --version | awk '{print $3}')"; \
+      if ! dpkg --compare-versions "$found" ge "$required"; then \
+        echo "apt git $found is older than $required; merge.conflictStyle=zdiff3 requires git 2.35 or newer" >&2; \
+        exit 1; \
+      fi; \
+    }; \
+    assert_git_version_at_least 2 35; \
+    command -v python3 >/dev/null || { echo "python3 is required before chezmoi apply" >&2; exit 1; }; \
+    git --version; \
+    python3 --version
+
 # Set up locale
 RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md
+++ b/docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md
@@ -5,9 +5,10 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "medium"
 parent-plan: "docs/plans/2026-08-21-0337-fix-python3-declared-dependency-plan.md"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -63,12 +64,21 @@ during the code review of the plan named in `parent-plan`.
    2026-08-21. Any future comparison must be taken against a post-change baseline, because
    removing the `python3` skip guards removed up to 56 potential skips.
 
-## Open decisions
+## Resolved decisions
 
-- Is a Docker-building CI job worth its runtime, given that the thing it protects — the
-  minimal render — only runs on push and pull_request events where the runner already
-  supplies its own git? The failure this guards against is a developer running the Docker
-  suite locally, not a CI break.
-- Should the build-time git assertion live in the Dockerfile or in a bats test that runs
-  inside the image? The Dockerfile catches it earlier; a bats test keeps the assertion
-  beside the other tool-presence checks.
+- Do not add a scheduled or `workflow_dispatch` Docker job here. The guarded failure is a
+  developer-local Docker image downgrade, while push and pull_request runs use GitHub
+  runner git and already select the CI-minimal render directly.
+- Put the executable git and python3 assertions in `docker/Dockerfile.ubuntu`, then pin
+  those assertions with a focused Bats source test. The Dockerfile catches the failure
+  during `make build-docker`; the Bats test prevents the gate from disappearing silently.
+
+## Resolution
+
+Added a Dockerfile build-time gate that asserts apt git is at least 2.35 and python3
+is present before any CI-minimal apply can run. Added a focused Bats regression test
+that fails if the Dockerfile loses the executable git-version comparison or python3
+assertion. Chose not to add a scheduled or manual Docker CI job because this issue
+protects the local Docker image path, while GitHub push and pull_request runs use runner
+git directly. Verified with the focused Bats test, make test-issues, make lint, and
+make build-docker.

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -47,6 +47,16 @@ teardown() {
   assert_failure
 }
 
+@test "Docker image fails at build time when apt git is too old for zdiff3" {
+  local repo_root="$BATS_TEST_DIRNAME/.."
+  local dockerfile="$repo_root/docker/Dockerfile.ubuntu"
+  [[ -f "$dockerfile" ]] || skip "repo-root Dockerfile is not available in this environment"
+
+  assert_file_contains "$dockerfile" '^      if ! dpkg --compare-versions "\$found" ge "\$required"; then \\$'
+  assert_file_contains "$dockerfile" '^    assert_git_version_at_least 2 35; \\$'
+  assert_file_contains "$dockerfile" '^    command -v python3 >/dev/null'
+}
+
 # ===========================================
 # install-packages script
 # ===========================================


### PR DESCRIPTION
## Summary

This PR makes the Docker image fail during `make build-docker` if its apt layer no longer satisfies the tools that the CI-minimal apply needs before Homebrew can install anything.

The image now asserts that apt `git` is at least 2.35, which is the floor required by the deployed `merge.conflictStyle = zdiff3` setting. It also asserts that `python3` is present, because the apply and command-palette tests depend on it before any Brewfile can help.

## Root cause

The CI-minimal Brewfile no longer installs Homebrew `git`, so the Docker path depends on the base image's apt `git`. `docker/Dockerfile.ubuntu` documented that Ubuntu 24.04 was required, but the build did not enforce the installed Git version. A later base-image downgrade could fail only during a manual CI-minimal apply, and the error would name `zdiff3` rather than the stale image.

## What changed

- Added a Dockerfile build-time gate for apt `git >= 2.35` and `python3` presence.
- Added a focused Bats source test that pins the executable Git-version comparison and Python assertion.
- Closed `docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md` with the explicit decision not to add a scheduled/manual Docker CI job here.

## Verification

- `bats --filter 'Docker image fails at build time when apt git is too old for zdiff3' tests/scripts.bats`
- `make test-issues`
- `make lint`
- `make build-docker`

## Related

- `docs/issues/2026-08-21-018-ci-minimal-docker-apply-has-no-automated-gate.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
