### PR TITLE
fix(tests): catch slow fail-open paths

### DIFF
--- a/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
+++ b/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
@@ -5,9 +5,10 @@ type: "bug"
 category: "repository-maintenance"
 tags: ["repository-maintenance","bug"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "medium"
 parent-plan: "docs/plans/2026-08-20-2217-perf-parallel-bats-suite-plan.md"
+closed: "2026-08-23"
 ---
 
 ## Why this exists
@@ -67,11 +68,13 @@ Do **not** simply lower the constant back toward 2 seconds. That reintroduces th
 exact flake this work removed, and a flaky assertion protects nothing because it
 gets muted.
 
-## Open decisions
+## Decisions resolved
 
-- Whether option 1 is reachable for all three sites, or only some. That needs a
-  read of each fail-open path for an observable signal; nobody has done it yet.
-- Whether a slow fail-open is worth catching at all. These are error paths whose
-  contract is "do not hang". If three seconds is acceptable there in production,
-  the 20-second guard is the right assertion and this issue closes as wontfix.
-  That is a real possibility and should be decided deliberately, not by default.
+Promptness is still part of the test contract. The selected fix keeps the
+generous hang guard but adds a same-run baseline plus a tight behavioral
+deadline, because these fail-open paths should not silently take several seconds
+before returning.
+
+## Resolution
+
+Added a two-budget fail-open guard in tests/helpers/herdr_task_sync.bash, updated the three promptness assertions in tests/scripts.bats to use it, and added a regression test proving a late success fails before the hang guard.

--- a/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
+++ b/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
@@ -71,10 +71,10 @@ gets muted.
 ## Decisions resolved
 
 Promptness is still part of the test contract. The selected fix keeps the
-generous hang guard but adds a same-run baseline plus a tight behavioral
+generous hang guard but adds a scaled same-run baseline plus a tight behavioral
 deadline, because these fail-open paths should not silently take several seconds
-before returning.
+before returning on an idle runner.
 
 ## Resolution
 
-Added a two-budget fail-open guard in tests/helpers/herdr_task_sync.bash, updated the three promptness assertions in tests/scripts.bats to use it, and added a regression test proving a late success fails before the hang guard.
+Added a two-budget fail-open guard in tests/helpers/herdr_task_sync.bash, updated the three promptness assertions in tests/scripts.bats to use it, and added a regression test proving a late success fails before the hang guard. The guard scales its same-run baseline so full-suite scheduler contention does not fail a healthy path.

--- a/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
+++ b/docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md
@@ -77,4 +77,4 @@ before returning on an idle runner.
 
 ## Resolution
 
-Added a two-budget fail-open guard in tests/helpers/herdr_task_sync.bash, updated the three promptness assertions in tests/scripts.bats to use it, and added a regression test proving a late success fails before the hang guard. The guard scales its same-run baseline so full-suite scheduler contention does not fail a healthy path.
+Added a two-budget fail-open guard in tests/helpers/herdr_task_sync.bash, updated the three promptness assertions in tests/scripts.bats to use it, and added a regression test proving a late success fails before the hang guard. The guard scales its same-run baseline so full-suite scheduler contention does not fail a healthy path; the regression test pins a strict multiplier to keep the late-success proof deterministic.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -568,7 +568,7 @@ HTS_GIT_BUDGET="${HTS_GIT_BUDGET:-2}"
 # The base deadline still catches idle multi-second regressions. The multiplier
 # gives loaded CI a margin for scheduler stalls that the baseline observes.
 HTS_FAIL_OPEN_BEHAVIOR_SECONDS="${HTS_FAIL_OPEN_BEHAVIOR_SECONDS:-2.5}"
-HTS_FAIL_OPEN_BASELINE_MULTIPLIER="${HTS_FAIL_OPEN_BASELINE_MULTIPLIER:-4}"
+HTS_FAIL_OPEN_BASELINE_MULTIPLIER="${HTS_FAIL_OPEN_BASELINE_MULTIPLIER:-8}"
 
 # Hang guard for the same assertions. A return after the behavioral budget is a
 # promptness regression. No return by this ceiling is a hung fail-open path.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -39,11 +39,14 @@ hts_teardown() {
   if [[ -n "${HTS_READER_PID:-}" ]]; then
     kill "$HTS_READER_PID" 2>/dev/null || true
     wait "$HTS_READER_PID" 2>/dev/null || true
+    unset HTS_READER_PID
   fi
   [[ -n "${HTS_WORK:-}" ]] && rm -rf "$HTS_WORK" || true
+  unset HTS_WORK HTS_STUB HTS_STATE HTS_LOG HTS_DEFAULT_SOCKET HTS_SOCKET_ROOT
 }
 
 hts_setup() {
+  [[ -z "${HTS_WORK:-}" ]] || hts_teardown
   HTS_WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/hts.XXXXXX")"
   HTS_STUB="$HTS_WORK/stub"
   HTS_STATE="$HTS_WORK/state"
@@ -559,12 +562,116 @@ hts_after_call_script() {
 # would SIGKILL those, which is the failure this value exists to prevent.
 HTS_GIT_BUDGET="${HTS_GIT_BUDGET:-2}"
 
-# Bound for the "fails open promptly rather than hanging" assertions. They
-# guard against a worker that blocks or retries without end; they are not
-# performance benchmarks. Two seconds was calibrated on an idle machine and
-# goes red under --jobs contention with no regression behind it -- the same
-# trap the eight-pane coordinator test documents above its own deadline.
+# Behavioral budget for the "fails open promptly rather than hanging" assertions.
+# The helper below adds a same-run process-launch baseline before enforcing this,
+# so scheduler contention is measured separately from the fail-open path itself.
+HTS_FAIL_OPEN_BEHAVIOR_SECONDS="${HTS_FAIL_OPEN_BEHAVIOR_SECONDS:-2}"
+
+# Hang guard for the same assertions. A return after the behavioral budget is a
+# promptness regression. No return by this ceiling is a hung fail-open path.
+# Twenty seconds is intentionally generous because this guard must tolerate
+# --jobs contention; it must not become the behavioral deadline.
 HTS_FAIL_OPEN_MAX_SECONDS="${HTS_FAIL_OPEN_MAX_SECONDS:-20}"
+
+hts_millis() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+hts_seconds_to_millis() {
+  python3 - "$1" <<'PY'
+import decimal
+import sys
+
+try:
+    seconds = decimal.Decimal(sys.argv[1])
+except decimal.InvalidOperation:
+    raise SystemExit(2)
+if seconds < 0:
+    raise SystemExit(2)
+print(int(seconds * 1000))
+PY
+}
+
+hts_millis_to_seconds() {
+  python3 - "$1" <<'PY'
+import decimal
+import sys
+
+try:
+    millis = decimal.Decimal(sys.argv[1])
+except decimal.InvalidOperation:
+    raise SystemExit(2)
+if millis < 0:
+    raise SystemExit(2)
+print(millis / decimal.Decimal(1000))
+PY
+}
+
+hts_run_fail_open_guard() {
+  local behavior_ms hang_ms baseline_start baseline_end baseline_ms
+  local start end elapsed_ms behavior_allowed_ms hang_allowed_ms hang_allowed_seconds
+  local input out err timeout_marker pid watchdog status
+
+  behavior_ms="$(hts_seconds_to_millis "$HTS_FAIL_OPEN_BEHAVIOR_SECONDS")" || return 2
+  hang_ms="$(hts_seconds_to_millis "$HTS_FAIL_OPEN_MAX_SECONDS")" || return 2
+  input="$(mktemp "$HTS_WORK/fail-open-stdin.XXXXXX")" || return 1
+  out="$(mktemp "$HTS_WORK/fail-open-stdout.XXXXXX")" || { rm -f "$input"; return 1; }
+  err="$(mktemp "$HTS_WORK/fail-open-stderr.XXXXXX")" || { rm -f "$input" "$out"; return 1; }
+  timeout_marker="$(mktemp "$HTS_WORK/fail-open-timeout.XXXXXX")" || {
+    rm -f "$input" "$out" "$err"
+    return 1
+  }
+  rm -f "$timeout_marker"
+  cat > "$input"
+
+  baseline_start="$(hts_millis)"
+  bash -c ':' >/dev/null 2>&1
+  baseline_end="$(hts_millis)"
+  baseline_ms=$((baseline_end - baseline_start))
+  behavior_allowed_ms=$((baseline_ms + behavior_ms))
+  hang_allowed_ms=$((baseline_ms + hang_ms))
+  hang_allowed_seconds="$(hts_millis_to_seconds "$hang_allowed_ms")" || {
+    rm -f "$input" "$out" "$err" "$timeout_marker"
+    return 2
+  }
+
+  start="$(hts_millis)"
+  "$@" < "$input" > "$out" 2> "$err" &
+  pid=$!
+  (
+    sleep "$hang_allowed_seconds"
+    if kill -0 "$pid" 2>/dev/null; then
+      : > "$timeout_marker"
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  ) >/dev/null 2>&1 &
+  watchdog=$!
+  wait "$pid"
+  status=$?
+  end="$(hts_millis)"
+  kill "$watchdog" >/dev/null 2>&1 || true
+  wait "$watchdog" 2>/dev/null || true
+  cat "$out" 2>/dev/null || true
+  cat "$err" >&2 2>/dev/null || true
+
+  elapsed_ms=$((end - start))
+  if [ -f "$timeout_marker" ]; then
+    rm -f "$input" "$out" "$err" "$timeout_marker"
+    printf 'fail-open command exceeded hang guard: elapsed_ms=%s allowed_ms=%s baseline_ms=%s\n' \
+      "$elapsed_ms" "$hang_allowed_ms" "$baseline_ms"
+    return 124
+  fi
+  rm -f "$input" "$out" "$err" "$timeout_marker"
+  if [ "$elapsed_ms" -gt "$behavior_allowed_ms" ]; then
+    printf 'fail-open command exceeded fail-open behavioral deadline: elapsed_ms=%s allowed_ms=%s baseline_ms=%s\n' \
+      "$elapsed_ms" "$behavior_allowed_ms" "$baseline_ms"
+    return 124
+  fi
+  return "$status"
+}
 
 # Watchdog for a single engine call, enforced by `kill -9` inside the engine's
 # own run_with_timeout. It is a hang guard, not a budget: every test here stubs

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -563,9 +563,12 @@ hts_after_call_script() {
 HTS_GIT_BUDGET="${HTS_GIT_BUDGET:-2}"
 
 # Behavioral budget for the "fails open promptly rather than hanging" assertions.
-# The helper below adds a same-run process-launch baseline before enforcing this,
-# so scheduler contention is measured separately from the fail-open path itself.
-HTS_FAIL_OPEN_BEHAVIOR_SECONDS="${HTS_FAIL_OPEN_BEHAVIOR_SECONDS:-2}"
+# The helper below scales a same-run process-launch baseline before enforcing this,
+# so full-suite scheduler contention does not become the behavioral deadline.
+# The base deadline still catches idle multi-second regressions. The multiplier
+# gives loaded CI a margin for scheduler stalls that the baseline observes.
+HTS_FAIL_OPEN_BEHAVIOR_SECONDS="${HTS_FAIL_OPEN_BEHAVIOR_SECONDS:-2.5}"
+HTS_FAIL_OPEN_BASELINE_MULTIPLIER="${HTS_FAIL_OPEN_BASELINE_MULTIPLIER:-4}"
 
 # Hang guard for the same assertions. A return after the behavioral budget is a
 # promptness regression. No return by this ceiling is a hung fail-open path.
@@ -611,12 +614,16 @@ PY
 }
 
 hts_run_fail_open_guard() {
-  local behavior_ms hang_ms baseline_start baseline_end baseline_ms
+  local behavior_ms hang_ms baseline_multiplier baseline_start baseline_end baseline_ms
   local start end elapsed_ms behavior_allowed_ms hang_allowed_ms hang_allowed_seconds
   local input out err timeout_marker pid watchdog status
 
   behavior_ms="$(hts_seconds_to_millis "$HTS_FAIL_OPEN_BEHAVIOR_SECONDS")" || return 2
   hang_ms="$(hts_seconds_to_millis "$HTS_FAIL_OPEN_MAX_SECONDS")" || return 2
+  case "$HTS_FAIL_OPEN_BASELINE_MULTIPLIER" in
+    '' | *[!0-9]*) return 2 ;;
+    *) baseline_multiplier="$HTS_FAIL_OPEN_BASELINE_MULTIPLIER" ;;
+  esac
   input="$(mktemp "$HTS_WORK/fail-open-stdin.XXXXXX")" || return 1
   out="$(mktemp "$HTS_WORK/fail-open-stdout.XXXXXX")" || { rm -f "$input"; return 1; }
   err="$(mktemp "$HTS_WORK/fail-open-stderr.XXXXXX")" || { rm -f "$input" "$out"; return 1; }
@@ -631,7 +638,7 @@ hts_run_fail_open_guard() {
   bash -c ':' >/dev/null 2>&1
   baseline_end="$(hts_millis)"
   baseline_ms=$((baseline_end - baseline_start))
-  behavior_allowed_ms=$((baseline_ms + behavior_ms))
+  behavior_allowed_ms=$((behavior_ms + baseline_ms * baseline_multiplier))
   hang_allowed_ms=$((baseline_ms + hang_ms))
   hang_allowed_seconds="$(hts_millis_to_seconds "$hang_allowed_ms")" || {
     rm -f "$input" "$out" "$err" "$timeout_marker"

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1765,16 +1765,24 @@ PY
   grep -q '^repository_anchor=' "$namespace_one/reconcile.state"
 }
 
+@test "herdr-task-sync fail-open deadline rejects late success before the hang guard" {
+  hts_setup
+  local HTS_FAIL_OPEN_BEHAVIOR_SECONDS=1
+  local HTS_FAIL_OPEN_MAX_SECONDS=5
+
+  run hts_run_fail_open_guard sleep 2
+
+  assert_failure 124
+  assert_output --partial "exceeded fail-open behavioral deadline"
+}
+
 @test "herdr-task-sync fails open for missing tools contention write failure and malformed input" {
   hts_setup
-  local start end pane_dir
-  start="$(date +%s)"
-  run env PATH="/usr/bin:/bin" HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
+  local pane_dir
+  run hts_run_fail_open_guard env PATH="/usr/bin:/bin" HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
     HERDR_SOCKET_PATH="$HTS_DEFAULT_SOCKET" HERDR_TASK_SYNC_STATE_DIR="$HTS_STATE" \
     bash "$HTS_ENGINE" --agent claude --session missing <<< 'missing herdr'
-  end="$(date +%s)"
   assert_success
-  [[ $((end - start)) -le $HTS_FAIL_OPEN_MAX_SECONDS ]]
 
   hts_setup
   pane_dir="$(hts_pane_state_dir "$HTS_DEFAULT_SOCKET" pane-1)"
@@ -1799,11 +1807,8 @@ PY
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
   rmdir "$namespace/tasks"
   printf 'not-a-directory\n' > "$namespace/tasks"
-  start="$(date +%s)"
-  run hts_worker_run
-  end="$(date +%s)"
+  run hts_run_fail_open_guard hts_worker_run
   assert_success
-  [[ $((end - start)) -le $HTS_FAIL_OPEN_MAX_SECONDS ]]
   [[ "$(hts_record_number "$control" generation)" -gt \
     "$(hts_record_number "$control" committed_generation)" ]]
 
@@ -1814,11 +1819,8 @@ PY
   local task_file
   task_file="$(hts_task_file "$HTS_DEFAULT_SOCKET" pi pane-1 commit-write-failure)"
   mkdir "$task_file"
-  start="$(date +%s)"
-  run hts_worker_run
-  end="$(date +%s)"
+  run hts_run_fail_open_guard hts_worker_run
   assert_success
-  [[ $((end - start)) -le $HTS_FAIL_OPEN_MAX_SECONDS ]]
   [[ "$(hts_record_number "$control" generation)" -gt \
     "$(hts_record_number "$control" committed_generation)" ]]
   assert_dir_not_exists "$(hts_pane_state_dir "$HTS_DEFAULT_SOCKET" pane-1)/worker.claim"

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1768,6 +1768,7 @@ PY
 @test "herdr-task-sync fail-open deadline rejects late success before the hang guard" {
   hts_setup
   local HTS_FAIL_OPEN_BEHAVIOR_SECONDS=1
+  local HTS_FAIL_OPEN_BASELINE_MULTIPLIER=1
   local HTS_FAIL_OPEN_MAX_SECONDS=5
 
   run hts_run_fail_open_guard sleep 2


### PR DESCRIPTION
## Summary

Fail-open tests now distinguish a slow return from a true hang. The promptness checks keep the 20-second hang guard for contended runners, but a scaled same-run baseline plus a 2.5-second behavioral deadline now fail an idle path that returns several seconds late.

The regression test pins a strict baseline multiplier so the late-success proof stays deterministic, while the real fail-open checks tolerate full-suite scheduler stalls in CI.

## Validation

- `bats --filter 'herdr-task-sync fail-open deadline rejects late success before the hang guard|herdr-task-sync fails open for missing tools contention write failure and malformed input' tests/scripts.bats`
- `bats --jobs 8 --no-parallelize-across-files tests/scripts.bats`
- Manual slow-open rehearsal: injected `sleep 3` into the missing-`herdr` guard and worker write-failure path; the focused fail-open test failed with `exceeded fail-open behavioral deadline`.
- Manual hang-guard rehearsal: ran a temporary Bats probe with a 1-second hang guard around `sleep 3`; it failed with `exceeded hang guard`.
- `make lint`
- `python3 scripts/issues validate`
- `bats tests/scripts.bats` — 202 tests passed, with the existing Smithers dependency skip.

## Related

- Repository issue: `docs/issues/2026-08-21-014-fail-open-assertions-no-longer-catch-a-slow-fail-open.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
