### PR TITLE
fix(herdr): keep visible agent labels stable

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_6-link-herdr-pane-labels.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_6-link-herdr-pane-labels.sh.tmpl
@@ -6,11 +6,14 @@
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh" | sha256sum }}
+# # {{ include "private_dot_config/herdr/config.toml" | sha256sum }}
+# # {{ include "dot_local/bin/executable_herdr-task-sync" | sha256sum }}
 
 # Keep this tolerant: missing Herdr or a stopped server should not make chezmoi apply fail.
 set -u
 
 plugin_dir="$HOME/.config/herdr/plugins/herdr-pane-labels"
+sync="$HOME/.local/bin/herdr-task-sync"
 
 if ! command -v herdr >/dev/null 2>&1; then
   echo "herdr not found; skipping pane-labels plugin link"
@@ -33,6 +36,18 @@ if herdr plugin link "$plugin_dir" >/dev/null 2>&1; then
     echo "Reloaded Herdr config"
   else
     echo "Warning: failed to reload Herdr config; restart Herdr or run: herdr server reload-config" >&2
+  fi
+  if [[ -f "$sync" ]] && command -v jq >/dev/null 2>&1; then
+    while IFS= read -r socket; do
+      [[ -n "$socket" ]] || continue
+      if ! HERDR_SOCKET_PATH="$socket" bash "$sync" --restart-daemon; then
+        echo "Warning: failed to restart pane-label sweep daemon for $socket" >&2
+        continue
+      fi
+      if ! HERDR_SOCKET_PATH="$socket" bash "$sync" --sweep; then
+        echo "Warning: failed to refresh pane labels for $socket" >&2
+      fi
+    done < <(herdr session list --json 2>/dev/null | jq -r '.sessions[]? | select(.running == true) | .socket_path // empty')
   fi
 else
   echo "Warning: failed to link Herdr pane-labels plugin. Run manually: herdr plugin link $plugin_dir" >&2

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -97,7 +97,8 @@ usage() {
   cat >&2 <<'EOF'
 Usage: herdr-task-sync --agent <name> --session <id> [--pane <id>]
                        [--transcript <path>] [--set <name>]
-       herdr-task-sync --event | --sweep | --sweep-daemon | --ensure-daemon
+       herdr-task-sync --event | --sweep | --sweep-daemon
+                       | --ensure-daemon | --restart-daemon
 The prompt is read from stdin.
 EOF
 }
@@ -115,6 +116,7 @@ while [ $# -gt 0 ]; do
     --sweep) mode="sweep"; shift ;;
     --sweep-daemon) mode="sweep-daemon"; shift ;;
     --ensure-daemon) mode="ensure-daemon"; shift ;;
+    --restart-daemon) mode="restart-daemon"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) shift ;;
   esac
@@ -353,7 +355,7 @@ command -v herdr >/dev/null 2>&1 || exit 0
 # starts them runs outside an agent's environment, so they clear the guards
 # below on their own: a reachable herdr CLI is all they need.
 case "$mode" in
-  event | presentation-worker | sweep | sweep-daemon | ensure-daemon) ;;
+  event | presentation-worker | sweep | sweep-daemon | ensure-daemon | restart-daemon) ;;
   *)
     # Every entry point exits silently outside herdr, so the same files apply on
     # Linux/CI without a .chezmoiignore rule.
@@ -474,16 +476,19 @@ import_legacy_state() {
 # rendered as empty boxes on any terminal without a patched font. An agent
 # with no prefix of its own falls back to its first letter.
 pane_label() {
-  local name="$1" slug="$2"
+  local name="$1" slug="$2" prefix
   case "$name" in
-    claude) printf 'cc:%s' "$slug"; return 0 ;;
-    opencode) printf 'oc:%s' "$slug"; return 0 ;;
-    pi) printf 'pi:%s' "$slug"; return 0 ;;
-    codex) printf 'cx:%s' "$slug"; return 0 ;;
+    claude) prefix=cc ;;
+    opencode) prefix=oc ;;
+    pi) prefix=pi ;;
+    codex) prefix=cx ;;
+    *) prefix="$(LC_ALL=C printf '%s' "$name" | cut -c1 | tr '[:upper:]' '[:lower:]')" ;;
   esac
-  printf '%s:%s' \
-    "$(LC_ALL=C printf '%s' "$name" | cut -c1 | tr '[:upper:]' '[:lower:]')" \
-    "$slug"
+  if [ -n "$slug" ]; then
+    printf '%s:%s' "$prefix" "$slug"
+  else
+    printf '%s' "$prefix"
+  fi
 }
 
 # A pane running no agent is named after its command. The name comes from the
@@ -1325,6 +1330,7 @@ EOF
     slug=""
     metadata_seq=0
     if [ -n "$agent_of" ]; then
+      intended="$(pane_label "$agent_of" "")"
       pane="$id"
       control="$(pane_state_dir)/control.state"
       active_agent="$(read_state_field "$control" active_agent)"
@@ -1662,6 +1668,43 @@ ensure_sweep_daemon() {
   return 0
 }
 
+# Deployment replaces the script on disk while its long-lived daemon keeps the
+# old program in memory. Stop only the process that both owns this socket's lock
+# and identifies itself as this script's sweep daemon, then start the new copy.
+restart_sweep_daemon() {
+  local self="$1" pid command tries=0
+  if [ -d "$SWEEP_LOCK_DIR" ]; then
+    pid="$(cat "$SWEEP_LOCK_DIR/pid" 2>/dev/null)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      command="$(ps -p "$pid" -o command= 2>/dev/null)"
+      case "$command" in
+        *"/herdr-task-sync --sweep-daemon" | *"/executable_herdr-task-sync --sweep-daemon")
+          kill -TERM "$pid" 2>/dev/null || return 1
+          ;;
+        *) printf '%s\n' "herdr-task-sync: refusing to stop unrelated sweep lock owner $pid" >&2; return 1 ;;
+      esac
+      while kill -0 "$pid" 2>/dev/null && [ "$tries" -lt 20 ]; do
+        tries=$((tries + 1))
+        sleep 0.1
+      done
+      # Bash defers TERM traps while waiting for the interval's `sleep` child.
+      # The command fingerprint above makes escalation safe and keeps deploys
+      # bounded even when the configured interval is long.
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || return 1
+        while kill -0 "$pid" 2>/dev/null && [ "$tries" -lt 50 ]; do
+          tries=$((tries + 1))
+          sleep 0.1
+        done
+      fi
+      kill -0 "$pid" 2>/dev/null && return 1
+    fi
+    rm -f "$SWEEP_LOCK_DIR/pid" 2>/dev/null
+    rmdir "$SWEEP_LOCK_DIR" 2>/dev/null
+  fi
+  ensure_sweep_daemon "$self"
+}
+
 # Claude Code writes one JSON object per line. Keep user entries that carry
 # real prose: drop meta entries, tool results, and slash-command envelopes.
 transcript_user_entries() {
@@ -1982,7 +2025,7 @@ case "$mode" in
     fi
     SWEEP_LOCK_DIR="$(namespace_dir)/sweep.lock"
     ;;
-  presentation-worker | sweep | sweep-daemon | ensure-daemon)
+  presentation-worker | sweep | sweep-daemon | ensure-daemon | restart-daemon)
     if [ -z "$SOCKET_PATH" ]; then
       printf '%s\n' 'herdr-task-sync: presentation skipped without HERDR_SOCKET_PATH' >&2
       exit 0
@@ -2018,6 +2061,10 @@ case "$mode" in
   ensure-daemon)
     ensure_sweep_daemon "$(script_path)"
     exit 0
+    ;;
+  restart-daemon)
+    restart_sweep_daemon "$(script_path)"
+    exit $?
     ;;
 esac
 

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -54,13 +54,12 @@ prompt_new_tab_name = false
 sidebar_min_width = 32
 
 # The `pane` row renders the pane label, which herdr-task-sync
-# (~/.local/bin/herdr-task-sync) sets to `<agent-prefix>:<task-slug>`. The same
-# script rebuilds each tab label from the labels of its panes. The second row
-# is the combined Git location token (place icon + ref + optional folder
-# qualifier + stale suffix icon); herdr 0.8 collapses the row entirely for
-# non-Git panes because the token is empty.
+# (~/.local/bin/herdr-task-sync) sets to `<agent-prefix>:<task-slug>`, or to the
+# prefix alone until a task slug exists. The same script rebuilds each tab label
+# from the labels of its panes. Repository and branch metadata remain available
+# to integrations, but are not rendered in the agent sidebar.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace", "pane"], ["$git_ref"]]
+rows = [["state_icon", "workspace", "pane"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -2013,6 +2013,21 @@ SH
   assert_equal "$(jq -r '.panes[0].label' "$state")" pi:session-path-task
 }
 
+@test "herdr-task-sync presentation labels a detected agent without task state" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  hts_set_pane "$HTS_DEFAULT_SOCKET" '{"pane_id":"pane-1","tab_id":"tab-1","workspace_id":"ws-1","terminal_id":"term-1","agent":"claude","agent_session":{"agent":"claude","kind":"id","value":"untracked"},"label":"~","tokens":{}}'
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":"~"}'
+
+  hts_event_run
+  hts_wait_for_presentation_quiescence "$HTS_DEFAULT_SOCKET"
+
+  local state
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].label' "$state")" cc
+  assert_equal "$(jq -r '.tabs[0].label' "$state")" cc
+}
+
 @test "herdr-task-sync presentation publishes only the newest accepted generation" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
@@ -3763,7 +3778,7 @@ SH
 }
 
 # Herdr keeps one label per tab and composes nothing itself. The engine joins
-# the labels of the tab's own agent panes; another tab's panes stay out.
+# normalized labels for the tab's own agent panes; another tab's panes stay out.
 @test "herdr-task-sync rebuilds the tab label from the pane labels" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
@@ -3776,7 +3791,7 @@ SH
   hts_run --agent claude --session s1 <<< 'review the cache layer please'
   hts_wait_for_call 'tab rename'
   run grep -m1 '^tab rename' "$HTS_LOG"
-  assert_output "tab rename tab-1 cc:cache-review · second"
+  assert_output "tab rename tab-1 cc:cache-review · pi · oc"
 }
 
 # A pane with no agent is named after its command. The name belongs to the
@@ -3958,6 +3973,47 @@ SH
   local pid; pid="$(cat "$sweep_lock/pid" 2>/dev/null)"
   [ -n "$pid" ] && [ "$pid" != "999999" ]
   kill "$pid" 2>/dev/null || true
+}
+
+@test "herdr-task-sync --restart-daemon replaces a live daemon" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  hts_tab_list '{"result":{"tabs":[{"tab_id":"tab-1","label":"1"}]}}'
+  hts_pane_list '{"result":{"panes":[
+    {"pane_id":"pane-1","tab_id":"tab-1","agent":"claude","label":"agent-label"}]}}'
+  local sweep_lock="$(hts_namespace "$HTS_DEFAULT_SOCKET")/sweep.lock" old_pid new_pid i
+  HTS_SWEEP_INTERVAL=30 hts_sweep_run --ensure-daemon
+  hts_wait_for_file "$sweep_lock/pid"
+  old_pid="$(cat "$sweep_lock/pid")"
+
+  HTS_SWEEP_INTERVAL=30 run hts_sweep_run --restart-daemon
+  assert_success
+  for i in $(seq 1 "$HTS_WAIT_POLLS"); do
+    new_pid="$(cat "$sweep_lock/pid" 2>/dev/null || true)"
+    [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ] && break
+    sleep 0.01
+  done
+
+  [ -n "$new_pid" ]
+  [ "$new_pid" != "$old_pid" ]
+  ! kill -0 "$old_pid" 2>/dev/null
+  kill "$new_pid" 2>/dev/null || true
+}
+
+@test "herdr-task-sync --restart-daemon refuses an unrelated lock owner" {
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  sleep 30 &
+  local live=$! sweep_lock="$(hts_namespace "$HTS_DEFAULT_SOCKET")/sweep.lock"
+  mkdir -p "$sweep_lock"
+  printf '%s' "$live" > "$sweep_lock/pid"
+
+  run hts_sweep_run --restart-daemon
+
+  assert_failure
+  assert_output --partial "refusing to stop unrelated sweep lock owner $live"
+  kill -0 "$live"
+  kill "$live" 2>/dev/null || true
 }
 
 @test "herdr-task-sync sweep daemon exits after three unreachable snapshots" {

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -1091,12 +1091,10 @@ assert_herdr_sidebar_deployment_contract() {
 
   assert_file_contains "$config" '^sidebar_min_width = 32$'
   assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
-  # Herdr 0.8 collapses an empty custom-token row when the token is the row's
-  # only item. The first row keeps workspace and task together, and the second
-  # row carries the one combined $git_ref token — stale state rides on it as
-  # a suffix icon, so there is no third row and no $location_status token.
-  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\], \["\$git_ref"\]\]$'
-  run grep -E '\$location_label|\$location_status' "$config"
+  # Git metadata remains available to integrations, but the agent sidebar is
+  # deliberately names-only: state, workspace, and pane/task label.
+  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\]\]$'
+  run grep -E '\$(git_ref|location_label|location_status)' "$config"
   assert_failure
   width="$(awk '
     $0 == "[ui]" { in_ui = 1; next }
@@ -1126,7 +1124,7 @@ assert_herdr_sidebar_deployment_contract() {
   run grep -hEi 'state_icon|(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
     "$config" "${writer_files[@]}"
   assert_success
-  assert_file_contains "$config" 'rows = \[\["state_icon", "workspace", "pane"\], \["\$git_ref"\]\]'
+  assert_file_contains "$config" 'rows = \[\["state_icon", "workspace", "pane"\]\]'
   assert_file_contains "$config" '"state_icon"'
   # The engine builds the five codicon glyphs of the $git_ref grammar from
   # bash 3.2-safe octal printf sequences. Raw PUA glyphs are easily lost when
@@ -1213,8 +1211,12 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml"'
   assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh"'
   assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh"'
+  assert_file_contains "$relink" 'include "private_dot_config/herdr/config.toml"'
+  assert_file_contains "$relink" 'include "dot_local/bin/executable_herdr-task-sync"'
   assert_file_contains "$relink" 'herdr plugin link'
   assert_file_contains "$relink" 'herdr plugin enable seigi.pane-labels'
+  assert_file_contains "$relink" 'restart-daemon'
+  assert_file_contains "$relink" ' --sweep'
 }
 
 # ===========================================


### PR DESCRIPTION
## Summary

Herdr now keeps Git metadata out of the agent sidebar and shows a detected agent immediately instead of falling back to `~` while task naming initializes. Deployments reload the config, replace old per-session sweep daemons, and reconcile labels immediately, so pre-deploy code cannot restore stale labels. Daemon replacement verifies the lock owner's command before signaling it and refuses unrelated processes.

Related: #73

## Validation

- `bats tests/scripts.bats`: 204 tests passed with 1 expected dependency skip.
- `make test-templates`: 43 tests passed.
- `make lint`: passed.
- `make test-ubuntu`: 370 tests passed with expected platform skips, including apply, idempotency, and deployed sidebar checks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-gpt--5.6--sol-000000)
