### PR TITLE
fix(ci): use lockf for macOS bats locks

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -353,15 +353,24 @@ jobs:
           test -x home/private_dot_claude/dot_smithers/node_modules/.bin/smithers
           test -x "$HOME/.claude/.smithers/node_modules/.bin/smithers"
 
-      # Within-file parallelism runs on bats' own semaphore, which hard-exits
-      # with "flock/shlock is required for parallelization within files!" when
-      # neither is present. Nothing is installed here: flock ships in Ubuntu,
-      # macOS ships /usr/bin/shlock. Asserting it gives that failure its own
-      # step instead of letting it surface mid-suite. --jobs needs bats >= 1.5;
-      # the version check guards against a runner-image pin-back.
+      # Bats prefers flock over shlock for its within-file semaphore. macOS
+      # ships lockf and shlock, but bats-core polls the shlock backend with a
+      # one-second sleep under contention. This PATH entry gives Bats a narrow
+      # flock-compatible command that maps only Bats' simple lock form to
+      # lockf, without adding a Homebrew package to the timed CI setup.
+      - name: Select the Bats flock wrapper
+        run: echo "$GITHUB_WORKSPACE/scripts/ci/macos-bats-flock-bin" >> "$GITHUB_PATH"
+
+      # Within-file parallelism runs on bats' own semaphore. The macOS job
+      # requires the local wrapper here rather than accepting shlock, because
+      # bats-core polls the shlock backend with a one-second sleep under
+      # contention. Asserting the chosen backend gives a PATH mistake its own
+      # step instead of silently measuring the old path. --jobs needs bats >=
+      # 1.5; the version check guards against a runner-image pin-back.
       - name: Assert the parallel-run prerequisites
         run: |
-          command -v flock || command -v shlock
+          test "$(command -v flock)" = "$GITHUB_WORKSPACE/scripts/ci/macos-bats-flock-bin/flock"
+          command -v lockf
           bats --version
           bats --version | awk '{print $2}' \
             | awk -F. '{ exit !($1 > 1 || ($1 == 1 && $2 >= 5)) }'

--- a/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
+++ b/docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md
@@ -115,9 +115,12 @@ sum to something near 283 s, the tail is the floor and more jobs will not help.
 
 ## Open decisions
 
-- Whether 67% of baseline on macOS is worth further work at all. The job already
-  runs inside its 25-minute timeout with room to spare, and the absolute saving is
-  already 140 s per run.
+- This branch chooses the lowest-cost experiment: add a Bats-only `flock` wrapper
+  to the macOS CI `PATH` and map Bats' simple `flock <directory> <command...>`
+  call to macOS `lockf -k <directory>/.bats-lockf.lock <command...>`. The
+  remaining decision is data-dependent: keep the wrapper if the suite wall-time
+  improves without new flakes; otherwise install Homebrew `flock`, measure a
+  macOS-specific `--jobs` curve, or close this issue as not worth further work.
 - If further work resumes, whether CI billed minutes matter. If wall time is the
   only constraint, repeating `chezmoi apply` across runner-level shards may be
   acceptable; if billed minutes matter too, sharding starts at a disadvantage.

--- a/scripts/ci/macos-bats-flock-bin/flock
+++ b/scripts/ci/macos-bats-flock-bin/flock
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Bats-only flock compatibility wrapper for macOS CI.
+#
+# Bats-core calls only: flock "$BATS_SEMAPHORE_DIR" command [args...]
+# macOS has lockf, not flock. This wrapper maps Bats' directory target to a
+# stable file inside that directory and rejects unsupported flock forms.
+
+set -eu
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: flock LOCK_TARGET COMMAND [ARG...]" >&2
+  exit 64
+fi
+
+case "$1" in
+  -*)
+    echo "unsupported flock option for Bats-only wrapper: $1" >&2
+    exit 64
+    ;;
+esac
+
+lock_target=$1
+shift
+
+if [ -d "$lock_target" ]; then
+  lock_file="$lock_target/.bats-lockf.lock"
+else
+  lock_file="$lock_target"
+fi
+
+exec lockf -k "$lock_file" "$@"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -51,6 +51,29 @@ class TestDotfilesWorkflow(unittest.TestCase):
                 )
                 self.assertIn("path: %s" % cache_path, save)
 
+    def test_macos_post_apply_suite_uses_local_bats_flock_wrapper(self):
+        text = self.workflow_text()
+        job = self.job_block(text, "test-macos")
+        select_wrapper = self.named_step_block(job, "Select the Bats flock wrapper")
+        prerequisites = self.named_step_block(job, "Assert the parallel-run prerequisites")
+
+        self.assertIn(
+            'echo "$GITHUB_WORKSPACE/scripts/ci/macos-bats-flock-bin" >> "$GITHUB_PATH"',
+            select_wrapper,
+            "macOS must put the Bats-only flock wrapper on PATH before the post-apply suite",
+        )
+        self.assertIn(
+            'test "$(command -v flock)" = "$GITHUB_WORKSPACE/scripts/ci/macos-bats-flock-bin/flock"',
+            prerequisites,
+            "macOS must fail before the suite if Bats would still fall back to shlock",
+        )
+        self.assertIn("command -v lockf", prerequisites)
+        self.assertNotIn(
+            "brew install flock",
+            job,
+            "the macOS flock experiment must not add Homebrew install time",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_macos_bats_flock_wrapper.py
+++ b/tests/test_macos_bats_flock_wrapper.py
@@ -1,0 +1,64 @@
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+WRAPPER = REPOSITORY / "scripts" / "ci" / "macos-bats-flock-bin" / "flock"
+
+
+class TestMacosBatsFlockWrapper(unittest.TestCase):
+    def test_wrapper_maps_directory_lock_target_to_stable_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            capture = root / "lockf.args"
+            fake_lockf = fake_bin / "lockf"
+            fake_lockf.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    printf '%s\n' "$@" > "$CAPTURE"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_lockf.chmod(fake_lockf.stat().st_mode | stat.S_IXUSR)
+
+            lock_dir = root / "semaphores"
+            lock_dir.mkdir()
+            env = os.environ.copy()
+            env["PATH"] = "%s:%s" % (fake_bin, env.get("PATH", ""))
+            env["CAPTURE"] = str(capture)
+
+            subprocess.run(
+                [str(WRAPPER), str(lock_dir), "bash", "-c", "true"],
+                env=env,
+                check=True,
+            )
+
+            self.assertEqual(
+                capture.read_text(encoding="utf-8").splitlines(),
+                ["-k", str(lock_dir / ".bats-lockf.lock"), "bash", "-c", "true"],
+            )
+
+    def test_wrapper_rejects_flock_options_it_does_not_implement(self):
+        completed = subprocess.run(
+            [str(WRAPPER), "-n", "/tmp/example.lock", "true"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 64)
+        self.assertIn("unsupported flock option", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

macOS CI now makes Bats use a blocking `lockf`-backed semaphore path instead of falling back to Bats' one-second `shlock` polling loop during the post-apply suite.

The wrapper is deliberately narrow: it supports only the `flock <lock-target> <command...>` form that Bats uses, maps directory targets to `.bats-lockf.lock`, and rejects unsupported `flock` flags so other behaviors cannot be assumed silently.

## Validation

- `make test-issues` ran 38 repository issue and workflow tests successfully.
- `shellcheck --severity=warning scripts/ci/macos-bats-flock-bin/flock` completed with no warnings.
- `git diff --check` completed with no whitespace errors.

## Residual risk

- The macOS wall-time improvement is not proven until GitHub Actions runs `test-macos` on this branch.

## Related

- Related: `docs/issues/2026-08-21-012-macos-suite-misses-the-60-percent-wall-time-gate.md`
