### PR TITLE
fix(ci): complete Docker gates and stabilize macOS tests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,6 +34,9 @@ services:
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
+      - ../scripts/issues:/home/testuser/issues-cli:ro
+      - ../docs/issues:/home/testuser/issues:ro
+      - ../Makefile:/home/testuser/Makefile:ro
       - ../README.md:/home/testuser/README.md:ro
     environment:
       - CHEZMOI_NAME=Test User
@@ -55,9 +58,12 @@ services:
       - |
         set -e
         echo "=== Staging writable test worktree ==="
-        mkdir -p /home/testuser/worktree
+        mkdir -p /home/testuser/worktree/.git /home/testuser/worktree/docs /home/testuser/worktree/scripts
         cp -r /home/testuser/dotfiles /home/testuser/worktree/home
         cp -r /home/testuser/tests /home/testuser/worktree/tests
+        cp /home/testuser/issues-cli /home/testuser/worktree/scripts/issues
+        cp -r /home/testuser/issues /home/testuser/worktree/docs/issues
+        cp /home/testuser/Makefile /home/testuser/worktree/Makefile
         cp /home/testuser/README.md /home/testuser/worktree/README.md
         rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
         cd /home/testuser/worktree
@@ -76,11 +82,8 @@ services:
         echo "=== Applying dotfiles (with package installation) ==="
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
 
-        echo "=== Installing smithers dependencies in the source tree ==="
-        bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
-
-        echo "=== Running Smithers type-check and tests ==="
-        (cd home/private_dot_claude/dot_smithers && bun run check)
+        echo "=== Running Smithers test gate ==="
+        make test-smithers
 
         echo "=== Running post-apply tests ==="
         tests/run-post-apply.sh full
@@ -95,6 +98,9 @@ services:
     volumes:
       - ../home:/home/testuser/dotfiles:ro
       - ../tests:/home/testuser/tests:ro
+      - ../scripts/issues:/home/testuser/issues-cli:ro
+      - ../docs/issues:/home/testuser/issues:ro
+      - ../Makefile:/home/testuser/Makefile:ro
       - ../README.md:/home/testuser/README.md:ro
     environment:
       - CHEZMOI_NAME=Test User
@@ -109,9 +115,12 @@ services:
     command:
       - |
         set -e
-        mkdir -p /home/testuser/worktree
+        mkdir -p /home/testuser/worktree/.git /home/testuser/worktree/docs /home/testuser/worktree/scripts
         cp -r /home/testuser/dotfiles /home/testuser/worktree/home
         cp -r /home/testuser/tests /home/testuser/worktree/tests
+        cp /home/testuser/issues-cli /home/testuser/worktree/scripts/issues
+        cp -r /home/testuser/issues /home/testuser/worktree/docs/issues
+        cp /home/testuser/Makefile /home/testuser/worktree/Makefile
         cp /home/testuser/README.md /home/testuser/worktree/README.md
         rm -rf /home/testuser/worktree/home/private_dot_claude/dot_smithers/node_modules
         cd /home/testuser/worktree
@@ -121,6 +130,5 @@ services:
           --promptString email="test@example.com"
         bats tests/templates.bats
         chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose
-        bun install --cwd home/private_dot_claude/dot_smithers --frozen-lockfile
-        (cd home/private_dot_claude/dot_smithers && bun run check)
+        make test-smithers
         tests/run-post-apply.sh full

--- a/docs/issues/2026-08-24-002-ubuntu-docker-omits-issue-cli-from-smithers-tests.md
+++ b/docs/issues/2026-08-24-002-ubuntu-docker-omits-issue-cli-from-smithers-tests.md
@@ -1,12 +1,13 @@
 ---
 title: "Ubuntu Docker omits issue CLI from Smithers tests"
-short_description: "make test-ubuntu fails the Smithers publishIssue real-CLI test because the staged Docker worktree omits scripts/issues, even though the same 626-test gate passes from the complete host checkout."
+short_description: "Docker test services now stage the issue CLI, issue records, a worktree marker, and the Makefile so the canonical Smithers gate and post-apply issue smoke test run from the reconstructed checkout."
 type: "bug"
 category: "testing-ci"
 tags: ["docker","smithers","test-gate"]
 date: "2026-08-24"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-24"
 ---
 
 ## Why this exists
@@ -32,3 +33,7 @@ can hide whether their post-apply tests pass in the container.
 ## Open decisions
 
 None.
+
+## Resolution
+
+Mounted and staged scripts/issues, docs/issues, and Makefile in both Docker test services, created the staged worktree marker required by the issue CLI, and replaced duplicated Bun commands with make test-smithers. Added a two-service Docker contract regression test and verified it red when the test-ubuntu CLI mount was removed and green after restoration. Verified make test-smithers with 626 passing tests, make test-issues with 41 passing tests, Compose validation, and make test-ubuntu through all 357 post-apply Bats cases.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -590,6 +590,17 @@ print(millis / decimal.Decimal(1000))
 PY
 }
 
+hts_fail_open_behavior_baseline_ms() {
+  local launch_ms="$1" multiplier="$2" reference_ms="$3"
+  local scaled_ms=$((launch_ms * multiplier))
+
+  if [ "$reference_ms" -gt "$scaled_ms" ]; then
+    printf '%s\n' "$reference_ms"
+  else
+    printf '%s\n' "$scaled_ms"
+  fi
+}
+
 hts_run_fail_open_guard() {
   local behavior_ms hang_ms baseline_multiplier reference_ms
   local baseline_start baseline_end baseline_ms behavior_baseline_ms
@@ -624,10 +635,9 @@ hts_run_fail_open_guard() {
   bash -c ':' >/dev/null 2>&1
   baseline_end="$(hts_millis)"
   baseline_ms=$((baseline_end - baseline_start))
-  behavior_baseline_ms=$((baseline_ms * baseline_multiplier))
-  if [ "$reference_ms" -gt "$behavior_baseline_ms" ]; then
-    behavior_baseline_ms="$reference_ms"
-  fi
+  behavior_baseline_ms="$(
+    hts_fail_open_behavior_baseline_ms "$baseline_ms" "$baseline_multiplier" "$reference_ms"
+  )"
   behavior_allowed_ms=$((behavior_ms + behavior_baseline_ms))
   hang_allowed_ms=$((baseline_ms + hang_ms))
   hang_allowed_seconds="$(hts_millis_to_seconds "$hang_allowed_ms")" || {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1903,42 +1903,92 @@ PY
   local pi_adapter="$SOURCE_ROOT/dot_pi/agent/extensions/herdr-task-sync.ts"
   local opencode_adapter="$SOURCE_ROOT/private_dot_config/opencode/plugins/herdr-task-sync.ts"
   local home="$BATS_TEST_TMPDIR/adapter-timeout-home"
+  local driver="$home/adapter-timeout-driver.ts"
   mkdir -p "$home/.local/bin"
   cat > "$home/.local/bin/herdr-task-sync" <<'SH'
 #!/bin/sh
+agent=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--agent" ] && [ "$#" -gt 1 ]; then
+    agent="$2"
+    break
+  fi
+  shift
+done
+[ -n "$agent" ] || exit 2
+started="$HOME/$agent.started"
+terminated="$HOME/$agent.terminated"
+trap 'touch "$terminated"; exit 0' TERM
+touch "$started"
 cat >/dev/null
-trap 'exit 0' TERM
 while :; do sleep 0.05; done
 SH
   chmod +x "$home/.local/bin/herdr-task-sync"
 
-  run env HOME="$home" HERDR_ENV=1 PI_ADAPTER_PATH="$pi_adapter" \
-    OPENCODE_ADAPTER_PATH="$opencode_adapter" bun -e '
-      const piHandlers = {}
-      const piExtension = (await import(`file://${process.env.PI_ADAPTER_PATH}`)).default
-      piExtension({
-        getSessionName: () => undefined,
-        on: (event, handler) => { piHandlers[event] = handler },
-      })
-      const context = {
-        hasUI: true,
-        sessionManager: { getSessionId: () => "pi-root" },
-      }
-      await piHandlers.session_start({}, context)
-      const piStart = performance.now()
-      await piHandlers.before_agent_start({ prompt: "hung pi engine" }, context)
-      if (performance.now() - piStart > 1750) throw new Error("pi adapter exceeded timeout")
+  cat > "$driver" <<'TS'
+const piHandlers = {}
+const piExtension = (await import(`file://${process.env.PI_ADAPTER_PATH}`)).default
+piExtension({
+  getSessionName: () => undefined,
+  on: (event, handler) => { piHandlers[event] = handler },
+})
+const context = {
+  hasUI: true,
+  sessionManager: { getSessionId: () => "pi-root" },
+}
+await piHandlers.session_start({}, context)
+await piHandlers.before_agent_start({ prompt: "hung pi engine" }, context)
 
-      const { HerdrTaskSyncPlugin } = await import(`file://${process.env.OPENCODE_ADAPTER_PATH}`)
-      const hooks = await HerdrTaskSyncPlugin()
-      const opencodeStart = performance.now()
-      await hooks["chat.message"](
-        { sessionID: "opencode-root" },
-        { parts: [{ type: "text", text: "hung opencode engine" }] },
-      )
-      if (performance.now() - opencodeStart > 1750) throw new Error("opencode adapter exceeded timeout")
-    '
+const { HerdrTaskSyncPlugin } = await import(`file://${process.env.OPENCODE_ADAPTER_PATH}`)
+const hooks = await HerdrTaskSyncPlugin()
+await hooks["chat.message"](
+  { sessionID: "opencode-root" },
+  { parts: [{ type: "text", text: "hung opencode engine" }] },
+)
+TS
+
+  run python3 - "$home" "$driver" "$pi_adapter" "$opencode_adapter" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+home, driver, pi_adapter, opencode_adapter = sys.argv[1:]
+env = os.environ.copy()
+env.update(
+    HOME=home,
+    HERDR_ENV="1",
+    PI_ADAPTER_PATH=pi_adapter,
+    OPENCODE_ADAPTER_PATH=opencode_adapter,
+)
+proc = subprocess.Popen(
+    ["bun", driver],
+    env=env,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    start_new_session=True,
+)
+try:
+    output, _ = proc.communicate(timeout=30)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    output, _ = proc.communicate()
+    sys.stdout.write(output)
+    print("adapter timeout fixture exceeded its 30-second hang guard", file=sys.stderr)
+    raise SystemExit(124)
+
+sys.stdout.write(output)
+raise SystemExit(proc.returncode)
+PY
   assert_success
+  assert_file_exists "$home/pi.started"
+  assert_file_exists "$home/pi.terminated"
+  assert_file_exists "$home/opencode.started"
+  assert_file_exists "$home/opencode.terminated"
 }
 
 @test "herdr-task-sync opencode forgets a deleted child session" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1754,15 +1754,14 @@ PY
   assert_output --partial "exceeded fail-open behavioral deadline"
 }
 
-@test "herdr-task-sync fail-open guard accepts a representative same-run baseline" {
-  hts_setup
-  local HTS_FAIL_OPEN_BEHAVIOR_SECONDS=0.1
-  local HTS_FAIL_OPEN_BASELINE_MULTIPLIER=0
-  local HTS_FAIL_OPEN_REFERENCE_MILLIS=1000
-
-  run hts_run_fail_open_guard sleep 0.5
-
+@test "herdr-task-sync fail-open guard uses the greater baseline" {
+  run hts_fail_open_behavior_baseline_ms 200 8 1000
   assert_success
+  assert_output 1600
+
+  run hts_fail_open_behavior_baseline_ms 100 8 1000
+  assert_success
+  assert_output 1000
 }
 
 @test "herdr-task-sync fails open for missing tools contention write failure and malformed input" {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -32,7 +32,6 @@ teardown() {
   assert_file_contains "$SOURCE_ROOT/private_dot_config/brewfiles/Brewfile.tmpl" '^brew "shellcheck"'
 }
 
-# Docker mounts only home/ and tests/, so the repo-root Makefile is absent there.
 @test "lint target propagates shellcheck failures" {
   local repo_root="$BATS_TEST_DIRNAME/.."
   [[ -f "$repo_root/Makefile" ]] || skip "repo-root Makefile is not available in this environment"

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -9,11 +9,19 @@ COMPOSE = REPOSITORY / "docker" / "docker-compose.yml"
 
 
 class TestDockerContract(unittest.TestCase):
-    def test_make_test_ubuntu_uses_clearly_named_full_apply_service(self):
-        makefile = MAKEFILE.read_text(encoding="utf-8")
-        compose = COMPOSE.read_text(encoding="utf-8")
+    @classmethod
+    def setUpClass(cls):
+        cls.makefile = MAKEFILE.read_text(encoding="utf-8")
+        cls.compose = COMPOSE.read_text(encoding="utf-8")
 
-        target = re.search(r"^test-ubuntu:.*\n\t(?P<command>[^\n]+)", makefile, re.MULTILINE)
+    def service_block(self, service_name):
+        pattern = r"^  %s:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|^\S|\Z)" % re.escape(service_name)
+        match = re.search(pattern, self.compose, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(match, "docker-compose.yml must define the %s service" % service_name)
+        return match.group("body")
+
+    def test_make_test_ubuntu_uses_clearly_named_full_apply_service(self):
+        target = re.search(r"^test-ubuntu:.*\n\t(?P<command>[^\n]+)", self.makefile, re.MULTILINE)
         self.assertIsNotNone(target, "Makefile must define the test-ubuntu target")
         self.assertIn(
             "docker compose -f docker/docker-compose.yml run --rm test-ubuntu",
@@ -21,10 +29,31 @@ class TestDockerContract(unittest.TestCase):
             "make test-ubuntu must not route through a misleading service name",
         )
 
-        self.assertRegex(compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
-        self.assertNotRegex(compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
-        self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", compose)
-        self.assertIn("tests/idempotent.bats", compose)
+        self.assertRegex(self.compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
+        self.assertNotRegex(self.compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
+        self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", self.compose)
+        self.assertIn("tests/idempotent.bats", self.compose)
+
+    def test_full_suite_services_stage_issue_cli_and_use_canonical_smithers_gate(self):
+        required = [
+            "../scripts/issues:/home/testuser/issues-cli:ro",
+            "../docs/issues:/home/testuser/issues:ro",
+            "../Makefile:/home/testuser/Makefile:ro",
+            "mkdir -p /home/testuser/worktree/.git /home/testuser/worktree/docs /home/testuser/worktree/scripts",
+            "cp /home/testuser/issues-cli /home/testuser/worktree/scripts/issues",
+            "cp -r /home/testuser/issues /home/testuser/worktree/docs/issues",
+            "cp /home/testuser/Makefile /home/testuser/worktree/Makefile",
+            "make test-smithers",
+        ]
+
+        for service_name in ("test-full", "test-ubuntu"):
+            with self.subTest(service=service_name):
+                service = self.service_block(service_name)
+                for contract_line in required:
+                    self.assertIn(contract_line, service)
+
+        self.assertNotIn("bun install --cwd home/private_dot_claude/dot_smithers", self.compose)
+        self.assertNotIn("bun run check", self.compose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`make test-ubuntu` now reaches and completes both the canonical Smithers gate and the post-apply suite. The reconstructed Docker worktree previously omitted the repository issue CLI, so Smithers failed before post-apply coverage; the staged checkout now carries the required repository-root contract and delegates to `make test-smithers` instead of duplicating part of that gate.

The macOS suite no longer mistakes scheduler contention for fail-open regressions. Baseline selection is verified as deterministic arithmetic, while hung Pi and OpenCode adapters now prove that the engine starts and receives `SIGTERM`; a separate process-group watchdog handles true hangs without turning elapsed runtime into the behavioral verdict. Production adapter and fail-open thresholds remain unchanged.

A fast two-service contract test guards the staging requirements for both Docker test services and was calibrated red by removing the `test-ubuntu` CLI mount before restoring the fix.

## Validation

- `make test-ubuntu` (626 Smithers tests and 357 post-apply Bats cases)
- `make test-issues` (41 tests)
- `make test-suite` (343 tests; 2 macOS-only skips)
- `bats --filter 'herdr-task-sync fail-open' tests/scripts.bats` (3 tests)
- `bats --filter '^herdr-task-sync adapters return when a direct engine hangs$' tests/scripts.bats`
- Adapter mutation calibration: removing Pi's `SIGTERM` fails with hang-guard status `124`
- `make lint`
- `docker compose -f docker/docker-compose.yml config --quiet`
- `git diff --check origin/main...HEAD`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
