### PR TITLE
feat(agent-platform): preserve explicit-only workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,21 @@ Adding a managed config, step by step:
 
 </important>
 
+<important if="you are adding or changing an explicit-only workflow">
+
+An explicit-only workflow interrupts the current task and must run only after a direct user request. Keep one canonical description and body in `home/.chezmoitemplates/explicit-only-<name>-description.txt` and `home/.chezmoitemplates/explicit-only-<name>-body.md`.
+
+Package the canonical content through two thin adapters:
+
+- Claude Code: `home/private_dot_claude/skills/<name>/SKILL.md.tmpl`, with `disable-model-invocation: true`. Pi reads this deployed skill through its existing `~/.claude/skills` source and needs no separate adapter.
+- OpenCode: `home/private_dot_config/opencode/commands/<name>.md.tmpl`, which exposes a manual command. Never add the workflow under `home/private_dot_config/opencode/skills/`.
+
+Use raw `include` with the explicit `.chezmoitemplates/<file>` path so literal Markdown and Go-template syntax remain data. Do not use `includeTemplate`, which executes the included content. Treat `$ARGUMENTS`, `$<digits>`, and unquoted `@path` as reserved OpenCode command syntax; a workflow that must preserve these sequences literally needs client-specific content instead.
+
+Keep both OpenCode discovery-disable exports in `home/dot_zshenv.tmpl`. After deployment, restart each client from the managed zsh environment before checking discovery. Add the workflow name to the `explicit-only workflows keep manual invocation boundaries` case in `tests/smoke.bats`, then run `make test-templates` and `make test-ubuntu`.
+
+</important>
+
 <important if="you are working with templates, secrets, or 1Password integration">
 
 - **Never** hardcode secrets — use `onepasswordRead` in templates.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -95,3 +95,8 @@ A Herdr intervention that attaches the operator to an agent inside its existing 
 
 ### Palette-only contract
 The rule that TUI theme files managed by this repo (Claude Code, opencode, pi) reference the terminal's ANSI palette slots — indices 0–15, `ansi:` names, or "terminal default" — never baked hex, so every tool follows the terminal scheme automatically. Enforced syntactically by bats tests in `tests/scripts.bats`; the terminal-theme-playground project is its visual counterpart ("eyes", not enforcement).
+
+## Agent platform
+
+### Explicit-only workflow
+A workflow that interrupts the current task and must run only after a direct user request. Its shared description and instructions are packaged as a Claude Code skill with model invocation disabled, consumed by Pi through the shared Claude skill path, and exposed to OpenCode as a manual command rather than a native skill.

--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -95,6 +95,13 @@ Local plugins kept in repo: `herdr-agent-state.js`.
 - `bundle:compound-engineering` — the `ce-*` set (37). Not enumerated.
 - Own: `lfg`.
 
+### Commands (`~/.config/opencode/commands/`)
+
+| Command        | Source | Managed | Invocation |
+| -------------- | ------ | ------- | ---------- |
+| eli5           | `repo` | repo    | manual     |
+| open-questions | `repo` | repo    | manual     |
+
 ### Agents (`~/.config/opencode/agent/` — ~51)
 
 - `bundle:compound-engineering` — the `ce-*` reviewer/researcher set (~48). Not enumerated.
@@ -115,6 +122,8 @@ is manual, and this inventory intentionally does not duplicate the package list.
 
 No Pi-only live skills are kept. Pi reads shared Claude skills from
 `~/.claude/skills` through `~/.pi/agent/settings.json` `skills[]`.
+This includes the explicit-only `eli5` and `open-questions` skills, invoked as
+`/skill:eli5` and `/skill:open-questions`.
 
 ### Agents (`~/.pi/agent/agents/`)
 
@@ -134,6 +143,25 @@ Ignored on purpose; not reproduced by this repo.
 | Skill | Claude | OpenCode | Pi   | Source |
 | ----- | ------ | -------- | ---- | ------ |
 | herdr | ✓      | want     | want | `repo` |
+
+## Explicit-only workflows
+
+`eli5` and `open-questions` share canonical descriptions and bodies from
+`home/.chezmoitemplates/explicit-only-<name>-*`. Claude Code adapters keep
+`disable-model-invocation: true`; Pi consumes those Claude skills; OpenCode
+receives manual command adapters and no native skill adapters.
+
+When adding or updating one of these workflows:
+
+1. Change its canonical description and body under `home/.chezmoitemplates/`.
+2. Add or update the Claude `SKILL.md.tmpl` and OpenCode command `.md.tmpl` thin adapters.
+3. Keep `$ARGUMENTS`, `$<digits>`, and unquoted `@path` out of canonical bodies unless OpenCode expansion is intentional.
+4. Keep both `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` and `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` in `home/dot_zshenv.tmpl`.
+5. Extend the focused explicit-only case in `tests/smoke.bats`, run the Docker verification, apply through the normal chezmoi source-clone workflow, and restart each client from managed zsh.
+
+Verified behavior baselines are OpenCode `1.18.20` and Pi `0.84.2`. If an
+observed client version differs, rerun the manual discovery and invocation
+checks before updating these baseline versions.
 
 ---
 

--- a/docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md
+++ b/docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md
@@ -11,11 +11,16 @@ priority: "low"
 
 ## Why this exists
 
-Describe the problem and its impact.
+`docs/agent-setup-inventory.md` says that OpenCode installs no plugins through
+`plugin[]`, while `home/private_dot_config/opencode/opencode.json.tmpl` installs
+the Compound Engineering plugin there. The contradiction makes the manual
+reinstall inventory unreliable.
 
 ## Scope
 
-Define the work that resolves this issue.
+Update the OpenCode plugin inventory to match the managed `plugin[]` value and
+state that chezmoi owns the configuration. Keep the inventory's bundle-level
+listing rule instead of enumerating the plugin's internal skills and agents.
 
 ## Open decisions
 

--- a/docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md
+++ b/docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md
@@ -1,0 +1,22 @@
+---
+title: "Correct OpenCode plugin inventory drift"
+short_description: "The inventory says OpenCode installs no plugin through plugin[], but the managed opencode.json installs Compound Engineering there."
+type: "follow-up"
+category: "agent-platform"
+tags: ["inventory","opencode"]
+date: "2026-08-23"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-23-004-update-writing-style-template-assertions.md
+++ b/docs/issues/2026-08-23-004-update-writing-style-template-assertions.md
@@ -22,8 +22,8 @@ assertions block unrelated template changes from getting a green baseline.
 
 Update the source-render and deployed-file assertions for the Claude output
 style, Pi `APPEND_SYSTEM`, and shared agent writing-style file to check a stable
-heading from the current canonical template. Keep all three adapters covered
-without changing the writing-style content as part of this fix.
+substantive rule from the current canonical template. Keep all three adapters
+covered without changing the writing-style content as part of this fix.
 
 ## Open decisions
 

--- a/docs/issues/2026-08-23-004-update-writing-style-template-assertions.md
+++ b/docs/issues/2026-08-23-004-update-writing-style-template-assertions.md
@@ -1,0 +1,34 @@
+---
+title: "Update writing-style template assertions"
+short_description: "Six template and smoke assertions required a sentence removed from the shared writing-style template, blocking both Docker verification targets on origin/main."
+type: "bug"
+category: "testing-ci"
+tags: ["regression","templates"]
+date: "2026-08-23"
+status: "done"
+priority: "medium"
+closed: "2026-08-23"
+---
+
+## Why this exists
+
+`make test-templates` and `make test-ubuntu` fail in six existing cases because
+`tests/templates.bats` and `tests/smoke.bats` still require `Answer first: the
+conclusion is line one.`, which no longer exists in
+`home/.chezmoitemplates/writing-style.md` on `origin/main`. The stale
+assertions block unrelated template changes from getting a green baseline.
+
+## Scope
+
+Update the source-render and deployed-file assertions for the Claude output
+style, Pi `APPEND_SYSTEM`, and shared agent writing-style file to check a stable
+heading from the current canonical template. Keep all three adapters covered
+without changing the writing-style content as part of this fix.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Updated all six shared writing-style rendering and deployment assertions to a substantive rule sentence from the current canonical template. `make test-templates` passes all 43 template tests, and `make test-ubuntu` passes all 368 post-apply tests with the expected environment-specific skips.

--- a/docs/plans/2026-08-23-001-feat-preserve-explicit-only-skills-across-agent-clients-plan.md
+++ b/docs/plans/2026-08-23-001-feat-preserve-explicit-only-skills-across-agent-clients-plan.md
@@ -1,0 +1,262 @@
+---
+title: Preserve Explicit-Only Skills Across Agent Clients - Plan
+type: feat
+date: 2026-08-23
+topic: preserve-explicit-only-skills-across-agent-clients
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+source_issue: docs/issues/2026-08-23-001-preserve-explicit-only-skills-across-agent-clients.md
+deepened: 2026-08-23
+---
+
+# Preserve Explicit-Only Skills Across Agent Clients - Plan
+
+## Goal Capsule
+
+- **Objective:** Give explicit-only workflows one reusable source while preserving manual-only invocation in Claude Code, OpenCode, and Pi.
+- **Product authority:** This Product Contract governs scope; the source issue records its provenance.
+- **Product Contract preservation:** Clarified without scope change; planning resolved the deferred template layout and test placement.
+- **Execution profile:** Three ordered units: package the workflows, protect the invocation contract, then document the convention.
+- **Stop conditions:** Stop if raw includes cannot preserve the current workflow bodies, OpenCode commands become model-discoverable, or the managed startup flags no longer control OpenCode skill discovery.
+- **Tail ownership:** The implementation owner runs the disposable-home verification and leaves the requirements, adapters, tests, and documentation consistent.
+
+---
+
+## Product Contract
+
+### Summary
+
+Create a reusable chezmoi template mechanism for workflows that must run only after a user request.
+Migrate `eli5` and `open-questions` so Claude Code and Pi receive skills while OpenCode receives manual commands rather than model-discoverable skills.
+
+### Problem Frame
+
+`eli5` and `open-questions` interrupt the current task, so automatic model invocation would violate their purpose.
+Claude Code and Pi honor `disable-model-invocation: true`, but OpenCode does not interpret that metadata.
+This repository already disables OpenCode's automatic import of Claude Code and other external skills, so OpenCode sees only skills deliberately exposed through its native skill paths.
+Copying workflow instructions into OpenCode commands would preserve invocation behavior but create independent content that can drift.
+
+### Key Decisions
+
+- **Share each workflow's description and body through chezmoi templates.** (session-settled: user-approved — chosen over treating the complete Claude Code skill as canonical: client-specific metadata must not leak into the shared content.) Governs R1, R2.
+- **Provide a reusable template library rather than a two-workflow patch.** (session-settled: user-directed — chosen over supporting only `eli5` and `open-questions`: future explicit-only workflows must follow the same packaging contract.) Governs R3.
+- **Keep the mechanism template-based rather than manifest-generated.** (session-settled: user-approved — chosen over a registry and generator: visible adapters are easier to maintain and diagnose.) Governs R3, R4, R6.
+- **Keep Pi's native skill invocation.** (session-settled: user-approved — chosen over separate Pi prompt templates: Pi already honors the shared Claude Code skill metadata.) Governs R5.
+- **Document the convention in active agent guidance and the setup inventory.** (session-settled: user-approved — chosen over an Architecture Decision Record alone: future agents must encounter the rule during ordinary work.) Governs R9.
+- **Use one focused contract test.** (session-settled: user-approved — chosen over per-client integration and rendered-content parity tests: the test should protect invocation boundaries without retesting client runtimes.) Governs R10.
+
+### Requirements
+
+**Canonical content and reuse**
+
+- R1. Each explicit-only workflow must have one canonical description and one canonical instruction body shared by its Claude Code skill and OpenCode command; Pi consumes the Claude Code skill.
+- R2. Client-facing files may add invocation metadata, but they must not maintain independent copies of the shared description or instruction body or alter literal Markdown and command syntax unintentionally.
+- R3. The mechanism must support another explicit-only workflow through the same template convention without adding a manifest, custom generator, or new packaging architecture.
+
+**Client behavior**
+
+- R4. Claude Code must receive each workflow as a skill with `disable-model-invocation: true`.
+- R5. Pi must continue reading shared Claude Code skills and invoking these workflows through `/skill:<name>`.
+- R6. OpenCode must receive each workflow as a manually invoked command and must not receive a corresponding native skill adapter.
+- R7. The existing OpenCode startup environment that disables automatic Claude Code and external skill discovery must remain part of the explicit-only packaging contract.
+
+```mermaid
+flowchart TB
+  S[Shared description and body] --> C[Claude Code skill adapter]
+  C --> CS[Claude Code skill]
+  CS --> P[Pi skill invocation]
+  S --> O[OpenCode command adapter]
+  O --> OC[OpenCode manual command]
+  F[Existing external-skill disable flags] --> D[Claude skill import disabled in OpenCode]
+```
+
+**Migration, guidance, and verification**
+
+- R8. `eli5` and `open-questions` must migrate without changing their workflow instructions, Claude Code invocation, or Pi invocation; OpenCode gains the new manual commands.
+- R9. `AGENTS.md` and `docs/agent-setup-inventory.md` must explain ownership, client packaging, and the update procedure for explicit-only workflows.
+- R10. One focused Bats contract case must verify the OpenCode manual commands, reject corresponding OpenCode native skill adapters, preserve `disable-model-invocation: true` in the Claude Code skills, and retain the existing external-skill disable flags; existing tests continue to own general Claude Code deployment and Pi shared-skill configuration.
+
+### Key Flows
+
+- F1. Add or update an explicit-only workflow.
+  - **Trigger:** A contributor changes an existing explicit-only workflow or adds another one.
+  - **Steps:** The contributor changes the canonical description and body, adds or updates the client adapters, and keeps the workflow out of OpenCode's native skill paths.
+  - **Outcome:** Every supported client receives the same workflow content with its required invocation semantics.
+  - **Covers:** R1-R9.
+- F2. Invoke an explicit-only workflow.
+  - **Trigger:** The user explicitly selects the workflow in an agent client.
+  - **Steps:** Claude Code or Pi loads the skill, while OpenCode expands the manual command.
+  - **Outcome:** The workflow runs only after the user's request and receives the canonical instruction body.
+  - **Covers:** R4-R7.
+
+### Acceptance Examples
+
+- AE1. **Covers R1, R2, R8.** Given `eli5` is packaged for Claude Code and OpenCode, when its canonical body changes, then both rendered client files receive that change without editing two instruction bodies or unintentionally expanding literal command syntax.
+- AE2. **Covers R4-R7.** Given OpenCode inherits the managed startup environment, when each client discovers available workflows, then Claude Code and Pi retain explicit-only skill behavior while OpenCode exposes a manual command without exposing a native `eli5` or `open-questions` skill.
+- AE3. **Covers R3, R9.** Given a future explicit-only workflow, when an agent follows the repository guidance, then the workflow uses the same shared-template and client-adapter convention without introducing a generator.
+- AE4. **Covers R10.** Given the repository test suite, when an invocation guard, OpenCode command, OpenCode skill boundary, or external-skill disable flag regresses, then the focused contract case fails.
+
+### Scope Boundaries
+
+- Do not add Pi prompt templates or rename Pi invocation commands.
+- Do not add a workflow manifest, schema, or custom generator.
+- Do not run Claude Code, OpenCode, or Pi as part of the new test.
+- Do not add rendered-content parity tests or duplicate existing Claude Code and Pi deployment assertions.
+- Do not change the behavior or wording of `eli5` and `open-questions` except for final-newline normalization required by templates.
+
+### Dependencies and Assumptions
+
+- Supported OpenCode sessions inherit the managed zsh startup environment containing `OPENCODE_DISABLE_EXTERNAL_SKILLS` and `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS`.
+- OpenCode continues to honor those flags when discovering skills.
+- OpenCode commands remain user-invoked and are not included in the model's available-skills context.
+- Pi continues to honor `disable-model-invocation: true` and the configured `~/.claude/skills` source.
+- Chezmoi templates can render the shared description and body into both client-specific formats.
+
+### Sources and Research
+
+- `home/private_dot_claude/skills/eli5/SKILL.md` and `home/private_dot_claude/skills/open-questions/SKILL.md` define the current workflows.
+- `home/dot_pi/agent/modify_settings.json` configures Pi to read `~/.claude/skills`.
+- `home/dot_zshenv.tmpl` disables OpenCode discovery of Claude Code and external skills.
+- `home/private_dot_config/opencode/skills/` demonstrates the repository's curated native-skill exposure pattern.
+- `tests/smoke.bats` and `tests/scripts.bats` contain the existing Claude Code deployment and Pi shared-skill checks.
+- OpenCode skill discovery and command behavior were verified against [`anomalyco/opencode@3a31c4e`](https://github.com/anomalyco/opencode/tree/3a31c4ea801915c0b050df4b3842997ea62b6e93).
+- Pi skill metadata and manual invocation were verified against [`earendil-works/pi@309b524`](https://github.com/earendil-works/pi/tree/309b524f4fc10ad7005c8ff41d834203b8d37121).
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Use four flat canonical files under `home/.chezmoitemplates/`.** Store one description text file and one Markdown body file for each workflow, named with an `explicit-only-<workflow>-` prefix. Each adapter passes the explicit source-root-relative `.chezmoitemplates/<file>` path to chezmoi's raw `include` function, because raw inclusion preserves literal Go-template and command syntax. (session-settled: user-approved — chosen over treating the complete Claude Code skill as canonical: client-specific metadata must not leak into shared content.) Governs R1-R3, R8.
+- KTD2. **Render thin native adapters for Claude Code and OpenCode.** Rename each Claude `SKILL.md` source to `SKILL.md.tmpl`, add one OpenCode command template per workflow, remove one final newline from the raw shared description before YAML quoting it, and raw-include the shared body. Pi receives no adapter because it consumes the deployed Claude Code skill. (session-settled: user-approved — chosen over a registry and generator: visible adapters are easier to maintain and diagnose.) Governs R1-R6, R8.
+- KTD3. **Keep OpenCode isolation at the existing startup boundary.** Preserve both discovery-disable exports in `home/dot_zshenv.tmpl` and do not add OpenCode skill symlinks or direct skill directories for these workflows. Per-skill permissions are unnecessary because the managed environment already disables Claude Code and external skill import. Governs R6, R7.
+- KTD4. **Protect the deployed invocation contract with one smoke case.** Add one loop-based case to `tests/smoke.bats` that checks both workflows after chezmoi applies the checkout in a disposable home. This catches deployment-path errors that source rendering alone cannot prove. (session-settled: user-approved — chosen over per-client integration and rendered-content parity tests: the test protects invocation boundaries without retesting client runtimes.) Governs R10.
+
+### High-Level Technical Design
+
+The canonical files are data even though they live under `.chezmoitemplates`: adapters read them with `include`, which returns literal contents. `includeTemplate` remains appropriate for existing shared content that intentionally executes Go-template syntax, but it is not used for explicit-only workflow bodies.
+
+The Claude Code adapter owns `name`, the YAML-quoted shared description, and `disable-model-invocation: true`. The OpenCode adapter owns only command frontmatter plus the same shared description and body. Pi continues through `home/dot_pi/agent/modify_settings.json` without a file change.
+
+OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents automatic external skill discovery, while the absence of `eli5` and `open-questions` under OpenCode's native skill directory prevents deliberate model exposure. The manual command directory remains outside the model's available-skills context.
+
+### System-Wide Impact
+
+- **Deployment propagation:** Claude Code receives each rendered skill, Pi reaches the same deployed skill through its configured shared path, and OpenCode receives an additive manual command. No existing target path changes for Claude Code or Pi.
+- **Failure propagation:** An invalid Claude adapter disables the workflow in Claude Code and Pi. An invalid OpenCode adapter affects only OpenCode. A canonical-content or chezmoi rendering failure can affect both adapters in one apply.
+- **Fail-open boundary:** If an OpenCode process does not inherit both discovery-disable exports, it can scan the deployed Claude skills and ignore `disable-model-invocation: true`. The absence of a native OpenCode skill adapter does not contain that separate import path.
+- **Process lifecycle:** Chezmoi updates files but cannot change an existing process environment or discovery cache. Operators must restart affected clients from the managed zsh environment before evaluating the new commands or skill visibility.
+- **Compatibility:** The change adds no persistent state, API, or Pi-specific adapter. Claude Code and Pi keep their current skill names and invocation paths.
+
+### Risks and Mitigations
+
+- **Client behavior churn:** OpenCode and Pi are unpinned Homebrew dependencies. Treat OpenCode commit `3a31c4e` with local version `1.18.20`, and Pi commit `309b524` with local version `0.84.2`, as the verified baselines. Revalidate discovery flags, command visibility, Pi filtering, and explicit Pi invocation when either client changes these areas.
+- **Environment inheritance:** The smoke case proves the deployed exports, not the environment of every launcher. Limit support to sessions started through the managed zsh environment and state this boundary in contributor guidance.
+- **Chezmoi path semantics:** Raw `include` resolves relative paths from the source root rather than `.chezmoitemplates`. Require explicit `.chezmoitemplates/<file>` paths and retain both template rendering and disposable-home application gates.
+- **Cached discovery state:** A running client may retain stale commands or skills after apply. Require a client restart before manual verification and do not treat stale live state as a packaging failure.
+
+### Implementation Constraints
+
+- Keep the current `eli5` and `open-questions` wording byte-equivalent after rendering, apart from final-newline normalization required by templates.
+- Keep descriptions valid YAML scalars by removing one final newline from the included text and quoting the result in both adapters.
+- Treat `$ARGUMENTS`, `$<digits>`, and unquoted `@path` in canonical bodies as reserved OpenCode command syntax. Use them only for intentional OpenCode expansion; a workflow that must preserve those sequences literally requires client-specific content and does not fit this shared-body mechanism.
+- Do not modify `home/dot_pi/agent/modify_settings.json`; `tests/scripts.bats` already proves that Pi retains `~/.claude/skills` and does so idempotently.
+- Do not add `permission.skill` entries to `home/private_dot_config/opencode/opencode.json.tmpl`.
+- Do not resolve the unrelated OpenCode plugin inventory drift in this work; it is tracked by `docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md`.
+
+### Sequencing
+
+1. Complete U1 so chezmoi has canonical content and both client adapters.
+2. Complete U2 against U1's deployed paths and metadata.
+3. Complete U3 after the final adapter and test conventions are stable.
+
+### Research
+
+- Existing raw shared rendering uses named templates in `home/.chezmoitemplates/writing-style.md` and thin adapters in `home/private_dot_config/agents/writing-style.md.tmpl`, `home/private_dot_claude/output-styles/writing-style.md.tmpl`, and `home/dot_pi/agent/APPEND_SYSTEM.md.tmpl`.
+- Chezmoi documents [`include`](https://www.chezmoi.io/reference/templates/functions/include/) as returning literal file contents and [`includeTemplate`](https://www.chezmoi.io/reference/templates/functions/includeTemplate/) as executing the included contents.
+- Local planning baselines are chezmoi `2.72.0`, OpenCode `1.18.20`, and Pi `0.84.2`.
+- OpenCode's [command documentation](https://opencode.ai/docs/commands) and source at commit `3a31c4e` separate command loading from model-visible `SKILL.md` discovery.
+- Pi's [skill documentation](https://github.com/earendil-works/pi/blob/309b524f4fc10ad7005c8ff41d834203b8d37121/packages/coding-agent/docs/skills.md) documents `disable-model-invocation` filtering and `/skill:<name>` invocation.
+- `tests/smoke.bats` verifies deployed homes, while `tests/templates.bats` demonstrates that checkout templates must render with the checkout passed as chezmoi's source.
+- `docs/solutions/design-patterns/skip-set-parity-proves-reduced-dependencies.md` establishes that a green source-level check does not replace verification through the complete apply path.
+
+---
+
+## Implementation Units
+
+### U1. Canonical explicit-only content and client adapters
+
+- **Goal:** Move `eli5` and `open-questions` to literal shared content with thin Claude Code and OpenCode adapters.
+- **Requirements:** R1-R8; F1, F2; AE1-AE3; KTD1-KTD3.
+- **Dependencies:** None.
+- **Files:**
+  - Add `home/.chezmoitemplates/explicit-only-eli5-description.txt`.
+  - Add `home/.chezmoitemplates/explicit-only-eli5-body.md`.
+  - Add `home/.chezmoitemplates/explicit-only-open-questions-description.txt`.
+  - Add `home/.chezmoitemplates/explicit-only-open-questions-body.md`.
+  - Rename `home/private_dot_claude/skills/eli5/SKILL.md` to `home/private_dot_claude/skills/eli5/SKILL.md.tmpl` and convert it to a thin adapter.
+  - Rename `home/private_dot_claude/skills/open-questions/SKILL.md` to `home/private_dot_claude/skills/open-questions/SKILL.md.tmpl` and convert it to a thin adapter.
+  - Add `home/private_dot_config/opencode/commands/eli5.md.tmpl`.
+  - Add `home/private_dot_config/opencode/commands/open-questions.md.tmpl`.
+- **Approach:** Extract each existing description and post-frontmatter body without semantic edits. Remove one final newline from each included description before YAML quoting it. Raw-include each canonical body through its explicit `.chezmoitemplates/<file>` path, keep client metadata local, confirm that reserved OpenCode command tokens occur only where expansion is intentional, and preserve the existing OpenCode discovery exports unchanged.
+- **Test scenarios:**
+  - Both Claude adapters render as `SKILL.md` files with their original names, descriptions, bodies, and `disable-model-invocation: true`.
+  - Both OpenCode adapters render as manual command files with the shared descriptions and bodies.
+  - Literal `{{ ... }}` text remains unchanged, while `$ARGUMENTS`, `$<digits>`, and unquoted `@path` appear only where OpenCode expansion is intentional.
+  - Pi still receives both workflows through the unchanged shared Claude skill path.
+- **Verification:** `make test-local`, then U2's disposable-home contract case.
+
+### U2. Deployed explicit-only invocation contract
+
+- **Goal:** Add one focused regression case that proves the invocation boundaries after chezmoi applies the checkout.
+- **Requirements:** R4-R7, R10; AE2, AE4; KTD3, KTD4.
+- **Dependencies:** U1.
+- **Files:** Modify `tests/smoke.bats`.
+- **Approach:** Add one `explicit-only` Bats case that loops over `eli5` and `open-questions`. For each name, assert the deployed Claude skill retains `disable-model-invocation: true`, the deployed OpenCode command exists, and no corresponding OpenCode native skill path exists. In the same case, assert the deployed `.zshenv` contains both OpenCode discovery-disable exports. Treat process inheritance and cache refresh as operational preconditions rather than claims made by this test.
+- **Test scenarios:**
+  - Removing either Claude invocation guard fails the case.
+  - Omitting either OpenCode command fails the case.
+  - Adding either workflow under OpenCode's native skill path fails the case.
+  - Removing either discovery-disable export fails the case.
+  - The existing Pi modifier tests remain unchanged and green.
+- **Verification:** Run the focused case inside the disposable environment when available, then run `make test-ubuntu` as the authoritative check.
+
+### U3. Explicit-only contributor guidance
+
+- **Goal:** Make the reusable packaging and update procedure discoverable to future agents and operators.
+- **Requirements:** R3, R9; F1; AE3; KTD1-KTD3.
+- **Dependencies:** U1, U2.
+- **Files:** Modify `AGENTS.md` and `docs/agent-setup-inventory.md`.
+- **Approach:** Add an active instruction for explicit-only workflows near the existing managed-config guidance. Document canonical content ownership, raw includes, reserved OpenCode command tokens, thin client adapters, Pi's shared-skill path, OpenCode's manual command path, the prohibition on native OpenCode skill adapters, the fail-open discovery flags, the restart requirement, and the focused contract test. Require maintainers who observe an OpenCode or Pi version change from the documented baseline to rerun the manual discovery and invocation checks before updating the baseline. Add an OpenCode Commands inventory section without resolving unrelated inventory drift tracked in `docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md`.
+- **Test scenarios:**
+  - A future agent can identify every source file required to add an explicit-only workflow without reading this plan.
+  - The inventory describes `eli5` and `open-questions` consistently across Claude Code, OpenCode, and Pi.
+  - The guidance distinguishes raw `include` from executable `includeTemplate` and explains why explicit-only bodies use the former.
+- **Verification:** Review both documents against U1's final paths, then run `make test-issues`.
+
+---
+
+## Verification Contract
+
+| Command | Applies to | Required result |
+|---|---|---|
+| `make test-issues` | U3 and repository issue integrity | Issue validation and issue CLI tests pass. |
+| `make test-local` | U1 | Chezmoi reports the intended dry-run changes without applying them to the host. |
+| `make test-templates` | U1 | Templates render successfully from the checkout source in Docker. |
+| `make test-ubuntu` | U1-U3 | The checkout applies in a disposable home and the complete Ubuntu suite passes, including the focused explicit-only contract case. |
+
+`make test-suite` is not evidence for U1 or U2 because it reads the already-applied host home and cannot observe unapplied files under `home/`.
+
+---
+
+## Definition of Done
+
+- The Product Contract remains satisfied without changing R1-R10, F1-F2, or AE1-AE4 semantics.
+- U1 renders both workflows from one canonical description and body per workflow into Claude Code skills and OpenCode commands.
+- U2 fails on each load-bearing invocation-boundary regression and passes through `make test-ubuntu`.
+- U3 gives future agents a complete update procedure in active instructions and the setup inventory.
+- All commands in the Verification Contract pass with no unreported skips.
+- The final diff contains no duplicate workflow bodies, OpenCode native skill adapters, manifest, generator, Pi prompt template, per-skill OpenCode permission, or abandoned experimental files.

--- a/docs/plans/2026-08-23-001-feat-preserve-explicit-only-skills-across-agent-clients-plan.md
+++ b/docs/plans/2026-08-23-001-feat-preserve-explicit-only-skills-across-agent-clients-plan.md
@@ -62,41 +62,11 @@ Copying workflow instructions into OpenCode commands would preserve invocation b
 - R6. OpenCode must receive each workflow as a manually invoked command and must not receive a corresponding native skill adapter.
 - R7. The existing OpenCode startup environment that disables automatic Claude Code and external skill discovery must remain part of the explicit-only packaging contract.
 
-```mermaid
-flowchart TB
-  S[Shared description and body] --> C[Claude Code skill adapter]
-  C --> CS[Claude Code skill]
-  CS --> P[Pi skill invocation]
-  S --> O[OpenCode command adapter]
-  O --> OC[OpenCode manual command]
-  F[Existing external-skill disable flags] --> D[Claude skill import disabled in OpenCode]
-```
-
 **Migration, guidance, and verification**
 
 - R8. `eli5` and `open-questions` must migrate without changing their workflow instructions, Claude Code invocation, or Pi invocation; OpenCode gains the new manual commands.
 - R9. `AGENTS.md` and `docs/agent-setup-inventory.md` must explain ownership, client packaging, and the update procedure for explicit-only workflows.
 - R10. One focused Bats contract case must verify the OpenCode manual commands, reject corresponding OpenCode native skill adapters, preserve `disable-model-invocation: true` in the Claude Code skills, and retain the existing external-skill disable flags; existing tests continue to own general Claude Code deployment and Pi shared-skill configuration.
-
-### Key Flows
-
-- F1. Add or update an explicit-only workflow.
-  - **Trigger:** A contributor changes an existing explicit-only workflow or adds another one.
-  - **Steps:** The contributor changes the canonical description and body, adds or updates the client adapters, and keeps the workflow out of OpenCode's native skill paths.
-  - **Outcome:** Every supported client receives the same workflow content with its required invocation semantics.
-  - **Covers:** R1-R9.
-- F2. Invoke an explicit-only workflow.
-  - **Trigger:** The user explicitly selects the workflow in an agent client.
-  - **Steps:** Claude Code or Pi loads the skill, while OpenCode expands the manual command.
-  - **Outcome:** The workflow runs only after the user's request and receives the canonical instruction body.
-  - **Covers:** R4-R7.
-
-### Acceptance Examples
-
-- AE1. **Covers R1, R2, R8.** Given `eli5` is packaged for Claude Code and OpenCode, when its canonical body changes, then both rendered client files receive that change without editing two instruction bodies or unintentionally expanding literal command syntax.
-- AE2. **Covers R4-R7.** Given OpenCode inherits the managed startup environment, when each client discovers available workflows, then Claude Code and Pi retain explicit-only skill behavior while OpenCode exposes a manual command without exposing a native `eli5` or `open-questions` skill.
-- AE3. **Covers R3, R9.** Given a future explicit-only workflow, when an agent follows the repository guidance, then the workflow uses the same shared-template and client-adapter convention without introducing a generator.
-- AE4. **Covers R10.** Given the repository test suite, when an invocation guard, OpenCode command, OpenCode skill boundary, or external-skill disable flag regresses, then the focused contract case fails.
 
 ### Scope Boundaries
 
@@ -167,12 +137,6 @@ OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents au
 - Do not add `permission.skill` entries to `home/private_dot_config/opencode/opencode.json.tmpl`.
 - Do not resolve the unrelated OpenCode plugin inventory drift in this work; it is tracked by `docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md`.
 
-### Sequencing
-
-1. Complete U1 so chezmoi has canonical content and both client adapters.
-2. Complete U2 against U1's deployed paths and metadata.
-3. Complete U3 after the final adapter and test conventions are stable.
-
 ### Research
 
 - Existing raw shared rendering uses named templates in `home/.chezmoitemplates/writing-style.md` and thin adapters in `home/private_dot_config/agents/writing-style.md.tmpl`, `home/private_dot_claude/output-styles/writing-style.md.tmpl`, and `home/dot_pi/agent/APPEND_SYSTEM.md.tmpl`.
@@ -190,7 +154,7 @@ OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents au
 ### U1. Canonical explicit-only content and client adapters
 
 - **Goal:** Move `eli5` and `open-questions` to literal shared content with thin Claude Code and OpenCode adapters.
-- **Requirements:** R1-R8; F1, F2; AE1-AE3; KTD1-KTD3.
+- **Requirements:** R1-R8; KTD1-KTD3.
 - **Dependencies:** None.
 - **Files:**
   - Add `home/.chezmoitemplates/explicit-only-eli5-description.txt`.
@@ -212,7 +176,7 @@ OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents au
 ### U2. Deployed explicit-only invocation contract
 
 - **Goal:** Add one focused regression case that proves the invocation boundaries after chezmoi applies the checkout.
-- **Requirements:** R4-R7, R10; AE2, AE4; KTD3, KTD4.
+- **Requirements:** R4-R7, R10; KTD3, KTD4.
 - **Dependencies:** U1.
 - **Files:** Modify `tests/smoke.bats`.
 - **Approach:** Add one `explicit-only` Bats case that loops over `eli5` and `open-questions`. For each name, assert the deployed Claude skill retains `disable-model-invocation: true`, the deployed OpenCode command exists, and no corresponding OpenCode native skill path exists. In the same case, assert the deployed `.zshenv` contains both OpenCode discovery-disable exports. Treat process inheritance and cache refresh as operational preconditions rather than claims made by this test.
@@ -227,7 +191,7 @@ OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents au
 ### U3. Explicit-only contributor guidance
 
 - **Goal:** Make the reusable packaging and update procedure discoverable to future agents and operators.
-- **Requirements:** R3, R9; F1; AE3; KTD1-KTD3.
+- **Requirements:** R3, R9; KTD1-KTD3.
 - **Dependencies:** U1, U2.
 - **Files:** Modify `AGENTS.md` and `docs/agent-setup-inventory.md`.
 - **Approach:** Add an active instruction for explicit-only workflows near the existing managed-config guidance. Document canonical content ownership, raw includes, reserved OpenCode command tokens, thin client adapters, Pi's shared-skill path, OpenCode's manual command path, the prohibition on native OpenCode skill adapters, the fail-open discovery flags, the restart requirement, and the focused contract test. Require maintainers who observe an OpenCode or Pi version change from the documented baseline to rerun the manual discovery and invocation checks before updating the baseline. Add an OpenCode Commands inventory section without resolving unrelated inventory drift tracked in `docs/issues/2026-08-23-003-correct-opencode-plugin-inventory-drift.md`.
@@ -241,20 +205,13 @@ OpenCode isolation has two independent parts. `home/dot_zshenv.tmpl` prevents au
 
 ## Verification Contract
 
-| Command | Applies to | Required result |
-|---|---|---|
-| `make test-issues` | U3 and repository issue integrity | Issue validation and issue CLI tests pass. |
-| `make test-local` | U1 | Chezmoi reports the intended dry-run changes without applying them to the host. |
-| `make test-templates` | U1 | Templates render successfully from the checkout source in Docker. |
-| `make test-ubuntu` | U1-U3 | The checkout applies in a disposable home and the complete Ubuntu suite passes, including the focused explicit-only contract case. |
-
-`make test-suite` is not evidence for U1 or U2 because it reads the already-applied host home and cannot observe unapplied files under `home/`.
+Run `make test-issues`, `make test-local`, `make test-templates`, and `make test-ubuntu`. Do not use `make test-suite` as managed-file evidence because it reads the already-applied host home.
 
 ---
 
 ## Definition of Done
 
-- The Product Contract remains satisfied without changing R1-R10, F1-F2, or AE1-AE4 semantics.
+- The Product Contract remains satisfied without changing R1-R10 semantics.
 - U1 renders both workflows from one canonical description and body per workflow into Claude Code skills and OpenCode commands.
 - U2 fails on each load-bearing invocation-boundary regression and passes through `make test-ubuntu`.
 - U3 gives future agents a complete update procedure in active instructions and the setup inventory.

--- a/home/.chezmoitemplates/explicit-only-eli5-body.md
+++ b/home/.chezmoitemplates/explicit-only-eli5-body.md
@@ -1,9 +1,3 @@
----
-name: eli5
-description: Re-explain the last message from zero context — plain words, no session labels, one question at a time.
-disable-model-invocation: true
----
-
 Stop. Your last message did not land. Re-explain it for a reader with zero context: they know nothing about this session, this repo, or any label you invented along the way.
 
 - Plain words, short sentences. Keep the exact technical terms, but explain each one at first use.

--- a/home/.chezmoitemplates/explicit-only-eli5-description.txt
+++ b/home/.chezmoitemplates/explicit-only-eli5-description.txt
@@ -1,0 +1,1 @@
+Re-explain the last message from zero context — plain words, no session labels, one question at a time.

--- a/home/.chezmoitemplates/explicit-only-open-questions-body.md
+++ b/home/.chezmoitemplates/explicit-only-open-questions-body.md
@@ -1,9 +1,3 @@
----
-name: open-questions
-description: Walk every open decision one at a time, in prose — zero context, plain words, each option with its pros and cons and a recommendation.
-disable-model-invocation: true
----
-
 Stop the work. There are open decisions left. Ask them one at a time, in prose, in the language I wrote in.
 
 First, before you write anything: list every open decision for yourself, drop the ones you can settle with a sensible default, and order the rest — what blocks the most work goes first. Do not show me that list; show me question one.

--- a/home/.chezmoitemplates/explicit-only-open-questions-description.txt
+++ b/home/.chezmoitemplates/explicit-only-open-questions-description.txt
@@ -1,0 +1,1 @@
+Walk every open decision one at a time, in prose — zero context, plain words, each option with its pros and cons and a recommendation.

--- a/home/private_dot_claude/skills/eli5/SKILL.md.tmpl
+++ b/home/private_dot_claude/skills/eli5/SKILL.md.tmpl
@@ -1,0 +1,7 @@
+---
+name: eli5
+description: {{ include ".chezmoitemplates/explicit-only-eli5-description.txt" | trimSuffix "\n" | quote }}
+disable-model-invocation: true
+---
+
+{{ include ".chezmoitemplates/explicit-only-eli5-body.md" -}}

--- a/home/private_dot_claude/skills/open-questions/SKILL.md.tmpl
+++ b/home/private_dot_claude/skills/open-questions/SKILL.md.tmpl
@@ -1,0 +1,7 @@
+---
+name: open-questions
+description: {{ include ".chezmoitemplates/explicit-only-open-questions-description.txt" | trimSuffix "\n" | quote }}
+disable-model-invocation: true
+---
+
+{{ include ".chezmoitemplates/explicit-only-open-questions-body.md" -}}

--- a/home/private_dot_config/opencode/commands/eli5.md.tmpl
+++ b/home/private_dot_config/opencode/commands/eli5.md.tmpl
@@ -1,0 +1,5 @@
+---
+description: {{ include ".chezmoitemplates/explicit-only-eli5-description.txt" | trimSuffix "\n" | quote }}
+---
+
+{{ include ".chezmoitemplates/explicit-only-eli5-body.md" -}}

--- a/home/private_dot_config/opencode/commands/open-questions.md.tmpl
+++ b/home/private_dot_config/opencode/commands/open-questions.md.tmpl
@@ -1,0 +1,5 @@
+---
+description: {{ include ".chezmoitemplates/explicit-only-open-questions-description.txt" | trimSuffix "\n" | quote }}
+---
+
+{{ include ".chezmoitemplates/explicit-only-open-questions-body.md" -}}

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -341,7 +341,7 @@ PY
   assert_file_exists "$HOME/.claude/output-styles/writing-style.md"
   run grep -q 'keep-coding-instructions: true' "$HOME/.claude/output-styles/writing-style.md"
   assert_success
-  run grep -q 'Answer first: the conclusion is line one.' "$HOME/.claude/output-styles/writing-style.md"
+  run grep -q 'Start with the useful thing. End when the response has done its job. State each point once.' "$HOME/.claude/output-styles/writing-style.md"
   assert_success
   run grep -q '"outputStyle": "writing-style"' "$HOME/.claude/settings.json"
   assert_success
@@ -349,7 +349,7 @@ PY
 
 @test "pi APPEND_SYSTEM.md carries the full writing-style rules" {
   assert_file_exists "$HOME/.pi/agent/APPEND_SYSTEM.md"
-  run grep -q 'Answer first: the conclusion is line one.' "$HOME/.pi/agent/APPEND_SYSTEM.md"
+  run grep -q 'Start with the useful thing. End when the response has done its job. State each point once.' "$HOME/.pi/agent/APPEND_SYSTEM.md"
   assert_success
 }
 
@@ -384,7 +384,7 @@ PY
 
 @test "opencode reads the shared writing-style file via instructions" {
   assert_file_exists "$HOME/.config/agents/writing-style.md"
-  run grep -q 'Answer first: the conclusion is line one.' "$HOME/.config/agents/writing-style.md"
+  run grep -q 'Start with the useful thing. End when the response has done its job. State each point once.' "$HOME/.config/agents/writing-style.md"
   assert_success
   run grep -q '"~/.config/agents/writing-style.md"' "$HOME/.config/opencode/opencode.json"
   assert_success
@@ -399,6 +399,43 @@ PY
     assert_output "$HOME/.claude/skills/$skill"
     assert_file_exists "$HOME/.config/opencode/skills/$skill/SKILL.md"
   done
+}
+
+@test "explicit-only workflows keep manual invocation boundaries" {
+  local workflow claude_skill opencode_command opencode_skill
+
+  for workflow in eli5 open-questions; do
+    claude_skill="$HOME/.claude/skills/$workflow/SKILL.md"
+    opencode_command="$HOME/.config/opencode/commands/$workflow.md"
+    opencode_skill="$HOME/.config/opencode/skills/$workflow"
+
+    assert_file_exists "$claude_skill"
+    run awk '
+      NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
+      frontmatter && $0 == "---" { frontmatter = 0; closed = 1; next }
+      frontmatter && /^disable-model-invocation:/ { keys++ }
+      frontmatter && $0 == "disable-model-invocation: true" { valid++ }
+      END { exit !(closed && keys == 1 && valid == 1) }
+    ' "$claude_skill"
+    assert_success
+
+    assert_file_exists "$opencode_command"
+    run awk '
+      NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
+      frontmatter && $0 == "---" { frontmatter = 0; closed = 1; next }
+      frontmatter && /^description: ".+"$/ { description = 1 }
+      closed && NF { body = 1 }
+      END { exit !(closed && description && body) }
+    ' "$opencode_command"
+    assert_success
+
+    if [[ -e "$opencode_skill" || -L "$opencode_skill" ]]; then
+      fail "explicit-only workflow exposed as native OpenCode skill: $opencode_skill"
+    fi
+  done
+
+  run zsh -dfc 'unset OPENCODE_DISABLE_EXTERNAL_SKILLS OPENCODE_DISABLE_CLAUDE_CODE_SKILLS; source "$1"; zsh -dfc "$2"' _ "$HOME/.zshenv" '[[ "$OPENCODE_DISABLE_EXTERNAL_SKILLS" == 1 && "$OPENCODE_DISABLE_CLAUDE_CODE_SKILLS" == 1 ]]'
+  assert_success
 }
 
 @test "CLAUDE.md no longer duplicates the Writing style section" {

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -309,20 +309,20 @@ render_with_source() {
   run render_with_source "$SOURCE_ROOT/private_dot_claude/output-styles/writing-style.md.tmpl"
   assert_success
   assert_output --partial 'keep-coding-instructions: true'
-  assert_output --partial 'Answer first: the conclusion is line one.'
+  assert_output --partial 'Start with the useful thing. End when the response has done its job. State each point once.'
 }
 
 @test "pi APPEND_SYSTEM renders the shared writing-style rules" {
   run render_with_source "$SOURCE_ROOT/dot_pi/agent/APPEND_SYSTEM.md.tmpl"
   assert_success
   assert_output --partial '# Writing style'
-  assert_output --partial 'Answer first: the conclusion is line one.'
+  assert_output --partial 'Start with the useful thing. End when the response has done its job. State each point once.'
 }
 
 @test "shared agents/writing-style.md renders the shared rules" {
   run render_with_source "$SOURCE_ROOT/private_dot_config/agents/writing-style.md.tmpl"
   assert_success
-  assert_output --partial 'Answer first: the conclusion is line one.'
+  assert_output --partial 'Start with the useful thing. End when the response has done its job. State each point once.'
 }
 
 @test "opencode instructions point at the shared writing-style file" {


### PR DESCRIPTION
## Summary

`eli5` and `open-questions` now share one canonical instruction source without making these interruptive workflows model-discoverable. Claude Code and Pi retain explicit skill invocation, while OpenCode receives manual commands and no native skill adapters.

The packaging uses raw chezmoi includes so Markdown and command syntax remain literal. A deployed-home contract now rejects missing Claude invocation guards, malformed or empty OpenCode commands, native OpenCode skill exposure, and ineffective discovery-disable exports.

Session-settled decisions carried from planning: shared descriptions and bodies, thin adapters, Pi's shared Claude skill path, active contributor guidance, and a focused contract test (user-approved); a reusable template convention for future explicit-only workflows (user-directed).

## Validation

- `make test-templates`: 43 passed.
- `make test-ubuntu`: 368 cases completed; 355 passed and 13 expected environment-specific cases skipped.
- `make test-issues`: 39 passed.
- `make lint` and `git diff --check`: passed.
- Independent correctness, testing, standards, and adversarial reviews found no remaining issues.

The host `make test-local` dry-run timed out during 1Password-backed rendering. The disposable Docker template and full apply gates passed instead, without applying chezmoi to the host.

## Post-Deploy Monitoring & Validation

No service metrics or logs apply to this dotfiles change. After the normal source-clone sync and `chezmoi apply`, the owner should restart Claude Code, OpenCode, and Pi from managed zsh during the next local setup update.

Healthy signals are deployed `/eli5` and `/open-questions` OpenCode commands, no matching OpenCode native skills, Claude skills with `disable-model-invocation: true`, and both `OPENCODE_DISABLE_*_SKILLS` values exported as `1`. Missing commands or model-visible OpenCode skills are rollback triggers; revert these commits, reapply the previous source, and restart the clients.

## New concepts

### Explicit-only workflow

An explicit-only workflow interrupts the current task, so the user must request it directly. This change separates shared instructions from each client's invocation metadata instead of treating one client's complete skill file as portable.

```mermaid
flowchart TB
  S[Canonical description and body] --> C[Claude skill with invocation disabled]
  C --> P[Pi shared skill path]
  S --> O[OpenCode manual command]
  E[Discovery-disable exports] --> X[No Claude skill import in OpenCode]
```

Use this pattern when automatic invocation would violate the workflow's purpose. Do not use it for ordinary capabilities that agents should discover and invoke autonomously.
