### PR TITLE
test: enforce complete gates and remove low-value checks

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -37,8 +37,8 @@ env:
   # clears this again per-job, below.
   MMS_CI_MINIMAL: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && '1' || '' }}
   # Declares this runner's $HOME disposable, which is the only thing that lets
-  # the four idempotency tests in tests/idempotent.bats run their real
-  # `chezmoi apply`. Unconditional on purpose: it must NOT copy the
+  # the idempotency scenario in tests/idempotent.bats run its real `chezmoi
+  # apply`. Unconditional on purpose: it must NOT copy the
   # trigger-conditional shape of MMS_CI_MINIMAL above, or the nightly
   # `schedule` and the manual `workflow_dispatch` runs would silently lose that
   # coverage. tests/idempotent.bats hard-fails when GITHUB_ACTIONS is set and
@@ -195,13 +195,8 @@ jobs:
       # The other smithers directory. Tests that set SE_SMITHERS_DIR point `se`
       # at the checkout instead of the deployed runtime, and nothing provisions
       # that copy — the apply deploys from it, it does not build it.
-      - name: Install smithers dependencies in the source tree
-        working-directory: home/private_dot_claude/dot_smithers
-        run: bun install --frozen-lockfile
-
-      - name: Test the Smithers issue writer
-        working-directory: home/private_dot_claude/dot_smithers
-        run: bun test workflows/lib/issue-writer.test.ts
+      - name: Run the Smithers test gate
+        run: make test-smithers
 
       # Report each gap once, here, instead of once per dependent test.
       - name: Verify both smithers directories the tests call
@@ -340,13 +335,8 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Install smithers dependencies in the source tree
-        working-directory: home/private_dot_claude/dot_smithers
-        run: bun install --frozen-lockfile
-
-      - name: Test the Smithers issue writer
-        working-directory: home/private_dot_claude/dot_smithers
-        run: bun test workflows/lib/issue-writer.test.ts
+      - name: Run the Smithers test gate
+        run: make test-smithers
 
       - name: Verify both smithers directories the tests call
         run: |

--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -151,6 +151,18 @@ jobs:
       - name: Add chezmoi to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      # CI-minimal Linux applies skip Homebrew entirely. Full applies install
+      # gitleaks into Linuxbrew, but that script-local shellenv does not reach
+      # later workflow steps. Keep the required Smithers scanner on the
+      # runner-facing PATH in both modes.
+      - name: Install gitleaks
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" gitleaks
+          gitleaks version
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+
       - name: Install bats
         run: |
           sudo apt-get update

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Reference docs (read on demand):
 | Command | What it does |
 |---|---|
 | `make test-issues` | Strictly validate repository issues and run issue CLI tests |
+| `make test-smithers` | Frozen install, required `gitleaks`, TypeScript check, and complete Bun test suite |
 | `make test-ubuntu` | Full test in Docker |
 | `make test-docker` | Build + run full Docker test suite |
 | `make test-suite` | Post-apply suite in parallel, host-safe files only. It keeps `tests/idempotent.bats` excluded as redundant defense behind that file's `MMS_DISPOSABLE_HOME` guard. Asserts against the **already-applied** `~/`, not this checkout — an unapplied edit under `home/` is not covered and still goes green |
@@ -82,7 +83,7 @@ Adding a managed config, step by step:
 1. Check `home/.chezmoiexternal.toml` — skills and configs managed there (e.g., `linear-cli`, `improve-claude-md`) must NOT be duplicated in `home/`, or chezmoi reports "inconsistent state".
 2. `chezmoi add ~/.config/tool` — creates the source file in `home/`.
 3. Add a `.tmpl` suffix if the file needs OS branching or secrets; OS-specific files also need a rule in `home/.chezmoiignore`.
-4. Add a smoke test in `tests/smoke.bats`.
+4. Add or extend the narrowest test that proves deployment behavior; use `tests/smoke.bats` only for cross-component coverage.
 5. Verify: `make test-local` (diff only), then `make test-ubuntu`.
 
 `modify_` scripts (e.g., `modify_dot_claude.json`) read the existing file from stdin and output a modified version — don't treat them as regular templates.
@@ -126,12 +127,18 @@ Use the `repository-issues` skill and `python3 scripts/issues` for `docs/issues/
 
 Costly-to-reverse architecture decisions go to `docs/decisions/` as minimal Architecture Decision Records with `Context`, `Considered options`, and `Decision` sections.
 
-<important if="you are adding a new feature, script, or config that should be tested">
+<important if="you are adding, changing, or reviewing tests">
 
-- Add a smoke test in `tests/smoke.bats` (bats-core syntax).
-- Run locally with `make test-suite` (parallel, host-safe files), or `make test-ubuntu` for the full Docker suite including `tests/idempotent.bats`.
+- Read `docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md`; it defines semantic regression tests, control fixtures, coverage ownership, and honest verification.
+- A regression test is complete only when it goes red for the intended regression and green for the corrected behavior.
+- Assert externally observable behavior. Assert literal source or rendered text only when consumers depend on that exact shape.
+- Assert command status before inspecting output. Pair rejection fixtures with a nearby valid control that reaches the intended success path.
+- Search existing coverage first and strengthen its best owner instead of duplicating the assertion. Put new coverage in the narrowest relevant suite; reserve `tests/smoke.bats` for deployed cross-component behavior.
+- Run the smallest canonical `make` target that covers the change instead of reconstructing its component commands. Smithers changes use `make test-smithers`.
+- Run `make test-suite` for the parallel host-safe files, or `make test-ubuntu` for the full Docker suite including `tests/idempotent.bats`.
 - `tests/idempotent.bats` guards every real chezmoi command with `MMS_DISPOSABLE_HOME=1`. Direct workstation runs skip those commands; `make test-ubuntu` declares a disposable `$HOME` and runs them.
 - `make test-suite` reads the deployed `~/` and applies nothing, so it cannot see an edit under `home/` that has not been applied yet. For a change to a managed file, `make test-ubuntu` is the one that proves it — it applies the checkout first.
+- Treat skips, partial runs, and isolated passes as incomplete evidence. If a required suite stalls, record the exact boundary, isolate the case, create a repository issue, and report the suite as incomplete.
 - CI runs both ubuntu and macos jobs.
 - Use `chezmoi_test_init()` from `tests/helpers/common.bash` instead of raw `chezmoi init`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local lint clean build-docker shell-ubuntu init-submodules
+.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local test-smithers lint clean build-docker shell-ubuntu init-submodules
 
 help:
 	@echo "Chezmoi Dotfiles - Available commands:"
@@ -8,6 +8,7 @@ help:
 	@echo "  make test-suite       Run the post-apply suite in parallel (host-safe files)"
 	@echo "  make test-templates   Run template tests only (fast, no apply)"
 	@echo "  make test-pi-agents-local  Run focused Pi local-instructions extension tests"
+	@echo "  make test-smithers    Install, type-check, and test the Smithers package"
 	@echo "  make test-local       Run chezmoi diff on current machine (dry-run)"
 	@echo "  make test-docker      Build and run full Docker test suite"
 	@echo "  make lint             Run shellcheck on all scripts"
@@ -39,6 +40,10 @@ test-templates: test-issues build-docker
 
 test-pi-agents-local:
 	bun test tests/pi-agents-local-extension.test.ts
+
+test-smithers:
+	cd home/private_dot_claude/dot_smithers && bun install --frozen-lockfile
+	cd home/private_dot_claude/dot_smithers && bun run check
 
 shell-ubuntu: build-docker
 	docker compose -f docker/docker-compose.yml run --rm ubuntu /bin/zsh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       # Empty by default, which selects the full Brewfile render, so R5 holds
       # unless the caller opts in.
       - MMS_CI_MINIMAL=${MMS_CI_MINIMAL:-}
-      # Declares this container's $HOME disposable, which is what lets the four
-      # idempotency tests in tests/idempotent.bats run their real
-      # `chezmoi apply`. Written literally in all three services, unlike
+      # Declares this container's $HOME disposable, which is what lets the
+      # idempotency scenario in tests/idempotent.bats run its real `chezmoi
+      # apply`. Written literally in all three services, unlike
       # MMS_CI_MINIMAL above, which is read from the host and is deliberately
       # absent from the test-ubuntu service. tests/idempotent.bats hard-fails when
       # /.dockerenv exists and this is missing.
@@ -79,6 +79,9 @@ services:
         echo "=== Installing smithers dependencies in the source tree ==="
         bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
 
+        echo "=== Running Smithers type-check and tests ==="
+        (cd home/private_dot_claude/dot_smithers && bun run check)
+
         echo "=== Running post-apply tests ==="
         tests/run-post-apply.sh full
 
@@ -119,4 +122,5 @@ services:
         bats tests/templates.bats
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
         bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
+        (cd home/private_dot_claude/dot_smithers && bun run check)
         tests/run-post-apply.sh full

--- a/docs/issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md
+++ b/docs/issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md
@@ -1,0 +1,46 @@
+---
+title: "Full scripts suite hangs after socket namespace test"
+short_description: "On macOS, bats tests/scripts.bats stalls for more than 25 minutes when entering the fail-open deadline case after test 74, while that case passes immediately in isolation."
+type: "bug"
+category: "testing-ci"
+tags: ["herdr-task-sync","test-hang"]
+date: "2026-08-24"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+During the test-suite semantic cleanup, a full macOS run of
+`bats tests/scripts.bats` printed tests 1 through 74 as passing, then remained
+inside test 75 for more than 25 minutes:
+
+```text
+ok 74 herdr-task-sync exact socket namespaces survive legacy sanitized-name collisions
+```
+
+Process inspection showed two nested `bats-exec-test` processes running
+`herdr-task-sync fail-open deadline rejects late success before the hang guard`.
+The same test passed immediately when invoked alone with `bats --filter`, so
+the failure depends on prior suite state rather than the test body in
+isolation. Sending SIGINT produced status 130 at the call to
+`hts_run_fail_open_guard sleep 2` and confirmed that only 75 of 194 tests had
+executed.
+
+This prevents a bounded local full-suite verification and can strand CI if the
+same ordering occurs there. It resembles the process/file-descriptor
+contention investigated in the now-closed
+`2026-08-20-010-two-herdr-task-sync-tests-flake-under-full-suite-load.md`, but
+the observed failure is a persistent hang rather than an assertion flake.
+
+## Scope
+
+- Reproduce tests 74 and 75 sequentially with process and descriptor tracing.
+- Identify which process, lock, or inherited descriptor survives test 74.
+- Ensure teardown terminates all owned workers before test 75 starts.
+- Add a bounded regression that fails rather than hanging indefinitely.
+- Verify `bats tests/scripts.bats` completes twice on macOS and in Ubuntu CI.
+
+## Open decisions
+
+None.

--- a/docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md
+++ b/docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md
@@ -1,0 +1,146 @@
+---
+title: Semantic regression tests over source shape
+date: 2026-08-24
+category: design-patterns
+module: testing
+problem_type: design_pattern
+component: testing_framework
+severity: high
+resolution_type: workflow_improvement
+related_components:
+  - ci
+  - chezmoi
+  - smithers
+applies_when:
+  - "Adding a regression test for a behavior that already has neighboring coverage"
+  - "Reviewing tests that grep source code or assert implementation-specific strings"
+  - "Building fixtures for validators, event aggregation, or subprocess behavior"
+  - "Choosing between a focused command and the repository's canonical test gate"
+  - "Reporting a suite with skipped, stalled, or only individually passing tests"
+symptoms:
+  - "A test stays green after the protected behavior is removed"
+  - "A subprocess error message satisfies an output assertion because status was never checked"
+  - "A fixture called valid never reaches the success path it claims to exercise"
+  - "A required package is declared or installed, but the process running the gate cannot resolve its binary"
+- "A partial or isolated run is reported as proof that the complete suite passed"
+tags:
+  - semantic-tests
+  - regression-tests
+  - behavior-testing
+  - source-shape
+  - control-fixtures
+  - coverage-ownership
+  - bats
+  - smithers
+---
+
+# Semantic regression tests over source shape
+
+## Context
+
+A test-suite audit found many green checks but less independent evidence than the pass count implied. Some tests searched source files for method names or wiring strings, several repeated facts already enforced by TypeScript or a stronger neighboring test, and some subprocess assertions inspected output without first proving the command succeeded. Other fixtures carried a success-oriented name while never reaching the validator or aggregation branch they claimed to cover.
+
+The audit also found verification drift. Different CI and Docker paths invoked selected Smithers commands directly, so a green path could omit the frozen install, secret scan, typecheck, or part of the Bun suite. At the repository level, `make test-suite` can pass while testing the already-deployed home directory rather than an unapplied checkout. A complete `tests/scripts.bats` run then stalled even though the blocked test passed alone, demonstrating that isolated success is not a suite verdict.
+
+These failures share one cause: the check proves that some implementation shape or execution fragment exists, not that the intended contract survives regression.
+
+## Guidance
+
+A **semantic regression test** changes verdict with the protected behavior: red when the regression is present, green when the behavior is correct. Its completion criterion is evidence of both states, not the presence of a new test case.
+
+### Start from the contract
+
+Name the externally observable contract before choosing an assertion. Prefer the lowest stable boundary that a consumer can observe:
+
+- Call the function and assert its result or side effect.
+- Run the command and assert its exit status before stdout or stderr.
+- Render or deploy the template and inspect the resulting file.
+- Query the real persistence boundary when aggregation or ownership semantics live in the database.
+
+Literal source assertions are appropriate only when literal shape is itself the contract. Examples include reserved command syntax that must survive templating, a required symlink target, or policy text consumed verbatim by another tool. A grep for an internal method call, type annotation, or helper name proves implementation shape instead of behavior; a refactor can break it while preserving behavior, and removing the behavior can leave the matching text behind.
+
+### Prove the red state
+
+For a new regression test, demonstrate that the intended regression makes the test fail. Use the cheapest faithful method:
+
+1. Run the test against the known-bad parent revision when it contains the regression.
+2. Temporarily make the smallest production mutation that recreates the regression.
+3. For a validator or fixture bug, run the fixture through the real boundary and show that the old fixture cannot distinguish the bad path.
+
+Restore the corrected implementation, rerun the same test, and require green. A test that was observed only in the green state remains uncalibrated: it may be useful, but it has not proved regression sensitivity.
+
+### Build discriminating controls
+
+A fixture proves a branch only when nearby controls isolate the property under test:
+
+- A rejection fixture needs a minimally different valid fixture that reaches success.
+- An aggregation fixture needs related and unrelated records, including collision-prone identifiers such as shared prefixes.
+- An event filter needs a same-entity wrong-event control, not only a different entity.
+- A timeout or concurrency test needs proof that it observed the intended process state rather than startup or cleanup noise.
+
+Controls turn a plausible example into a discriminator. Without them, the fixture can pass because every input follows the same accidental path.
+
+### Give each contract one owner
+
+Search existing tests before adding coverage. Choose the narrowest suite that can observe the complete contract, then strengthen that case:
+
+- Unit tests own pure function and validator semantics.
+- Template tests own rendered output across configuration branches.
+- Deployment or idempotency tests own filesystem effects after `chezmoi apply`.
+- Smoke tests own deployed cross-component behavior that no narrower suite can prove.
+- TypeScript and lint gates own type and static-analysis guarantees.
+
+Repeating the same assertion in smoke, template, and unit suites does not create three independent proofs. It creates three maintenance sites with correlated blind spots. Keep additional layers only when each catches a distinct failure mode.
+
+### Preserve gate integrity
+
+Use the smallest canonical `make` target that covers the changed contract. A canonical target owns setup and the complete sequence; manually invoking its components is a different gate even when the visible test command matches.
+
+For Smithers, `make test-smithers` owns the frozen dependency install, required `gitleaks`, TypeScript check, and complete Bun suite. For managed files under `home/`, `make test-ubuntu` applies the checkout inside a disposable environment. `make test-suite` is host-safe by design and observes the already-deployed home directory, so it cannot prove an unapplied managed-file change.
+
+Dependency presence is not command reachability. Verify required binaries from the exact process that runs the gate. A package declaration, a successful installer log, or a `shellenv` export in an earlier subprocess does not prove that a later CI step can resolve the command.
+
+Check what actually ran as well as its exit code. Skips can remove coverage while preserving green, and a partial run can stop before the relevant test. When dependencies or environments change, compare skip identities and reasons rather than only pass counts.
+
+### Report incomplete evidence honestly
+
+A stalled full suite and a passing isolated test are two separate observations:
+
+- The isolated result narrows the cause away from a deterministic failure in that test alone.
+- The stalled suite remains incomplete because ordering, leaked state, contention, or cleanup can exist only in the full run.
+
+Record the last completed test, the test active at the boundary, elapsed time, process state, and isolated reproduction result. Create a repository issue for unresolved behavior. Report only the checks that completed; never promote an isolated pass into a full-suite verdict.
+
+## Why This Matters
+
+A false green is more dangerous than an obvious missing test because it looks like evidence and suppresses further investigation. Source-shape assertions, duplicate coverage, inaccessible dependencies, and partial runs all inflate confidence without adding an independent verdict on behavior.
+
+Semantic ownership also lowers maintenance cost. One calibrated test at the correct boundary survives internal refactors, fails for the regression it names, and gives canonical gates one authoritative path to execute.
+
+## Examples
+
+The 2026-08-24 audit applied these rules in several forms:
+
+- Source-grep smoke checks for Smithers type and wiring details were removed because `tsc --noEmit` and behavior tests own those contracts.
+- Validator success fixtures were changed to satisfy the real success contract instead of merely avoiding one rejection branch.
+- Cost aggregation moved to real SQLite-backed events with child, unrelated, shared-prefix, and wrong-event controls.
+- Platform subprocess checks now require successful status before accepting output.
+- Repeated apply/idempotency paths were consolidated under one state-transition owner.
+- CI and Docker paths now call `make test-smithers` instead of maintaining partial command lists.
+- Ubuntu CI now provisions `gitleaks` on its runner-facing path: ordinary runs skip Linuxbrew entirely, while full installs export Linuxbrew only inside the apply subprocess.
+- The stalled `tests/scripts.bats` run was reported as incomplete even though its active test passed in isolation.
+
+The important result is not fewer tests by itself. The resulting suite has fewer assertions whose verdict can remain green while the protected behavior is absent.
+
+## When to Apply
+
+Apply this pattern whenever a test is added, changed, reviewed, or used as release evidence. It is especially important for source-grep tests, subprocess wrappers, validators, event aggregators, generated configuration, test suites with skip guards, and repositories with multiple CI entry points.
+
+Do not replace exact-format contract tests merely because they inspect text. First decide whether consumers depend on the exact text. If they do, render or deploy through the real producer and assert that contract at its consumption boundary.
+
+## Related
+
+- `skip-set-parity-proves-reduced-dependencies.md` — why a green suite does not prove unchanged coverage when skips can expand.
+- `completion-is-not-a-verdict.md` — why execution completion and an acceptance verdict are separate states.
+- `idle-machine-wall-clock-bounds-are-latent-flakes.md` — why timing observations need a bounded, state-aware contract.
+- `../../issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md` — unresolved full-suite stall discovered during the audit.

--- a/home/private_dot_claude/dot_smithers/bun.lock
+++ b/home/private_dot_claude/dot_smithers/bun.lock
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "26.1.1",
+        "typescript": "6.0.3",
       },
     },
   },
@@ -313,8 +314,6 @@
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@ocavue/utils": ["@ocavue/utils@1.7.0", "", {}, "sha512-yEk9ATNBjTZTtuVFMB/MAIF6zJBvJ2+lVNQvK2+O+ggEBGTgx2tp27d4FPgmD5bRsNHHP3D0SleQia/bvIeV8w=="],
-
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
@@ -707,46 +706,6 @@
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
-
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
-
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
-
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
-
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
-
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
-
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
-
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
-
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
-
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
-
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
@@ -1617,8 +1576,6 @@
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "bun-ffi-structs/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 

--- a/home/private_dot_claude/dot_smithers/package.json
+++ b/home/private_dot_claude/dot_smithers/package.json
@@ -2,13 +2,17 @@
   "name": "claude-smithers-workflows",
   "private": true,
   "type": "module",
+  "scripts": {
+    "check": "command -v gitleaks >/dev/null || { echo 'gitleaks is required for Smithers tests' >&2; exit 1; }; tsc --noEmit && bun test"
+  },
   "dependencies": {
     "smithers-orchestrator": "0.32.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
-    "@types/node": "26.1.1"
+    "@types/node": "26.1.1",
+    "typescript": "6.0.3"
   },
   "trustedDependencies": [
     "@smithers-orchestrator/jj-darwin-arm64"

--- a/home/private_dot_claude/dot_smithers/workflows/lib/agents.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/agents.test.ts
@@ -79,12 +79,6 @@ describe("simplify apply model", () => {
 });
 
 describe("factories", () => {
-  test("claude review factory builds for all three profiles", () => {
-    expect(makeClaudeReviewAgent({ cwd: "/tmp", profile: "codeReview" })).toBeDefined();
-    expect(makeClaudeReviewAgent({ cwd: "/tmp", profile: "simplifyReview" })).toBeDefined();
-    expect(makeClaudeReviewAgent({ cwd: "/tmp", profile: "docReview", jsonField: "envelope" })).toBeDefined();
-  });
-
   test("codeReview + simplifyReview emit the raw-object json-schema; docReview keeps the envelope wrapper", () => {
     const jsonSchemaOf = (agent: ReturnType<typeof makeClaudeReviewAgent>): Record<string, unknown> =>
       JSON.parse((agent as unknown as { opts: { jsonSchema: string } }).opts.jsonSchema);
@@ -126,10 +120,5 @@ describe("factories", () => {
     expect(opencode.idleTimeoutMs).toBe(AGENT_PROFILES.opencodeReview.idleTimeoutMs);
     const work = makeWorkAgent({ cwd: "/tmp", timeoutMs: 60_000, maxBudgetUsd: 1, jsonField: "report" });
     expect(work.idleTimeoutMs).toBeUndefined();
-  });
-
-  test("opencode and work factories build", () => {
-    expect(makeOpencodeReviewAgent({ cwd: "/tmp" })).toBeDefined();
-    expect(makeWorkAgent({ cwd: "/tmp", timeoutMs: 60_000, maxBudgetUsd: 1, jsonField: "report" })).toBeDefined();
   });
 });

--- a/home/private_dot_claude/dot_smithers/workflows/lib/cost.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/cost.test.ts
@@ -144,25 +144,6 @@ describe("agentCapUsd", () => {
 });
 
 describe("readRunUsage", () => {
-  test("reads this run's events and its subflow children's", () => {
-    // #given a database that answers the usage query
-    const seen: string[] = [];
-    const db = {
-      rows: (_sql: string, runId: string) => {
-        seen.push(runId);
-        return [{ payload_json: JSON.stringify({ nodeId: "work", model: "claude-sonnet-5", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0 }) }];
-      },
-      close: () => {},
-    };
-
-    // #when usage is read
-    const events = readRunUsage("run-1", "/launch", () => db);
-
-    // #then the run id is passed through and the event is parsed
-    expect(seen).toEqual(["run-1"]);
-    expect(events[0]).toMatchObject({ nodeId: "work", inputTokens: 10, outputTokens: 5 });
-  });
-
   test("falls through to the parent directory when the launch dir has no database", () => {
     const opened: string[] = [];
     readRunUsage("run-1", "/launch/dir", (dbPath) => {
@@ -202,21 +183,41 @@ describe("openUsageDb", () => {
     expect(openUsageDb(dbPath)).toBeNull();
   });
 
-  test("a real database answers the usage query end to end", () => {
-    // #given a state database holding one TokenUsageReported event
+  test("a real database includes parent and subflow-child usage but excludes unrelated runs", () => {
+    // #given a state database holding usage for the parent run, one of its
+    // subflows, and an unrelated run
     const dbPath = join(mkdtempSync(join(tmpdir(), "cost-test-")), "smithers.db");
     const seed = new Database(dbPath);
     seed.run("CREATE TABLE _smithers_events (type TEXT, run_id TEXT, payload_json TEXT)");
     seed.run(
       "INSERT INTO _smithers_events VALUES ('TokenUsageReported', 'run-1', ?1)",
-      [JSON.stringify({ nodeId: "work", model: "claude-sonnet-5", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0 })],
+      [JSON.stringify({ nodeId: "parent", model: "claude-sonnet-5", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0 })],
+    );
+    seed.run(
+      "INSERT INTO _smithers_events VALUES ('TokenUsageReported', 'run-1:child:simplify', ?1)",
+      [JSON.stringify({ nodeId: "subflow-child", model: "claude-sonnet-5", inputTokens: 20, outputTokens: 8, cacheReadTokens: 2 })],
+    );
+    seed.run(
+      "INSERT INTO _smithers_events VALUES ('TokenUsageReported', 'run-2', ?1)",
+      [JSON.stringify({ nodeId: "unrelated", model: "claude-sonnet-5", inputTokens: 999, outputTokens: 999, cacheReadTokens: 999 })],
+    );
+    seed.run(
+      "INSERT INTO _smithers_events VALUES ('TokenUsageReported', 'run-10', ?1)",
+      [JSON.stringify({ nodeId: "same-prefix", model: "claude-sonnet-5", inputTokens: 999, outputTokens: 999, cacheReadTokens: 999 })],
+    );
+    seed.run(
+      "INSERT INTO _smithers_events VALUES ('OtherEvent', 'run-1', ?1)",
+      [JSON.stringify({ nodeId: "wrong-event", model: "claude-sonnet-5", inputTokens: 999, outputTokens: 999, cacheReadTokens: 999 })],
     );
     seed.close();
 
     // #when the production opener is handed to the reader
     const events = readRunUsage("run-1", dirname(dbPath), openUsageDb);
 
-    // #then the event round-trips through real sqlite
-    expect(events).toEqual([{ nodeId: "work", model: "claude-sonnet-5", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 }]);
+    // #then only the parent and its subflow child round-trip through real sqlite
+    expect(events.sort((a, b) => a.nodeId.localeCompare(b.nodeId))).toEqual([
+      { nodeId: "parent", model: "claude-sonnet-5", inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      { nodeId: "subflow-child", model: "claude-sonnet-5", inputTokens: 20, outputTokens: 8, cacheReadTokens: 2, cacheWriteTokens: 0 },
+    ]);
   });
 })

--- a/home/private_dot_claude/dot_smithers/workflows/lib/flow-validate.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/flow-validate.test.ts
@@ -77,17 +77,18 @@ describe("validateFlowSpec", () => {
   });
 
   test("a pr block with a secret-scan ancestor is accepted", () => {
-    // #given the same flow with the scan inserted
+    // #given the same flow with the scan inserted and every bound edge
+    // schema-compatible
     const s = spec([
       block({ id: "fix", block: "work" }),
       block({ id: "scan", block: "secret-scan", after: ["fix"], bindTo: ["fix"] }),
-      block({ id: "ship", block: "pr", after: ["scan"], bindTo: ["scan"] }),
+      block({ id: "review", block: "code-review", after: ["scan"], bindTo: ["scan"] }),
+      block({ id: "ship", block: "pr", after: ["review"], bindTo: ["review"] }),
     ]);
 
     // #when / #then
     const result = validateFlowSpec(s, deps);
-    const scanErrors = result.ok ? [] : result.errors.filter((e) => e.invariant === "scan-before-external");
-    expect(scanErrors).toEqual([]);
+    expect(result.ok).toBe(true);
   });
 
   test("AE1: external review without a preceding secret-scan is rejected naming the block", () => {

--- a/home/private_dot_claude/dot_smithers/workflows/lib/pipeline-simplify.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/pipeline-simplify.test.ts
@@ -2,17 +2,14 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import sePipeline from "../se-pipeline.tsx";
-import seSimplify from "../se-simplify.tsx";
-
 // The pipeline's simplify wiring is orchestration inside a smithers render, not
 // a pure function — the repo tests pure decisions in lib/ (see stage-gate.test:
 // shouldRunSimplify + simplifyCommitDecision) and transpile-checks workflows by
 // importing them. These cases pin the STRUCTURAL contract the render must hold:
 // verify-doc is conditional, simplify sits after secret-scan and before
 // verify-code, its commit + rescan land before verify-code, and the subflow
-// targets the run worktree. Deterministic source assertions + a load check —
-// the live render is exercised by the pipeline smoke run (Verification Contract).
+// targets the run worktree. workflow-construction.test.ts owns the shared load
+// checks; the live render is exercised by the pipeline smoke run (Verification Contract).
 const pipelineSrc = fs.readFileSync(path.join(import.meta.dir, "..", "se-pipeline.tsx"), "utf8");
 
 const idxOf = (needle: string): number => {
@@ -20,13 +17,6 @@ const idxOf = (needle: string): number => {
   expect(i, `expected to find ${needle} in se-pipeline.tsx`).toBeGreaterThanOrEqual(0);
   return i;
 };
-
-describe("se-pipeline transpiles / loads", () => {
-  test("both workflows import and expose a workflow definition", () => {
-    expect(sePipeline).toBeDefined();
-    expect(seSimplify).toBeDefined();
-  });
-});
 
 describe("docReview gating (R7)", () => {
   test("inputSchema declares docReview defaulting to false", () => {

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -57,6 +57,8 @@ brew "ripgrep"      # rg
 brew "bat"
 {{ end -}}
 brew "jq"
+{{/* gitleaks is kept: the required Smithers gate runs real secret-scanner tests */ -}}
+brew "gitleaks"
 
 {{ if $full -}}
 # File management
@@ -75,7 +77,6 @@ brew "herdr"        # agent multiplexer
 
 # Dev tools
 brew "act"          # run GitHub Actions locally
-brew "gitleaks"     # secret scan gate in se-pipeline (KTD10)
 
 # Testing
 brew "bats-core"    # bats

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -204,9 +204,3 @@ render_with_config() {
     --config "$config_file" --source "$SOURCE_ROOT" \
     execute-template < "$template_file"
 }
-
-assert_no_template_markers() {
-  local file="$1"
-  run grep -n '{{.*}}' "$file"
-  assert_failure
-}

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -320,9 +320,6 @@ if [ -d "$fixture" ]; then
   : > "$fixture/started"
   mkdir -p "$HTS_WORK/git-started"
   : > "$HTS_WORK/git-started/${fixture##*/}"
-  if [ -n "${HTS_GIT_PROBE_ID:-}" ]; then
-    : > "$HTS_WORK/git-started/$HTS_GIT_PROBE_ID"
-  fi
   if [ -f "$fixture/block" ]; then
     while [ ! -f "$fixture/release" ]; do sleep 0.01; done
   fi
@@ -349,29 +346,6 @@ SH
   chmod +x "$HTS_STUB/git"
   "$HTS_STUB/git" --version >/dev/null 2>&1 || true
 
-  cat > "$HTS_STUB/hts-crash-worker" <<'SH'
-#!/usr/bin/env bash
-set -e
-state="$1"
-crash_after="${2:-none}"
-markers="$state.markers"
-mkdir -p "$markers"
-[ -f "$state" ] || printf '%s\n' '{"completed":[],"complete":false}' > "$state"
-for boundary in enqueue state presentation; do
-  if jq -e --arg boundary "$boundary" '.completed | index($boundary)' "$state" >/dev/null; then
-    continue
-  fi
-  tmp="$state.tmp.$$"
-  jq --arg boundary "$boundary" '.completed += [$boundary]' "$state" > "$tmp"
-  mv "$tmp" "$state"
-  : > "$markers/$boundary"
-  [ "$crash_after" != "$boundary" ] || exit 97
-done
-tmp="$state.tmp.$$"
-jq '.complete = true' "$state" > "$tmp"
-mv "$tmp" "$state"
-SH
-  chmod +x "$HTS_STUB/hts-crash-worker"
   # jq lives outside /usr/bin on Homebrew installs (macOS and the Linux test
   # container alike), so link it in rather than widening the pinned PATH — a
   # wider PATH would also expose the real pi and claude.
@@ -898,36 +872,6 @@ hts_location_source_tokens() {
 
 hts_location_source_seq() {
   jq -r --arg pane "$2" '.metadata[$pane]["location-sync"].seq // 0' "$(hts_socket_state "$1")"
-}
-
-hts_git_probe() {
-  local pane="$1" cwd="$2" result_dir="$HTS_WORK/git-results" git_pid timer_pid git_status
-  mkdir -p "$result_dir"
-  env PATH="$HTS_STUB:/usr/bin:/bin" HTS_GIT_PROBE_ID="$pane" \
-    git -C "$cwd" rev-parse --show-toplevel \
-    > "$result_dir/$pane.output" 2>/dev/null &
-  git_pid=$!
-  hts_wait_for_file "$HTS_WORK/git-started/$pane"
-  (
-    sleep 0.075
-    if kill -0 "$git_pid" 2>/dev/null; then
-      : > "$result_dir/$pane.timed-out"
-      kill "$git_pid" 2>/dev/null || true
-    fi
-  ) &
-  timer_pid=$!
-  if wait "$git_pid"; then git_status=0; else git_status=$?; fi
-  kill "$timer_pid" 2>/dev/null || true
-  wait "$timer_pid" 2>/dev/null || true
-  if [[ -e "$result_dir/$pane.timed-out" || "$git_status" -ne 0 ]]; then
-    printf '%s\n' stale > "$result_dir/$pane"
-  else
-    printf 'fresh:%s\n' "$(cat "$result_dir/$pane.output")" > "$result_dir/$pane"
-  fi
-}
-
-hts_crash_run() {
-  "$HTS_STUB/hts-crash-worker" "$1" "${2:-none}"
 }
 
 # The sweep modes carry no agent and no pane, so they run the script directly

--- a/tests/idempotent.bats
+++ b/tests/idempotent.bats
@@ -2,23 +2,23 @@
 
 load 'helpers/common'
 
-# The four tests below run a real `chezmoi apply`, and its destination is
+# The apply scenario below runs a real `chezmoi apply`, and its destination is
 # $HOME. `--source` only selects where templates are read from; nothing here
-# redirects the write. So each of them deploys the source tree onto whatever
-# machine runs the file, and the run scripts under home/.chezmoiscripts/ target
-# $HOME directly -- installing Homebrew, running brew bundle, and on macOS
-# calling sudo defaults write.
+# redirects the write. It deploys the source tree onto whatever machine runs
+# the file, and the run scripts under home/.chezmoiscripts/ target $HOME
+# directly -- installing Homebrew, running brew bundle, and on macOS calling
+# sudo defaults write.
 #
-# require_disposable_home is therefore the first statement of each one. It runs
-# them only where MMS_DISPOSABLE_HOME=1 declares this $HOME throwaway, skips on
-# a workstation, and hard-fails on a runner that lost the marker
+# require_disposable_home is therefore the first statement of each scenario.
+# It runs them only where MMS_DISPOSABLE_HOME=1 declares this $HOME throwaway,
+# skips on a workstation, and hard-fails on a runner that lost the marker
 # (tests/helpers/disposable-home.bash holds the truth table). The guard is
 # inline rather than in setup_file() on purpose: a skip there would take the
 # `guard:` tests below with it, and those are what keep this file honest.
 #
-# Where the marker is set, the four still mutate the shared $HOME that every
-# other test file reads deployed state from. Two of them applying at once would
-# race, so this file stays sequential even when the suite runs with --jobs,
+# Where the marker is set, the scenarios still inspect or mutate the shared
+# $HOME that every other test file reads deployed state from. Concurrent applies
+# would race, so this file stays sequential even when the suite runs with --jobs,
 # and the shared tests/run-post-apply.sh wrapper keeps
 # --no-parallelize-across-files in both modes. It is 1.3 s of a 268 s suite,
 # so serializing it costs nothing measurable.
@@ -31,29 +31,24 @@ BATS_NO_PARALLELIZE_WITHIN_FILE=true
 # Idempotency tests
 # ===========================================
 
-@test "chezmoi apply succeeds" {
+@test "chezmoi apply is idempotent and leaves no pending diff" {
   require_disposable_home
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" apply --source="$CHEZMOI_SOURCE" --force --verbose
   assert_success
-}
 
-@test "second chezmoi apply succeeds (idempotency)" {
-  require_disposable_home
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" apply --source="$CHEZMOI_SOURCE" --force
   assert_success
-}
+  assert_output ""
 
-@test "chezmoi diff is empty after apply (no pending changes)" {
-  require_disposable_home
-  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" apply --source="$CHEZMOI_SOURCE" --force
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" diff --source="$CHEZMOI_SOURCE"
+  assert_success
   assert_output ""
 }
 
 @test "chezmoi verify succeeds" {
   # Read-only, so safe on a host, but it would assert against the chezmoi
   # clone rather than this checkout -- a weaker and different claim. Guarded
-  # with the other three so the file has one rule, not two.
+  # with the apply scenario so the file has one rule, not two.
   require_disposable_home
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" verify --source="$CHEZMOI_SOURCE"
   assert_success
@@ -66,7 +61,7 @@ BATS_NO_PARALLELIZE_WITHIN_FILE=true
 # Everything below is unguarded on purpose: it must run on every host, so this
 # file is never fully inert locally. Each test name is prefixed `guard:` so a
 # developer can exercise the guard alone -- `bats --filter 'guard:'
-# tests/idempotent.bats` -- without reaching the four chezmoi commands above.
+# tests/idempotent.bats` -- without reaching the chezmoi scenarios above.
 
 # Answer the predicate in a controlled environment. `env -u` drops whatever the
 # calling shell exported, so a developer who already has CI or the marker set
@@ -140,7 +135,7 @@ predicate_verdict() {
   fi
 
   [[ "${MMS_DISPOSABLE_HOME:-}" == "1" ]] || \
-    fail "This environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists), but MMS_DISPOSABLE_HOME is '${MMS_DISPOSABLE_HOME:-<unset>}' instead of 1. The four idempotency tests in this file would skip here, removing that coverage without turning anything red. Declare the marker at the site that launched this suite: .github/workflows/test-dotfiles.yml (top-level env: block), or docker/docker-compose.yml (services ubuntu, test-ubuntu, test-full)."
+    fail "This environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists), but MMS_DISPOSABLE_HOME is '${MMS_DISPOSABLE_HOME:-<unset>}' instead of 1. The idempotency scenarios in this file would skip here, removing that coverage without turning anything red. Declare the marker at the site that launched this suite: .github/workflows/test-dotfiles.yml (top-level env: block), or docker/docker-compose.yml (services ubuntu, test-ubuntu, test-full)."
 }
 
 @test "guard: the marker's claim covers chezmoi's real destination" {

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -12,7 +12,8 @@ setup() {
 
 @test "chezmoiignore filters macOS files on Linux" {
   is_linux || skip "Only relevant on Linux"
-  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed
+  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed --source "$SOURCE_ROOT"
+  assert_success
   refute_output --partial ".hammerspoon"
   refute_output --partial "Library"
   refute_output --partial ".config/ghostty"
@@ -23,34 +24,11 @@ setup() {
 
 @test "chezmoiignore includes macOS files on macOS" {
   is_macos || skip "Only relevant on macOS"
-  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed
+  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed --source "$SOURCE_ROOT"
+  assert_success
   assert_output --partial ".hammerspoon"
   assert_output --partial ".config/ghostty"
   assert_output --partial ".config/kitty"
   assert_output --partial ".config/karabiner"
   assert_output --partial ".config/zed"
-}
-
-# ===========================================
-# Platform-specific file presence after apply
-# ===========================================
-
-@test "hammerspoon absent on Linux" {
-  is_linux || skip "Only relevant on Linux"
-  assert_dir_not_exists "$HOME/.hammerspoon"
-}
-
-@test "Library absent on Linux" {
-  is_linux || skip "Only relevant on Linux"
-  assert_dir_not_exists "$HOME/Library"
-}
-
-@test "ghostty config absent on Linux" {
-  is_linux || skip "Only relevant on Linux"
-  assert_dir_not_exists "$HOME/.config/ghostty"
-}
-
-@test "kitty config absent on Linux" {
-  is_linux || skip "Only relevant on Linux"
-  assert_dir_not_exists "$HOME/.config/kitty"
 }

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -118,30 +118,15 @@ render_install_packages() {
 
 @test "install-packages script renders as valid bash" {
   skip_if_no_chezmoi
-  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl"
-  [[ -f "$script" ]] || skip "install-packages script not found at $script"
-
   BATS_TEST_TMPFILE="$BATS_TEST_TMPDIR/install-packages.sh"
   render_install_packages > "$BATS_TEST_TMPFILE"
   run bash -n "$BATS_TEST_TMPFILE"
   assert_success
 }
 
-@test "install-packages template has no rendering errors" {
-  skip_if_no_chezmoi
-  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl"
-  [[ -f "$script" ]] || skip "install-packages script not found at $script"
-  run render_install_packages
-  assert_success
-}
-
 # ===========================================
 # macOS tunes script
 # ===========================================
-
-@test "macos-tunes script exists in darwin-specific directory" {
-  assert_file_exists "$SOURCE_ROOT/.chezmoiscripts/darwin/run_once_after_macos-tunes.sh"
-}
 
 @test "macos-tunes script is valid bash" {
   local script="$SOURCE_ROOT/.chezmoiscripts/darwin/run_once_after_macos-tunes.sh"
@@ -197,9 +182,7 @@ SH
   chmod +x "$CHILD_STUB/herdr-child" "$CHILD_STUB/herdr"
 }
 
-@test "ask-in-herdr script is valid bash and requires arguments" {
-  run bash -n "$ASK_HERDR_DIR/ask.sh"
-  assert_success
+@test "ask-in-herdr script requires arguments" {
   run bash "$ASK_HERDR_DIR/ask.sh"
   assert_failure 2
   assert_output --partial "Usage:"
@@ -801,15 +784,6 @@ child_start() {
 
 HERDR_INTEGRATIONS_TMPL="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_3-setup-herdr-integrations.sh.tmpl"
 
-@test "herdr-integrations script renders to valid bash" {
-  skip_if_no_chezmoi
-  [[ -f "$HERDR_INTEGRATIONS_TMPL" ]] || skip "herdr-integrations script not found"
-  BATS_TEST_TMPFILE="$BATS_TEST_TMPDIR/herdr-integrations.sh"
-  PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" execute-template < "$HERDR_INTEGRATIONS_TMPL" > "$BATS_TEST_TMPFILE"
-  run bash -n "$BATS_TEST_TMPFILE"
-  assert_success
-}
-
 @test "herdr-integrations script guards on command -v herdr and stays tolerant" {
   run grep -q "command -v herdr" "$HERDR_INTEGRATIONS_TMPL"
   assert_success
@@ -839,13 +813,6 @@ HERDR_INTEGRATIONS_TMPL="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_3-setup
 HOOKS_DIR="$SOURCE_ROOT/private_dot_claude/hooks"
 FFF_GUARD="$HOOKS_DIR/executable_fff-grep-guard.sh"
 WEBFETCH_HINT="$HOOKS_DIR/executable_webfetch-markdown-hint.sh"
-
-@test "PreToolUse hook scripts are valid bash" {
-  run bash -n "$FFF_GUARD"
-  assert_success
-  run bash -n "$WEBFETCH_HINT"
-  assert_success
-}
 
 @test "fff-grep-guard denies a query of several bare words" {
   command -v jq >/dev/null || skip "jq not available"
@@ -1405,45 +1372,6 @@ PY
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane rename pane-1 converged
   run hts_socket_run "$HTS_DEFAULT_SOCKET" pane get pane-1
   assert_output --partial '"label":"converged"'
-}
-
-@test "herdr-task-sync harness restarts from every durable crash boundary" {
-  command -v jq >/dev/null || skip "jq not available"
-  hts_setup
-  local boundary state
-  for boundary in enqueue state presentation; do
-    state="$HTS_WORK/crash-$boundary.json"
-    run hts_crash_run "$state" "$boundary"
-    assert_failure 97
-    assert_equal "$(jq -r '.complete' "$state")" false
-    assert_file_exists "$state.markers/$boundary"
-
-    run hts_crash_run "$state"
-    assert_success
-    assert_equal "$(jq -r '.complete' "$state")" true
-    assert_equal "$(jq -r '.completed | length' "$state")" 3
-    assert_equal "$(jq -r '.completed | unique | length' "$state")" 3
-  done
-}
-
-@test "herdr-task-sync harness gives eight panes independent 75 ms Git budgets" {
-  hts_setup
-  local i pids= pid
-  for i in 1 2 3 4 5 6 7; do
-    hts_git_fixture "/repo/$i" "/repo/$i"
-  done
-  hts_git_fixture /repo/8 /repo/8 0 block
-
-  for i in 1 2 3 4 5 6 7 8; do
-    hts_git_probe "pane-$i" "/repo/$i" &
-    pids="$pids $!"
-  done
-  for pid in $pids; do wait "$pid"; done
-
-  for i in 1 2 3 4 5 6 7; do
-    assert_equal "$(cat "$HTS_WORK/git-results/pane-$i")" "fresh:/repo/$i"
-  done
-  assert_equal "$(cat "$HTS_WORK/git-results/pane-8")" stale
 }
 
 @test "herdr-task-sync latest committed request survives stale completion and a third request" {
@@ -3505,11 +3433,6 @@ socket_path=$(printf '%s' "$HTS_DEFAULT_SOCKET" | base64 | tr -d '\n')"
   assert_file_contains "$HTS_LOG" '^pane rename pane-1 cargo test$'
 }
 
-@test "herdr-task-sync passes bash syntax check" {
-  run bash -n "$HTS_ENGINE"
-  assert_success
-}
-
 @test "herdr-task-sync stays silent outside herdr" {
   hts_setup
   hts_stub_engine pi never-used 0 0
@@ -4058,11 +3981,6 @@ SH
 
 hts_hook_run() {
   env PATH="$HTS_STUB:/usr/bin:/bin" bash "$HTS_HOOK" "$@"
-}
-
-@test "herdr-task-sync hook passes bash syntax check" {
-  run bash -n "$HTS_HOOK"
-  assert_success
 }
 
 # Claude Code injects a UserPromptSubmit hook's stdout into the conversation,

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -890,29 +890,6 @@ se_fixture_repo() {
   assert_success
 }
 
-@test "smithers workflows carry a tsconfig so the package can be type-checked" {
-  # `bun build` resolves the module graph without type-checking, so a green
-  # build says nothing about types — a reserved output field refused every
-  # launch for a day while the build stayed green
-  # (docs/issues/2026-08-14-004). The tsconfig is what makes `bunx tsc
-  # --noEmit` runnable at all (docs/issues/2026-08-15-006).
-  local config="$SE_ROOT/private_dot_claude/dot_smithers/tsconfig.json"
-  assert_file_exists "$config"
-  # The JSX pragma is per-file today; the config must agree with it, or a file
-  # that omits the pragma type-checks against the wrong runtime.
-  run grep -q 'smithers-orchestrator' "$config"
-  assert_success
-}
-
-@test "smithers workflows declare bun's own type definitions" {
-  # Without @types/bun the language server cannot resolve bun:sqlite / bun:test
-  # and reports an error in nearly every file, which trains its reader to
-  # ignore it (docs/issues/2026-08-15-006).
-  local manifest="$SE_ROOT/private_dot_claude/dot_smithers/package.json"
-  run grep -q '"@types/bun"' "$manifest"
-  assert_success
-}
-
 @test "chezmoiignore excludes smithers runtime state from management" {
   local ignore="$SE_ROOT/.chezmoiignore"
   for entry in '.claude/.smithers/node_modules' '.claude/.smithers/smithers.db*' '.claude/.smithers/executions'; do

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -58,12 +58,6 @@ teardown() {
   assert_output --partial "email = "
 }
 
-@test "gitconfig template has no unresolved markers" {
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/dot_gitconfig.tmpl" > "$BATS_TEST_TMPFILE"
-  assert_no_template_markers "$BATS_TEST_TMPFILE"
-}
-
 # ===========================================
 # dot_zshenv.tmpl
 # ===========================================
@@ -71,12 +65,6 @@ teardown() {
 @test "zshenv template renders without op in PATH" {
   run render_template "$SOURCE_ROOT/dot_zshenv.tmpl"
   assert_success
-}
-
-@test "zshenv template output has no unresolved markers" {
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/dot_zshenv.tmpl" > "$BATS_TEST_TMPFILE" || true
-  assert_no_template_markers "$BATS_TEST_TMPFILE"
 }
 
 @test "zshenv sources Cargo environment only when readable" {
@@ -92,12 +80,6 @@ teardown() {
 @test "zshrc template renders successfully" {
   run render_template "$SOURCE_ROOT/dot_zshrc.tmpl"
   assert_success
-}
-
-@test "zshrc template has no unresolved markers" {
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/dot_zshrc.tmpl" > "$BATS_TEST_TMPFILE"
-  assert_no_template_markers "$BATS_TEST_TMPFILE"
 }
 
 # ===========================================
@@ -246,7 +228,7 @@ PROBE
 }
 
 # ===========================================
-# opencode.json.tmpl (macOS-only plugin path guarded by .is_darwin)
+# opencode.json.tmpl
 # ===========================================
 
 @test "opencode.json.tmpl renders valid JSON" {
@@ -268,18 +250,6 @@ PROBE
   run jq -r '[.mcp.fff.command[0], (.provider.openrouter.models | has("qwen/qwen3-coder:free")), .plugin[0]] | @tsv' "$BATS_TEST_TMPFILE"
   assert_success
   assert_output $'fff-mcp\ttrue\tcompound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git'
-}
-
-@test "opencode.json.tmpl renders with no unresolved template markers" {
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
-  assert_no_template_markers "$BATS_TEST_TMPFILE"
-}
-
-@test "opencode.json.tmpl omits the macOS brew plugin path on Linux" {
-  is_linux || skip "Only relevant on Linux"
-  run render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl"
-  refute_output --partial "/opt/homebrew"
 }
 
 @test "opencode skill symlinks target canonical claude skills" {
@@ -358,12 +328,6 @@ render_with_source() {
   assert_output "3"
 }
 
-@test "private_settings.json.tmpl has no unresolved template markers" {
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
-  assert_no_template_markers "$BATS_TEST_TMPFILE"
-}
-
 # ===========================================
 # .chezmoiremove
 # ===========================================
@@ -434,6 +398,7 @@ assert_minimal_brewfile() {
   assert_line 'brew "node"'
   assert_line --partial 'brew "oven-sh/bun/bun"'
   assert_line 'brew "jq"'
+  assert_line 'brew "gitleaks"'
 
   refute_line 'brew "git"'
   # rgrc stays out of the minimal set: no test references it, and the shell
@@ -510,8 +475,6 @@ assert_minimal_brewfile() {
 }
 
 @test "MMS_CI_MINIMAL=0 selects the minimal render, because 0 is non-empty" {
-  # The flag is emptiness-tested, not parsed. Reading '0' as "off" is wrong,
-  # and this pins which reading the implementation actually has.
   local cfg="$BATS_TEST_TMPDIR/zero.yaml"
   MMS_CI_MINIMAL=0 write_test_config "$cfg"
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -74,6 +74,24 @@ class TestDotfilesWorkflow(unittest.TestCase):
             "the macOS flock experiment must not add Homebrew install time",
         )
 
+    def test_ubuntu_provisions_gitleaks_outside_skipped_linuxbrew(self):
+        text = self.workflow_text()
+        job = self.job_block(text, "test-ubuntu")
+        install = self.named_step_block(job, "Install gitleaks")
+
+        self.assertIn("gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz", install)
+        self.assertIn('$HOME/.local/bin', install)
+        self.assertIn("gitleaks version", install)
+        self.assertNotIn(
+            "brew install",
+            install,
+            "ordinary Ubuntu CI skips Linuxbrew, so the required scanner needs an independent install",
+        )
+        self.assertLess(
+            job.index("      - name: Install gitleaks"),
+            job.index("      - name: Run the Smithers test gate"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -204,8 +204,12 @@ class ReadTests(IssueFixtures):
     def test_repeated_filter_matrix_for_list_and_search(self):
         self.write_issue("2026-08-21-001-first.md", issue_text(title="Needle first", category="herdr", priority="high", type="bug", tags='["alpha","beta"]'))
         self.write_issue("2026-08-21-002-second.md", issue_text(title="Needle second", status="in-progress", category="testing-ci", priority="low", type="chore", tags='["alpha","beta","gamma"]'))
+        self.write_issue("2026-08-21-003-control.md", issue_text(title="Needle control", category="repository-maintenance", priority="medium", type="idea", tags='["alpha"]'))
+        done = issue_text(title="Needle done", status="done", closed="2026-08-21", category="testing-ci", priority="low", type="chore", tags='["alpha","beta"]')
+        done_frontmatter = done.split(b"\n---\n", 1)[0] + b"\n---\n"
+        self.write_issue("2026-08-21-004-done.md", done_frontmatter + b"\n## Why this exists\n\nReason.\n\n## Resolution\n\nDone.\n")
         cases = (
-            (("--status", "open", "--status", "in-progress"), ["2026-08-21-001-first", "2026-08-21-002-second"]),
+            (("--status", "in-progress", "--status", "done"), ["2026-08-21-002-second", "2026-08-21-004-done"]),
             (("--category", "herdr", "--category", "testing-ci"), ["2026-08-21-001-first", "2026-08-21-002-second"]),
             (("--priority", "high", "--priority", "low"), ["2026-08-21-001-first", "2026-08-21-002-second"]),
             (("--type", "bug", "--type", "chore"), ["2026-08-21-001-first", "2026-08-21-002-second"]),


### PR DESCRIPTION
## Summary

- Linux, macOS, and Docker now share one canonical Smithers verdict: frozen dependencies, a required secret scanner, TypeScript validation, and all Bun tests must succeed together.
- Regression coverage now favors observable behavior and discriminating controls over duplicate source-shape assertions, including real persistence boundaries for cost aggregation and valid success fixtures for flow validation.
- Ubuntu provisions `gitleaks` outside Linuxbrew, so both ordinary minimal runs and full Brewfile verification runs can resolve the scanner from the workflow process.
- Repository guidance now defines semantic regression-test completion, coverage ownership, and honest reporting for skipped, partial, or stalled suites.

## Validation

- GitHub Actions: Ubuntu passed in 7m32s, macOS passed in 12m59s, lint passed in 16s.
- `make test-smithers` (626 passed)
- `make test-issues` (40 passed)
- `bats tests/templates.bats tests/platform.bats tests/idempotent.bats` (49 passed, 4 expected host-safety skips)
- `bats tests/smoke.bats` (82 passed)
- `make test-templates` (37 passed in Docker)
- `make lint`
- `docker compose -f docker/docker-compose.yml config --quiet`
- `git diff --check origin/main...HEAD`

## Known Issue

The complete standalone `bats tests/scripts.bats` run was stopped after it hung for more than 25 minutes after test 74 while entering `herdr-task-sync fail-open deadline rejects late success before the hang guard`. The same test passes in isolation, and both CI post-apply suites now complete successfully. Follow-up is tracked in `docs/issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md`.
