### PR TITLE
fix(skills): prevent truncated herdr peer reports

### DIFF
--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -12,7 +12,7 @@ Resolve these values before launch:
 
 Require `HERDR_ENV=1`, `herdr`, `claude`, and `opencode`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
 
-The **cleanup boundary** begins when the first pane is created. Track each created pane ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every pane created by this run before control returns to the calling skill.
+The **cleanup boundary** begins when the report transport directory is created. Track each created pane ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every pane created by this run and removes its report transport files before control returns to the calling skill.
 
 ## Create panes
 
@@ -22,6 +22,11 @@ Use run-scoped agent names no longer than 32 characters:
 PEER_RUN_ID="$(date +%s)-$$"
 CLAUDE_NAME="se-claude-$PEER_RUN_ID"
 OPENCODE_NAME="se-opencode-$PEER_RUN_ID"
+
+PEER_REPORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/se-peer-$PEER_RUN_ID.XXXXXX")
+chmod 700 "$PEER_REPORT_DIR"
+CLAUDE_REPORT_PATH="$PEER_REPORT_DIR/claude.report"
+OPENCODE_REPORT_PATH="$PEER_REPORT_DIR/opencode.report"
 ```
 
 Create sibling panes rooted at the repository without taking focus:
@@ -71,7 +76,21 @@ Each start is complete only when the command succeeds and reports `interactive_r
 
 ## Prompt both peers
 
-Submit both prompts before either wait can block:
+Append the report transport contract to each calling prompt. This is the only permitted file-write exception in a report-only peer: it does not permit changes to the checkout, reviewed document, or any other file.
+
+```bash
+CLAUDE_PROMPT="$CLAUDE_PROMPT
+
+[peer-report-transport]
+Before ending this turn, write the exact complete report you are returning, byte-for-byte, to $CLAUDE_REPORT_PATH. Write it atomically through $CLAUDE_REPORT_PATH.tmp and rename the completed file to $CLAUDE_REPORT_PATH. The file is the authoritative report transport. After it is durable, return the same report in the UI as usual. Do not write any other file."
+
+OPENCODE_PROMPT="$OPENCODE_PROMPT
+
+[peer-report-transport]
+Before ending this turn, write the exact complete report you are returning, byte-for-byte, to $OPENCODE_REPORT_PATH. Write it atomically through $OPENCODE_REPORT_PATH.tmp and rename the completed file to $OPENCODE_REPORT_PATH. The file is the authoritative report transport. After it is durable, return the same report in the UI as usual. Do not write any other file."
+```
+
+Submit both augmented prompts before either wait can block:
 
 ```bash
 herdr agent prompt "$CLAUDE_NAME" "$CLAUDE_PROMPT"
@@ -80,29 +99,58 @@ herdr agent prompt "$OPENCODE_NAME" "$OPENCODE_PROMPT"
 
 After both submissions, perform any concurrent local work explicitly defined by the calling skill. Skills with no concurrent work proceed directly to waiting.
 
-## Wait and read
+## Wait and collect
 
 ```bash
 herdr agent wait "$CLAUDE_NAME" --timeout 1800000
 herdr agent wait "$OPENCODE_NAME" --timeout 1800000
 ```
 
-Read Claude from `visible` and OpenCode from `recent-unwrapped`:
+The report files are the primary transport. A settled peer that did not create a non-empty regular report file gets one bounded recovery prompt to persist its previous answer:
 
 ```bash
-CLAUDE_REPORT=$(herdr agent read "$CLAUDE_NAME" --source visible --format text)
-OPENCODE_REPORT=$(herdr agent read "$OPENCODE_NAME" --source recent-unwrapped --format text)
+recover_peer_report() {
+  local agent_name="$1" report_path="$2"
+  [ -f "$report_path" ] && [ -s "$report_path" ] && return 0
+
+  herdr agent prompt "$agent_name" \
+    "The report transport file is missing or empty. Write your exact complete previous report, byte-for-byte, atomically through $report_path.tmp and rename it to $report_path. Then reply with only the path." \
+    --wait --timeout 120000 || return 1
+
+  [ -f "$report_path" ] && [ -s "$report_path" ]
+}
+
+CLAUDE_TRANSPORT_OK=1
+if ! recover_peer_report "$CLAUDE_NAME" "$CLAUDE_REPORT_PATH"; then
+  CLAUDE_TRANSPORT_OK=0
+  CLAUDE_DIAGNOSTIC=$(herdr agent read "$CLAUDE_NAME" --source visible --lines 200 --format text || true)
+fi
+
+OPENCODE_TRANSPORT_OK=1
+if ! recover_peer_report "$OPENCODE_NAME" "$OPENCODE_REPORT_PATH"; then
+  OPENCODE_TRANSPORT_OK=0
+  OPENCODE_DIAGNOSTIC=$(herdr agent read "$OPENCODE_NAME" --source recent-unwrapped --lines 200 --format text || true)
+fi
+
+[ "$CLAUDE_TRANSPORT_OK" -eq 0 ] || CLAUDE_REPORT=$(<"$CLAUDE_REPORT_PATH")
+[ "$OPENCODE_TRANSPORT_OK" -eq 0 ] || OPENCODE_REPORT=$(<"$OPENCODE_REPORT_PATH")
 ```
 
-A settled state is only a wake-up signal. The calling skill must validate a complete report before accepting either result.
+A settled state is only a wake-up signal. Pane-backed reads can silently omit alternate-screen history and are diagnostic only; never accept `CLAUDE_DIAGNOSTIC` or `OPENCODE_DIAGNOSTIC` as a report. A failed transport degrades that peer. The calling skill must still validate the complete file-backed report before accepting it.
 
-## Close before synthesis
+## Close and clean before synthesis
 
-After reading every available report, close both panes before synthesis:
+After collecting every available report into memory, close both panes and remove the transport directory before synthesis:
 
 ```bash
-herdr pane close "$CLAUDE_PANE"
-herdr pane close "$OPENCODE_PANE"
+CLEANUP_ERRORS=""
+herdr pane close "$CLAUDE_PANE" || CLEANUP_ERRORS="$CLEANUP_ERRORS pane:$CLAUDE_PANE"
+herdr pane close "$OPENCODE_PANE" || CLEANUP_ERRORS="$CLEANUP_ERRORS pane:$OPENCODE_PANE"
+rm -f "$CLAUDE_REPORT_PATH" "$CLAUDE_REPORT_PATH.tmp" \
+  "$OPENCODE_REPORT_PATH" "$OPENCODE_REPORT_PATH.tmp" \
+  || CLEANUP_ERRORS="$CLEANUP_ERRORS reports:$PEER_REPORT_DIR"
+rmdir "$PEER_REPORT_DIR" || CLEANUP_ERRORS="$CLEANUP_ERRORS directory:$PEER_REPORT_DIR"
+[ -z "$CLEANUP_ERRORS" ] || printf 'peer cleanup incomplete:%s\n' "$CLEANUP_ERRORS" >&2
 ```
 
-Pane closure completes the cleanup boundary. Attempt every recorded pane closure even when an earlier close command fails; report any pane that remains open.
+Pane closure and report-directory removal complete the cleanup boundary. Attempt every recorded pane closure and every cleanup command even when an earlier command fails; report any pane or transport path that remains.

--- a/home/private_dot_claude/skills/se-code-review/SKILL.md
+++ b/home/private_dot_claude/skills/se-code-review/SKILL.md
@@ -38,8 +38,9 @@ Invoke `/compound-engineering:ce-code-review` with these exact arguments:
 
 mode:agent <resolved arguments>
 
-This is an independent report-only review. Do not edit files, stage changes,
-commit, push, switch branches, or ask interactive questions.
+This is an independent report-only review. Do not edit repository files, stage
+changes, commit, push, switch branches, or ask interactive questions. The shared
+lifecycle's report transport file is the only permitted write.
 
 Run the complete reviewer selection, persona dispatch, validation, merge, and
 JSON output flow. Return the final raw JSON report.
@@ -52,8 +53,9 @@ Use the `ce-code-review` skill with these exact arguments:
 
 mode:agent <resolved arguments>
 
-This is an independent report-only review. Do not edit files, stage changes,
-commit, push, switch branches, or ask interactive questions.
+This is an independent report-only review. Do not edit repository files, stage
+changes, commit, push, switch branches, or ask interactive questions. The shared
+lifecycle's report transport file is the only permitted write.
 
 Run the complete reviewer selection, persona dispatch, validation, merge, and
 JSON output flow. Return the final raw JSON report.

--- a/home/private_dot_claude/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_claude/skills/se-doc-review/SKILL.md
@@ -61,9 +61,10 @@ Run the complete document classification, persona selection and dispatch,
 validation, synthesis, and headless-envelope flow.
 
 This is an independent report-only review. Do not create, edit, or delete any
-file; stage changes; commit; push; switch branches; or ask interactive
-questions. Where the workflow would apply a safe_auto fix, keep it in the
-envelope as an applied-candidate finding with the exact suggested edit.
+repository file or the reviewed document; stage changes; commit; push; switch
+branches; or ask interactive questions. The shared lifecycle's report transport
+file is the only permitted write. Where the workflow would apply a safe_auto fix,
+keep it in the envelope as an applied-candidate finding with the exact suggested edit.
 
 Return the canonical complete headless envelope, not a completion note.
 Coverage must name every persona attempted and its status.
@@ -87,9 +88,10 @@ Run the complete document classification, persona selection and dispatch,
 validation, synthesis, and headless-envelope flow.
 
 This is an independent report-only review. Do not create, edit, or delete any
-file; stage changes; commit; push; switch branches; or ask interactive
-questions. Where the workflow would apply a safe_auto fix, keep it in the
-envelope as an applied-candidate finding with the exact suggested edit.
+repository file or the reviewed document; stage changes; commit; push; switch
+branches; or ask interactive questions. The shared lifecycle's report transport
+file is the only permitted write. Where the workflow would apply a safe_auto fix,
+keep it in the envelope as an applied-candidate finding with the exact suggested edit.
 
 Return the canonical complete headless envelope, not a completion note.
 Coverage must name every persona attempted and its status.

--- a/home/private_dot_claude/skills/se-simplify/SKILL.md
+++ b/home/private_dot_claude/skills/se-simplify/SKILL.md
@@ -39,8 +39,9 @@ Invoke `/compound-engineering:ce-simplify-code` as the governing rubric for this
 Execute only Step 1 and Step 2: resolve the scope and run the code-reuse,
 code-quality, and efficiency reviewers. Do not execute Steps 3 through 5.
 
-This is an independent report-only simplification review. Do not edit files,
-stage changes, commit, push, switch branches, or ask interactive questions.
+This is an independent report-only simplification review. Do not edit repository
+files, stage changes, commit, push, switch branches, or ask interactive questions.
+The shared lifecycle's report transport file is the only permitted write.
 
 Return a complete report with these sections:
 - Coverage: status for code-reuse, code-quality, and efficiency.
@@ -62,8 +63,9 @@ Use the `ce-simplify-code` skill as the governing rubric for this scope:
 Execute only Step 1 and Step 2: resolve the scope and run the code-reuse,
 code-quality, and efficiency reviewers. Do not execute Steps 3 through 5.
 
-This is an independent report-only simplification review. Do not edit files,
-stage changes, commit, push, switch branches, or ask interactive questions.
+This is an independent report-only simplification review. Do not edit repository
+files, stage changes, commit, push, switch branches, or ask interactive questions.
+The shared lifecycle's report transport file is the only permitted write.
 
 Return a complete report with these sections:
 - Coverage: status for code-reuse, code-quality, and efficiency.


### PR DESCRIPTION
## Summary

Long Claude and OpenCode peer reports can no longer arrive at synthesis as plausible-looking JSON or Markdown tails with most findings silently missing. Herdr pane snapshots remain useful for diagnostics, but they are no longer trusted as an unbounded report transport.

Each peer now writes its complete report atomically into a private run-scoped directory during the original turn. A missing or empty file receives one bounded recovery prompt; if transport still fails, that peer degrades instead of passing truncated pane content downstream. Report files and panes are cleaned before synthesis, and the three report-only workflows permit only this transport write while continuing to forbid repository or document edits.

## Related

Related: #80

## Validation

- Parsed all 9 Bash blocks in `herdr-peer-launch.md` with `bash -n`
- `make test-templates`: 27 passed
- `make lint`
- `make test-ubuntu`: 338 Bats cases and 542 Smithers tests passed, including disposable-home apply, verify, and idempotency
- The original long-report failure was reproduced twice in the supplied handoff; no additional paid peer review run was required

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
