### PR TITLE
docs(issues): record ci sharding trade-off

### DIFF
--- a/docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md
+++ b/docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md
@@ -5,9 +5,10 @@ type: "idea"
 category: "testing-ci"
 tags: ["testing-ci","idea"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "low"
 parent-plan: "docs/plans/2026-08-20-2217-perf-parallel-bats-suite-plan.md"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -50,3 +51,13 @@ the suite is green but stays above 60% of baseline. At that point compare three 
   matters? The answer decides whether sharding is viable at all.
 - Splitting `tests/scripts.bats` into topic files would help sharding *and* cross-file
   parallelism. Is that refactor worth doing on its own merits, independent of speed?
+
+## Resolution
+
+Carried the runner-level matrix sharding comparison into
+`docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md`,
+the active stable-but-slow residual issue. The residual now records why sharding
+avoids shared-home interleaving but remains lower priority: every shard repeats
+the dominant `chezmoi apply` setup, local and Docker runs do not improve, and
+`tests/scripts.bats` must be split before a file matrix can reduce wall time
+materially.

--- a/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
+++ b/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
@@ -97,6 +97,16 @@ sum to something near 283 s, the tail is the floor and more jobs will not help.
   tracks as duplicated across five sites -- weigh that before splitting it.
 - Measure the per-test wall-time distribution of `tests/scripts.bats` to find out
   whether a serial tail sets the floor.
+- Runner-level matrix sharding is the CI-only variant of cross-file
+  parallelism. It avoids the shared-`$HOME` hazard because each GitHub Actions
+  runner gets a separate home directory, but it repeats the dominant
+  `chezmoi apply` setup on every shard, does not help local or Docker runs, and
+  has little wall-time upside while `tests/scripts.bats` remains 85% of the
+  Ubuntu baseline. Treat it as lower priority than measuring `shlock`, the
+  macOS job-count curve, and the per-test distribution inside `tests/scripts.bats`.
+  This records the option from
+  `docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md`
+  in the active residual issue.
 - Cross-file parallelism is the deferred lever. It was ruled out by decision, not
   by measurement: `tests/idempotent.bats` mutates the shared `$HOME` through a
   real `chezmoi apply` while other files read deployed state from it. Making the
@@ -108,3 +118,9 @@ sum to something near 283 s, the tail is the floor and more jobs will not help.
 - Whether 67% of baseline on macOS is worth further work at all. The job already
   runs inside its 25-minute timeout with room to spare, and the absolute saving is
   already 140 s per run.
+- If further work resumes, whether CI billed minutes matter. If wall time is the
+  only constraint, repeating `chezmoi apply` across runner-level shards may be
+  acceptable; if billed minutes matter too, sharding starts at a disadvantage.
+- Whether splitting `tests/scripts.bats` into topic files is worth doing on its
+  own merits. That split would help both runner-level sharding and same-runner
+  cross-file parallelism.


### PR DESCRIPTION
## Summary

This records runner-level GitHub Actions matrix sharding in the active macOS stable-but-slow residual issue instead of leaving it as a separate reminder. The older reminder issue is now marked done, and the residual now explains why sharding stays below same-runner bottleneck measurements: each shard repeats `chezmoi apply`, local and Docker runs do not improve, and `tests/scripts.bats` still dominates wall time.

## Related

Related: `docs/issues/2026-08-21-006-ci-sharding-not-evaluated-against-within-file-parallelism.md`

## Validation

- `git diff --check`
- `make test-issues` (34 unittest tests)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
