### PR TITLE
fix(tests): guard python3 floor drift

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
+      - ../README.md:/home/testuser/README.md:ro
     environment:
       - CHEZMOI_NAME=Test User
       - CHEZMOI_EMAIL=test@example.com
@@ -33,6 +34,7 @@ services:
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
+      - ../README.md:/home/testuser/README.md:ro
     environment:
       - CHEZMOI_NAME=Test User
       - CHEZMOI_EMAIL=test@example.com
@@ -56,6 +58,7 @@ services:
         mkdir -p /home/testuser/worktree
         cp -r /home/testuser/dotfiles /home/testuser/worktree/home
         cp -r /home/testuser/tests /home/testuser/worktree/tests
+        cp /home/testuser/README.md /home/testuser/worktree/README.md
         rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
         cd /home/testuser/worktree
 
@@ -89,6 +92,7 @@ services:
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
+      - ../README.md:/home/testuser/README.md:ro
     environment:
       - CHEZMOI_NAME=Test User
       - CHEZMOI_EMAIL=test@example.com
@@ -105,6 +109,7 @@ services:
         mkdir -p /home/testuser/worktree
         cp -r /home/testuser/dotfiles /home/testuser/worktree/home
         cp -r /home/testuser/tests /home/testuser/worktree/tests
+        cp /home/testuser/README.md /home/testuser/worktree/README.md
         rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
         cd /home/testuser/worktree
         (cd home && cp -r . /home/testuser/.local/share/chezmoi/)

--- a/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
+++ b/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
@@ -5,9 +5,10 @@ type: "follow-up"
 category: "repository-maintenance"
 tags: ["repository-maintenance","follow-up"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "low"
 parent-plan: "docs/plans/2026-08-21-0337-fix-python3-declared-dependency-plan.md"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -60,3 +61,7 @@ Raised by the testing reviewer during the code review of the plan named in `pare
   measured). If macOS ever ships newer, the floor could rise — but the decision of when to
   raise it belongs with whoever checks that all four command-palette sources still compile
   under the new floor, not with a drift check.
+
+## Resolution
+
+Added a Bats regression test in tests/palette.bats that reads README.md's Requirements section and compares the documented python3 floor with PYTHON3_MIN_VERSION from tests/helpers/common.bash. Mutation verification changed README.md to 3.10 and confirmed the new test fails before restoration; the normal palette suite passes.

--- a/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
+++ b/docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md
@@ -51,12 +51,13 @@ Raised by the testing reviewer during the code review of the plan named in `pare
    stubbing difficulty. It is currently proven only by an ad-hoc harness run, not by
    anything in the repo.
 
-## Open decisions
+## Resolved decisions
 
-- Is `README.md` the right home for a machine-readable constant at all? It is the file a
-  human reads, which is why the assertion points there. A grep-based test couples the test
-  suite to prose formatting, which is its own fragility — a heading rename or a reworded
-  sentence would break it for no real reason.
+- `README.md` stays the checked document. It is the file the failure message names and the
+  file a human reads during setup, so the drift test intentionally couples to the two
+  current Requirements-section sentences that carry the floor. The test now fails if
+  either sentence disappears, which keeps a prose edit from silently removing the setup
+  requirement while preserving the rationale sentence.
 - The floor is 3.9 because that is what macOS ships at `/usr/bin/python3` (3.9.6,
   measured). If macOS ever ships newer, the floor could rise — but the decision of when to
   raise it belongs with whoever checks that all four command-palette sources still compile
@@ -64,4 +65,4 @@ Raised by the testing reviewer during the code review of the plan named in `pare
 
 ## Resolution
 
-Added a Bats regression test in tests/palette.bats that reads README.md's Requirements section and compares the documented python3 floor with PYTHON3_MIN_VERSION from tests/helpers/common.bash. Mutation verification changed README.md to 3.10 and confirmed the new test fails before restoration; the normal palette suite passes.
+Added Bats regression tests in tests/palette.bats that read README.md's Requirements section, require both python3 floor sentences, and compare each documented floor with PYTHON3_MIN_VERSION from tests/helpers/common.bash. The same test now fails instead of skipping when README.md is absent, and docker/docker-compose.yml copies README.md into the Docker test worktree so make test-ubuntu exercises the check. The absent-python3 branch is also covered by a committed PATH-stub test. Mutation verification changed README.md to 3.10 and confirmed the drift test fails before restoration; the normal palette suite passes.

--- a/tests/palette.bats
+++ b/tests/palette.bats
@@ -44,7 +44,10 @@ teardown() {
 @test "README.md declares the same python3 floor the test helper enforces" {
   local repository_root
   repository_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-  [[ -f "$repository_root/README.md" ]] || skip "repository checkout is not mounted"
+  if [[ ! -f "$repository_root/README.md" ]]; then
+    fail "README.md is missing, so the python3 floor cannot be checked against the documented requirement"
+    return 1
+  fi
 
   run python3 - "$repository_root/README.md" "$PYTHON3_MIN_VERSION" <<'PY'
 import re
@@ -58,22 +61,33 @@ match = re.search(r"(?ms)^## Requirements\n(?P<section>.*?)(?:^## |\Z)", text)
 assert match, "README.md has no Requirements section"
 
 section = match.group("section")
-patterns = [
-    r"python3` is on your `PATH` and reports at least \*\*([0-9]+\.[0-9]+)\*\*",
-    r"where the ([0-9]+\.[0-9]+) floor comes from",
-]
-found = []
-for pattern in patterns:
-    found.extend(re.findall(pattern, section))
+patterns = {
+    "setup requirement": r"python3` is on your `PATH` and reports at least \*\*([0-9]+\.[0-9]+)\*\*",
+    "floor rationale": r"where the ([0-9]+\.[0-9]+) floor comes from",
+}
 
-assert found, "README.md Requirements section states no python3 floor"
-wrong = [version for version in found if version != expected]
-assert not wrong, (
-    f"README.md states python3 floor(s) {', '.join(found)}, "
-    f"but tests/helpers/common.bash enforces {expected}"
-)
+for label, pattern in patterns.items():
+    matches = re.findall(pattern, section)
+    assert matches, f"README.md Requirements section is missing the python3 {label} floor"
+    assert len(matches) == 1, f"README.md Requirements section has multiple python3 {label} floors: {', '.join(matches)}"
+    assert matches[0] == expected, (
+        f"README.md {label} states python3 floor {matches[0]}, "
+        f"but tests/helpers/common.bash enforces {expected}"
+    )
 PY
   assert_success
+}
+
+@test "a missing python3 is rejected" {
+  local stub="$PALETTE_WORK/nopython" saved="$PATH"
+  mkdir -p "$stub"
+
+  PATH="$stub"
+  run assert_python3_available
+  PATH="$saved"
+
+  assert_failure
+  assert_output --partial "python3 is not on PATH"
 }
 
 # The gate has to reject, not fall through. Before the shape check in

--- a/tests/palette.bats
+++ b/tests/palette.bats
@@ -41,6 +41,41 @@ teardown() {
   assert_python3_available
 }
 
+@test "README.md declares the same python3 floor the test helper enforces" {
+  local repository_root
+  repository_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  [[ -f "$repository_root/README.md" ]] || skip "repository checkout is not mounted"
+
+  run python3 - "$repository_root/README.md" "$PYTHON3_MIN_VERSION" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+readme = Path(sys.argv[1])
+expected = sys.argv[2]
+text = readme.read_text()
+match = re.search(r"(?ms)^## Requirements\n(?P<section>.*?)(?:^## |\Z)", text)
+assert match, "README.md has no Requirements section"
+
+section = match.group("section")
+patterns = [
+    r"python3` is on your `PATH` and reports at least \*\*([0-9]+\.[0-9]+)\*\*",
+    r"where the ([0-9]+\.[0-9]+) floor comes from",
+]
+found = []
+for pattern in patterns:
+    found.extend(re.findall(pattern, section))
+
+assert found, "README.md Requirements section states no python3 floor"
+wrong = [version for version in found if version != expected]
+assert not wrong, (
+    f"README.md states python3 floor(s) {', '.join(found)}, "
+    f"but tests/helpers/common.bash enforces {expected}"
+)
+PY
+  assert_success
+}
+
 # The gate has to reject, not fall through. Before the shape check in
 # assert_python3_available, a stub printing "3.8.1" made the minor component
 # "8.1", which is an arithmetic syntax error -- (( )) returned non-zero, the


### PR DESCRIPTION
## Summary

The Python version floor can no longer drift between `README.md` and the Bats helper that enforces it. A README-only bump, a deleted floor sentence, or a missing README now fails in the palette test suite instead of leaving tests to enforce a different number than the documentation states.

Related: `docs/issues/2026-08-21-019-python3-floor-is-stated-in-two-places-with-no-cross-check.md`

## Validation

- Mutated `README.md` from 3.9 to 3.10 and confirmed the drift test failed with the expected mismatch message. Restored `README.md` after the check.
- Removed the setup requirement sentence and confirmed the drift test failed.
- Removed the floor rationale sentence and confirmed the drift test failed.
- Temporarily moved `README.md` away and confirmed the drift test failed instead of skipping.
- `bats --filter 'README.md declares the same python3 floor|a missing python3 is rejected' tests/palette.bats`
- `timeout 300 bats tests/palette.bats`
- `python3 scripts/issues validate`
- `make test-issues`
- `make lint`
- `make test-suite`
- `docker compose -f docker/docker-compose.yml config`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
