### PR TITLE
fix(tests): share post-apply suite invocation

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -224,7 +224,7 @@ jobs:
 
       # Stage 5: Post-apply tests
       - name: Run post-apply tests
-        run: bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats
+        run: tests/run-post-apply.sh full
 
       # Save-only keeps scheduled and manual full-Brewfile runs useful as cache
       # seeders without letting a restored archive mask upstream fetch decay.
@@ -376,7 +376,7 @@ jobs:
             | awk -F. '{ exit !($1 > 1 || ($1 == 1 && $2 >= 5)) }'
 
       - name: Run post-apply tests
-        run: bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats
+        run: tests/run-post-apply.sh full
 
       # Save-only keeps scheduled and manual full-Brewfile runs useful as cache
       # seeders without letting a restored archive mask upstream fetch decay.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-suite: init-submodules
 	@echo "NOTE: asserts against the ALREADY-APPLIED ~/ , not this checkout."
 	@echo "      An edit under home/ is not covered until it is applied."
 	@echo "      To test an unapplied edit, use: make test-ubuntu"
-	bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats
+	tests/run-post-apply.sh host-safe
 
 test-docker: test-issues build-docker
 	@echo "=== Running Ubuntu tests ==="

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -77,7 +77,7 @@ services:
         bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
 
         echo "=== Running post-apply tests ==="
-        bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats
+        tests/run-post-apply.sh full
 
         echo "=== All done! ==="
 
@@ -114,4 +114,4 @@ services:
         bats tests/templates.bats
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
         bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
-        bats --jobs 8 --no-parallelize-across-files tests/smoke.bats tests/scripts.bats tests/palette.bats tests/platform.bats tests/idempotent.bats
+        tests/run-post-apply.sh full

--- a/docs/issues/2026-08-21-005-post-apply-suite-invocation-duplicated.md
+++ b/docs/issues/2026-08-21-005-post-apply-suite-invocation-duplicated.md
@@ -5,9 +5,10 @@ type: "follow-up"
 category: "repository-maintenance"
 tags: ["repository-maintenance","follow-up"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "medium"
 parent-plan: "docs/plans/2026-08-20-2217-perf-parallel-bats-suite-plan.md"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -20,7 +21,7 @@ parallel-bats plan adds a fifth:
   `test-ubuntu` job
 - `.github/workflows/test-dotfiles.yml` — the same step in the `test-macos` job
 - `docker/docker-compose.yml` — the `test-full` service `command`
-- `docker/docker-compose.yml` — the `test-quick` service `command`
+- `docker/docker-compose.yml` — the `test-ubuntu` service `command`
 - `Makefile` — the `test-suite` target the parallel-bats plan's U3 adds
 
 The failure mode is that a missed site does not fail. Drop `--jobs` from one of them and
@@ -58,7 +59,7 @@ them carry behaviour rather than just a file list:
 - `.github/workflows/test-dotfiles.yml`, `test-ubuntu` -- `bats --jobs 8 --no-parallelize-across-files <5 files>`
 - `.github/workflows/test-dotfiles.yml`, `test-macos` -- same
 - `docker/docker-compose.yml`, `test-full` -- same
-- `docker/docker-compose.yml`, `test-quick` -- same
+- `docker/docker-compose.yml`, `test-ubuntu` -- same
 - `Makefile`, `test-suite` -- same flags over **four** files, not five
 
 That last one is a deliberate difference, not drift: the local target omits
@@ -70,3 +71,7 @@ own -- it needs the file list and the host-safe file list as two names.
 
 The drift risk named above is now concrete: dropping `--jobs 8` from any one site
 silently returns that runtime to sequential execution, and nothing goes red.
+
+## Resolution
+
+Added tests/run-post-apply.sh with full and host-safe modes, routed the GitHub Actions jobs, Docker services, and make test-suite through it, and added tests/test_post_apply_suite_contract.py so future flag or file-list drift fails in the Python contract suite.

--- a/tests/idempotent.bats
+++ b/tests/idempotent.bats
@@ -19,11 +19,9 @@ load 'helpers/common'
 # Where the marker is set, the four still mutate the shared $HOME that every
 # other test file reads deployed state from. Two of them applying at once would
 # race, so this file stays sequential even when the suite runs with --jobs,
-# and all five invocation sites keep --no-parallelize-across-files: Makefile
-# `test-suite`, the two `Run post-apply tests` steps in
-# .github/workflows/test-dotfiles.yml, and the test-full and test-ubuntu
-# services in docker/docker-compose.yml. It is 1.3 s of a 268 s suite, so
-# serializing it costs nothing measurable.
+# and the shared tests/run-post-apply.sh wrapper keeps
+# --no-parallelize-across-files in both modes. It is 1.3 s of a 268 s suite,
+# so serializing it costs nothing measurable.
 BATS_NO_PARALLELIZE_WITHIN_FILE=true
 
 # All chezmoi commands use PATH_WITHOUT_OP to prevent 1Password auth

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+usage: tests/run-post-apply.sh full|host-safe
+
+full      Run the complete post-apply suite against a disposable home.
+host-safe Run only the files that do not execute real chezmoi apply commands.
+USAGE
+}
+
+case "${1:-}" in
+  full)
+    set -- \
+      tests/smoke.bats \
+      tests/scripts.bats \
+      tests/palette.bats \
+      tests/platform.bats \
+      tests/idempotent.bats
+    ;;
+  host-safe)
+    set -- \
+      tests/smoke.bats \
+      tests/scripts.bats \
+      tests/palette.bats \
+      tests/platform.bats
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+exec bats --jobs 8 --no-parallelize-across-files "$@"

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -28,6 +28,16 @@ load 'helpers/common'
   assert_success
 }
 
+@test "post-apply suite wrapper rejects an unknown mode with usage" {
+  local repository_root
+  repository_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  [[ -x "$repository_root/tests/run-post-apply.sh" ]] || skip "repository checkout is not mounted"
+
+  run "$repository_root/tests/run-post-apply.sh" unknown
+  [ "$status" -eq 2 ]
+  assert_output --partial "usage: tests/run-post-apply.sh full|host-safe"
+}
+
 # ===========================================
 # Chezmoi-managed files exist
 # ===========================================

--- a/tests/test_post_apply_suite_contract.py
+++ b/tests/test_post_apply_suite_contract.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import unittest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+MAKEFILE = REPOSITORY / "Makefile"
+WORKFLOW = REPOSITORY / ".github" / "workflows" / "test-dotfiles.yml"
+COMPOSE = REPOSITORY / "docker" / "docker-compose.yml"
+RUNNER = REPOSITORY / "tests" / "run-post-apply.sh"
+
+
+class TestPostApplySuiteContract(unittest.TestCase):
+    def test_post_apply_suite_uses_one_wrapper_with_two_explicit_modes(self):
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        compose = COMPOSE.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            workflow.count("run: tests/run-post-apply.sh full"),
+            2,
+            "both GitHub Actions post-apply steps must call the shared full-suite wrapper",
+        )
+        self.assertEqual(
+            compose.count("tests/run-post-apply.sh full"),
+            2,
+            "both Docker full-suite services must call the shared full-suite wrapper",
+        )
+        self.assertEqual(
+            makefile.count("tests/run-post-apply.sh host-safe"),
+            1,
+            "make test-suite must call the host-safe wrapper mode exactly once",
+        )
+
+        if not RUNNER.exists():
+            self.fail("tests/run-post-apply.sh must own the post-apply bats command")
+
+        runner = RUNNER.read_text(encoding="utf-8")
+        self.assertIn(
+            'exec bats --jobs 8 --no-parallelize-across-files "$@"',
+            runner,
+            "the wrapper must own the parallel bats flags so callers cannot drift",
+        )
+        self.assertIn("tests/idempotent.bats", runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_post_apply_suite_contract.py
+++ b/tests/test_post_apply_suite_contract.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import os
+import subprocess
+import tempfile
 import unittest
 
 
@@ -31,16 +34,62 @@ class TestPostApplySuiteContract(unittest.TestCase):
             "make test-suite must call the host-safe wrapper mode exactly once",
         )
 
+        self.assertEqual(
+            self.wrapper_argv("full"),
+            [
+                "--jobs",
+                "8",
+                "--no-parallelize-across-files",
+                "tests/smoke.bats",
+                "tests/scripts.bats",
+                "tests/palette.bats",
+                "tests/platform.bats",
+                "tests/idempotent.bats",
+            ],
+            "full mode must run the complete post-apply suite with the shared parallel flags",
+        )
+        self.assertEqual(
+            self.wrapper_argv("host-safe"),
+            [
+                "--jobs",
+                "8",
+                "--no-parallelize-across-files",
+                "tests/smoke.bats",
+                "tests/scripts.bats",
+                "tests/palette.bats",
+                "tests/platform.bats",
+            ],
+            "host-safe mode must keep tests/idempotent.bats excluded behind the shared flags",
+        )
+
+    def wrapper_argv(self, mode):
         if not RUNNER.exists():
             self.fail("tests/run-post-apply.sh must own the post-apply bats command")
 
-        runner = RUNNER.read_text(encoding="utf-8")
-        self.assertIn(
-            'exec bats --jobs 8 --no-parallelize-across-files "$@"',
-            runner,
-            "the wrapper must own the parallel bats flags so callers cannot drift",
-        )
-        self.assertIn("tests/idempotent.bats", runner)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            fake_bin = temp_path / "bin"
+            fake_bin.mkdir()
+            argv_file = temp_path / "argv"
+            fake_bats = fake_bin / "bats"
+            fake_bats.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\n' \"$@\" > \"$BATS_ARGV_FILE\"\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_bats.chmod(0o755)
+
+            env = os.environ.copy()
+            env["BATS_ARGV_FILE"] = str(argv_file)
+            env["PATH"] = "%s%s%s" % (fake_bin, os.pathsep, env["PATH"])
+            subprocess.run(
+                [str(RUNNER), mode],
+                cwd=REPOSITORY,
+                env=env,
+                check=True,
+            )
+            return argv_file.read_text(encoding="utf-8").splitlines()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The post-apply suite now has one wrapper for Bats flags and file lists, so workflow, Docker, and local callers cannot drift silently back to sequential or partial coverage. The wrapper keeps the full CI and Docker suite separate from the host-safe local subset.

## Validation

- `python3 -m unittest discover -s tests -p 'test_post_apply_suite_contract.py'`
- `make test-issues`
- `make lint`
- `make test-suite`

## Related

Related: `docs/issues/2026-08-21-005-post-apply-suite-invocation-duplicated.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
