### PR TITLE
fix(tests): stabilize fail-open guards under terminal and CI load

### DIFF
--- a/docs/issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md
+++ b/docs/issues/2026-08-24-001-full-scripts-suite-hangs-after-socket-namespace-test.md
@@ -1,12 +1,13 @@
 ---
 title: "Full scripts suite hangs after socket namespace test"
-short_description: "On macOS, bats tests/scripts.bats stalls for more than 25 minutes when entering the fail-open deadline case after test 74, while that case passes immediately in isolation."
+short_description: "Interactive macOS runs blocked before the fail-open watchdog because the test helper copied inherited TTY stdin; the helper now treats a terminal as empty input and has a bounded PTY regression."
 type: "bug"
 category: "testing-ci"
 tags: ["herdr-task-sync","test-hang"]
 date: "2026-08-24"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-24"
 ---
 
 ## Why this exists
@@ -21,11 +22,12 @@ ok 74 herdr-task-sync exact socket namespaces survive legacy sanitized-name coll
 
 Process inspection showed two nested `bats-exec-test` processes running
 `herdr-task-sync fail-open deadline rejects late success before the hang guard`.
-The same test passed immediately when invoked alone with `bats --filter`, so
-the failure depends on prior suite state rather than the test body in
-isolation. Sending SIGINT produced status 130 at the call to
-`hts_run_fail_open_guard sleep 2` and confirmed that only 75 of 194 tests had
-executed.
+The same test passed immediately when invoked noninteractively with
+`bats --filter`, which initially made the failure look order-dependent. The
+actual difference was stdin: the full suite inherited an interactive terminal,
+while the isolated invocation received immediate EOF. Sending SIGINT produced
+status 130 at the call to `hts_run_fail_open_guard sleep 2` and confirmed that
+only 75 of 194 tests had executed.
 
 This prevents a bounded local full-suite verification and can strand CI if the
 same ordering occurs there. It resembles the process/file-descriptor
@@ -44,3 +46,14 @@ the observed failure is a persistent hang rather than an assertion flake.
 ## Open decisions
 
 None.
+
+## Resolution
+
+Fixed `hts_run_fail_open_guard` so an inherited terminal is treated as empty
+test input while redirected payloads are still forwarded. Added a PTY-backed
+regression that was observed red against the old helper and green after the
+fix; a separate mutation proved the same test rejects discarded redirected
+bytes. Verified three focused fail-open cases, two complete interactive macOS
+`scripts.bats` runs with 198 passing tests, and the focused regression in
+Ubuntu. The canonical `make test-ubuntu` gate remains blocked before post-apply
+tests by the separate `2026-08-24-002` issue.

--- a/docs/issues/2026-08-24-002-ubuntu-docker-omits-issue-cli-from-smithers-tests.md
+++ b/docs/issues/2026-08-24-002-ubuntu-docker-omits-issue-cli-from-smithers-tests.md
@@ -1,0 +1,34 @@
+---
+title: "Ubuntu Docker omits issue CLI from Smithers tests"
+short_description: "make test-ubuntu fails the Smithers publishIssue real-CLI test because the staged Docker worktree omits scripts/issues, even though the same 626-test gate passes from the complete host checkout."
+type: "bug"
+category: "testing-ci"
+tags: ["docker","smithers","test-gate"]
+date: "2026-08-24"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+`make test-ubuntu` fails before post-apply Bats coverage in the Smithers test
+`publishIssue > retries the real CLI idempotently by run ID`. The Docker
+worktree stages only `home/`, `tests/`, and `README.md`, but the test copies
+`scripts/issues` from the repository root. That path is absent in the staged
+worktree, so the test fails immediately. The same 626-test Smithers gate passes
+from the complete host checkout.
+
+This blocks the canonical Ubuntu verification target for unrelated changes and
+can hide whether their post-apply tests pass in the container.
+
+## Scope
+
+- Stage the repository issue CLI and any required root files in the Docker
+  worktree used by `test-ubuntu` and `test-full`.
+- Keep Docker and GitHub Actions on the canonical `make test-smithers` contract
+  rather than reconstructing only part of that gate.
+- Verify `make test-ubuntu` reaches and completes the post-apply Bats suite.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-24-003-code-review-secret-gate-rejects-api-key-fixture.md
+++ b/docs/issues/2026-08-24-003-code-review-secret-gate-rejects-api-key-fixture.md
@@ -1,0 +1,34 @@
+---
+title: "Code review secret gate rejects API-key fixture"
+short_description: "The se-code-review external harness refuses the current tree because gitleaks reports the intentional issue-writer API-key redaction fixture as a new generic-api-key finding outside its baseline."
+type: "bug"
+category: "se-pipeline"
+tags: ["code-review","secret-scan","smithers"]
+date: "2026-08-24"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The `/se-code-review` external harness refused the snapshot before launching
+either Claude or OpenCode. Its whole-tree gitleaks gate reported
+`home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.test.ts` as a
+new `generic-api-key` finding not present in the stored baseline. The matching
+string is an intentional redaction fixture, but bypassing the gate would send a
+snapshot that the safety policy explicitly rejected.
+
+This prevents the required independent review legs for unrelated branches
+until the fixture and baseline agree.
+
+## Scope
+
+- Confirm the reported string is only a synthetic redaction fixture.
+- Redact or allowlist the fixture without weakening production secret scans.
+- Refresh the managed baseline through its documented workflow if the finding
+  is intentionally accepted.
+- Re-run `/se-code-review` and confirm both external legs receive the snapshot.
+
+## Open decisions
+
+None.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -543,6 +543,9 @@ HTS_GIT_BUDGET="${HTS_GIT_BUDGET:-2}"
 # gives loaded CI a margin for scheduler stalls that the baseline observes.
 HTS_FAIL_OPEN_BEHAVIOR_SECONDS="${HTS_FAIL_OPEN_BEHAVIOR_SECONDS:-2.5}"
 HTS_FAIL_OPEN_BASELINE_MULTIPLIER="${HTS_FAIL_OPEN_BASELINE_MULTIPLIER:-8}"
+# Process-heavy commands can provide a same-run healthy-path duration. The guard
+# uses it only when it exceeds the scaled one-process launch baseline.
+HTS_FAIL_OPEN_REFERENCE_MILLIS="${HTS_FAIL_OPEN_REFERENCE_MILLIS:-}"
 
 # Hang guard for the same assertions. A return after the behavioral budget is a
 # promptness regression. No return by this ceiling is a hung fail-open path.
@@ -588,7 +591,8 @@ PY
 }
 
 hts_run_fail_open_guard() {
-  local behavior_ms hang_ms baseline_multiplier baseline_start baseline_end baseline_ms
+  local behavior_ms hang_ms baseline_multiplier reference_ms
+  local baseline_start baseline_end baseline_ms behavior_baseline_ms
   local start end elapsed_ms behavior_allowed_ms hang_allowed_ms hang_allowed_seconds
   local input out err timeout_marker pid watchdog status
 
@@ -597,6 +601,11 @@ hts_run_fail_open_guard() {
   case "$HTS_FAIL_OPEN_BASELINE_MULTIPLIER" in
     '' | *[!0-9]*) return 2 ;;
     *) baseline_multiplier="$HTS_FAIL_OPEN_BASELINE_MULTIPLIER" ;;
+  esac
+  case "$HTS_FAIL_OPEN_REFERENCE_MILLIS" in
+    '' ) reference_ms=0 ;;
+    *[!0-9]*) return 2 ;;
+    *) reference_ms="$HTS_FAIL_OPEN_REFERENCE_MILLIS" ;;
   esac
   input="$(mktemp "$HTS_WORK/fail-open-stdin.XXXXXX")" || return 1
   out="$(mktemp "$HTS_WORK/fail-open-stdout.XXXXXX")" || { rm -f "$input"; return 1; }
@@ -615,7 +624,11 @@ hts_run_fail_open_guard() {
   bash -c ':' >/dev/null 2>&1
   baseline_end="$(hts_millis)"
   baseline_ms=$((baseline_end - baseline_start))
-  behavior_allowed_ms=$((behavior_ms + baseline_ms * baseline_multiplier))
+  behavior_baseline_ms=$((baseline_ms * baseline_multiplier))
+  if [ "$reference_ms" -gt "$behavior_baseline_ms" ]; then
+    behavior_baseline_ms="$reference_ms"
+  fi
+  behavior_allowed_ms=$((behavior_ms + behavior_baseline_ms))
   hang_allowed_ms=$((baseline_ms + hang_ms))
   hang_allowed_seconds="$(hts_millis_to_seconds "$hang_allowed_ms")" || {
     rm -f "$input" "$out" "$err" "$timeout_marker"
@@ -651,7 +664,7 @@ hts_run_fail_open_guard() {
   rm -f "$input" "$out" "$err" "$timeout_marker"
   if [ "$elapsed_ms" -gt "$behavior_allowed_ms" ]; then
     printf 'fail-open command exceeded fail-open behavioral deadline: elapsed_ms=%s allowed_ms=%s baseline_ms=%s\n' \
-      "$elapsed_ms" "$behavior_allowed_ms" "$baseline_ms"
+      "$elapsed_ms" "$behavior_allowed_ms" "$behavior_baseline_ms"
     return 124
   fi
   return "$status"

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -606,7 +606,10 @@ hts_run_fail_open_guard() {
     return 1
   }
   rm -f "$timeout_marker"
-  cat > "$input"
+  # A test with no redirected input must not consume the runner's terminal.
+  if [[ ! -t 0 ]]; then
+    cat > "$input"
+  fi
 
   baseline_start="$(hts_millis)"
   bash -c ':' >/dev/null 2>&1

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1755,9 +1755,21 @@ PY
   assert_output --partial "exceeded fail-open behavioral deadline"
 }
 
+@test "herdr-task-sync fail-open guard accepts a representative same-run baseline" {
+  hts_setup
+  local HTS_FAIL_OPEN_BEHAVIOR_SECONDS=0.1
+  local HTS_FAIL_OPEN_BASELINE_MULTIPLIER=0
+  local HTS_FAIL_OPEN_REFERENCE_MILLIS=1000
+
+  run hts_run_fail_open_guard sleep 0.5
+
+  assert_success
+}
+
 @test "herdr-task-sync fails open for missing tools contention write failure and malformed input" {
   hts_setup
-  local pane_dir
+  local pane_dir namespace control task_file
+  local baseline_start baseline_end baseline_status
   run hts_run_fail_open_guard env PATH="/usr/bin:/bin" HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
     HERDR_SOCKET_PATH="$HTS_DEFAULT_SOCKET" HERDR_TASK_SYNC_STATE_DIR="$HTS_STATE" \
     bash "$HTS_ENGINE" --agent claude --session missing <<< 'missing herdr'
@@ -1781,7 +1793,6 @@ PY
   hts_setup
   HERDR_TASK_SYNC_TEST_NO_WORKER=1 hts_run \
     --agent pi --session worker-write-failure --set pending-task < /dev/null
-  local namespace control
   namespace="$(hts_namespace "$HTS_DEFAULT_SOCKET")"
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
   rmdir "$namespace/tasks"
@@ -1793,9 +1804,18 @@ PY
 
   hts_setup
   HERDR_TASK_SYNC_TEST_NO_WORKER=1 hts_run \
+    --agent pi --session commit-write-control --set pending-task < /dev/null
+  HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1
+  baseline_start="$(hts_millis)"
+  baseline_status=0
+  hts_worker_run || baseline_status=$?
+  baseline_end="$(hts_millis)"
+  assert_equal "$baseline_status" 0
+  local HTS_FAIL_OPEN_REFERENCE_MILLIS=$((baseline_end - baseline_start))
+
+  HERDR_TASK_SYNC_TEST_NO_WORKER=1 hts_run \
     --agent pi --session commit-write-failure --set pending-task < /dev/null
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
-  local task_file
   task_file="$(hts_task_file "$HTS_DEFAULT_SOCKET" pi pane-1 commit-write-failure)"
   mkdir "$task_file"
   run hts_run_fail_open_guard hts_worker_run

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1693,6 +1693,56 @@ PY
   grep -q '^repository_anchor=' "$namespace_one/reconcile.state"
 }
 
+@test "herdr-task-sync fail-open guard ignores terminal input and preserves redirected input" {
+  hts_setup
+  local helper="$BATS_TEST_DIRNAME/helpers/herdr_task_sync.bash"
+
+  run python3 - "$helper" <<'PY'
+import os
+import pty
+import signal
+import subprocess
+import sys
+
+master, slave = pty.openpty()
+proc = subprocess.Popen(
+    [
+        "bash",
+        "-c",
+        'source "$1"; hts_run_fail_open_guard true',
+        "bash",
+        sys.argv[1],
+    ],
+    stdin=slave,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    start_new_session=True,
+)
+os.close(slave)
+try:
+    output, _ = proc.communicate(timeout=10)
+except subprocess.TimeoutExpired:
+    os.killpg(proc.pid, signal.SIGKILL)
+    output, _ = proc.communicate()
+    sys.stdout.write(output)
+    print("fail-open guard read from its interactive terminal for 10 seconds", file=sys.stderr)
+    raise SystemExit(124)
+finally:
+    os.close(master)
+
+sys.stdout.write(output)
+raise SystemExit(proc.returncode)
+PY
+
+  assert_success
+
+  run hts_run_fail_open_guard cat <<< 'redirected payload'
+
+  assert_success
+  assert_output 'redirected payload'
+}
+
 @test "herdr-task-sync fail-open deadline rejects late success before the hang guard" {
   hts_setup
   local HTS_FAIL_OPEN_BEHAVIOR_SECONDS=1


### PR DESCRIPTION
## Summary

Interactive `tests/scripts.bats` runs now complete instead of blocking after test 74. The fail-open harness ignores inherited terminal stdin while preserving explicit redirected payloads.

Parallel macOS CI also remains strict without flaking on process-heavy workers. Complex fail-open checks calibrate against a healthy same-path worker observed in the same run, while simple checks retain the scaled shell-launch baseline; the 2.5-second behavioral budget and 20-second hang guard remain unchanged.

## Validation

- PR CI: macOS passed in 9m59s, Ubuntu passed in 6m36s, lint passed in 14s
- Two complete interactive macOS runs: 198/198 tests passed in 4m37s and 4m43s
- Three focused fail-open cases passed after the final change
- Commit-write failure passed under 32 CPU burners in 6.396s
- A temporary 3-second commit delay made the integration test fail at its behavioral deadline
- `make test-smithers`: 626 passed
- `make test-issues`: 40 passed
- `make lint` and `git diff --check`

## Known Residuals

- Local `make test-ubuntu` is blocked before post-apply tests because its staged worktree omits `scripts/issues`; tracked by `2026-08-24-002`. PR Ubuntu CI passed the full gate.
- External Claude/OpenCode review legs were not dispatched because the secret gate rejected an intentional API-key fixture outside its baseline; tracked by `2026-08-24-003`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
