### PR TITLE
feat: add herdr git-status plugin comparison playground

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ lint:
 	@echo "=== Running shellcheck ==="
 	find . -name "*.sh" -type f -not -path "./.git/*" -not -path "*/node_modules/*" | xargs shellcheck --severity=warning
 	find home -name "run_*" -type f 2>/dev/null | xargs shellcheck --severity=warning
-	find home -name "executable_*" -type f -not -name "*.py" 2>/dev/null | xargs shellcheck --severity=warning
+	find home -name "executable_*" -type f -exec sh -c 'for file do case "$$(head -n 1 "$$file")" in *python*) ;; *) shellcheck --severity=warning "$$file" || exit ;; esac; done' sh {} +
 
 clean:
 	docker compose -f docker/docker-compose.yml down --rmi local --volumes --remove-orphans 2>/dev/null || true

--- a/docs/herdr-git-status-playground.md
+++ b/docs/herdr-git-status-playground.md
@@ -1,0 +1,216 @@
+# Herdr Git status playground runbook
+
+A disposable comparison rig for four Herdr Git/pull-request status plugins
+(`ez-corp.git-status`, `git-detail`, `gitlab-ci-status`,
+`jmarbutt.spaces-pr-status`), each run alone against the same local Git and
+GitHub pull-request fixture catalog. The goal of a run is one attributed
+inventory — evidence for a later sidebar-design decision, never a winner.
+
+The controller is `home/dot_local/bin/executable_herdr-git-status-playground`,
+deployed by chezmoi to `~/.local/bin/herdr-git-status-playground`. It never
+mutates the live Herdr profile, and standard automated tests never contact
+GitHub or a real Herdr install (they run against stateful stubs). One real,
+authenticated macOS trial is the only place this playground talks to a real
+Herdr, Git, and GitHub — and that trial is owned by the operator, not by CI.
+
+## Prerequisites
+
+The command itself needs only Python 3.9+. A **real trial** additionally
+needs, on `PATH`:
+
+| Tool | Used by |
+|---|---|
+| Herdr 0.8.2 (exact version, resolved to an approved absolute path) | every profile |
+| Git | fixture construction, all four candidates |
+| Cargo | `ez-corp.git-status` build |
+| Node.js 20+ | `jmarbutt.spaces-pr-status` build |
+| `jq` | `gitlab-ci-status` |
+| `gh` (GitHub CLI), authenticated with two **separate** tokens | remote candidates and controller bootstrap |
+
+None of these are added to the managed Homebrew bundle: they are specific to
+this disposable trial, not to the base machine contract. `start` preflights
+every one of them and fails closed, before any profile or server exists, if
+any is missing, at the wrong version, or resolves somewhere other than the
+approved path passed via `--approved-herdr`. On failure the reported error
+message includes a `toolchain_status` map recording every optional
+toolchain's own state (`found` or `missing`), not just the first one checked,
+so a single failed preflight tells the operator the complete gap — not one
+tool at a time. Remediation is always one of:
+
+- install the missing toolchain **temporarily**, in a scratch location
+  removed after the trial (for example a throwaway `rustup`/`npm` prefix), or
+- point `PATH` at an already-configured install that lives elsewhere.
+
+Never add a trial-only toolchain to the managed Brewfile.
+
+Herdr identity is checked the same way: the resolved executable's absolute
+path, device, and inode are recorded, and any executable reporting a version
+other than `0.8.2` — or resolving somewhere other than the approved path —
+fails preflight (`HERDR_VERSION_UNAPPROVED` / `HERDR_PATH_CHANGED`).
+
+Two **separate**, least-privilege GitHub credentials are required beyond the
+toolchains: a controller-write credential (repository administration:
+bootstrap, lease, pending-workflow settlement) and a candidate-read
+credential (scoped read-only access for the four candidate profiles). They
+are supplied through environment variables
+(`HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN`,
+`HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN`), never written to a config
+file, and never appear together in the same process's environment.
+
+## Fixture ownership
+
+The GitHub side of the catalog lives in one operator-supplied, pre-existing,
+otherwise-empty repository — never `my-mac-setup`, and never created or
+deleted by the playground. `bootstrap --initialize --fixture-ownership
+<path>` performs the one-time atomic claim: it verifies the repository's
+canonical host/owner/name and immutable ID, then creates its default branch
+with an owned marker file and an inert pinned GitHub Actions workflow
+(`permissions: {}`, no secrets, no third-party actions, bounded runtime).
+Later runs call plain `bootstrap --fixture-ownership <path>` to converge the
+durable pull-request fixtures (`no-pr`, `draft`, `checks-failed`,
+`checks-passed`, `merge-conflict`) plus the per-run `checks-pending` fixture,
+without recreating or duplicating anything already owned. The
+`--fixture-ownership` file records `host`, `owner`, `name`, and
+`repository_id` — keep it out of version control; it is a claim record, not
+a secret, but it is specific to one operator's fixture repository.
+
+The local side of the catalog (`checkout-clean`, `checkout-dirty`,
+`worktree-clean`, `worktree-dirty`, `conflict`, `diverged-stash`, `detached`,
+`non-git`) is built fresh, under the run's own disposable directory, on
+every `start` — there is nothing to bootstrap for it.
+
+Approved and changes-requested pull-request review states are intentionally
+absent from the catalog: a single operator cannot produce a genuine
+self-review decision, so those two states are deferred until a second
+reviewer identity exists. Do not add them to this playground; a future
+review-state pass owns that work.
+
+## Normal use (F1 → F2 → F3)
+
+```
+herdr-git-status-playground bootstrap --initialize --fixture-ownership <path>   # once per fixture repository
+herdr-git-status-playground bootstrap --fixture-ownership <path>                # idempotent convergence
+herdr-git-status-playground start --approved-herdr <path> \
+  --fixture-ownership <path> --audit-attestation <path>
+herdr-git-status-playground view <run-id>                                       # attach the four-pane comparison viewer
+herdr-git-status-playground snapshot <run-id> --profile <name> --fixture <label> \
+  --notes "..." --dependency-note "..." --error-link "..." \
+  [--applicability applicable|not-applicable|no-visible-signal|discrepancy --applicability-reason "..."] \
+  [--screenshot <path>]
+herdr-git-status-playground snapshot <run-id> --finalize
+herdr-git-status-playground stop <run-id>
+```
+
+`--audit-attestation` points at a JSON file recording an operator-approved
+audit of each pinned candidate's exact commit and fetched tree — launch is
+blocked without one (KTD16). `start` is non-interactive by default: it
+returns the run ID once the run reaches `active-ready` and leaves `view` for
+later. An interactive terminal instead attaches the viewer immediately.
+
+Candidate names are `ezcorp`, `sfroment`, `krystof`, `jmarbutt`. Fixture
+labels are the eight local names above plus the GitHub fixtures prefixed
+`gh-` (`gh-no-pr`, `gh-draft`, `gh-checks-failed`, `gh-checks-passed`,
+`gh-merge-conflict`) and `gh-checks-pending`. `snapshot --finalize` accepts
+the run only once every candidate has exactly one recorded observation for
+every fixture, every required field is present, GitHub authority has not
+drifted since capture, the four viewer panes are still equal, and every
+candidate's live focus matches the run's recorded current fixture.
+
+### Applicability, not ranking
+
+Every snapshot records one of four applicability states:
+
+- `applicable` — the candidate produced ordinary, attributable output.
+- `not-applicable` — the candidate has no capability for this fixture family
+  at all (for example a pull-request-only candidate against a local-only
+  fixture). This is expected, not a defect.
+- `no-visible-signal` — the candidate is applicable in principle but showed
+  nothing for this fixture; record why in `--applicability-reason`.
+- `discrepancy` — the candidate showed something that disagrees with ground
+  truth; record the disagreement in the reason.
+
+The inventory never turns any of these into a ranking. It is evidence for
+the follow-up sidebar-design brainstorm to weigh, not a verdict this
+playground reaches itself.
+
+## Recovery from every non-terminal state
+
+| State | Meaning | Recovery |
+|---|---|---|
+| `provisioning` | `start` is mid-flight or was interrupted before readiness | `status <run-id>` to inspect; `stop <run-id>` reconciles and tears down whatever was partially launched |
+| `active-ready` | Every profile, fixture, and socket is current | Normal `view`/`snapshot`/`stop` |
+| `active-degraded` | The run reached `active-ready` once, but a later probe (GitHub authority drift, a dead owned process) failed | `view` still works if you explicitly ask for it; `snapshot` remains diagnostic evidence but cannot satisfy `--finalize`; `stop` is available and is the usual next step |
+| `startup-failed-cleaned` | Initial activation failed and automatic cleanup fully succeeded | Nothing to recover — evidence and diagnostics remain readable; start a new run |
+| `stopping` | `stop` currently owns the run's mutation lease | Wait, or inspect with `status` from another process; a concurrent `stop` reports `RUN_BUSY` rather than racing |
+| `cleanup-incomplete` | `stop` could not prove every owned resource (process, socket, pending GitHub workflow, repository lease, or the live-profile invariant below) was settled | Inspect `teardown.json` and `logs/controller.log` for the exact unresolved code, fix the underlying condition (for example restore a process the operator killed by hand, or confirm no unrelated GitHub activity moved the fixture ref), then run `stop <run-id>` again — repeated `stop` resumes only the still-incomplete phases |
+| `stopped` | Every owned local and remote transient is gone, the live-profile invariant matched, and disposable runtime was removed | Terminal; `status` and evidence remain readable indefinitely |
+
+`stop` is always idempotent and safe to repeat. It never signals a process
+whose recorded start identity does not match what is actually running, so a
+`cleanup-incomplete` run never becomes a reason to reach for `kill` by hand.
+
+## Evidence interpretation
+
+Each run's durable bundle lives under
+`${XDG_STATE_HOME:-~/.local/state}/herdr-git-status-playground/runs/<run-id>/`:
+
+- `manifest.json` — run identity, lifecycle state, profile/process ownership,
+  and the KTD15 live-profile invariant (`before`/`after`/`match`, see below).
+- `ground-truth/` — independently measured Git and GitHub state, captured
+  before any candidate can influence what "correct" means for a fixture.
+- `observations/` — one timestamped, hashed record per candidate/fixture
+  snapshot, plus the no-plugin baseline captured before any candidate
+  activated.
+- `evidence-index.json` — the flat row list `inventory.md` is projected from;
+  each row carries every category below plus its observation ID and evidence
+  hashes.
+- `inventory.md` — the human worksheet. Every column is an immutable
+  controller measurement **except** the three marked `(operator)`
+  (readability note, dependency note, error link), which are free text and
+  never a ranking. Columns cover: capability family, baseline signal,
+  candidate-visible signal, companion surface, ground truth, refresh/
+  authority state, terminal dimensions, displaced/duplicated baseline
+  signals, applicability, lifecycle state, observation ID, and evidence
+  hashes.
+- `logs/controller.log` — raw (redacted) diagnostics for troubleshooting a
+  run that has not yet reached a fully cleaned terminal state. Removed the
+  moment teardown reaches `stopped` (or `startup-failed-cleaned`); it is
+  never part of the evidence a successful run retains.
+- `teardown.json` — the teardown record: per-candidate adapter cleanup
+  results, owned-process verification, pending GitHub run settlement,
+  repository-lease release, and the live-profile invariant after-check.
+
+Every durable record is redacted before it is written: both scoped
+credential values are scrubbed to `<redacted>` wherever they would otherwise
+appear (configuration, environment dumps, subprocess diagnostics, or a
+candidate's own output), and nothing under a run directory is ever readable
+by another user (`0700`/`0600` throughout).
+
+### The live-profile invariant (KTD15)
+
+`start` captures a read-only snapshot of the **live** Herdr profile — the
+one this playground must never touch — before any playground-owned resource
+exists: its plugin registry, spaces/labels, sidebar rows, and session-socket
+identity. `stop` captures the same snapshot again immediately before
+releasing the repository lease and removing disposable runtime, and compares
+the two. A run that reaches `active-ready` and tears down cleanly always
+records a matching `before`/`after` pair. A mismatch — something changed the
+live profile while the run was active, whether or not the playground caused
+it — blocks teardown at `cleanup-incomplete` with
+`LIVE_PROFILE_INVARIANT_MISMATCH` and preserves both snapshots for
+inspection; nothing here is repaired automatically, since the playground
+does not know what the correct live state should be.
+
+## Deferred review states
+
+Approved and changes-requested pull-request states are excluded from every
+fixture catalog and every candidate observation by design (see "Fixture
+ownership" above), not because of a bug or an oversight. A future unit that
+introduces a second reviewer identity is the only place this should change.
+
+## Retain-or-retire
+
+This playground's own continued existence is not settled by finishing an
+inventory. The follow-up sidebar-design work must explicitly decide to keep
+it as a standing evaluation tool, or to retire the command, its fixtures,
+and its tests once the accepted inventory has been captured elsewhere.

--- a/docs/issues/2026-08-27-001-playground-identity-checks-flake-under-full-suite-cpu-load.md
+++ b/docs/issues/2026-08-27-001-playground-identity-checks-flake-under-full-suite-cpu-load.md
@@ -1,0 +1,26 @@
+---
+title: "Playground identity checks flake under full-suite CPU load"
+short_description: "The viewer minimum-dimensions bats case (and occasionally other playground cases) intermittently fails full-suite runs with PROCESS_IDENTITY_MISMATCH reaching cleanup-incomplete, passes in isolation, and reproduces on the pre-U7 baseline, indicating load-sensitive process-identity verification rather than a regression."
+type: "bug"
+category: "testing-ci"
+tags: ["flaky-test","herdr-git-status-playground"]
+date: "2026-08-27"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Full runs of `bats tests/scripts.bats` intermittently fail one playground case — most often `enforces minimum equal terminal dimensions and marks a shrunk view diagnostic until restored` — with `PROCESS_IDENTITY_MISMATCH` ("owned resource cleanup could not be proved") and the run landing in `cleanup-incomplete`. The same case passes in isolation every time. During U7 verification the flake reproduced on the pre-U7 baseline as well (two of five full runs, a different test each time), so this is load-sensitive behavior in the process-identity verification path (`verify_process` reading the live command line via `ps` while teardown races process exit), not a regression from any single unit.
+
+Impact: an otherwise green branch can show a spurious single-test failure in full-suite runs on a loaded machine; CI or local reruns then pass, costing rerun time and eroding trust in the suite.
+
+## Scope
+
+- Reproduce under controlled CPU load and capture which `verify_process` read races which teardown step.
+- Make the identity check tolerant of the benign race (e.g. re-probe once on mismatch when the process has exited between reads) without weakening the ownership guarantee for genuinely mismatched processes.
+- Prove the fix with a loaded-run regression check; keep the isolation-run behavior unchanged.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md
+++ b/docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md
@@ -1,0 +1,27 @@
+---
+title: "Bare mid-test [[ ]] assertions are silently inert in bats"
+short_description: "A bare [[ ... ]] check that is not the last statement of a bats test body does not fail the test under the local bash/bats combination (empirically confirmed twice during playground work), so pre-existing mid-test bracket assertions across the suite may be unenforced and need an audit converting them to '[[ ... ]] || fail'."
+type: "bug"
+category: "testing-ci"
+tags: ["test-integrity"]
+date: "2026-08-27"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Under this repo's bash/bats combination, a bare `[[ ... ]]` assertion that is not the last statement of a `@test` body returns false without failing the test — bats' errexit propagation does not fire for it mid-function. This was discovered twice independently during the git-status-playground work: a query-bound assertion in `tests/scripts.bats` was provably never enforced locally (it only fired inside the Docker environment), and a standalone repro `.bats` file confirmed the mechanism. Any pre-existing mid-test bare-bracket assertion in the suite may therefore be silently inert: the test passes even when the asserted condition is false.
+
+Impact: false confidence — assertions that reviewers believe are enforced are not, and regressions they were written to catch pass green.
+
+## Scope
+
+- Audit all `.bats` files for bare `[[ ... ]]` (and bare `(( ... ))`) statements that are not the final statement of their test body.
+- Convert each to an enforced form: `[[ ... ]] || fail "..."` (bats-support `fail` is already in use) or an appropriate `assert_*` helper.
+- For each converted assertion, verify it can actually fail (temporarily invert the condition) before accepting the conversion.
+- Consider a lint/CI guard (e.g. a grep-based check) that rejects new bare mid-test bracket assertions.
+
+## Open decisions
+
+None.

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -40,6 +40,11 @@ CANDIDATE_REVISIONS = {
     "jmarbutt": "8a56c5dce0bd65e47eddc9a1d862ddae870cddc3",
 }
 SAFE_INHERITED = ("LANG", "LC_ALL", "LC_CTYPE", "TERM", "TZ", "NO_COLOR")
+# Every subprocess.run/check_output call in the controller shares this bound
+# (see subprocess_timeout_seconds()) so a hung external tool fails through the
+# normal PlaygroundError path instead of wedging start/teardown indefinitely.
+SUBPROCESS_TIMEOUT_SECONDS = 120
+SUBPROCESS_TIMEOUT_SECONDS_TEST_MODE = 30
 SECRET_NAMES = ("TOKEN", "PASSWORD", "CREDENTIAL", "SECRET")
 NOT_APPLICABLE = "not applicable"
 FIXTURE_AUTHOR_NAME = "Herdr Playground Fixture"
@@ -152,6 +157,24 @@ def test_mode() -> bool:
 
 def test_failpoint() -> str:
     return os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "") if test_mode() else ""
+
+
+def subprocess_timeout_seconds() -> float:
+    """One shared bound for every controller-launched subprocess.run/
+    check_output call: a hung external tool (git, gh, herdr, a candidate
+    watcher script) must resolve through the normal PlaygroundError path
+    instead of blocking start/teardown forever. Shrunk in test mode, and
+    shrunk further by an HGSP knob so a regression test can force the
+    timeout to fire without waiting on SUBPROCESS_TIMEOUT_SECONDS for real."""
+    if not test_mode():
+        return SUBPROCESS_TIMEOUT_SECONDS
+    override = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_SUBPROCESS_TIMEOUT_SECONDS")
+    if override:
+        try:
+            return float(override)
+        except ValueError:
+            pass
+    return SUBPROCESS_TIMEOUT_SECONDS_TEST_MODE
 
 
 def source_environment() -> Dict[str, str]:
@@ -293,8 +316,9 @@ def process_start_identity(pid: int) -> Optional[str]:
             ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
             stderr=subprocess.DEVNULL,
             text=True,
+            timeout=subprocess_timeout_seconds(),
         ).strip()
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return output or None
 
@@ -312,8 +336,9 @@ def process_command(pid: int) -> Optional[str]:
             ["/bin/ps", "-ww", "-o", "command=", "-p", str(pid)],
             stderr=subprocess.DEVNULL,
             text=True,
+            timeout=subprocess_timeout_seconds(),
         ).strip()
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
     return output or None
 
@@ -411,6 +436,7 @@ def minimal_environment(source: Dict[str, str], executable_paths: Dict[str, str]
 
 
 def run_checked(arguments: List[str], environment: Dict[str, str], code: str) -> str:
+    timeout = subprocess_timeout_seconds()
     try:
         completed = subprocess.run(
             arguments,
@@ -419,7 +445,10 @@ def run_checked(arguments: List[str], environment: Dict[str, str], code: str) ->
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            timeout=timeout,
         )
+    except subprocess.TimeoutExpired:
+        raise PlaygroundError(code, "timed out after %ss" % timeout)
     except OSError as error:
         raise PlaygroundError(code, str(error))
     if completed.returncode != 0:
@@ -1183,6 +1212,7 @@ def git_run(
     code: str,
     allow_failure: bool = False,
 ) -> "subprocess.CompletedProcess":
+    timeout = subprocess_timeout_seconds()
     try:
         completed = subprocess.run(
             [git_path] + arguments,
@@ -1192,7 +1222,10 @@ def git_run(
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            timeout=timeout,
         )
+    except subprocess.TimeoutExpired:
+        raise PlaygroundError(code, "timed out after %ss" % timeout)
     except OSError as error:
         raise PlaygroundError(code, str(error))
     if completed.returncode != 0 and not allow_failure:
@@ -1817,6 +1850,7 @@ def gh_api(
         arguments.extend(["--method", method])
     for flag, pair in fields or []:
         arguments.extend([flag, pair])
+    timeout = subprocess_timeout_seconds()
     try:
         completed = subprocess.run(
             arguments,
@@ -1826,7 +1860,10 @@ def gh_api(
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            timeout=timeout,
         )
+    except subprocess.TimeoutExpired:
+        raise PlaygroundError(code, "timed out after %ss" % timeout)
     except OSError as error:
         raise PlaygroundError(code, str(error))
     if completed.returncode != 0:
@@ -3591,6 +3628,10 @@ def quarantine_plugin_record(
     Returns the removed contents so discovery can still verify them."""
     manifest = mutation.manifest
     assert manifest is not None
+    if reason == "teardown" and test_failpoint() == "quarantine-teardown-%s" % name:
+        raise PlaygroundError(
+            "INJECTED_QUARANTINE_TEARDOWN_FAILURE", "injected teardown quarantine failure for %s" % name
+        )
     try:
         contents = record_path.read_bytes()
     except FileNotFoundError:
@@ -3818,6 +3859,7 @@ def sfroment_traced_once(
     script = profile_data_dir(profiles, name) / adapter["watcher_script"]
     once_environment = dict(environment)
     once_environment["PATH"] = str(shim_dir) + os.pathsep + environment["PATH"]
+    once_timeout = subprocess_timeout_seconds()
     try:
         completed = subprocess.run(
             [str(script), "once"],
@@ -3826,7 +3868,10 @@ def sfroment_traced_once(
             stderr=subprocess.PIPE,
             text=True,
             check=False,
+            timeout=once_timeout,
         )
+    except subprocess.TimeoutExpired:
+        raise PlaygroundError("SFROMENT_ONCE_FAILED", "timed out after %ss" % once_timeout)
     except OSError as error:
         raise PlaygroundError("SFROMENT_ONCE_FAILED", str(error))
 
@@ -4175,7 +4220,7 @@ def provision_candidates(
         except PlaygroundError as error:
             manifest.setdefault("candidate_diagnostics", {})[name] = {
                 "code": error.code,
-                "message": error.message,
+                "message": redact_text(error.message),
                 "at": utc_now(),
             }
             mutation.persist("candidate-%s-diagnostics" % name)
@@ -4202,8 +4247,10 @@ def provision_candidates(
 
 def process_group_members(pgid: int) -> List[int]:
     try:
-        output = subprocess.check_output(["/bin/ps", "-axo", "pid=,pgid="], text=True)
-    except (OSError, subprocess.CalledProcessError):
+        output = subprocess.check_output(
+            ["/bin/ps", "-axo", "pid=,pgid="], text=True, timeout=subprocess_timeout_seconds()
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
     members: List[int] = []
     for line in output.splitlines():
@@ -4273,13 +4320,24 @@ def teardown_candidates(mutation: Mutation, source: Dict[str, str], unresolved: 
 
         daemon = settle_detached_intent(mutation, name, adapter, candidate_unresolved, result)
         # Atomically quarantine the plugin-owned PID record before any native
-        # action could reread signal-capable state.
+        # action could reread signal-capable state. Guarded like the
+        # metadata_cleanup_action/restore_labels steps below: an unguarded
+        # raise here (PlaygroundError from an unreadable record, or a raw
+        # OSError from the directory/rename calls quarantine_plugin_record
+        # does not itself wrap) would abort the whole teardown loop and wedge
+        # the run in "stopping" with the repository lease never released.
         if adapter["pid_record"] and state_dir.exists():
-            quarantined = quarantine_plugin_record(
-                mutation, name, state_dir / adapter["pid_record"], "teardown"
-            )
-            if quarantined is not None:
-                result["pid_record_quarantined"] = True
+            try:
+                quarantined = quarantine_plugin_record(
+                    mutation, name, state_dir / adapter["pid_record"], "teardown"
+                )
+                if quarantined is not None:
+                    result["pid_record_quarantined"] = True
+            except (PlaygroundError, OSError) as error:
+                result["pid_record_quarantined"] = False
+                candidate_unresolved.append(
+                    error.code if isinstance(error, PlaygroundError) else "PLUGIN_RECORD_QUARANTINE_FAILED"
+                )
 
         if adapter["daemon_ends_with_socket"]:
             # Closing the profile socket should end the daemon: stop this
@@ -5284,7 +5342,13 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
         with Mutation(root, run_id) as mutation:
             manifest = mutation.manifest
             assert manifest is not None
-            build_local_fixture_catalog(mutation, environments, executable_paths)
+            fixture_error: Optional[PlaygroundError] = None
+            try:
+                build_local_fixture_catalog(mutation, environments, executable_paths)
+            except PlaygroundError as error:
+                fixture_error = error
+            if fixture_error is not None:
+                return handle_startup_failure(mutation, root, run_dir, run_id, fixture_error, source)
 
             remote_error: Optional[PlaygroundError] = None
             try:
@@ -5682,8 +5746,11 @@ def main() -> int:
         return launch_wrapper(sys.argv[2:])
     parser = build_parser()
     arguments = parser.parse_args()
+    source: Optional[Dict[str, str]] = None
     try:
         source = source_environment()
+        if test_failpoint() == "internal-error":
+            raise RuntimeError("injected internal error for INTERNAL_ERROR boundary coverage")
         if arguments.command == "start":
             return command_start(arguments, source)
         if arguments.command == "status":
@@ -5699,6 +5766,22 @@ def main() -> int:
         return command_not_implemented(arguments.command, arguments, source)
     except PlaygroundError as error:
         return error_result(error)
+    except Exception as error:
+        # Last-resort boundary for a genuine bug, not a modeled PlaygroundError:
+        # emit well-formed JSON instead of a bare traceback so the caller can
+        # still parse the result. KeyboardInterrupt derives from BaseException,
+        # not Exception, so it is never caught here and keeps propagating with
+        # its existing exit semantics.
+        run_id = getattr(arguments, "run_id", None)
+        manifest = None
+        if run_id and source is not None:
+            try:
+                manifest = read_manifest(state_root(source), run_id)
+            except PlaygroundError:
+                manifest = None
+        next_command = ("stop %s" % run_id) if run_id else None
+        print_json(output_record(manifest, "INTERNAL_ERROR", str(error), next_command))
+        return 1
 
 
 if __name__ == "__main__":

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -383,6 +383,10 @@ def minimal_environment(source: Dict[str, str], executable_paths: Dict[str, str]
         directory = str(Path(executable).parent)
         if directory not in directories:
             directories.append(directory)
+    # Standard system utilities only; never ambient user-writable directories.
+    for directory in ("/usr/bin", "/bin"):
+        if directory not in directories:
+            directories.append(directory)
     environment = {
         "PATH": os.pathsep.join(directories),
         "HOME": str(home),
@@ -394,9 +398,11 @@ def minimal_environment(source: Dict[str, str], executable_paths: Dict[str, str]
         if name in source:
             environment[name] = source[name]
     if test_mode():
-        for name in ("HGSP_WORK", "HGSP_CALL_LOG", "HGSP_HERDR_VERSION", "HGSP_GH_AUTH_STATUS"):
-            if name in os.environ:
-                environment[name] = os.environ[name]
+        # The stateful test simulators and their behavior knobs all ride on
+        # HGSP_-prefixed variables; pass them through every scrubbed class.
+        for name, value in os.environ.items():
+            if name.startswith("HGSP_"):
+                environment[name] = value
     return environment
 
 
@@ -435,7 +441,7 @@ def load_fixture_ownership(path: str) -> Dict[str, str]:
     return {key: value[key] for key in expected}
 
 
-def load_audit_attestation(path: str) -> str:
+def load_audit_attestation(path: str) -> Tuple[str, Dict[str, Dict[str, Any]]]:
     try:
         contents = Path(path).read_bytes()
         value = json.loads(contents.decode("utf-8"))
@@ -451,17 +457,21 @@ def load_audit_attestation(path: str) -> str:
             or record.get("revision") != revision
             or not isinstance(record.get("tree"), str)
             or not record["tree"]
+            or record.get("approved") is not True
         ):
-            raise PlaygroundError("AUDIT_ATTESTATION_INVALID", "audit is absent or stale for %s" % candidate)
+            raise PlaygroundError(
+                "AUDIT_ATTESTATION_INVALID", "audit is absent, stale, or unapproved for %s" % candidate
+            )
     canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(canonical).hexdigest()
+    digest = hashlib.sha256(canonical).hexdigest()
+    return digest, {name: dict(candidates[name]) for name in CANDIDATE_REVISIONS}
 
 
 def preflight(
     arguments: argparse.Namespace, source: Dict[str, str]
-) -> Tuple[Dict[str, str], Dict[str, str], str, Dict[str, str]]:
+) -> Tuple[Dict[str, str], Dict[str, str], str, Dict[str, str], Dict[str, Dict[str, Any]]]:
     fixture = load_fixture_ownership(arguments.fixture_ownership)
-    audit_digest = load_audit_attestation(arguments.audit_attestation)
+    audit_digest, audit_candidates = load_audit_attestation(arguments.audit_attestation)
     controller_token = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN", "")
     candidate_token = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN", "")
     if not controller_token or not candidate_token or controller_token == candidate_token:
@@ -533,7 +543,7 @@ def preflight(
         "inode": str(herdr_stat.st_ino),
         "version": APPROVED_HERDR_VERSION,
     }
-    return executable_paths, fixture, audit_digest, herdr_identity
+    return executable_paths, fixture, audit_digest, herdr_identity, audit_candidates
 
 
 def live_herdr_roots(source: Dict[str, str]) -> List[Path]:
@@ -811,7 +821,9 @@ def effective_state(manifest: Dict[str, Any]) -> str:
     for process in manifest.get("processes", {}).values():
         if process.get("status") == "running":
             verdict, _ = verify_process(process)
-            if verdict == "mismatch" and lifecycle.startswith("active"):
+            if verdict in ("mismatch", "gone") and lifecycle.startswith("active"):
+                # A lost or replaced owned process degrades only a run that was
+                # already ready; provisioning failures fail startup instead.
                 return "active-degraded"
     return lifecycle
 
@@ -856,6 +868,7 @@ def launch_wrapper(arguments: List[str]) -> int:
     parser.add_argument("--intent-id", required=True)
     parser.add_argument("--profile", required=True)
     parser.add_argument("target")
+    parser.add_argument("target_args", nargs=argparse.REMAINDER)
     namespace = parser.parse_args(arguments)
     claim = {
         "schema_version": SCHEMA_VERSION,
@@ -871,7 +884,7 @@ def launch_wrapper(arguments: List[str]) -> int:
     gate = Path(namespace.gate)
     while not gate.exists():
         time.sleep(0.01)
-    os.execve(namespace.target, [namespace.target], dict(os.environ))
+    os.execve(namespace.target, [namespace.target] + namespace.target_args, dict(os.environ))
     return 127
 
 
@@ -886,33 +899,35 @@ def wait_for_claim(path: Path, process: subprocess.Popen) -> Dict[str, Any]:
     raise PlaygroundError("LAUNCH_CLAIM_MISSING", "launch wrapper did not claim ownership")
 
 
-def start_foundation_process(
+def spawn_owned_process(
     mutation: Mutation,
     environment: Dict[str, str],
+    intent_id: str,
+    profile: str,
     target: str,
-) -> Optional[PlaygroundError]:
+    target_args: Tuple[str, ...] = (),
+    process_class: str = "managed",
+) -> Dict[str, Any]:
+    """Durable-intent controller spawn: intent, launch wrapper claim, identity
+    verification, then release through the gate. Raises on any unproved step."""
     assert mutation.manifest is not None
     manifest = mutation.manifest
     run_dir = mutation.run_dir
-    intent_id = "foundation-supervisor"
     claim_path = claim_path_for(run_dir, intent_id)
     gate_path = gate_path_for(run_dir, intent_id)
     ensure_private_directory(claim_path.parent)
     manifest["launch_intents"][intent_id] = {
         "intent_id": intent_id,
-        "profile": "ezcorp",
+        "profile": profile,
         "executable": os.path.realpath(target),
         "phase": "intent-committed",
         "claim": str(claim_path.relative_to(run_dir)),
     }
-    try:
-        mutation.persist("intent")
-    except AtomicWriteError as error:
-        return error
+    mutation.persist("intent")
 
     failpoint = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "")
     if failpoint == "before-spawn":
-        return PlaygroundError("INJECTED_BEFORE_SPAWN", "injected crash before spawn")
+        raise PlaygroundError("INJECTED_BEFORE_SPAWN", "injected crash before spawn")
 
     manifest["launch_intents"][intent_id]["phase"] = "spawn-attempted"
     mutation.persist("spawn-attempt")
@@ -927,9 +942,9 @@ def start_foundation_process(
         "--intent-id",
         intent_id,
         "--profile",
-        "ezcorp",
+        profile,
         os.path.realpath(target),
-    ]
+    ] + list(target_args)
     process = subprocess.Popen(
         wrapper,
         env=environment,
@@ -941,18 +956,31 @@ def start_foundation_process(
     )
     claim = wait_for_claim(claim_path, process)
     if failpoint == "after-spawn":
-        return PlaygroundError("INJECTED_AFTER_SPAWN", "injected crash after spawn")
+        raise PlaygroundError("INJECTED_AFTER_SPAWN", "injected crash after spawn")
     if failpoint == "before-identity-commit":
-        return PlaygroundError("INJECTED_BEFORE_IDENTITY_COMMIT", "injected crash before identity commit")
+        raise PlaygroundError("INJECTED_BEFORE_IDENTITY_COMMIT", "injected crash before identity commit")
 
     verdict, reason = verify_process(claim)
     if verdict != "owned":
-        return PlaygroundError("PROCESS_IDENTITY_UNPROVED", reason)
+        raise PlaygroundError("PROCESS_IDENTITY_UNPROVED", reason)
     claim["status"] = "running"
+    claim["class"] = process_class
     manifest["processes"][intent_id] = claim
     manifest["launch_intents"][intent_id]["phase"] = "identity-recorded"
     mutation.persist("identity")
     gate_path.touch(mode=0o600)
+    return claim
+
+
+def start_foundation_process(
+    mutation: Mutation,
+    environment: Dict[str, str],
+    target: str,
+) -> Optional[PlaygroundError]:
+    try:
+        spawn_owned_process(mutation, environment, "foundation-supervisor", "ezcorp", target)
+    except (AtomicWriteError, PlaygroundError) as error:
+        return error
     return None
 
 
@@ -3240,6 +3268,972 @@ def probe_remote_observation(mutation: Mutation, source: Dict[str, str]) -> None
         ctx.cleanup()
 
 
+# ---- Candidate installation and lifecycle adapters (U5) --------------------
+
+
+CANDIDATE_ORDER = ("ezcorp", "sfroment", "krystof", "jmarbutt")
+# The shared no-plugin sidebar base: the current managed agent rows plus the
+# Herdr default spaces row. Baselines must contain exactly these rows.
+SHARED_SIDEBAR_ROWS = ("state_icon", "workspace", "pane", "git_ref", "spaces_default")
+
+# The candidate adapter contract (KTD4): every per-candidate difference is data
+# in this table; the lifecycle pipeline itself is candidate-agnostic. Paths are
+# relative to the profile's Herdr state root (records) or data root (payloads).
+CANDIDATE_ADAPTERS: Dict[str, Dict[str, Any]] = {
+    "ezcorp": {
+        "plugin_id": "ez-corp.git-status",
+        "ownership": "plugin-detached",
+        "github": False,
+        "sidebar_tokens": ("git_state", "git_staged", "git_unstaged", "git_untracked", "git_stash"),
+        "activation_actions": ("status-enable",),
+        "pid_record": "plugins/ez-corp.git-status/updater.pid",
+        "state_record": "plugins/ez-corp.git-status/state.json",
+        # Signal-capable native paths that reread PID state; never invoked.
+        "signal_capable_native_actions": ("status-disable",),
+        "metadata_cleanup_action": "metadata-cleanup",
+        "restore_labels": False,
+        "notifications_disabled": False,
+        "daemon_ends_with_socket": False,
+        "readiness": "updater-metadata",
+        "known_discrepancies": ("skips-worktree-child-spaces",),
+    },
+    "sfroment": {
+        "plugin_id": "git-detail",
+        "ownership": "controller-watcher",
+        "github": False,
+        "sidebar_tokens": ("git_detail",),
+        "activation_actions": (),
+        "pid_record": None,
+        "state_record": None,
+        "signal_capable_native_actions": (),
+        "metadata_cleanup_action": None,
+        "restore_labels": False,
+        "notifications_disabled": False,
+        "daemon_ends_with_socket": False,
+        "readiness": "traced-once",
+        "watcher_script": "plugins/git-detail/git-detail.sh",
+        "known_discrepancies": ("purely-unstaged-records-may-increment-staged",),
+    },
+    "krystof": {
+        "plugin_id": "gitlab-ci-status",
+        "ownership": "plugin-detached",
+        "github": True,
+        "sidebar_tokens": ("ci_status", "pr_state"),
+        "activation_actions": ("start",),
+        "pid_record": "plugins/gitlab-ci-status/poller.pid",
+        "state_record": "plugins/gitlab-ci-status/state.json",
+        "signal_capable_native_actions": ("stop",),
+        "metadata_cleanup_action": None,
+        "restore_labels": True,
+        "notifications_disabled": False,
+        "daemon_ends_with_socket": False,
+        "readiness": "pid-and-labels",
+        "known_discrepancies": ("ci-marker-reflects-newest-single-actions-run",),
+    },
+    "jmarbutt": {
+        "plugin_id": "jmarbutt.spaces-pr-status",
+        "ownership": "plugin-detached",
+        "github": True,
+        "sidebar_tokens": ("pr_status", "pr_checks"),
+        "activation_actions": ("startup", "refresh"),
+        "pid_record": "plugins/jmarbutt.spaces-pr-status/daemon.json",
+        "state_record": "plugins/jmarbutt.spaces-pr-status/state.json",
+        "signal_capable_native_actions": (),
+        "metadata_cleanup_action": None,
+        "restore_labels": False,
+        "notifications_disabled": True,
+        "daemon_ends_with_socket": True,
+        "readiness": "daemon-refresh",
+        "known_discrepancies": ("no-merge-conflict-reporting", "caches-no-pr-after-gh-failures"),
+    },
+}
+
+
+def candidate_attempts() -> int:
+    return 300 if test_mode() else 90
+
+
+def profile_state_dir(profiles: Dict[str, Dict[str, str]], name: str) -> Path:
+    return Path(profiles[name]["state_home"]) / "herdr"
+
+
+def profile_data_dir(profiles: Dict[str, Dict[str, str]], name: str) -> Path:
+    return Path(profiles[name]["data_home"]) / "herdr"
+
+
+def profile_config_path(profiles: Dict[str, Dict[str, str]], name: str) -> Path:
+    return Path(profiles[name]["config_home"]) / "herdr" / "config.toml"
+
+
+def candidate_runtime_environment(
+    source: Dict[str, str],
+    executable_paths: Dict[str, str],
+    profiles: Dict[str, Dict[str, str]],
+    name: str,
+    with_token: bool,
+) -> Dict[str, str]:
+    profile = profiles[name]
+    environment = minimal_environment(source, executable_paths, Path(profile["home"]))
+    environment.update(
+        {
+            "XDG_CONFIG_HOME": profile["config_home"],
+            "XDG_STATE_HOME": profile["state_home"],
+            "XDG_DATA_HOME": profile["data_home"],
+        }
+    )
+    adapter = CANDIDATE_ADAPTERS.get(name)
+    if adapter and adapter["github"]:
+        environment["GH_CONFIG_DIR"] = str(Path(profile["config_home"]) / "gh")
+        candidate_token = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN")
+        if with_token and candidate_token:
+            environment["GH_TOKEN"] = candidate_token
+    return environment
+
+
+def write_private_text(path: Path, text: str) -> None:
+    ensure_private_directory(path.parent)
+    descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(descriptor, text.encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def write_sidebar_config(profiles: Dict[str, Dict[str, str]], name: str, tokens: Tuple[str, ...]) -> None:
+    lines = ["# generated by %s" % APP_NAME]
+    lines.extend('sidebar_row = "%s"' % row for row in SHARED_SIDEBAR_ROWS)
+    lines.extend('sidebar_row = "%s"' % token for token in tokens)
+    write_private_text(profile_config_path(profiles, name), "\n".join(lines) + "\n")
+
+
+def herdr_json(herdr_path: str, arguments: List[str], environment: Dict[str, str], code: str) -> Any:
+    output = run_checked([herdr_path] + arguments, environment, code)
+    try:
+        return json.loads(output) if output else None
+    except ValueError as error:
+        raise PlaygroundError(code, "invalid herdr output: %s" % error)
+
+
+def sidebar_snapshot(herdr_path: str, environment: Dict[str, str]) -> List[str]:
+    output = run_checked([herdr_path, "sidebar", "snapshot"], environment, "SIDEBAR_SNAPSHOT_FAILED")
+    return [line for line in output.splitlines() if line]
+
+
+def build_space_catalog(mutation: Mutation, ownership: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Stable shared space order: the local catalog first, then the recorded
+    durable GitHub fixture checkouts when the repository is bootstrapped."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    catalog: List[Dict[str, Any]] = []
+    for name in LOCAL_FIXTURES:
+        local = manifest["local_fixtures"][name]
+        catalog.append(
+            {
+                "label": name,
+                "path": local["path"],
+                "worktree_child": name.startswith("worktree-"),
+                "kind": "local",
+            }
+        )
+    if manifest.get("remote"):
+        record_path = repository_state_directory(mutation.root, ownership) / "repository.json"
+        record = read_json(record_path)
+        for name in GITHUB_FIXTURES:
+            checkout = (record["fixtures"].get(name) or {}).get("checkout")
+            if not checkout:
+                raise PlaygroundError(
+                    "FIXTURE_CHECKOUT_FAILED", "no recorded local checkout for the %s fixture" % name
+                )
+            catalog.append(
+                {"label": "gh-%s" % name, "path": checkout["path"], "worktree_child": False, "kind": "github"}
+            )
+    return catalog
+
+
+def quarantine_plugin_record(
+    mutation: Mutation, name: str, record_path: Path, reason: str
+) -> Optional[bytes]:
+    """Atomically move a plugin-owned record out of every native path's reach.
+    Returns the removed contents so discovery can still verify them."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    try:
+        contents = record_path.read_bytes()
+    except FileNotFoundError:
+        return None
+    except OSError as error:
+        raise PlaygroundError("PLUGIN_RECORD_UNREADABLE", "%s: %s" % (record_path, error))
+    quarantine_dir = mutation.run_dir / "runtime" / "quarantine" / name
+    ensure_private_directory(quarantine_dir)
+    target = quarantine_dir / ("%s-%d" % (record_path.name, time.time_ns()))
+    os.replace(str(record_path), str(target))
+    manifest.setdefault("quarantines", []).append(
+        {
+            "candidate": name,
+            "record": record_path.name,
+            "quarantined_to": str(target.relative_to(mutation.run_dir)),
+            "reason": reason,
+            "at": utc_now(),
+        }
+    )
+    return contents
+
+
+def discover_detached_daemon(
+    profiles: Dict[str, Dict[str, str]], name: str, adapter: Dict[str, Any]
+) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Adapter-specific discovery per KTD9: adopt only when plugin state,
+    process identity, executable, and profile socket all agree."""
+    state_path = profile_state_dir(profiles, name) / adapter["state_record"]
+    try:
+        with state_path.open(encoding="utf-8") as handle:
+            state = json.load(handle)
+    except FileNotFoundError:
+        return None, "plugin state is absent"
+    except (OSError, ValueError) as error:
+        return None, "plugin state is unreadable: %s" % error
+    pid = state.get("pid")
+    executable = state.get("executable")
+    socket_path = state.get("socket")
+    if not isinstance(pid, int) or pid <= 0 or not isinstance(executable, str) or not executable:
+        return None, "plugin state does not identify a process"
+    if socket_path != profiles[name]["socket"]:
+        return None, "plugin state names a different profile socket"
+    if not process_alive(pid):
+        return None, "gone"
+    if process_group(pid) != pid:
+        return None, "process group identity disagrees"
+    command = process_command(pid)
+    if command is None or executable not in command:
+        return None, "process executable disagrees with plugin state"
+    return (
+        {
+            "pid": pid,
+            "process_group": pid,
+            "start_identity": process_start_identity(pid),
+            "executable": executable,
+            "profile": name,
+            "class": "plugin-detached",
+            "status": "running",
+        },
+        "adopted",
+    )
+
+
+def promote_detached_ownership(
+    mutation: Mutation, name: str, adapter: Dict[str, Any]
+) -> Dict[str, Any]:
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    last_reason = "plugin state never appeared"
+    for _ in range(candidate_attempts()):
+        record, reason = discover_detached_daemon(profiles, name, adapter)
+        if record is not None:
+            manifest["processes"]["candidate-%s" % name] = record
+            manifest["detached_intents"][name]["phase"] = "promoted"
+            mutation.persist("candidate-%s-promoted" % name)
+            return record
+        last_reason = reason
+        if reason == "gone":
+            break
+        poll_sleep()
+    raise PlaygroundError(
+        "CANDIDATE_OWNERSHIP_UNPROVED", "%s ownership promotion failed: %s" % (name, last_reason)
+    )
+
+
+def read_plugin_state(profiles: Dict[str, Dict[str, str]], name: str, adapter: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not adapter["state_record"]:
+        return None
+    path = profile_state_dir(profiles, name) / adapter["state_record"]
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def ezcorp_readiness(mutation: Mutation, name: str, adapter: Dict[str, Any]) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    expected = {entry["label"] for entry in manifest["space_catalog"]}
+    allowed_missing = {entry["label"] for entry in manifest["space_catalog"] if entry["worktree_child"]}
+    missing: set = expected
+    for _ in range(candidate_attempts()):
+        state = read_plugin_state(profiles, name, adapter)
+        if state and state.get("metadata_complete") is True:
+            reported = set(state.get("spaces") or [])
+            missing = expected - reported
+            if missing <= allowed_missing:
+                record = manifest["candidates"][name]
+                record["readiness"] = {"updater_state": True, "reported_spaces": sorted(reported)}
+                if missing:
+                    # A known candidate discrepancy is inventory evidence, not
+                    # a readiness failure (R11: recorded, never hidden).
+                    record.setdefault("notes", []).append(
+                        {"known": "skips-worktree-child-spaces", "spaces": sorted(missing)}
+                    )
+                return
+        poll_sleep()
+    raise PlaygroundError(
+        "CANDIDATE_READINESS_FAILED",
+        "%s updater metadata is incomplete; unexplained missing spaces %r" % (name, sorted(missing - allowed_missing) or sorted(missing)),
+    )
+
+
+def krystof_readiness(
+    mutation: Mutation, name: str, herdr_path: str, environment: Dict[str, str]
+) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    snapshot = {entry["label"]: entry["label_text"] for entry in manifest["candidates"][name]["label_snapshot"]}
+    process = manifest["processes"]["candidate-%s" % name]
+    for _ in range(candidate_attempts()):
+        verdict, reason = verify_process(process)
+        if verdict != "owned":
+            raise PlaygroundError("CANDIDATE_READINESS_FAILED", "%s poller is not owned: %s" % (name, reason))
+        spaces = herdr_json(herdr_path, ["space", "list"], environment, "SPACE_LIST_FAILED") or []
+        decorated = [space for space in spaces if space.get("label_text") != snapshot.get(space.get("label"))]
+        if spaces and len(decorated) == len(spaces):
+            manifest["candidates"][name]["readiness"] = {
+                "pid": process["pid"],
+                "decorated_labels": [space["label_text"] for space in spaces],
+            }
+            return
+        poll_sleep()
+    raise PlaygroundError("CANDIDATE_READINESS_FAILED", "%s label decoration never covered every space" % name)
+
+
+def jmarbutt_readiness(mutation: Mutation, name: str, adapter: Dict[str, Any]) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    process = manifest["processes"]["candidate-%s" % name]
+    for _ in range(candidate_attempts()):
+        verdict, reason = verify_process(process)
+        if verdict != "owned":
+            raise PlaygroundError("CANDIDATE_READINESS_FAILED", "%s daemon is not owned: %s" % (name, reason))
+        state = read_plugin_state(profiles, name, adapter)
+        if state and state.get("refreshed") is True:
+            manifest["candidates"][name]["readiness"] = {"pid": process["pid"], "refreshed_at": state.get("refreshed_at")}
+            return
+        poll_sleep()
+    raise PlaygroundError("CANDIDATE_READINESS_FAILED", "%s never recorded a completed refresh" % name)
+
+
+def expected_git_detail_value(run_dir: Path, entry: Dict[str, Any]) -> Optional[str]:
+    """Independent expectation for one space: local ground truth, or the clean
+    bootstrap checkout premise for GitHub fixtures. None means the space is not
+    a repository and must keep its sentinel (no publication)."""
+    if entry["kind"] == "github":
+        return "staged:0 unstaged:0 untracked:0"
+    truth = read_json(ground_truth_directory(run_dir) / ("%s.json" % entry["label"]))
+    if truth["repository"] == "none":
+        return None
+
+    def count(key: str) -> int:
+        value = truth[key]
+        return len(value) if isinstance(value, list) else 0
+
+    return "staged:%d unstaged:%d untracked:%d" % (count("staged_paths"), count("unstaged_paths"), count("untracked_paths"))
+
+
+def sfroment_traced_once(
+    mutation: Mutation,
+    name: str,
+    adapter: Dict[str, Any],
+    herdr_path: str,
+    environment: Dict[str, str],
+) -> None:
+    """Run the plugin's terminating once path through a generation-specific
+    tracing shim. Its exit status is recorded but never trusted: readiness
+    requires successful current-generation queries and publications that
+    replace the preloaded sentinels with ground-truth-matching values."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    run_dir = mutation.run_dir
+    profiles = manifest["profiles"]
+    epoch = manifest["generation"]
+    shim_dir = run_dir / "runtime" / "shims" / ("sfroment-%d" % epoch)
+    ensure_private_directory(shim_dir)
+    trace_path = shim_dir / "trace.log"
+    # The shim is generated per generation so a stale trace can never satisfy
+    # the current readiness check.
+    shim = (
+        "#!/bin/sh\n"
+        "printf '%d|begin|%%s\\n' \"$*\" >> '%s'\n"
+        "'%s' \"$@\"\n"
+        "status=$?\n"
+        "printf '%d|end|%%s|%%s\\n' \"$status\" \"$*\" >> '%s'\n"
+        "exit \"$status\"\n" % (epoch, trace_path, herdr_path, epoch, trace_path)
+    )
+    write_private_text(shim_dir / "herdr", shim)
+    os.chmod(str(shim_dir / "herdr"), 0o700)
+
+    sentinel = "sentinel-%d" % epoch
+    catalog = manifest["space_catalog"]
+    for entry in catalog:
+        run_checked(
+            [herdr_path, "pane", "publish", entry["label"], "git_detail=%s" % sentinel],
+            environment,
+            "SFROMENT_SENTINEL_FAILED",
+        )
+    script = profile_data_dir(profiles, name) / adapter["watcher_script"]
+    once_environment = dict(environment)
+    once_environment["PATH"] = str(shim_dir) + os.pathsep + environment["PATH"]
+    try:
+        completed = subprocess.run(
+            [str(script), "once"],
+            env=once_environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PlaygroundError("SFROMENT_ONCE_FAILED", str(error))
+
+    queries = 0
+    cwd_success: set = set()
+    failed_publications: List[str] = []
+    try:
+        trace_lines = trace_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        trace_lines = []
+    prefix = "%d|" % epoch
+    for line in trace_lines:
+        if not line.startswith(prefix):
+            continue
+        body = line[len(prefix):]
+        if body.startswith("end|"):
+            _, _, status, arguments = line.split("|", 3)
+            if arguments.startswith("space list") and status == "0":
+                queries += 1
+            elif arguments.startswith("pane cwd ") and status == "0":
+                cwd_success.add(arguments[len("pane cwd "):].split(" ")[0])
+            elif arguments.startswith("pane publish") and status != "0":
+                failed_publications.append(arguments)
+    if completed.returncode != 0:
+        raise PlaygroundError(
+            "SFROMENT_READINESS_FAILED", "the once path exited %d" % completed.returncode
+        )
+    if queries < 1:
+        raise PlaygroundError(
+            "SFROMENT_READINESS_FAILED",
+            "the trace shows no successful current-generation workspace query; a clean exit alone is not readiness",
+        )
+    missing_cwd = {entry["label"] for entry in catalog} - cwd_success
+    if missing_cwd:
+        raise PlaygroundError(
+            "SFROMENT_READINESS_FAILED", "no successful pane/CWD query for %r" % sorted(missing_cwd)
+        )
+    if failed_publications:
+        raise PlaygroundError(
+            "SFROMENT_READINESS_FAILED", "swallowed publication failure: %r" % failed_publications
+        )
+    spaces = herdr_json(herdr_path, ["space", "list"], environment, "SPACE_LIST_FAILED") or []
+    tokens = {space.get("label"): (space.get("tokens") or {}).get("git_detail") for space in spaces}
+    matched: Dict[str, str] = {}
+    for entry in catalog:
+        expected = expected_git_detail_value(run_dir, entry)
+        observed = tokens.get(entry["label"])
+        if expected is None:
+            if observed != sentinel:
+                raise PlaygroundError(
+                    "SFROMENT_READINESS_FAILED",
+                    "unexpected publication %r for the non-repository space %s" % (observed, entry["label"]),
+                )
+            continue
+        if observed == sentinel:
+            raise PlaygroundError(
+                "SFROMENT_READINESS_FAILED",
+                "the sentinel for %s was never replaced by a publication" % entry["label"],
+            )
+        if observed != expected:
+            raise PlaygroundError(
+                "SFROMENT_READINESS_FAILED",
+                "publication for %s was %r, ground truth expects %r" % (entry["label"], observed, expected),
+            )
+        matched[entry["label"]] = observed
+    manifest["candidates"][name]["readiness"] = {
+        "once_status": completed.returncode,
+        "queries": queries,
+        "publications": matched,
+        "epoch": epoch,
+    }
+
+
+def wait_for_path(path: Path, code: str, detail: str) -> None:
+    for _ in range(candidate_attempts()):
+        if path.exists():
+            return
+        poll_sleep()
+    raise PlaygroundError(code, detail)
+
+
+def candidate_auth_probe(
+    mutation: Mutation, name: str, gh_path: str, environment: Dict[str, str]
+) -> None:
+    """Prove authentication and one repository-scoped read through the exact
+    candidate runtime environment before activation (KTD16)."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    fixture = manifest["fixture_repository"]
+    output = run_checked(
+        [gh_path, "api", "--hostname", fixture["host"], "repos/%s/%s" % (fixture["owner"], fixture["name"])],
+        environment,
+        "CANDIDATE_AUTH_UNPROVED",
+    )
+    try:
+        payload = json.loads(output)
+    except ValueError:
+        raise PlaygroundError(
+            "CANDIDATE_AUTH_UNPROVED", "the %s candidate read returned no parseable repository" % name
+        )
+    if not isinstance(payload, dict) or payload.get("node_id") != fixture["repository_id"]:
+        raise PlaygroundError(
+            "CANDIDATE_AUTH_UNPROVED",
+            "the %s candidate read resolved a different repository identity" % name,
+        )
+    manifest["candidates"][name]["auth_probe"] = {
+        "repository_id": payload["node_id"],
+        "proved_at": utc_now(),
+    }
+
+
+def activate_candidate(
+    mutation: Mutation,
+    name: str,
+    herdr_path: str,
+    gh_path: str,
+    environment: Dict[str, str],
+) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    adapter = CANDIDATE_ADAPTERS[name]
+    record = manifest["candidates"][name]
+
+    # Candidate-specific sidebar rows and plugin configuration, then reload.
+    write_sidebar_config(profiles, name, adapter["sidebar_tokens"])
+    if adapter["notifications_disabled"]:
+        write_private_text(
+            profile_data_dir(profiles, name) / "plugins" / adapter["plugin_id"] / "config.json",
+            json.dumps({"notifications": False}, sort_keys=True) + "\n",
+        )
+    run_checked([herdr_path, "config", "reload"], environment, "CONFIG_RELOAD_FAILED")
+    record["sidebar_tokens"] = list(adapter["sidebar_tokens"])
+    record["notifications_disabled"] = adapter["notifications_disabled"]
+
+    if adapter["github"]:
+        candidate_auth_probe(mutation, name, gh_path, environment)
+
+    # Quarantine stale plugin-owned records before any startup hook or native
+    # action can reread them (KTD9).
+    if adapter["pid_record"]:
+        stale = quarantine_plugin_record(
+            mutation, name, profile_state_dir(profiles, name) / adapter["pid_record"], "stale-before-activation"
+        )
+        record["stale_record_quarantined"] = stale is not None
+    if adapter["ownership"] == "plugin-detached":
+        manifest["detached_intents"][name] = {
+            "plugin_id": adapter["plugin_id"],
+            "record": adapter["pid_record"],
+            "state": adapter["state_record"],
+            "socket": profiles[name]["socket"],
+            "phase": "intent-committed",
+        }
+    mutation.persist("candidate-%s-configured" % name)
+
+    if adapter["ownership"] == "controller-watcher":
+        script = profile_data_dir(profiles, name) / adapter["watcher_script"]
+        spawn_owned_process(
+            mutation,
+            environment,
+            "watcher-%s" % name,
+            name,
+            str(script),
+            ("watch",),
+            process_class="watcher",
+        )
+    else:
+        run_checked([herdr_path, "plugin", "enable", adapter["plugin_id"]], environment, "CANDIDATE_ACTIVATION_FAILED")
+        for action in adapter["activation_actions"]:
+            if action == "refresh":
+                # jmarbutt refresh is meaningful only once its daemon owns
+                # state and spaces exist; promotion happens first below.
+                continue
+            manifest["detached_intents"][name]["phase"] = "detached"
+            mutation.persist("candidate-%s-detaching" % name)
+            try:
+                run_checked(
+                    [herdr_path, "plugin", "run", adapter["plugin_id"], action],
+                    environment,
+                    "CANDIDATE_ACTIVATION_FAILED",
+                )
+            except PlaygroundError:
+                # The action reported failure; discovery still runs during
+                # teardown, but an absent daemon is then a settled outcome.
+                manifest["detached_intents"][name]["phase"] = "action-failed"
+                mutation.persist("candidate-%s-action-failed" % name)
+                raise
+    record["activated_at"] = utc_now()
+    mutation.persist("candidate-%s-activated" % name)
+    if test_failpoint() == "candidate-%s-detached" % name:
+        raise PlaygroundError(
+            "INJECTED_CANDIDATE_%s_DETACHED" % name.upper(),
+            "injected crash immediately after %s detachment, before ownership promotion" % name,
+        )
+
+    if adapter["ownership"] == "plugin-detached":
+        promote_detached_ownership(mutation, name, adapter)
+        if "refresh" in adapter["activation_actions"]:
+            run_checked(
+                [herdr_path, "plugin", "run", adapter["plugin_id"], "refresh"],
+                environment,
+                "CANDIDATE_ACTIVATION_FAILED",
+            )
+
+    readiness = adapter["readiness"]
+    if readiness == "updater-metadata":
+        ezcorp_readiness(mutation, name, adapter)
+    elif readiness == "traced-once":
+        sfroment_traced_once(mutation, name, adapter, herdr_path, environment)
+    elif readiness == "pid-and-labels":
+        krystof_readiness(mutation, name, herdr_path, environment)
+    elif readiness == "daemon-refresh":
+        jmarbutt_readiness(mutation, name, adapter)
+    record["ready_at"] = utc_now()
+    mutation.persist("candidate-%s-ready" % name)
+
+
+def provision_candidates(
+    mutation: Mutation,
+    source: Dict[str, str],
+    executable_paths: Dict[str, str],
+    environments: Dict[str, Dict[str, str]],
+    audit_candidates: Dict[str, Dict[str, Any]],
+) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    run_dir = mutation.run_dir
+    profiles = manifest["profiles"]
+    herdr_path = executable_paths["herdr"]
+    gh_path = executable_paths["gh"]
+    build_environment = environments["candidate-build"]
+
+    runtime_environments = {
+        name: candidate_runtime_environment(source, executable_paths, profiles, name, with_token=True)
+        for name in CANDIDATE_ORDER
+    }
+    record_test_environments(
+        {"candidate-runtime-%s" % name: environment for name, environment in runtime_environments.items()}
+    )
+
+    # Resolve every candidate's fetched tree and verify it against the
+    # operator-approved attestation before any build or server starts (KTD16).
+    manifest["candidates"] = {}
+    manifest["detached_intents"] = {}
+    for name in CANDIDATE_ORDER:
+        adapter = CANDIDATE_ADAPTERS[name]
+        revision = CANDIDATE_REVISIONS[name]
+        fetched = herdr_json(
+            herdr_path,
+            ["plugin", "fetch", adapter["plugin_id"], "--revision", revision],
+            build_environment,
+            "CANDIDATE_FETCH_FAILED",
+        )
+        tree = (fetched or {}).get("tree")
+        if not tree or tree != audit_candidates[name]["tree"]:
+            raise PlaygroundError(
+                "AUDIT_TREE_MISMATCH",
+                "the fetched %s tree %r does not match the attested tree %r"
+                % (name, tree, audit_candidates[name]["tree"]),
+            )
+        manifest["candidates"][name] = {"plugin_id": adapter["plugin_id"], "revision": revision, "tree": tree}
+    mutation.persist("candidate-trees")
+
+    # Shared no-plugin sidebar base, pinned-revision install with activation
+    # disabled, and an exact isolated-registry check per profile.
+    for name in CANDIDATE_ORDER:
+        adapter = CANDIDATE_ADAPTERS[name]
+        revision = CANDIDATE_REVISIONS[name]
+        environment = runtime_environments[name]
+        write_sidebar_config(profiles, name, ())
+        run_checked(
+            [herdr_path, "plugin", "install", adapter["plugin_id"], "--revision", revision, "--disabled"],
+            environment,
+            "CANDIDATE_INSTALL_FAILED",
+        )
+        registry = herdr_json(herdr_path, ["plugin", "registry"], environment, "CANDIDATE_REGISTRY_INVALID")
+        entries = registry if isinstance(registry, list) else []
+        if len(entries) != 1 or entries[0].get("plugin_id") != adapter["plugin_id"] or entries[0].get(
+            "revision"
+        ) != revision or entries[0].get("enabled") is not False:
+            raise PlaygroundError(
+                "CANDIDATE_REGISTRY_INVALID",
+                "the isolated %s registry does not contain exactly the pinned disabled candidate" % name,
+            )
+        manifest["candidates"][name]["registry"] = entries[0]
+    mutation.persist("candidate-installed")
+
+    # Start each candidate server as a controller-owned process, then wait for
+    # its profile socket.
+    for name in CANDIDATE_ORDER:
+        spawn_owned_process(
+            mutation,
+            runtime_environments[name],
+            "server-%s" % name,
+            name,
+            herdr_path,
+            ("server", "run"),
+            process_class="server",
+        )
+        wait_for_path(
+            Path(profiles[name]["socket"]),
+            "CANDIDATE_SERVER_SOCKET_MISSING",
+            "the %s profile socket never appeared" % name,
+        )
+
+    # Spaces in stable shared order, then the current-managed/default baseline.
+    catalog = build_space_catalog(mutation, manifest["fixture_repository"])
+    manifest["space_catalog"] = catalog
+    for name in CANDIDATE_ORDER:
+        environment = runtime_environments[name]
+        for entry in catalog:
+            arguments = [herdr_path, "space", "create", entry["label"], "--cwd", entry["path"]]
+            if entry["worktree_child"]:
+                arguments.append("--worktree-child")
+            run_checked(arguments, environment, "SPACE_CREATE_FAILED")
+        spaces = herdr_json(herdr_path, ["space", "list"], environment, "SPACE_LIST_FAILED") or []
+        if [space.get("label") for space in spaces] != [entry["label"] for entry in catalog]:
+            raise PlaygroundError("SPACE_ORDER_INVALID", "the %s profile spaces are not in catalog order" % name)
+        manifest["candidates"][name]["label_snapshot"] = [
+            {"label": space["label"], "label_text": space["label_text"]} for space in spaces
+        ]
+        rows = sidebar_snapshot(herdr_path, environment)
+        if rows != list(SHARED_SIDEBAR_ROWS):
+            raise PlaygroundError(
+                "BASELINE_CONTAMINATED",
+                "the %s baseline rows %r are not exactly the shared no-plugin rows" % (name, rows),
+            )
+        atomic_write_json(
+            run_dir / "observations" / ("baseline-%s.json" % name),
+            {
+                "schema_version": SCHEMA_VERSION,
+                "run_id": manifest["run_id"],
+                "profile": name,
+                "rows": rows,
+                "captured_at": utc_now(),
+            },
+            "baseline",
+        )
+    mutation.persist("candidate-baseline")
+
+    # Per-candidate activation in stable order; the first failure aborts and
+    # triggers cleanup for every earlier profile.
+    for name in CANDIDATE_ORDER:
+        try:
+            activate_candidate(mutation, name, herdr_path, gh_path, runtime_environments[name])
+        except PlaygroundError as error:
+            manifest.setdefault("candidate_diagnostics", {})[name] = {
+                "code": error.code,
+                "message": error.message,
+                "at": utc_now(),
+            }
+            mutation.persist("candidate-%s-diagnostics" % name)
+            raise
+        rows = sidebar_snapshot(herdr_path, runtime_environments[name])
+        atomic_write_json(
+            run_dir / "observations" / ("activation-%s.json" % name),
+            {
+                "schema_version": SCHEMA_VERSION,
+                "run_id": manifest["run_id"],
+                "profile": name,
+                "rows": rows,
+                "captured_at": utc_now(),
+            },
+            "activation-observation",
+        )
+
+
+def process_group_members(pgid: int) -> List[int]:
+    try:
+        output = subprocess.check_output(["/bin/ps", "-axo", "pid=,pgid="], text=True)
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    members: List[int] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1] == str(pgid):
+            members.append(int(parts[0]))
+    return members
+
+
+def teardown_runtime_environment(source: Dict[str, str], manifest: Dict[str, Any], name: str) -> Dict[str, str]:
+    return candidate_runtime_environment(
+        source, manifest["dependencies"], manifest["profiles"], name, with_token=False
+    )
+
+
+def settle_detached_intent(
+    mutation: Mutation, name: str, adapter: Dict[str, Any], unresolved: List[str], result: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Return the daemon process record to stop, adopting an unpromoted daemon
+    only on full identity agreement (KTD9)."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    process_key = "candidate-%s" % name
+    process = manifest["processes"].get(process_key)
+    intent = (manifest.get("detached_intents") or {}).get(name)
+    if process is not None or intent is None:
+        return process
+    if intent.get("phase") in ("intent-committed", None):
+        intent["phase"] = "cancelled-before-detach"
+        return None
+    record, reason = discover_detached_daemon(manifest["profiles"], name, adapter)
+    result["adoption"] = reason
+    if record is not None:
+        manifest["processes"][process_key] = record
+        intent["phase"] = "adopted"
+        return record
+    if reason in ("gone", "plugin state is absent"):
+        # The plugin state file is the authoritative registry of detached
+        # resources: a dead recorded process, or no registration at all,
+        # proves nothing owned remains. A live but disagreeing record below
+        # never does.
+        intent["phase"] = "settled-gone"
+        return None
+    unresolved.append("DETACHED_RESOURCE_UNRESOLVED")
+    return None
+
+
+def teardown_candidates(mutation: Mutation, source: Dict[str, str], unresolved: List[str]) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    candidates = manifest.get("candidates") or {}
+    if not candidates:
+        return
+    profiles = manifest["profiles"]
+    herdr_path = manifest["dependencies"]["herdr"]
+    results = manifest.setdefault("candidate_teardown", {})
+    for name in CANDIDATE_ORDER:
+        if name not in candidates:
+            continue
+        adapter = CANDIDATE_ADAPTERS[name]
+        result = results.setdefault(name, {})
+        if result.get("completed"):
+            continue
+        environment = teardown_runtime_environment(source, manifest, name)
+        state_dir = profile_state_dir(profiles, name)
+        candidate_unresolved: List[str] = []
+
+        daemon = settle_detached_intent(mutation, name, adapter, candidate_unresolved, result)
+        # Atomically quarantine the plugin-owned PID record before any native
+        # action could reread signal-capable state.
+        if adapter["pid_record"] and state_dir.exists():
+            quarantined = quarantine_plugin_record(
+                mutation, name, state_dir / adapter["pid_record"], "teardown"
+            )
+            if quarantined is not None:
+                result["pid_record_quarantined"] = True
+
+        if adapter["daemon_ends_with_socket"]:
+            # Closing the profile socket should end the daemon: stop this
+            # profile's server first, then verify the recorded process is gone.
+            server = manifest["processes"].get("server-%s" % name)
+            if server is not None and server.get("status") == "running":
+                stopped, code = terminate_owned_process(server)
+                result["socket_closed"] = stopped
+                if not stopped and code:
+                    candidate_unresolved.append(code)
+            if daemon is not None and daemon.get("status") == "running":
+                gone = False
+                for _ in range(candidate_attempts()):
+                    verdict, _ = verify_process(daemon)
+                    if verdict == "gone":
+                        gone = True
+                        break
+                    poll_sleep()
+                result["daemon_gone"] = gone
+                if gone:
+                    daemon["status"] = "stopped"
+                else:
+                    # Identity-checked escalation of the one remaining owned
+                    # process; never a broad or name-based signal.
+                    stopped, code = terminate_owned_process(daemon)
+                    result["escalated"] = True
+                    if not stopped and code:
+                        candidate_unresolved.append(code)
+        elif daemon is not None and daemon.get("status") == "running":
+            stopped, code = terminate_owned_process(daemon)
+            result["controller_signalled"] = stopped
+            if not stopped and code:
+                candidate_unresolved.append(code)
+
+        if adapter["ownership"] == "controller-watcher":
+            watcher = manifest["processes"].get("watcher-%s" % name)
+            if watcher is not None:
+                if watcher.get("status") == "running":
+                    stopped, code = terminate_owned_process(watcher)
+                    if not stopped and code:
+                        candidate_unresolved.append(code)
+                # Process-group quiescence before teardown passes: the watcher
+                # has no native stop, so its whole owned group must be empty.
+                pgid = watcher.get("process_group")
+                members = process_group_members(pgid) if isinstance(pgid, int) else []
+                if members:
+                    result["escalated"] = True
+                    try:
+                        os.killpg(pgid, signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError, OSError):
+                        pass
+                    for _ in range(candidate_attempts()):
+                        members = process_group_members(pgid)
+                        if not members:
+                            break
+                        poll_sleep()
+                result["group_quiescent"] = not members
+                if members:
+                    candidate_unresolved.append("WATCHER_GROUP_ACTIVE")
+
+        # Only non-signalling metadata and label restoration; the adapter's
+        # signal-capable native paths are bypassed by contract.
+        if not candidate_unresolved:
+            if adapter["metadata_cleanup_action"] and not result.get("metadata_cleanup"):
+                try:
+                    run_checked(
+                        [herdr_path, "plugin", "run", adapter["plugin_id"], adapter["metadata_cleanup_action"]],
+                        environment,
+                        "CANDIDATE_METADATA_CLEANUP_FAILED",
+                    )
+                    result["metadata_cleanup"] = True
+                except PlaygroundError as error:
+                    result["metadata_cleanup"] = False
+                    candidate_unresolved.append(error.code)
+            if adapter["restore_labels"] and not result.get("labels_restored"):
+                try:
+                    for entry in candidates[name].get("label_snapshot") or []:
+                        run_checked(
+                            [herdr_path, "space", "label", "set", entry["label"], entry["label_text"]],
+                            environment,
+                            "LABEL_RESTORE_FAILED",
+                        )
+                    result["labels_restored"] = True
+                except PlaygroundError as error:
+                    result["labels_restored"] = False
+                    candidate_unresolved.append(error.code)
+        result["native_stop_invoked"] = False
+        if not candidate_unresolved:
+            result["completed"] = True
+        unresolved.extend(candidate_unresolved)
+    mutation.persist("candidate-teardown")
+
+
 def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     ctx: Optional[BootstrapContext] = None
     try:
@@ -3276,7 +4270,7 @@ def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> 
 
 def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     try:
-        executable_paths, fixture, audit_digest, herdr_identity = preflight(arguments, source)
+        executable_paths, fixture, audit_digest, herdr_identity, audit_candidates = preflight(arguments, source)
     except PlaygroundError as error:
         return error_result(error)
 
@@ -3350,29 +4344,74 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 return remote_error.status
 
             target = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS") if test_mode() else None
-            if not target:
+            if target:
+                launch_error = start_foundation_process(mutation, environments["candidate-runtime"], target)
+                if launch_error is not None:
+                    current = read_manifest(root, run_id)
+                    print_json(output_record(current, launch_error.code, launch_error.message, "stop %s" % run_id))
+                    return launch_error.status
+
                 manifest["error"] = {
-                    "code": "PROFILE_STARTUP_NOT_IMPLEMENTED",
-                    "message": "candidate startup belongs to a later implementation unit",
+                    "code": "FOUNDATION_PROCESS_RUNNING",
+                    "message": "foundation test process is owned; candidate startup is not implemented",
                 }
-                final_manifest, _ = teardown_phases(mutation, source, "startup-failed-cleaned")
+                manifest["next_command"] = "stop %s" % run_id
+                mutation.persist("foundation-running")
                 mutation.finish()
-                print_json(output_record(final_manifest))
-                return 1
+            else:
+                candidate_error: Optional[PlaygroundError] = None
+                try:
+                    provision_candidates(mutation, source, executable_paths, environments, audit_candidates)
+                except PlaygroundError as error:
+                    candidate_error = error
+                if candidate_error is not None:
+                    if candidate_error.code.startswith("INJECTED_"):
+                        # Injected crash boundary: leave durable state exactly
+                        # as a real crash would, for recovery through stop.
+                        current = read_manifest(root, run_id)
+                        print_json(
+                            output_record(current, candidate_error.code, candidate_error.message, "stop %s" % run_id)
+                        )
+                        return candidate_error.status
+                    # A candidate activation failure triggers cleanup for all
+                    # earlier profiles and preserves its diagnostics.
+                    manifest["error"] = playground_error_json(candidate_error)
+                    final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
+                    mutation.finish()
+                    if cleanup_status == 0:
+                        print_json(
+                            output_record(
+                                final_manifest, candidate_error.code, candidate_error.message, "status %s" % run_id
+                            )
+                        )
+                    else:
+                        print_json(output_record(final_manifest))
+                    return candidate_error.status
+                manifest["lifecycle_state"] = "active-ready"
+                manifest["error"] = None
+                manifest["next_command"] = "view %s" % run_id
+                mutation.persist("active-ready")
+                mutation.finish()
 
-            launch_error = start_foundation_process(mutation, environments["candidate-runtime"], target)
-            if launch_error is not None:
-                current = read_manifest(root, run_id)
-                print_json(output_record(current, launch_error.code, launch_error.message, "stop %s" % run_id))
-                return launch_error.status
-
-            manifest["error"] = {
-                "code": "FOUNDATION_PROCESS_RUNNING",
-                "message": "foundation test process is owned; candidate startup is not implemented",
-            }
-            manifest["next_command"] = "stop %s" % run_id
-            mutation.persist("foundation-running")
-            mutation.finish()
+                try:
+                    wait_for_test_marker(
+                        "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
+                        "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
+                    )
+                except KeyboardInterrupt:
+                    stopped, stop_status = stop_run(root, run_id, source)
+                    print_json(
+                        output_record(
+                            stopped,
+                            "START_INTERRUPTED",
+                            "start was interrupted and verified teardown ran",
+                            "status %s" % run_id,
+                        )
+                    )
+                    return 130 if stop_status == 0 else stop_status
+                manifest = read_manifest(root, run_id)
+                print_json(output_record(manifest))
+                return 0
 
         try:
             wait_for_test_marker(
@@ -3495,6 +4534,11 @@ def teardown_phases(
     manifest["next_command"] = "stop %s" % run_id
     mutation.persist("stopping")
     unresolved: List[str] = []
+
+    # Candidate adapters first: quarantine plugin-owned records, settle
+    # detached daemons, and perform non-signalling restoration while the
+    # profile servers are still available.
+    teardown_candidates(mutation, source, unresolved)
 
     for intent_id, intent in manifest.get("launch_intents", {}).items():
         process = manifest.get("processes", {}).get(intent_id)

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -1007,6 +1007,9 @@ def new_manifest(
         "launch_intents": {},
         "processes": {},
         "remote": None,
+        "viewer": None,
+        "current_fixture": None,
+        "fixture_epoch": 0,
         "mutation_lease": None,
         "error": None,
         "next_command": "status %s" % run_id,
@@ -4060,6 +4063,12 @@ def provision_candidates(
             "activation-observation",
         )
 
+    # Every candidate shares one comparison fixture at a time (the product
+    # goal is the same repository state across all four panes); establish it
+    # now so `view` has a well-defined header and `snapshot` has a causal
+    # starting point (KTD7).
+    set_current_fixture(mutation, herdr_path, runtime_environments, LOCAL_FIXTURES[0])
+
 
 def process_group_members(pgid: int) -> List[int]:
     try:
@@ -4234,6 +4243,727 @@ def teardown_candidates(mutation: Mutation, source: Dict[str, str], unresolved: 
     mutation.persist("candidate-teardown")
 
 
+# ---- Comparison viewer and evidence snapshots (U6) --------------------------
+# Documented minimum terminal size for four equal panes; both dimensions are
+# even so a 2x2 split is always an exact division with no remainder pane.
+MIN_VIEWER_COLUMNS = 80
+MIN_VIEWER_ROWS = 24
+VIEWER_WORKSPACE_NAME = "comparison"
+# The full R11 field set every finalized inventory row must carry. Values may
+# be None (an operator note the operator skipped, or a controller measurement
+# that legitimately has nothing to report); the key itself must be present.
+R11_FIELDS = (
+    "capability_family",
+    "baseline_signal",
+    "candidate_visible_signal",
+    "companion_surface",
+    "ground_truth_classification",
+    "refresh_authority_state",
+    "terminal_dimensions",
+    "displaced_or_duplicated",
+    "readability_note",
+    "dependency_note",
+    "error_link",
+    "lifecycle_note",
+    "observation_id",
+    "hashes",
+    "applicability",
+)
+
+
+def interactive_mode(source: Dict[str, str]) -> bool:
+    if test_mode():
+        override = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_INTERACTIVE")
+        if override is not None:
+            return override == "1"
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def full_fixture_catalog(manifest: Dict[str, Any]) -> List[str]:
+    """Every fixture label a finalized run must cover for every candidate,
+    matching the shared order build_space_catalog installed as spaces."""
+    labels = list(LOCAL_FIXTURES)
+    if manifest.get("remote"):
+        labels.extend("gh-%s" % name for name in GITHUB_FIXTURES)
+    return labels
+
+
+def known_fixture_labels(manifest: Dict[str, Any]) -> List[str]:
+    return [entry["label"] for entry in manifest.get("space_catalog", [])]
+
+
+def build_candidate_runtime_environments(
+    source: Dict[str, str], executable_paths: Dict[str, str], profiles: Dict[str, Dict[str, str]]
+) -> Dict[str, Dict[str, str]]:
+    return {
+        name: candidate_runtime_environment(source, executable_paths, profiles, name, with_token=False)
+        for name in CANDIDATE_ORDER
+    }
+
+
+def viewer_environment(
+    source: Dict[str, str], executable_paths: Dict[str, str], profiles: Dict[str, Dict[str, str]]
+) -> Dict[str, str]:
+    viewer = profiles["viewer"]
+    environment = minimal_environment(source, executable_paths, Path(viewer["home"]))
+    environment.update(
+        {
+            "XDG_CONFIG_HOME": viewer["config_home"],
+            "XDG_STATE_HOME": viewer["state_home"],
+            "XDG_DATA_HOME": viewer["data_home"],
+        }
+    )
+    return environment
+
+
+def viewer_terminal_dimensions(source: Dict[str, str]) -> Tuple[int, int]:
+    override = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEWER_DIMENSIONS") if test_mode() else None
+    if override:
+        columns_text, _, rows_text = override.partition("x")
+        try:
+            return int(columns_text), int(rows_text)
+        except ValueError:
+            raise PlaygroundError("VIEWER_DIMENSIONS_INVALID", override)
+    # Without a real controlling terminal (piped, ssh -T, non-interactive
+    # automation), fall back to the documented minimum itself rather than a
+    # 0x0 that would fail every otherwise-healthy attach.
+    size = shutil.get_terminal_size(fallback=(MIN_VIEWER_COLUMNS, MIN_VIEWER_ROWS))
+    return size.columns, size.lines
+
+
+def require_viewer_dimensions(columns: int, rows: int) -> None:
+    if columns < MIN_VIEWER_COLUMNS or rows < MIN_VIEWER_ROWS or columns % 2 != 0 or rows % 2 != 0:
+        raise PlaygroundError(
+            "VIEWER_DIMENSIONS_TOO_SMALL",
+            "the terminal is %dx%d; the playground viewer requires an even %dx%d or larger"
+            % (columns, rows, MIN_VIEWER_COLUMNS, MIN_VIEWER_ROWS),
+        )
+
+
+def known_fixture_labels_or_raise(manifest: Dict[str, Any], label: str) -> None:
+    if label not in known_fixture_labels(manifest):
+        raise PlaygroundError("FIXTURE_UNKNOWN", "%s is not in this run's fixture catalog" % label)
+
+
+def set_current_fixture(
+    mutation: Mutation, herdr_path: str, environments: Dict[str, Dict[str, str]], label: str
+) -> None:
+    """Move every candidate profile's focus to one shared fixture and bump the
+    run's fixture epoch (KTD7): a read from before this call, even if its
+    value happens to equal the new one, carries the old epoch and can never
+    be confused with a fresh post-switch observation."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    known_fixture_labels_or_raise(manifest, label)
+    if manifest.get("current_fixture") == label:
+        return
+    focus: Dict[str, Any] = {}
+    for name in CANDIDATE_ORDER:
+        environment = environments[name]
+        run_checked([herdr_path, "space", "focus", label], environment, "FIXTURE_FOCUS_FAILED")
+        echoed = herdr_json(herdr_path, ["space", "current"], environment, "FIXTURE_FOCUS_UNPROVED")
+        if not isinstance(echoed, dict) or echoed.get("label") != label:
+            raise PlaygroundError(
+                "FIXTURE_FOCUS_UNPROVED", "the %s profile did not confirm focus on %s" % (name, label)
+            )
+        focus[name] = echoed
+    manifest["current_fixture"] = label
+    manifest["fixture_epoch"] = manifest.get("fixture_epoch", 0) + 1
+    manifest["candidate_focus"] = focus
+    mutation.persist("fixture-%s" % label)
+
+
+def candidate_current_focus(herdr_path: str, environment: Dict[str, str]) -> Dict[str, Any]:
+    echoed = herdr_json(herdr_path, ["space", "current"], environment, "FIXTURE_FOCUS_UNPROVED")
+    if not isinstance(echoed, dict):
+        raise PlaygroundError("FIXTURE_FOCUS_UNPROVED", "the candidate never confirmed a focused fixture")
+    return echoed
+
+
+def pane_header(manifest: Dict[str, Any], name: str) -> Dict[str, Any]:
+    return {
+        "run_id": manifest["run_id"],
+        "generation": manifest["generation"],
+        "candidate": manifest["candidates"][name]["revision"],
+        "profile": name,
+        "fixture": manifest.get("current_fixture"),
+    }
+
+
+def verify_candidate_socket(manifest: Dict[str, Any], name: str) -> None:
+    """KTD14: a missing or mismatched candidate socket fails attachment; the
+    viewer never creates a replacement server or connects back to itself."""
+    profiles = manifest["profiles"]
+    socket_path = Path(profiles[name]["socket"])
+    process = manifest["processes"].get("server-%s" % name)
+    if not socket_path.exists() or process is None:
+        raise PlaygroundError(
+            "VIEWER_ATTACH_SOCKET_MISSING", "the %s candidate socket is unavailable for attachment" % name
+        )
+    verdict, reason = verify_process(process)
+    if verdict != "owned":
+        raise PlaygroundError(
+            "VIEWER_ATTACH_SOCKET_MISMATCHED", "the %s candidate server is not owned: %s" % (name, reason)
+        )
+
+
+def create_viewer_workspace(
+    mutation: Mutation, herdr_path: str, environment: Dict[str, str], columns: int, rows: int
+) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    run_checked(
+        [herdr_path, "workspace", "create", VIEWER_WORKSPACE_NAME, "--cwd", manifest["viewer_workspace"]],
+        environment,
+        "VIEWER_WORKSPACE_FAILED",
+    )
+    layout = herdr_json(
+        herdr_path,
+        ["workspace", "layout", VIEWER_WORKSPACE_NAME, "--panes", "4", "--columns", str(columns), "--rows", str(rows)],
+        environment,
+        "VIEWER_LAYOUT_FAILED",
+    )
+    panes = layout.get("panes") if isinstance(layout, dict) else None
+    if not isinstance(panes, list) or len(panes) != 4:
+        raise PlaygroundError("VIEWER_LAYOUT_INVALID", "the viewer layout did not return four panes")
+    widths = {pane["width"] for pane in panes}
+    heights = {pane["height"] for pane in panes}
+    if len(widths) != 1 or len(heights) != 1:
+        raise PlaygroundError("VIEWER_LAYOUT_UNEQUAL", "the viewer panes are not equal regions")
+    manifest["viewer"] = {
+        "workspace": VIEWER_WORKSPACE_NAME,
+        "dimensions": {"columns": columns, "rows": rows},
+        "pane_size": {"width": panes[0]["width"], "height": panes[0]["height"]},
+        "diagnostic": False,
+        "panes": {},
+        "attached_at": None,
+    }
+
+
+def attach_viewer_pane(mutation: Mutation, name: str, pane_id: str, herdr_path: str, environment: Dict[str, str]) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    verify_candidate_socket(manifest, name)
+    header = pane_header(manifest, name)
+    spawn_owned_process(
+        mutation,
+        environment,
+        "client-%s" % name,
+        "viewer",
+        herdr_path,
+        (
+            "client",
+            "attach",
+            "--socket",
+            profiles[name]["socket"],
+            "--nested",
+            "--no-auto-start",
+            "--pane",
+            pane_id,
+            "--header",
+            json.dumps(header, sort_keys=True),
+        ),
+        process_class="viewer-client",
+    )
+    # Re-verify after the spawn race window: a candidate that died during
+    # attachment must never leave a connected pane or spawn a replacement
+    # server (KTD14).
+    try:
+        verify_candidate_socket(manifest, name)
+    except PlaygroundError:
+        process = manifest["processes"].get("client-%s" % name)
+        if process is not None:
+            terminate_owned_process(process)
+        raise PlaygroundError(
+            "VIEWER_ATTACH_CANDIDATE_DIED", "the %s candidate died during viewer attachment" % name
+        )
+    manifest["viewer"]["panes"][name] = {"pane_id": pane_id, "header": header, "attached_at": utc_now()}
+
+
+def attach_viewer(mutation: Mutation, source: Dict[str, str], executable_paths: Dict[str, str]) -> None:
+    """Create or reconcile the disposable viewer profile: one workspace, an
+    equal 2x2 pane layout, and one no-auto-start nested client per candidate
+    socket (KTD3, KTD14). Never touches the live Herdr socket."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    profiles = manifest["profiles"]
+    herdr_path = executable_paths["herdr"]
+    environment = viewer_environment(source, executable_paths, profiles)
+    record_test_environments({"viewer-attach": environment})
+    columns, rows = viewer_terminal_dimensions(source)
+
+    existing = manifest.get("viewer")
+    if existing is None:
+        require_viewer_dimensions(columns, rows)
+        server_process = manifest["processes"].get("server-viewer")
+        if server_process is None:
+            spawn_owned_process(
+                mutation, environment, "server-viewer", "viewer", herdr_path, ("server", "run"), process_class="server"
+            )
+            wait_for_path(
+                Path(profiles["viewer"]["socket"]),
+                "VIEWER_SERVER_SOCKET_MISSING",
+                "the viewer profile socket never appeared",
+            )
+        create_viewer_workspace(mutation, herdr_path, environment, columns, rows)
+        mutation.persist("viewer-workspace")
+        existing = manifest["viewer"]
+    else:
+        try:
+            require_viewer_dimensions(columns, rows)
+        except PlaygroundError:
+            existing["diagnostic"] = True
+            mutation.persist("viewer-diagnostic")
+            raise
+        if existing["diagnostic"] or existing["dimensions"] != {"columns": columns, "rows": rows}:
+            existing["dimensions"] = {"columns": columns, "rows": rows}
+            existing["pane_size"] = {"width": columns // 2, "height": rows // 2}
+            existing["diagnostic"] = False
+            mutation.persist("viewer-resized")
+
+    for name in CANDIDATE_ORDER:
+        process = manifest["processes"].get("client-%s" % name)
+        pane = existing["panes"].get(name)
+        if process is None or pane is None or verify_process(process)[0] != "owned":
+            pane_id = (pane or {}).get("pane_id", "pane-%s" % name)
+            attach_viewer_pane(mutation, name, pane_id, herdr_path, environment)
+            mutation.persist("viewer-attached-%s" % name)
+
+    if not manifest["viewer"].get("attached_at"):
+        manifest["viewer"]["attached_at"] = utc_now()
+        mutation.persist("viewer-ready")
+
+
+def perform_view(root: Path, run_id: str, source: Dict[str, str]) -> int:
+    """Attach the viewer from active-ready/active-degraded; from any other
+    state (including the legacy foundation-test-process scaffold used to
+    exercise interrupt/detach plumbing) skip straight to the marker wait
+    below without touching Mutation, matching the pre-attach behavior every
+    caller of `view` for signal semantics still relies on."""
+    manifest: Optional[Dict[str, Any]] = None
+    viewable_error: Optional[PlaygroundError] = None
+    try:
+        manifest = read_manifest(root, run_id)
+        if manifest["lifecycle_state"] in ("active-ready", "active-degraded"):
+            executable_paths = manifest["dependencies"]
+            with Mutation(root, run_id) as mutation:
+                manifest = mutation.manifest
+                assert manifest is not None
+                state_before_probe = manifest["lifecycle_state"]
+                try:
+                    probe_remote_observation(mutation, source)
+                except PlaygroundError as error:
+                    manifest["error"] = playground_error_json(error)
+                    viewable_error = error
+                if (
+                    viewable_error is None
+                    and state_before_probe == "active-ready"
+                    and manifest["lifecycle_state"] == "active-degraded"
+                ):
+                    # The probe just now found the drift that degraded this
+                    # run; surface that finding directly instead of letting a
+                    # downstream attach failure (no candidate infrastructure
+                    # is guaranteed once degraded) clobber the diagnosis.
+                    degradation = manifest["error"] or {}
+                    viewable_error = PlaygroundError(
+                        degradation.get("code", "AUTHORITY_DRIFT"), degradation.get("message", "observation drift")
+                    )
+                if viewable_error is None:
+                    try:
+                        attach_viewer(mutation, source, executable_paths)
+                    except PlaygroundError as error:
+                        manifest["error"] = playground_error_json(error)
+                        viewable_error = error
+                mutation.finish()
+            manifest = read_manifest(root, run_id)
+        else:
+            viewable_error = PlaygroundError(
+                "RUN_NOT_VIEWABLE", "view requires an active run; current state is %s" % manifest["lifecycle_state"]
+            )
+    except PlaygroundError as error:
+        return error_result(error)
+    try:
+        wait_for_test_marker(
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_MARKER",
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_RELEASE",
+            detached=True,
+        )
+    except ViewDetached:
+        print_json(
+            output_record(
+                manifest,
+                "VIEW_DETACHED",
+                "view detached without signalling managed processes",
+                "stop %s" % run_id,
+            )
+        )
+        return 130
+    if viewable_error is not None:
+        return error_result(viewable_error, manifest)
+    print_json(output_record(manifest))
+    return 0
+
+
+def hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_file(path: Path) -> str:
+    return hash_bytes(path.read_bytes())
+
+
+def observation_identifier(run_id: str, name: str, fixture: str, epoch: int) -> str:
+    digest = hashlib.sha256(("%s|%s|%s|%d" % (run_id, name, fixture, epoch)).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def ground_truth_for_fixture(mutation: Mutation, label: str) -> Dict[str, Any]:
+    manifest = mutation.manifest
+    assert manifest is not None
+    if label.startswith("gh-"):
+        record_path = repository_state_directory(mutation.root, manifest["fixture_repository"]) / "repository.json"
+        record = read_json(record_path)
+        fixture_record = record["fixtures"].get(label[len("gh-") :])
+        if fixture_record is None:
+            raise PlaygroundError("GROUND_TRUTH_MISSING", "no recorded GitHub fixture for %s" % label)
+        return {"kind": "github", "fixture": fixture_record}
+    truth = read_json(ground_truth_directory(mutation.run_dir) / ("%s.json" % label))
+    return {"kind": "local", "fixture": truth}
+
+
+def write_inventory(run_dir: Path, rows: List[Dict[str, Any]]) -> None:
+    lines = ["# Herdr Git status playground inventory", "", "Controller-measured fields are immutable; notes are operator free text.", ""]
+    lines.append("| candidate | fixture | applicability | candidate-visible | notes |")
+    lines.append("|---|---|---|---|---|")
+    for row in rows:
+        lines.append(
+            "| %s | %s | %s | %s | %s |"
+            % (
+                row["profile"],
+                row["fixture"],
+                row["applicability"]["state"],
+                ", ".join(row["candidate_visible_signal"]) or NOT_APPLICABLE,
+                row.get("readability_note") or "",
+            )
+        )
+    path = run_dir / "inventory.md"
+    ensure_private_directory(path.parent)
+    descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(descriptor, ("\n".join(lines) + "\n").encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def capture_snapshot(
+    mutation: Mutation,
+    source: Dict[str, str],
+    executable_paths: Dict[str, str],
+    profile: str,
+    fixture: str,
+    notes: Optional[str],
+    dependency_note: Optional[str],
+    error_link: Optional[str],
+    applicability: str,
+    applicability_reason: Optional[str],
+    screenshot: Optional[str],
+) -> Dict[str, Any]:
+    manifest = mutation.manifest
+    assert manifest is not None
+    if profile not in CANDIDATE_ORDER:
+        raise PlaygroundError("SNAPSHOT_PROFILE_UNKNOWN", profile)
+    record = (manifest.get("candidates") or {}).get(profile)
+    if record is None or not record.get("ready_at"):
+        raise PlaygroundError("SNAPSHOT_CANDIDATE_NOT_READY", "%s never reached candidate readiness" % profile)
+    if applicability != "applicable" and not applicability_reason:
+        raise PlaygroundError(
+            "SNAPSHOT_APPLICABILITY_REASON_REQUIRED", "an explicit %s reason is required" % applicability
+        )
+
+    herdr_path = executable_paths["herdr"]
+    profiles = manifest["profiles"]
+    environments = build_candidate_runtime_environments(source, executable_paths, profiles)
+    known_fixture_labels_or_raise(manifest, fixture)
+    set_current_fixture(mutation, herdr_path, environments, fixture)
+
+    environment = environments[profile]
+    focus = candidate_current_focus(herdr_path, environment)
+    if focus.get("label") != fixture:
+        raise PlaygroundError(
+            "SNAPSHOT_FIXTURE_MISMATCH", "the %s profile is not currently focused on %s" % (profile, fixture)
+        )
+    captured_at = utc_now()
+    if record["ready_at"] > captured_at:
+        raise PlaygroundError("SNAPSHOT_NOT_CAUSAL", "the observation cannot precede candidate activation")
+
+    viewer = manifest.get("viewer") or {}
+    header = None
+    if viewer.get("panes", {}).get(profile):
+        header = pane_header(manifest, profile)
+        viewer["panes"][profile]["header"] = header
+        mutation.persist("pane-header-refresh-%s" % profile)
+    generation = manifest["generation"]
+
+    rows = sidebar_snapshot(herdr_path, environment)
+    baseline = read_json(mutation.run_dir / "observations" / ("baseline-%s.json" % profile))["rows"]
+    candidate_visible = [row for row in rows if row not in baseline]
+    ground_truth = ground_truth_for_fixture(mutation, fixture)
+
+    raw_observation = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": manifest["run_id"],
+        "generation": generation,
+        "candidate": record["revision"],
+        "profile": profile,
+        "fixture": fixture,
+        "fixture_epoch": manifest["fixture_epoch"],
+        "focus": focus,
+        "rows": rows,
+        "ground_truth": ground_truth,
+        "captured_at": captured_at,
+    }
+    observation_id = observation_identifier(manifest["run_id"], profile, fixture, manifest["fixture_epoch"])
+    observation_path = mutation.run_dir / "observations" / (
+        "snapshot-%s-%s-%s.json" % (profile, fixture, observation_id)
+    )
+    atomic_write_json(observation_path, raw_observation, "snapshot-observation")
+    raw_hash = hash_file(observation_path)
+
+    screenshot_hash = None
+    screenshot_relative = None
+    if screenshot:
+        source_path = Path(screenshot)
+        if not source_path.is_file():
+            raise PlaygroundError("SNAPSHOT_SCREENSHOT_MISSING", screenshot)
+        destination = mutation.run_dir / "observations" / (
+            "screenshot-%s-%s-%s%s" % (profile, fixture, observation_id, source_path.suffix)
+        )
+        ensure_private_directory(destination.parent)
+        data = source_path.read_bytes()
+        descriptor = os.open(str(destination), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(descriptor, data)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        screenshot_hash = hash_bytes(data)
+        screenshot_relative = str(destination.relative_to(mutation.run_dir))
+
+    row = {
+        "run_id": manifest["run_id"],
+        "generation": generation,
+        "candidate": record["revision"],
+        "profile": profile,
+        "fixture": fixture,
+        "fixture_epoch": manifest["fixture_epoch"],
+        "captured_at": captured_at,
+        "header": header,
+        "capability_family": list(CANDIDATE_ADAPTERS[profile]["sidebar_tokens"]),
+        "baseline_signal": baseline,
+        "candidate_visible_signal": candidate_visible,
+        "companion_surface": NOT_APPLICABLE,
+        "ground_truth_classification": ground_truth,
+        "refresh_authority_state": "authority-checked" if ground_truth["kind"] == "github" else "n/a-local",
+        "terminal_dimensions": viewer.get("pane_size"),
+        "displaced_or_duplicated": sorted(set(rows) & set(baseline) & set(candidate_visible)),
+        "readability_note": notes,
+        "dependency_note": dependency_note,
+        "error_link": error_link,
+        "lifecycle_note": effective_state(manifest),
+        "observation_id": observation_id,
+        "hashes": {"raw_observation_sha256": raw_hash, "screenshot_sha256": screenshot_hash},
+        "screenshot_path": screenshot_relative,
+        "applicability": {"state": applicability, "reason": applicability_reason},
+        "captured_lifecycle_state": manifest["lifecycle_state"],
+    }
+    index_path = mutation.run_dir / "evidence-index.json"
+    try:
+        rows_list = read_json(index_path).get("rows", [])
+    except PlaygroundError:
+        rows_list = []
+    rows_list.append(row)
+    atomic_write_json(
+        index_path,
+        {"schema_version": SCHEMA_VERSION, "run_id": manifest["run_id"], "rows": rows_list},
+        "evidence-index",
+    )
+    write_inventory(mutation.run_dir, rows_list)
+    return row
+
+
+def finalize_snapshot(mutation: Mutation, source: Dict[str, str], executable_paths: Dict[str, str]) -> Dict[str, Any]:
+    manifest = mutation.manifest
+    assert manifest is not None
+    if manifest["lifecycle_state"] != "active-ready":
+        raise PlaygroundError(
+            "FINALIZE_REQUIRES_ACTIVE_READY",
+            "finalize requires an active-ready run; a degraded run's snapshots are diagnostic only",
+        )
+    try:
+        index = read_json(mutation.run_dir / "evidence-index.json")
+    except PlaygroundError:
+        raise PlaygroundError("FINALIZE_MISSING_RECORD", "no evidence has been captured for this run")
+    rows = index.get("rows", [])
+    by_pair: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for row in rows:
+        by_pair.setdefault((row["profile"], row["fixture"]), []).append(row)
+
+    expected = full_fixture_catalog(manifest)
+    missing = []
+    duplicate = []
+    for name in CANDIDATE_ORDER:
+        for label in expected:
+            entries = by_pair.get((name, label), [])
+            if not entries:
+                missing.append("%s/%s" % (name, label))
+            elif len(entries) > 1:
+                duplicate.append("%s/%s" % (name, label))
+    if missing:
+        raise PlaygroundError(
+            "FINALIZE_MISSING_RECORD", "missing candidate-fixture records: %s" % ", ".join(sorted(missing))
+        )
+    if duplicate:
+        raise PlaygroundError(
+            "FINALIZE_DUPLICATE_RECORD", "duplicate candidate-fixture records: %s" % ", ".join(sorted(duplicate))
+        )
+
+    for key, entries in by_pair.items():
+        row = entries[0]
+        for field in R11_FIELDS:
+            if field not in row:
+                raise PlaygroundError(
+                    "FINALIZE_MISSING_FIELDS", "%s/%s is missing field %s" % (key[0], key[1], field)
+                )
+        if row.get("screenshot_path") and row.get("header") is None:
+            raise PlaygroundError(
+                "FINALIZE_SCREENSHOT_IDENTITY_MISMATCH",
+                "%s/%s has a screenshot but no visible viewer header to attribute it" % key,
+            )
+        if row.get("header") is not None:
+            header = row["header"]
+            if (
+                header.get("run_id") != row["run_id"]
+                or header.get("generation") != row["generation"]
+                or header.get("candidate") != row["candidate"]
+                or header.get("profile") != row["profile"]
+                or header.get("fixture") != row["fixture"]
+            ):
+                raise PlaygroundError(
+                    "FINALIZE_SCREENSHOT_IDENTITY_MISMATCH",
+                    "%s/%s recorded header identity disagrees with the row" % key,
+                )
+
+    viewer = manifest.get("viewer")
+    if viewer:
+        dims = viewer.get("dimensions") or {}
+        if dims.get("columns", 0) % 2 != 0 or dims.get("rows", 0) % 2 != 0 or viewer.get("diagnostic"):
+            raise PlaygroundError("FINALIZE_UNEQUAL_PANES", "the viewer panes are not equal or the view is diagnostic")
+
+    if manifest.get("remote"):
+        remote_executables = controller_remote_tools(source)
+        ctx = BootstrapContext(mutation.root, manifest["fixture_repository"], remote_executables, source)
+        try:
+            refs = ls_remote(ctx)
+            for key, entries in by_pair.items():
+                row = entries[0]
+                if not row["fixture"].startswith("gh-"):
+                    continue
+                name = row["fixture"][len("gh-") :]
+                classification = row["ground_truth_classification"]["fixture"]
+                fixture_record = {"branch": classification["branch"], "head_sha": classification["head_sha"]}
+                if "pr_number" in classification:
+                    fixture_record["pr_number"] = classification["pr_number"]
+                if "workflow_run_id" in classification:
+                    fixture_record["workflow_run_id"] = classification["workflow_run_id"]
+                current = fixture_authority(ctx, name, fixture_record, refs)
+                if current["ref_sha"] != fixture_record["head_sha"]:
+                    raise PlaygroundError(
+                        "FINALIZE_STALE_AUTHORITY", "the %s fixture head moved since capture" % row["fixture"]
+                    )
+        finally:
+            ctx.cleanup()
+
+    profiles = manifest["profiles"]
+    environments = build_candidate_runtime_environments(source, executable_paths, profiles)
+    for name in CANDIDATE_ORDER:
+        try:
+            focus = candidate_current_focus(executable_paths["herdr"], environments[name])
+        except PlaygroundError as error:
+            raise PlaygroundError("FINALIZE_WRONG_ACTIVE_FIXTURE", str(error))
+        if focus.get("label") != manifest.get("current_fixture"):
+            raise PlaygroundError(
+                "FINALIZE_WRONG_ACTIVE_FIXTURE",
+                "the %s profile is focused on %r, not the run's current fixture %r"
+                % (name, focus.get("label"), manifest.get("current_fixture")),
+            )
+
+    manifest["inventory_finalized_at"] = utc_now()
+    manifest["inventory_row_count"] = len(rows)
+    mutation.persist("finalized")
+    return {"row_count": len(rows), "finalized_at": manifest["inventory_finalized_at"]}
+
+
+def command_snapshot(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    root = state_root(source)
+    try:
+        manifest = read_manifest(root, arguments.run_id)
+    except PlaygroundError as error:
+        return error_result(error)
+    if manifest["lifecycle_state"] not in ("active-ready", "active-degraded"):
+        return error_result(
+            PlaygroundError(
+                "SNAPSHOT_NOT_VIEWABLE",
+                "snapshot requires an active run; current state is %s" % manifest["lifecycle_state"],
+            ),
+            manifest,
+        )
+    executable_paths = manifest["dependencies"]
+    result: Optional[Dict[str, Any]] = None
+    try:
+        with Mutation(root, arguments.run_id) as mutation:
+            manifest = mutation.manifest
+            assert manifest is not None
+            try:
+                probe_remote_observation(mutation, source)
+                if arguments.finalize:
+                    result = finalize_snapshot(mutation, source, executable_paths)
+                else:
+                    if not arguments.profile or not arguments.fixture:
+                        raise PlaygroundError(
+                            "SNAPSHOT_ARGUMENTS_REQUIRED", "snapshot requires --profile and --fixture"
+                        )
+                    result = capture_snapshot(
+                        mutation,
+                        source,
+                        executable_paths,
+                        arguments.profile,
+                        arguments.fixture,
+                        arguments.notes,
+                        arguments.dependency_note,
+                        arguments.error_link,
+                        arguments.applicability,
+                        arguments.applicability_reason,
+                        arguments.screenshot,
+                    )
+            except PlaygroundError as error:
+                manifest["error"] = playground_error_json(error)
+                mutation.finish()
+                return error_result(error, read_manifest(root, arguments.run_id))
+            mutation.finish()
+    except PlaygroundError as error:
+        return error_result(error)
+    manifest = read_manifest(root, arguments.run_id)
+    output = output_record(manifest)
+    output["result"] = result
+    print_json(output)
+    return 0
+
+
 def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     ctx: Optional[BootstrapContext] = None
     try:
@@ -4277,6 +5007,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     root = state_root(source)
     run_dir: Optional[Path] = None
     manifest: Optional[Dict[str, Any]] = None
+    pending_view = False
     try:
         run_dir, profiles, run_id = allocate_run(root, source)
         manifest = new_manifest(
@@ -4393,25 +5124,36 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 mutation.persist("active-ready")
                 mutation.finish()
 
-                try:
-                    wait_for_test_marker(
-                        "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
-                        "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
-                    )
-                except KeyboardInterrupt:
-                    stopped, stop_status = stop_run(root, run_id, source)
-                    print_json(
-                        output_record(
-                            stopped,
-                            "START_INTERRUPTED",
-                            "start was interrupted and verified teardown ran",
-                            "status %s" % run_id,
+                # Interactive start attaches the viewer only once active-ready
+                # is reached; non-interactive start returns the run identity
+                # without requiring a TTY and leaves `view` for later (KTD2).
+                # perform_view opens its own lease, so it must run after this
+                # `with Mutation(...)` block has released its file lock.
+                if interactive_mode(source):
+                    pending_view = True
+                else:
+                    try:
+                        wait_for_test_marker(
+                            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
+                            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
                         )
-                    )
-                    return 130 if stop_status == 0 else stop_status
-                manifest = read_manifest(root, run_id)
-                print_json(output_record(manifest))
-                return 0
+                    except KeyboardInterrupt:
+                        stopped, stop_status = stop_run(root, run_id, source)
+                        print_json(
+                            output_record(
+                                stopped,
+                                "START_INTERRUPTED",
+                                "start was interrupted and verified teardown ran",
+                                "status %s" % run_id,
+                            )
+                        )
+                        return 130 if stop_status == 0 else stop_status
+                    manifest = read_manifest(root, run_id)
+                    print_json(output_record(manifest))
+                    return 0
+
+        if pending_view:
+            return perform_view(root, run_id, source)
 
         try:
             wait_for_test_marker(
@@ -4646,43 +5388,7 @@ def command_status(arguments: argparse.Namespace, source: Dict[str, str]) -> int
 
 
 def command_view(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
-    root = state_root(source)
-    try:
-        manifest = read_manifest(root, arguments.run_id)
-        if manifest.get("remote") and manifest["lifecycle_state"] in ("active-ready", "active-degraded"):
-            # view acquires the run lease and persists any resulting
-            # degradation before attaching.
-            with Mutation(root, arguments.run_id) as mutation:
-                probe_remote_observation(mutation, source)
-                mutation.finish()
-            manifest = read_manifest(root, arguments.run_id)
-    except PlaygroundError as error:
-        return error_result(error)
-    try:
-        wait_for_test_marker(
-            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_MARKER",
-            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_RELEASE",
-            detached=True,
-        )
-    except ViewDetached:
-        print_json(
-            output_record(
-                manifest,
-                "VIEW_DETACHED",
-                "view detached without signalling managed processes",
-                "stop %s" % arguments.run_id,
-            )
-        )
-        return 130
-    print_json(
-        output_record(
-            manifest,
-            "RUN_NOT_VIEWABLE",
-            "viewer startup belongs to a later implementation unit",
-            "stop %s" % arguments.run_id,
-        )
-    )
-    return 1
+    return perform_view(state_root(source), arguments.run_id, source)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -4707,6 +5413,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     snapshot = subparsers.add_parser("snapshot", help="capture attributed evidence")
     snapshot.add_argument("run_id")
+    snapshot.add_argument("--profile", choices=CANDIDATE_ORDER)
+    snapshot.add_argument("--fixture")
+    snapshot.add_argument("--notes")
+    snapshot.add_argument("--dependency-note")
+    snapshot.add_argument("--error-link")
+    snapshot.add_argument(
+        "--applicability",
+        choices=("applicable", "not-applicable", "no-visible-signal", "discrepancy"),
+        default="applicable",
+    )
+    snapshot.add_argument("--applicability-reason")
+    snapshot.add_argument("--screenshot")
+    snapshot.add_argument("--finalize", action="store_true")
 
     stop = subparsers.add_parser("stop", help="idempotently stop verified owned resources")
     stop.add_argument("run_id")
@@ -4743,6 +5462,8 @@ def main() -> int:
             return command_stop(arguments, source)
         if arguments.command == "view":
             return command_view(arguments, source)
+        if arguments.command == "snapshot":
+            return command_snapshot(arguments, source)
         if arguments.command == "bootstrap":
             return command_bootstrap(arguments, source)
         return command_not_implemented(arguments.command, arguments, source)

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -1,0 +1,1294 @@
+#!/usr/bin/env python3
+"""Safe lifecycle foundation for the disposable Herdr Git status playground."""
+
+import argparse
+import datetime as dt
+import errno
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+APP_NAME = "herdr-git-status-playground"
+APPROVED_HERDR_VERSION = "0.8.2"
+SCHEMA_VERSION = 1
+RUN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+PROFILE_IDS = ("ezcorp", "sfroment", "krystof", "jmarbutt", "viewer")
+ACTIVE_STATES = {
+    "provisioning",
+    "active-ready",
+    "active-degraded",
+    "stopping",
+    "cleanup-incomplete",
+}
+CANDIDATE_REVISIONS = {
+    "ezcorp": "f144c8dac2860e344b6b379d2bcfee229dcf10ad",
+    "sfroment": "b726977143adc2847dc25e3327bc0b1b4fc26455",
+    "krystof": "fe6575a89de9006c35d9d0b9707397839d983cff",
+    "jmarbutt": "8a56c5dce0bd65e47eddc9a1d862ddae870cddc3",
+}
+SAFE_INHERITED = ("LANG", "LC_ALL", "LC_CTYPE", "TERM", "TZ", "NO_COLOR")
+SECRET_NAMES = ("TOKEN", "PASSWORD", "CREDENTIAL", "SECRET")
+
+
+class PlaygroundError(Exception):
+    def __init__(self, code: str, message: str, status: int = 1):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+
+
+class AtomicWriteError(PlaygroundError):
+    pass
+
+
+class ViewDetached(Exception):
+    pass
+
+
+_atomic_pause_used = False
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def test_mode() -> bool:
+    return os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE") == "1"
+
+
+def source_environment() -> Dict[str, str]:
+    environment = dict(os.environ)
+    fixture = environment.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PARENT_ENV")
+    if test_mode() and fixture:
+        try:
+            with open(fixture, encoding="utf-8") as handle:
+                supplied = json.load(handle)
+        except (OSError, ValueError) as error:
+            raise PlaygroundError("TEST_ENVIRONMENT_INVALID", str(error))
+        if not isinstance(supplied, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in supplied.items()
+        ):
+            raise PlaygroundError("TEST_ENVIRONMENT_INVALID", "test parent environment must be a string map")
+        environment.update(supplied)
+    return environment
+
+
+def state_root(environment: Dict[str, str]) -> Path:
+    home = Path(environment.get("HOME") or str(Path.home()))
+    xdg_state = Path(environment.get("XDG_STATE_HOME") or home / ".local" / "state")
+    return xdg_state / APP_NAME
+
+
+def ensure_private_directory(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if path.is_symlink() or not path.is_dir():
+        raise PlaygroundError("UNSAFE_STATE_PATH", str(path))
+    os.chmod(path, 0o700)
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def atomic_write_json(path: Path, value: Dict[str, Any], label: str = "record") -> None:
+    global _atomic_pause_used
+    ensure_private_directory(path.parent)
+    payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    failpoint = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "") if test_mode() else ""
+    injected = failpoint.startswith("intent-") and label == "intent"
+    kind = failpoint[len("intent-") :] if injected else ""
+    code = "INTENT_%s_FAILED" % kind.upper() if kind else "ATOMIC_WRITE_FAILED"
+    if injected and kind == "permission":
+        raise AtomicWriteError(code, "injected permission failure before intent commit")
+
+    descriptor = -1
+    temporary = ""
+    try:
+        descriptor, temporary = tempfile.mkstemp(prefix=".%s-" % path.name, dir=str(path.parent))
+        os.fchmod(descriptor, 0o600)
+        if injected and kind == "write":
+            raise AtomicWriteError(code, "injected write failure before intent commit")
+        if injected and kind == "space":
+            raise AtomicWriteError(code, "injected space failure before intent commit")
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        marker = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_ATOMIC_MARKER")
+        release = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_ATOMIC_RELEASE")
+        if test_mode() and marker and release and not _atomic_pause_used:
+            _atomic_pause_used = True
+            Path(marker).touch()
+            while not Path(release).exists():
+                time.sleep(0.01)
+
+        if injected and kind == "replace":
+            raise AtomicWriteError(code, "injected rename failure before intent commit")
+        os.replace(temporary, path)
+        temporary = ""
+        os.chmod(path, 0o600)
+        fsync_directory(path.parent)
+    except AtomicWriteError:
+        raise
+    except OSError as error:
+        raise AtomicWriteError("ATOMIC_WRITE_FAILED", "%s: %s" % (path, error))
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    try:
+        mode = path.lstat().st_mode
+        if path.is_symlink() or not stat.S_ISREG(mode):
+            raise PlaygroundError("UNSAFE_STATE_PATH", str(path))
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        raise PlaygroundError("RUN_NOT_FOUND", path.parent.name)
+    except (OSError, ValueError) as error:
+        raise PlaygroundError("MANIFEST_INVALID", str(error))
+    if not isinstance(value, dict) or value.get("schema_version") != SCHEMA_VERSION:
+        raise PlaygroundError("MANIFEST_INVALID", str(path))
+    return value
+
+
+def validate_run_id(run_id: str) -> None:
+    if not RUN_ID.fullmatch(run_id):
+        raise PlaygroundError("RUN_ID_INVALID", run_id, 2)
+
+
+def run_directory(root: Path, run_id: str) -> Path:
+    validate_run_id(run_id)
+    return root / "runs" / run_id
+
+
+def manifest_path(root: Path, run_id: str) -> Path:
+    return run_directory(root, run_id) / "manifest.json"
+
+
+def read_manifest(root: Path, run_id: str) -> Dict[str, Any]:
+    manifest = read_json(manifest_path(root, run_id))
+    if manifest.get("run_id") != run_id:
+        raise PlaygroundError("MANIFEST_ID_MISMATCH", run_id)
+    return manifest
+
+
+def process_start_identity(pid: int) -> Optional[str]:
+    try:
+        output = subprocess.check_output(
+            ["/bin/ps", "-o", "lstart=", "-p", str(pid)],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return output or None
+
+
+def process_group(pid: int) -> Optional[int]:
+    try:
+        return os.getpgid(pid)
+    except (OSError, ProcessLookupError):
+        return None
+
+
+def process_command(pid: int) -> Optional[str]:
+    try:
+        output = subprocess.check_output(
+            ["/bin/ps", "-ww", "-o", "command=", "-p", str(pid)],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return output or None
+
+
+def process_alive(pid: int) -> bool:
+    try:
+        waited, _ = os.waitpid(pid, os.WNOHANG)
+        if waited == pid:
+            return False
+    except ChildProcessError:
+        pass
+    except OSError as error:
+        if error.errno != errno.ECHILD:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def output_record(
+    manifest: Optional[Dict[str, Any]],
+    code: Optional[str] = None,
+    message: Optional[str] = None,
+    next_command: Optional[str] = None,
+) -> Dict[str, Any]:
+    if manifest is None:
+        return {
+            "run_id": None,
+            "generation": 0,
+            "lifecycle_state": "not-allocated",
+            "effective_state": "not-allocated",
+            "error": {"code": code, "message": message} if code else None,
+            "next_command": next_command or "fix preflight and rerun start",
+        }
+    return {
+        "run_id": manifest["run_id"],
+        "generation": manifest["generation"],
+        "lifecycle_state": manifest["lifecycle_state"],
+        "effective_state": effective_state(manifest),
+        "error": {"code": code, "message": message}
+        if code
+        else manifest.get("error"),
+        "next_command": next_command if next_command is not None else manifest.get("next_command"),
+    }
+
+
+def print_json(value: Dict[str, Any]) -> None:
+    print(json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+
+def error_result(error: PlaygroundError, manifest: Optional[Dict[str, Any]] = None) -> int:
+    next_command = None
+    if manifest is not None:
+        next_command = "stop %s" % manifest["run_id"]
+    print_json(output_record(manifest, error.code, error.message, next_command))
+    return error.status
+
+
+def resolve_executable(name: str, path: str) -> Optional[str]:
+    resolved = shutil.which(name, path=path)
+    return os.path.realpath(resolved) if resolved else None
+
+
+def minimal_environment(source: Dict[str, str], executable_paths: Dict[str, str], home: Path) -> Dict[str, str]:
+    directories: List[str] = []
+    for executable in executable_paths.values():
+        directory = str(Path(executable).parent)
+        if directory not in directories:
+            directories.append(directory)
+    environment = {
+        "PATH": os.pathsep.join(directories),
+        "HOME": str(home),
+        "XDG_CONFIG_HOME": str(home / ".config"),
+        "XDG_STATE_HOME": str(home / ".state"),
+        "XDG_DATA_HOME": str(home / ".data"),
+    }
+    for name in SAFE_INHERITED:
+        if name in source:
+            environment[name] = source[name]
+    if test_mode():
+        for name in ("HGSP_WORK", "HGSP_CALL_LOG", "HGSP_HERDR_VERSION", "HGSP_GH_AUTH_STATUS"):
+            if name in os.environ:
+                environment[name] = os.environ[name]
+    return environment
+
+
+def run_checked(arguments: List[str], environment: Dict[str, str], code: str) -> str:
+    try:
+        completed = subprocess.run(
+            arguments,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PlaygroundError(code, str(error))
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "status %d" % completed.returncode
+        raise PlaygroundError(code, detail)
+    return completed.stdout.strip()
+
+
+def load_fixture_ownership(path: str) -> Dict[str, str]:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, ValueError) as error:
+        raise PlaygroundError("FIXTURE_OWNERSHIP_UNPROVED", str(error))
+    expected = ("host", "owner", "name", "repository_id")
+    if (
+        not isinstance(value, dict)
+        or value.get("owned") is not True
+        or any(not isinstance(value.get(key), str) or not value[key] for key in expected)
+        or value.get("name") == "my-mac-setup"
+    ):
+        raise PlaygroundError("FIXTURE_OWNERSHIP_UNPROVED", "fixture repository ownership is not exact")
+    return {key: value[key] for key in expected}
+
+
+def load_audit_attestation(path: str) -> str:
+    try:
+        contents = Path(path).read_bytes()
+        value = json.loads(contents.decode("utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError) as error:
+        raise PlaygroundError("AUDIT_ATTESTATION_INVALID", str(error))
+    candidates = value.get("candidates") if isinstance(value, dict) else None
+    if not isinstance(candidates, dict):
+        raise PlaygroundError("AUDIT_ATTESTATION_INVALID", "candidate audit map is missing")
+    for candidate, revision in CANDIDATE_REVISIONS.items():
+        record = candidates.get(candidate)
+        if (
+            not isinstance(record, dict)
+            or record.get("revision") != revision
+            or not isinstance(record.get("tree"), str)
+            or not record["tree"]
+        ):
+            raise PlaygroundError("AUDIT_ATTESTATION_INVALID", "audit is absent or stale for %s" % candidate)
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def preflight(
+    arguments: argparse.Namespace, source: Dict[str, str]
+) -> Tuple[Dict[str, str], Dict[str, str], str, Dict[str, str]]:
+    fixture = load_fixture_ownership(arguments.fixture_ownership)
+    audit_digest = load_audit_attestation(arguments.audit_attestation)
+    controller_token = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN", "")
+    candidate_token = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN", "")
+    if not controller_token or not candidate_token or controller_token == candidate_token:
+        raise PlaygroundError(
+            "CREDENTIAL_AUTHORITY_INVALID",
+            "separate controller-write and candidate-read credentials are required",
+        )
+
+    dependency_names = ("cargo", "node", "jq", "gh", "git", "python3", "herdr")
+    executable_paths: Dict[str, str] = {}
+    search_path = source.get("PATH", "")
+    for name in dependency_names:
+        resolved = resolve_executable(name, search_path)
+        if resolved is None:
+            raise PlaygroundError("%s_NOT_FOUND" % name.upper(), "%s is not on the approved PATH" % name)
+        executable_paths[name] = resolved
+
+    approved_herdr = os.path.realpath(arguments.approved_herdr)
+    if executable_paths["herdr"] != approved_herdr:
+        raise PlaygroundError("HERDR_PATH_CHANGED", "resolved Herdr differs from the approved path")
+
+    preflight_home = Path(tempfile.mkdtemp(prefix=".%s-preflight-" % APP_NAME))
+    try:
+        environment = minimal_environment(source, executable_paths, preflight_home)
+        versions = {
+            "cargo": run_checked([executable_paths["cargo"], "--version"], environment, "CARGO_INVALID"),
+            "node": run_checked([executable_paths["node"], "--version"], environment, "NODE_INVALID"),
+            "jq": run_checked([executable_paths["jq"], "--version"], environment, "JQ_INVALID"),
+            "gh": run_checked([executable_paths["gh"], "--version"], environment, "GH_INVALID"),
+            "git": run_checked([executable_paths["git"], "--version"], environment, "GIT_INVALID"),
+            "python3": run_checked(
+                [executable_paths["python3"], "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+                environment,
+                "PYTHON3_INVALID",
+            ),
+            "herdr": run_checked([executable_paths["herdr"], "--version"], environment, "HERDR_INVALID"),
+        }
+        node_match = re.search(r"(\d+)", versions["node"])
+        if node_match is None or int(node_match.group(1)) < 20:
+            raise PlaygroundError("NODE_VERSION_UNSUPPORTED", versions["node"])
+        python_match = re.fullmatch(r"(\d+)\.(\d+)", versions["python3"])
+        if python_match is None or tuple(map(int, python_match.groups())) < (3, 9):
+            raise PlaygroundError("PYTHON3_VERSION_UNSUPPORTED", versions["python3"])
+        herdr_match = re.search(r"(?:^|\s)(\d+\.\d+\.\d+)(?:\s|$)", versions["herdr"])
+        if herdr_match is None or herdr_match.group(1) != APPROVED_HERDR_VERSION:
+            raise PlaygroundError("HERDR_VERSION_UNAPPROVED", versions["herdr"])
+
+        for token, suffix in ((controller_token, "controller"), (candidate_token, "candidate")):
+            auth_home = preflight_home / suffix
+            ensure_private_directory(auth_home)
+            auth_environment = minimal_environment(source, executable_paths, auth_home)
+            auth_environment["GH_CONFIG_DIR"] = str(preflight_home / suffix / "gh")
+            auth_environment["GH_TOKEN"] = token
+            run_checked(
+                [executable_paths["gh"], "auth", "status", "--hostname", fixture["host"]],
+                auth_environment,
+                "%s_AUTH_FAILED" % suffix.upper(),
+            )
+    finally:
+        shutil.rmtree(str(preflight_home), ignore_errors=True)
+
+    try:
+        herdr_stat = os.stat(approved_herdr)
+    except OSError as error:
+        raise PlaygroundError("HERDR_PATH_CHANGED", str(error))
+    herdr_identity = {
+        "path": approved_herdr,
+        "device": str(herdr_stat.st_dev),
+        "inode": str(herdr_stat.st_ino),
+        "version": APPROVED_HERDR_VERSION,
+    }
+    return executable_paths, fixture, audit_digest, herdr_identity
+
+
+def live_herdr_roots(source: Dict[str, str]) -> List[Path]:
+    home = Path(source.get("HOME") or str(Path.home()))
+    config = Path(source.get("XDG_CONFIG_HOME") or home / ".config") / "herdr"
+    state = Path(source.get("XDG_STATE_HOME") or home / ".local" / "state") / "herdr"
+    data = Path(source.get("XDG_DATA_HOME") or home / ".local" / "share") / "herdr"
+    return [path.resolve(strict=False) for path in (config, state, data)]
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(parent.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def build_profiles(run_dir: Path, source: Dict[str, str]) -> Dict[str, Dict[str, str]]:
+    profiles: Dict[str, Dict[str, str]] = {}
+    live_roots = live_herdr_roots(source)
+    for profile_id in PROFILE_IDS:
+        profile_root = run_dir / "runtime" / "profiles" / profile_id
+        record = {
+            "home": str(profile_root / "home"),
+            "config_home": str(profile_root / "config"),
+            "state_home": str(profile_root / "state"),
+            "data_home": str(profile_root / "data"),
+            "socket": str(profile_root / "state" / "herdr" / "session.sock"),
+        }
+        for value in record.values():
+            path = Path(value)
+            if any(is_within(path, root) for root in live_roots):
+                raise PlaygroundError("PROFILE_ISOLATION_FAILED", str(path))
+        for key in ("home", "config_home", "state_home", "data_home"):
+            ensure_private_directory(Path(record[key]))
+        profiles[profile_id] = record
+    return profiles
+
+
+def allocate_run(root: Path, source: Dict[str, str]) -> Tuple[Path, Dict[str, Dict[str, str]], str]:
+    ensure_private_directory(root)
+    ensure_private_directory(root / "runs")
+    for _ in range(20):
+        run_id = "run-%s-%s" % (dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ"), secrets.token_hex(4))
+        run_dir = root / "runs" / run_id
+        try:
+            run_dir.mkdir(mode=0o700)
+            fsync_directory(run_dir.parent)
+            profiles = build_profiles(run_dir, source)
+            return run_dir, profiles, run_id
+        except FileExistsError:
+            continue
+    raise PlaygroundError("RUN_ALLOCATION_FAILED", "could not allocate a unique run ID")
+
+
+def canonical_remote(fixture: Dict[str, str]) -> str:
+    return "https://%s/%s/%s.git" % (fixture["host"], fixture["owner"], fixture["name"])
+
+
+def build_environments(
+    source: Dict[str, str],
+    executable_paths: Dict[str, str],
+    run_dir: Path,
+    profiles: Dict[str, Dict[str, str]],
+    fixture: Dict[str, str],
+) -> Dict[str, Dict[str, str]]:
+    controller_home = run_dir / "runtime" / "controller" / "home"
+    ensure_private_directory(controller_home)
+    git_environment = minimal_environment(source, executable_paths, controller_home)
+    git_environment.update(
+        {
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(controller_home / ".gitconfig"),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "/usr/bin/false",
+            "GIT_SSH_COMMAND": "ssh -o BatchMode=yes -o IdentityAgent=none",
+            "HERDR_PLAYGROUND_CANONICAL_REMOTE": canonical_remote(fixture),
+        }
+    )
+    gh_environment = minimal_environment(source, executable_paths, controller_home)
+    gh_environment.update(
+        {
+            "GH_CONFIG_DIR": str(run_dir / "runtime" / "controller" / "gh"),
+            "GH_TOKEN": os.environ["HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"],
+        }
+    )
+    build_home = run_dir / "runtime" / "build" / "home"
+    ensure_private_directory(build_home)
+    build_environment = minimal_environment(source, executable_paths, build_home)
+    candidate = profiles["ezcorp"]
+    runtime_environment = minimal_environment(source, executable_paths, Path(candidate["home"]))
+    runtime_environment.update(
+        {
+            "XDG_CONFIG_HOME": candidate["config_home"],
+            "XDG_STATE_HOME": candidate["state_home"],
+            "XDG_DATA_HOME": candidate["data_home"],
+            "GH_TOKEN": os.environ["HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN"],
+        }
+    )
+    viewer = profiles["viewer"]
+    viewer_environment = minimal_environment(source, executable_paths, Path(viewer["home"]))
+    viewer_environment.update(
+        {
+            "XDG_CONFIG_HOME": viewer["config_home"],
+            "XDG_STATE_HOME": viewer["state_home"],
+            "XDG_DATA_HOME": viewer["data_home"],
+        }
+    )
+    return {
+        "controller-git": git_environment,
+        "controller-gh": gh_environment,
+        "candidate-build": build_environment,
+        "candidate-runtime": runtime_environment,
+        "viewer": viewer_environment,
+    }
+
+
+def redacted_environment(environment: Dict[str, str]) -> Dict[str, str]:
+    redacted: Dict[str, str] = {}
+    for name, value in environment.items():
+        if any(part in name.upper() for part in SECRET_NAMES):
+            redacted[name] = "<redacted>"
+        else:
+            redacted[name] = value
+    return redacted
+
+
+def record_test_environments(environments: Dict[str, Dict[str, str]]) -> None:
+    path = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG")
+    if not test_mode() or not path:
+        return
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
+            for name, environment in environments.items():
+                handle.write(
+                    json.dumps(
+                        {"class": name, "environment": redacted_environment(environment)},
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+    except Exception:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise
+
+
+def create_git_credential_file(run_dir: Path, fixture: Dict[str, str]) -> Path:
+    path = run_dir / "runtime" / "controller" / "git-credentials"
+    token = os.environ["HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"]
+    contents = "https://x-access-token:%s@%s/%s/%s.git\n" % (
+        token,
+        fixture["host"],
+        fixture["owner"],
+        fixture["name"],
+    )
+    descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(descriptor, contents.encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return path
+
+
+def verify_herdr_identity(record: Dict[str, str], search_path: str) -> None:
+    resolved = resolve_executable("herdr", search_path)
+    if resolved != record["path"]:
+        raise PlaygroundError("HERDR_PATH_CHANGED", "Herdr path changed after preflight")
+    try:
+        current = os.stat(resolved)
+    except OSError as error:
+        raise PlaygroundError("HERDR_PATH_CHANGED", str(error))
+    if str(current.st_dev) != record["device"] or str(current.st_ino) != record["inode"]:
+        raise PlaygroundError("HERDR_PATH_CHANGED", "Herdr file identity changed after preflight")
+
+
+class Mutation:
+    def __init__(self, root: Path, run_id: str):
+        self.root = root
+        self.run_id = run_id
+        self.run_dir = run_directory(root, run_id)
+        self.lock_handle: Optional[Any] = None
+        self.manifest: Optional[Dict[str, Any]] = None
+        self.owner_id = ""
+
+    def __enter__(self) -> "Mutation":
+        lock_path = self.run_dir / "mutation.lock"
+        try:
+            descriptor = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+            self.lock_handle = os.fdopen(descriptor, "r+")
+            fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            if self.lock_handle is not None:
+                self.lock_handle.close()
+            raise PlaygroundError("RUN_BUSY", "another mutating command owns the run")
+        except OSError as error:
+            raise PlaygroundError("RUN_LOCK_FAILED", str(error))
+
+        self.manifest = read_manifest(self.root, self.run_id)
+        lease = self.manifest.get("mutation_lease")
+        if isinstance(lease, dict) and lease.get("owner_id"):
+            pid = lease.get("pid")
+            start = lease.get("start_identity")
+            if (
+                isinstance(pid, int)
+                and isinstance(start, str)
+                and process_start_identity(pid) == start
+                and pid != os.getpid()
+            ):
+                raise PlaygroundError("RUN_BUSY", "durable mutation owner is still alive")
+
+        self.owner_id = secrets.token_hex(12)
+        self.manifest["mutation_lease"] = {
+            "owner_id": self.owner_id,
+            "pid": os.getpid(),
+            "start_identity": process_start_identity(os.getpid()),
+            "claimed_at": utc_now(),
+        }
+        self.persist("lease-claim")
+
+        marker = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_MARKER")
+        release = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_RELEASE")
+        if test_mode() and marker and release:
+            Path(marker).touch()
+            while not Path(release).exists():
+                time.sleep(0.01)
+        return self
+
+    def persist(self, label: str) -> None:
+        assert self.manifest is not None
+        self.manifest["generation"] += 1
+        atomic_write_json(manifest_path(self.root, self.run_id), self.manifest, label)
+
+    def finish(self) -> None:
+        assert self.manifest is not None
+        self.manifest["mutation_lease"] = None
+        self.persist("lease-release")
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        if self.lock_handle is not None:
+            try:
+                fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                self.lock_handle.close()
+
+
+def effective_state(manifest: Dict[str, Any]) -> str:
+    lifecycle = manifest["lifecycle_state"]
+    if lifecycle in ("stopped", "startup-failed-cleaned"):
+        return lifecycle
+    for process in manifest.get("processes", {}).values():
+        if process.get("status") == "running":
+            verdict, _ = verify_process(process)
+            if verdict == "mismatch" and lifecycle.startswith("active"):
+                return "active-degraded"
+    return lifecycle
+
+
+def verify_process(record: Dict[str, Any]) -> Tuple[str, str]:
+    pid = record.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return "mismatch", "PID is absent"
+    if not process_alive(pid):
+        return "gone", "process exited"
+    current_start = process_start_identity(pid)
+    if current_start != record.get("start_identity"):
+        return "mismatch", "process start identity changed"
+    current_group = process_group(pid)
+    if current_group != record.get("process_group") or current_group != pid:
+        return "mismatch", "process group identity changed"
+    command = process_command(pid)
+    if command is None:
+        return "mismatch", "process command is unavailable"
+    controller = record.get("controller_executable", "")
+    target = record.get("executable", "")
+    if not (
+        (controller and controller in command and "__launch-wrapper" in command)
+        or (target and target in command)
+    ):
+        return "mismatch", "process executable changed"
+    return "owned", "verified"
+
+
+def claim_path_for(run_dir: Path, intent_id: str) -> Path:
+    return run_dir / "runtime" / "launch" / intent_id / "claim.json"
+
+
+def gate_path_for(run_dir: Path, intent_id: str) -> Path:
+    return run_dir / "runtime" / "launch" / intent_id / "release"
+
+
+def launch_wrapper(arguments: List[str]) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--claim", required=True)
+    parser.add_argument("--gate", required=True)
+    parser.add_argument("--intent-id", required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("target")
+    namespace = parser.parse_args(arguments)
+    claim = {
+        "schema_version": SCHEMA_VERSION,
+        "intent_id": namespace.intent_id,
+        "profile": namespace.profile,
+        "pid": os.getpid(),
+        "process_group": os.getpgrp(),
+        "start_identity": process_start_identity(os.getpid()),
+        "controller_executable": os.path.realpath(sys.executable),
+        "executable": os.path.realpath(namespace.target),
+    }
+    atomic_write_json(Path(namespace.claim), claim, "launch-claim")
+    gate = Path(namespace.gate)
+    while not gate.exists():
+        time.sleep(0.01)
+    os.execve(namespace.target, [namespace.target], dict(os.environ))
+    return 127
+
+
+def wait_for_claim(path: Path, process: subprocess.Popen) -> Dict[str, Any]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.exists():
+            return read_json(path)
+        if process.poll() is not None:
+            raise PlaygroundError("LAUNCH_CLAIM_MISSING", "launch wrapper exited before claiming ownership")
+        time.sleep(0.01)
+    raise PlaygroundError("LAUNCH_CLAIM_MISSING", "launch wrapper did not claim ownership")
+
+
+def start_foundation_process(
+    mutation: Mutation,
+    environment: Dict[str, str],
+    target: str,
+) -> Optional[PlaygroundError]:
+    assert mutation.manifest is not None
+    manifest = mutation.manifest
+    run_dir = mutation.run_dir
+    intent_id = "foundation-supervisor"
+    claim_path = claim_path_for(run_dir, intent_id)
+    gate_path = gate_path_for(run_dir, intent_id)
+    ensure_private_directory(claim_path.parent)
+    manifest["launch_intents"][intent_id] = {
+        "intent_id": intent_id,
+        "profile": "ezcorp",
+        "executable": os.path.realpath(target),
+        "phase": "intent-committed",
+        "claim": str(claim_path.relative_to(run_dir)),
+    }
+    try:
+        mutation.persist("intent")
+    except AtomicWriteError as error:
+        return error
+
+    failpoint = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "")
+    if failpoint == "before-spawn":
+        return PlaygroundError("INJECTED_BEFORE_SPAWN", "injected crash before spawn")
+
+    manifest["launch_intents"][intent_id]["phase"] = "spawn-attempted"
+    mutation.persist("spawn-attempt")
+    wrapper = [
+        sys.executable,
+        os.path.realpath(__file__),
+        "__launch-wrapper",
+        "--claim",
+        str(claim_path),
+        "--gate",
+        str(gate_path),
+        "--intent-id",
+        intent_id,
+        "--profile",
+        "ezcorp",
+        os.path.realpath(target),
+    ]
+    process = subprocess.Popen(
+        wrapper,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+    )
+    claim = wait_for_claim(claim_path, process)
+    if failpoint == "after-spawn":
+        return PlaygroundError("INJECTED_AFTER_SPAWN", "injected crash after spawn")
+    if failpoint == "before-identity-commit":
+        return PlaygroundError("INJECTED_BEFORE_IDENTITY_COMMIT", "injected crash before identity commit")
+
+    verdict, reason = verify_process(claim)
+    if verdict != "owned":
+        return PlaygroundError("PROCESS_IDENTITY_UNPROVED", reason)
+    claim["status"] = "running"
+    manifest["processes"][intent_id] = claim
+    manifest["launch_intents"][intent_id]["phase"] = "identity-recorded"
+    mutation.persist("identity")
+    gate_path.touch(mode=0o600)
+    return None
+
+
+def new_manifest(
+    run_id: str,
+    profiles: Dict[str, Dict[str, str]],
+    fixture: Dict[str, str],
+    audit_digest: str,
+    executable_paths: Dict[str, str],
+    herdr_identity: Dict[str, str],
+) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "generation": 0,
+        "lifecycle_state": "provisioning",
+        "created_at": utc_now(),
+        "fixture_repository": fixture,
+        "canonical_remote": canonical_remote(fixture),
+        "audit_attestation_sha256": audit_digest,
+        "dependencies": executable_paths,
+        "herdr_identity": herdr_identity,
+        "profiles": profiles,
+        "launch_intents": {},
+        "processes": {},
+        "mutation_lease": None,
+        "error": None,
+        "next_command": "status %s" % run_id,
+    }
+
+
+def wait_for_test_marker(marker_name: str, release_name: str, detached: bool = False) -> None:
+    marker = os.environ.get(marker_name)
+    release = os.environ.get(release_name)
+    if not test_mode() or not marker or not release:
+        return
+
+    def interrupted(signum: int, frame: Any) -> None:
+        if detached:
+            raise ViewDetached()
+        raise KeyboardInterrupt()
+
+    previous_int = signal.signal(signal.SIGINT, interrupted)
+    previous_hup = signal.signal(signal.SIGHUP, interrupted)
+    try:
+        Path(marker).write_text("%d\n" % os.getpid(), encoding="utf-8")
+        while not Path(release).exists():
+            time.sleep(0.01)
+    finally:
+        signal.signal(signal.SIGINT, previous_int)
+        signal.signal(signal.SIGHUP, previous_hup)
+
+
+def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    try:
+        executable_paths, fixture, audit_digest, herdr_identity = preflight(arguments, source)
+    except PlaygroundError as error:
+        return error_result(error)
+
+    root = state_root(source)
+    run_dir: Optional[Path] = None
+    manifest: Optional[Dict[str, Any]] = None
+    try:
+        run_dir, profiles, run_id = allocate_run(root, source)
+        manifest = new_manifest(
+            run_id,
+            profiles,
+            fixture,
+            audit_digest,
+            executable_paths,
+            herdr_identity,
+        )
+        atomic_write_json(run_dir / "manifest.json", manifest, "allocate")
+        environments = build_environments(source, executable_paths, run_dir, profiles, fixture)
+
+        credential_file = create_git_credential_file(run_dir, fixture)
+        try:
+            git_environment = dict(environments["controller-git"])
+            git_environment.update(
+                {
+                    "GIT_CONFIG_COUNT": "2",
+                    "GIT_CONFIG_KEY_0": "credential.helper",
+                    "GIT_CONFIG_VALUE_0": "store --file=%s" % credential_file,
+                    "GIT_CONFIG_KEY_1": "credential.useHttpPath",
+                    "GIT_CONFIG_VALUE_1": "true",
+                }
+            )
+            environments["controller-git"] = git_environment
+            run_checked([executable_paths["git"], "--version"], git_environment, "GIT_PREFLIGHT_FAILED")
+        finally:
+            try:
+                credential_file.unlink()
+                fsync_directory(credential_file.parent)
+            except FileNotFoundError:
+                pass
+        record_test_environments(environments)
+
+        verify_herdr_identity(herdr_identity, source.get("PATH", ""))
+        with Mutation(root, run_id) as mutation:
+            manifest = mutation.manifest
+            assert manifest is not None
+            target = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS") if test_mode() else None
+            if not target:
+                manifest["lifecycle_state"] = "startup-failed-cleaned"
+                manifest["error"] = {
+                    "code": "PROFILE_STARTUP_NOT_IMPLEMENTED",
+                    "message": "candidate startup belongs to a later implementation unit",
+                }
+                manifest["next_command"] = "status %s" % run_id
+                mutation.persist("foundation-only")
+                runtime = run_dir / "runtime"
+                if runtime.exists():
+                    shutil.rmtree(str(runtime))
+                    fsync_directory(run_dir)
+                mutation.finish()
+                print_json(output_record(manifest))
+                return 1
+
+            launch_error = start_foundation_process(mutation, environments["candidate-runtime"], target)
+            if launch_error is not None:
+                current = read_manifest(root, run_id)
+                print_json(output_record(current, launch_error.code, launch_error.message, "stop %s" % run_id))
+                return launch_error.status
+
+            manifest["error"] = {
+                "code": "FOUNDATION_PROCESS_RUNNING",
+                "message": "foundation test process is owned; candidate startup is not implemented",
+            }
+            manifest["next_command"] = "stop %s" % run_id
+            mutation.persist("foundation-running")
+            mutation.finish()
+
+        try:
+            wait_for_test_marker(
+                "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
+                "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
+            )
+        except KeyboardInterrupt:
+            stopped, stop_status = stop_run(root, run_id)
+            print_json(
+                output_record(
+                    stopped,
+                    "START_INTERRUPTED",
+                    "start was interrupted and verified teardown ran",
+                    "status %s" % run_id,
+                )
+            )
+            return 130 if stop_status == 0 else stop_status
+
+        manifest = read_manifest(root, run_id)
+        print_json(output_record(manifest))
+        return 1
+    except PlaygroundError as error:
+        if manifest is None or run_dir is None:
+            return error_result(error)
+        try:
+            current = read_manifest(root, manifest["run_id"])
+        except PlaygroundError:
+            current = manifest
+        return error_result(error, current)
+    except KeyboardInterrupt:
+        if manifest is None or run_dir is None:
+            return error_result(PlaygroundError("START_INTERRUPTED", "start was interrupted", 130))
+        stopped, stop_status = stop_run(root, manifest["run_id"])
+        print_json(
+            output_record(
+                stopped,
+                "START_INTERRUPTED",
+                "start was interrupted and verified teardown ran",
+                "status %s" % manifest["run_id"],
+            )
+        )
+        return 130 if stop_status == 0 else stop_status
+
+
+def adopt_claim(run_dir: Path, intent: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    claim_name = intent.get("claim")
+    if not isinstance(claim_name, str):
+        return None
+    claim_path = (run_dir / claim_name).resolve(strict=False)
+    if not is_within(claim_path, run_dir / "runtime") or not claim_path.exists():
+        return None
+    try:
+        claim = read_json(claim_path)
+    except PlaygroundError:
+        return None
+    if (
+        claim.get("intent_id") != intent.get("intent_id")
+        or claim.get("profile") != intent.get("profile")
+        or claim.get("executable") != intent.get("executable")
+    ):
+        return None
+    claim["status"] = "running"
+    return claim
+
+
+def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+    verdict, reason = verify_process(record)
+    if verdict == "gone":
+        record["status"] = "stopped"
+        return True, None
+    if verdict != "owned":
+        return False, "PROCESS_IDENTITY_MISMATCH"
+    pid = record["pid"]
+    group = record["process_group"]
+    try:
+        os.killpg(group, signal.SIGTERM)
+    except ProcessLookupError:
+        record["status"] = "stopped"
+        return True, None
+    except (PermissionError, OSError):
+        return False, "PROCESS_SIGNAL_FAILED"
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if not process_alive(pid):
+            record["status"] = "stopped"
+            return True, None
+        time.sleep(0.01)
+    verdict, _ = verify_process(record)
+    if verdict == "gone":
+        record["status"] = "stopped"
+        return True, None
+    if verdict != "owned":
+        return False, "PROCESS_IDENTITY_MISMATCH"
+    try:
+        os.killpg(group, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except (PermissionError, OSError):
+        return False, "PROCESS_SIGNAL_FAILED"
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if not process_alive(pid):
+            record["status"] = "stopped"
+            return True, None
+        time.sleep(0.01)
+    return False, "PROCESS_STOP_TIMEOUT"
+
+
+def stop_run(root: Path, run_id: str) -> Tuple[Dict[str, Any], int]:
+    current = read_manifest(root, run_id)
+    if current["lifecycle_state"] == "stopped":
+        return current, 0
+    try:
+        with Mutation(root, run_id) as mutation:
+            manifest = mutation.manifest
+            assert manifest is not None
+            manifest["lifecycle_state"] = "stopping"
+            manifest["next_command"] = "stop %s" % run_id
+            mutation.persist("stopping")
+            unresolved: List[str] = []
+
+            for intent_id, intent in manifest.get("launch_intents", {}).items():
+                process = manifest.get("processes", {}).get(intent_id)
+                if process is None:
+                    process = adopt_claim(mutation.run_dir, intent)
+                    if process is not None:
+                        manifest["processes"][intent_id] = process
+                if process is None:
+                    if intent.get("phase") == "intent-committed":
+                        intent["phase"] = "cancelled-before-spawn"
+                        continue
+                    unresolved.append("PROCESS_IDENTITY_UNRESOLVED")
+                    continue
+                stopped, code = terminate_owned_process(process)
+                if stopped:
+                    intent["phase"] = "stopped"
+                elif code:
+                    unresolved.append(code)
+
+            if unresolved:
+                code = "PROCESS_IDENTITY_MISMATCH" if "PROCESS_IDENTITY_MISMATCH" in unresolved else unresolved[0]
+                manifest["lifecycle_state"] = "cleanup-incomplete"
+                manifest["error"] = {"code": code, "message": "owned process cleanup could not be proved"}
+                manifest["next_command"] = "stop %s" % run_id
+                mutation.persist("cleanup-incomplete")
+                mutation.finish()
+                return manifest, 1
+
+            manifest["lifecycle_state"] = "stopped"
+            manifest["error"] = None
+            manifest["next_command"] = "status %s" % run_id
+            mutation.persist("stopped")
+            runtime = mutation.run_dir / "runtime"
+            if runtime.exists():
+                shutil.rmtree(str(runtime))
+                fsync_directory(mutation.run_dir)
+            mutation.finish()
+            return manifest, 0
+    except PlaygroundError as error:
+        current = read_manifest(root, run_id)
+        current["_operation_error"] = {"code": error.code, "message": error.message}
+        return current, error.status
+
+
+def command_stop(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    root = state_root(source)
+    try:
+        manifest, status = stop_run(root, arguments.run_id)
+    except PlaygroundError as error:
+        return error_result(error)
+    operation_error = manifest.pop("_operation_error", None)
+    if operation_error:
+        print_json(
+            output_record(
+                manifest,
+                operation_error["code"],
+                operation_error["message"],
+                "stop %s" % arguments.run_id,
+            )
+        )
+    else:
+        print_json(output_record(manifest))
+    return status
+
+
+def command_status(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    root = state_root(source)
+    if arguments.all:
+        runs: List[Dict[str, Any]] = []
+        runs_dir = root / "runs"
+        if runs_dir.is_dir():
+            for path in sorted(runs_dir.iterdir()):
+                if not path.is_dir() or not RUN_ID.fullmatch(path.name):
+                    continue
+                try:
+                    manifest = read_manifest(root, path.name)
+                except PlaygroundError:
+                    continue
+                if manifest["lifecycle_state"] in ACTIVE_STATES:
+                    runs.append(output_record(manifest))
+        print_json({"runs": runs, "error": None})
+        return 0
+    if not arguments.run_id:
+        raise PlaygroundError("RUN_ID_REQUIRED", "status requires RUN_ID or --all", 2)
+    try:
+        manifest = read_manifest(root, arguments.run_id)
+    except PlaygroundError as error:
+        return error_result(error)
+    print_json(output_record(manifest))
+    return 0
+
+
+def command_view(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    root = state_root(source)
+    try:
+        manifest = read_manifest(root, arguments.run_id)
+    except PlaygroundError as error:
+        return error_result(error)
+    try:
+        wait_for_test_marker(
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_MARKER",
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_RELEASE",
+            detached=True,
+        )
+    except ViewDetached:
+        print_json(
+            output_record(
+                manifest,
+                "VIEW_DETACHED",
+                "view detached without signalling managed processes",
+                "stop %s" % arguments.run_id,
+            )
+        )
+        return 130
+    print_json(
+        output_record(
+            manifest,
+            "RUN_NOT_VIEWABLE",
+            "viewer startup belongs to a later implementation unit",
+            "stop %s" % arguments.run_id,
+        )
+    )
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=APP_NAME)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap = subparsers.add_parser("bootstrap", help="initialize or validate the fixture repository")
+    bootstrap.add_argument("--initialize", action="store_true")
+
+    start = subparsers.add_parser("start", help="preflight and allocate a recoverable run")
+    start.add_argument("--approved-herdr", required=True)
+    start.add_argument("--fixture-ownership", required=True)
+    start.add_argument("--audit-attestation", required=True)
+
+    view = subparsers.add_parser("view", help="attach to a ready comparison viewer")
+    view.add_argument("run_id")
+
+    status = subparsers.add_parser("status", help="inspect one run or discover incomplete runs")
+    status.add_argument("run_id", nargs="?")
+    status.add_argument("--all", action="store_true")
+
+    snapshot = subparsers.add_parser("snapshot", help="capture attributed evidence")
+    snapshot.add_argument("run_id")
+
+    stop = subparsers.add_parser("stop", help="idempotently stop verified owned resources")
+    stop.add_argument("run_id")
+    return parser
+
+
+def command_not_implemented(command: str, arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    manifest = None
+    run_id = getattr(arguments, "run_id", None)
+    if run_id:
+        try:
+            manifest = read_manifest(state_root(source), run_id)
+        except PlaygroundError as error:
+            return error_result(error)
+    error = PlaygroundError(
+        "%s_NOT_IMPLEMENTED" % command.upper(),
+        "%s belongs to a later implementation unit" % command,
+    )
+    return error_result(error, manifest)
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "__launch-wrapper":
+        return launch_wrapper(sys.argv[2:])
+    parser = build_parser()
+    arguments = parser.parse_args()
+    try:
+        source = source_environment()
+        if arguments.command == "start":
+            return command_start(arguments, source)
+        if arguments.command == "status":
+            return command_status(arguments, source)
+        if arguments.command == "stop":
+            return command_stop(arguments, source)
+        if arguments.command == "view":
+            return command_view(arguments, source)
+        return command_not_implemented(arguments.command, arguments, source)
+    except PlaygroundError as error:
+        return error_result(error)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -41,6 +41,19 @@ CANDIDATE_REVISIONS = {
 }
 SAFE_INHERITED = ("LANG", "LC_ALL", "LC_CTYPE", "TERM", "TZ", "NO_COLOR")
 SECRET_NAMES = ("TOKEN", "PASSWORD", "CREDENTIAL", "SECRET")
+NOT_APPLICABLE = "not applicable"
+FIXTURE_AUTHOR_NAME = "Herdr Playground Fixture"
+FIXTURE_AUTHOR_EMAIL = "playground-fixture@example.invalid"
+LOCAL_FIXTURES = (
+    "checkout-clean",
+    "checkout-dirty",
+    "worktree-clean",
+    "worktree-dirty",
+    "conflict",
+    "diverged-stash",
+    "detached",
+    "non-git",
+)
 
 
 class PlaygroundError(Exception):
@@ -68,6 +81,10 @@ def utc_now() -> str:
 
 def test_mode() -> bool:
     return os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE") == "1"
+
+
+def test_failpoint() -> str:
+    return os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "") if test_mode() else ""
 
 
 def source_environment() -> Dict[str, str]:
@@ -538,6 +555,22 @@ def build_environments(
             "GH_TOKEN": os.environ["HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"],
         }
     )
+    fixtures_home = run_dir / "runtime" / "fixtures" / "home"
+    ensure_private_directory(fixtures_home)
+    fixtures_environment = minimal_environment(source, executable_paths, fixtures_home)
+    fixtures_environment.update(
+        {
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(fixtures_home / ".gitconfig"),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_CEILING_DIRECTORIES": str(run_dir / "runtime" / "fixtures"),
+            "GIT_AUTHOR_NAME": FIXTURE_AUTHOR_NAME,
+            "GIT_AUTHOR_EMAIL": FIXTURE_AUTHOR_EMAIL,
+            "GIT_COMMITTER_NAME": FIXTURE_AUTHOR_NAME,
+            "GIT_COMMITTER_EMAIL": FIXTURE_AUTHOR_EMAIL,
+        }
+    )
     build_home = run_dir / "runtime" / "build" / "home"
     ensure_private_directory(build_home)
     build_environment = minimal_environment(source, executable_paths, build_home)
@@ -566,6 +599,7 @@ def build_environments(
         "candidate-build": build_environment,
         "candidate-runtime": runtime_environment,
         "viewer": viewer_environment,
+        "local-fixtures": fixtures_environment,
     }
 
 
@@ -905,6 +939,515 @@ def wait_for_test_marker(marker_name: str, release_name: str, detached: bool = F
         signal.signal(signal.SIGHUP, previous_hup)
 
 
+def local_fixtures_root(run_dir: Path) -> Path:
+    return run_dir / "runtime" / "fixtures" / "local"
+
+
+def ground_truth_directory(run_dir: Path) -> Path:
+    return run_dir / "ground-truth"
+
+
+def git_run(
+    git_path: str,
+    arguments: List[str],
+    cwd: Path,
+    environment: Dict[str, str],
+    code: str,
+    allow_failure: bool = False,
+) -> "subprocess.CompletedProcess":
+    try:
+        completed = subprocess.run(
+            [git_path] + arguments,
+            cwd=str(cwd),
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PlaygroundError(code, str(error))
+    if completed.returncode != 0 and not allow_failure:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "status %d" % completed.returncode
+        raise PlaygroundError(code, "%s: %s" % (" ".join(arguments), detail))
+    return completed
+
+
+def git_porcelain_status(git_path: str, path: Path, environment: Dict[str, str], code: str) -> List[str]:
+    output = git_run(git_path, ["status", "--porcelain=v1"], path, environment, code).stdout
+    return [line for line in output.splitlines() if line]
+
+
+def git_head(git_path: str, path: Path, environment: Dict[str, str], code: str) -> str:
+    return git_run(git_path, ["rev-parse", "HEAD"], path, environment, code).stdout.strip()
+
+
+def set_repository_identity(git_path: str, path: Path, environment: Dict[str, str]) -> None:
+    git_run(git_path, ["config", "user.name", FIXTURE_AUTHOR_NAME], path, environment, "FIXTURE_IDENTITY_FAILED")
+    git_run(git_path, ["config", "user.email", FIXTURE_AUTHOR_EMAIL], path, environment, "FIXTURE_IDENTITY_FAILED")
+
+
+def init_simple_repository(git_path: str, path: Path, environment: Dict[str, str], code: str) -> None:
+    path.mkdir(parents=True)
+    git_run(git_path, ["init", "--quiet", "--initial-branch=main"], path, environment, code)
+    set_repository_identity(git_path, path, environment)
+
+
+def parse_porcelain(lines: List[str]) -> Tuple[List[str], List[str], List[str], List[str]]:
+    staged: List[str] = []
+    unstaged: List[str] = []
+    untracked: List[str] = []
+    unmerged: List[str] = []
+    for line in lines:
+        index_state, tree_state, name = line[0], line[1], line[3:]
+        if line.startswith("??"):
+            untracked.append(name)
+        elif index_state + tree_state in ("DD", "AU", "UD", "UA", "DU", "AA", "UU"):
+            unmerged.append(name)
+        else:
+            if index_state != " ":
+                staged.append(name)
+            if tree_state != " ":
+                unstaged.append(name)
+    return staged, unstaged, untracked, unmerged
+
+
+def measure_fixture_ground_truth(
+    git_path: str, label: str, path: Path, environment: Dict[str, str]
+) -> Dict[str, Any]:
+    code = "FIXTURE_%s_MEASURE_FAILED" % label.upper().replace("-", "_")
+    record: Dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "label": label,
+        "path": str(path),
+        "repository": NOT_APPLICABLE,
+        "linked_worktree": NOT_APPLICABLE,
+        "branch": NOT_APPLICABLE,
+        "head": NOT_APPLICABLE,
+        "staged_paths": NOT_APPLICABLE,
+        "unstaged_paths": NOT_APPLICABLE,
+        "untracked_paths": NOT_APPLICABLE,
+        "unmerged_paths": NOT_APPLICABLE,
+        "ahead": NOT_APPLICABLE,
+        "behind": NOT_APPLICABLE,
+        "stash_count": NOT_APPLICABLE,
+        "measured_at": utc_now(),
+    }
+    probe = git_run(git_path, ["rev-parse", "--is-inside-work-tree"], path, environment, code, allow_failure=True)
+    if probe.returncode != 0 or probe.stdout.strip() != "true":
+        record["repository"] = "none"
+        return record
+    record["repository"] = "work-tree"
+    git_dir = git_run(git_path, ["rev-parse", "--git-dir"], path, environment, code).stdout.strip()
+    common_dir = git_run(git_path, ["rev-parse", "--git-common-dir"], path, environment, code).stdout.strip()
+    record["linked_worktree"] = os.path.realpath(os.path.join(str(path), git_dir)) != os.path.realpath(
+        os.path.join(str(path), common_dir)
+    )
+    symbolic = git_run(git_path, ["symbolic-ref", "-q", "--short", "HEAD"], path, environment, code, allow_failure=True)
+    record["branch"] = symbolic.stdout.strip() if symbolic.returncode == 0 else None
+    record["head"] = git_head(git_path, path, environment, code)
+    staged, unstaged, untracked, unmerged = parse_porcelain(git_porcelain_status(git_path, path, environment, code))
+    record["staged_paths"] = staged
+    record["unstaged_paths"] = unstaged
+    record["untracked_paths"] = untracked
+    record["unmerged_paths"] = unmerged
+    upstream = git_run(
+        git_path,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        path,
+        environment,
+        code,
+        allow_failure=True,
+    )
+    if upstream.returncode == 0:
+        counts = git_run(
+            git_path,
+            ["rev-list", "--left-right", "--count", "%s...HEAD" % upstream.stdout.strip()],
+            path,
+            environment,
+            code,
+        ).stdout.split()
+        if len(counts) != 2:
+            raise PlaygroundError(code, "could not measure ahead/behind counts")
+        record["behind"] = int(counts[0])
+        record["ahead"] = int(counts[1])
+    stash_lines = [
+        line for line in git_run(git_path, ["stash", "list"], path, environment, code).stdout.splitlines() if line
+    ]
+    record["stash_count"] = len(stash_lines)
+    return record
+
+
+def build_checkout_clean_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    init_simple_repository(git_path, path, environment, "FIXTURE_CHECKOUT_CLEAN_INIT_FAILED")
+    (path / "README.md").write_text("herdr playground checkout-clean fixture\n", encoding="utf-8")
+    git_run(git_path, ["add", "README.md"], path, environment, "FIXTURE_CHECKOUT_CLEAN_ADD_FAILED")
+    git_run(
+        git_path,
+        ["commit", "--quiet", "-m", "checkout-clean fixture"],
+        path,
+        environment,
+        "FIXTURE_CHECKOUT_CLEAN_COMMIT_FAILED",
+    )
+    status = git_porcelain_status(git_path, path, environment, "FIXTURE_CHECKOUT_CLEAN_STATUS_FAILED")
+    if status:
+        raise PlaygroundError("FIXTURE_CHECKOUT_CLEAN_DIRTY", "expected a clean checkout, found %r" % status)
+    return {
+        "repository": "work-tree",
+        "linked_worktree": False,
+        "branch": "main",
+        "head": git_head(git_path, path, environment, "FIXTURE_CHECKOUT_CLEAN_HEAD_FAILED"),
+        "staged_paths": [],
+        "unstaged_paths": [],
+        "untracked_paths": [],
+        "unmerged_paths": [],
+    }
+
+
+def make_dirty_working_tree(
+    git_path: str, path: Path, environment: Dict[str, str], code_prefix: str
+) -> Dict[str, Any]:
+    (path / "tracked.txt").write_text("modified\n", encoding="utf-8")
+    (path / "staged.txt").write_text("staged\n", encoding="utf-8")
+    git_run(git_path, ["add", "staged.txt"], path, environment, "%s_ADD_FAILED" % code_prefix)
+    if test_failpoint() != "sabotage-dirty":
+        (path / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+    status = git_porcelain_status(git_path, path, environment, "%s_STATUS_FAILED" % code_prefix)
+    staged, unstaged, untracked, unmerged = parse_porcelain(status)
+    if staged != ["staged.txt"] or unstaged != ["tracked.txt"] or untracked != ["untracked.txt"] or unmerged:
+        raise PlaygroundError(
+            "%s_INCOMPLETE" % code_prefix,
+            "expected one staged, one unstaged, and one untracked path, found %r" % status,
+        )
+    return {"staged_paths": staged, "unstaged_paths": unstaged, "untracked_paths": untracked, "unmerged_paths": []}
+
+
+def build_checkout_dirty_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    init_simple_repository(git_path, path, environment, "FIXTURE_CHECKOUT_DIRTY_INIT_FAILED")
+    (path / "tracked.txt").write_text("original\n", encoding="utf-8")
+    git_run(git_path, ["add", "tracked.txt"], path, environment, "FIXTURE_CHECKOUT_DIRTY_ADD_FAILED")
+    git_run(
+        git_path,
+        ["commit", "--quiet", "-m", "checkout-dirty base"],
+        path,
+        environment,
+        "FIXTURE_CHECKOUT_DIRTY_COMMIT_FAILED",
+    )
+    ground_truth = make_dirty_working_tree(git_path, path, environment, "FIXTURE_CHECKOUT_DIRTY")
+    ground_truth.update(
+        {
+            "repository": "work-tree",
+            "linked_worktree": False,
+            "branch": "main",
+            "head": git_head(git_path, path, environment, "FIXTURE_CHECKOUT_DIRTY_HEAD_FAILED"),
+        }
+    )
+    return ground_truth
+
+
+def worktree_base_repository(git_path: str, fixtures_root: Path, environment: Dict[str, str]) -> Path:
+    base = fixtures_root / ".worktree-base"
+    if not base.exists():
+        init_simple_repository(git_path, base, environment, "FIXTURE_WORKTREE_BASE_INIT_FAILED")
+        (base / "README.md").write_text("herdr playground worktree base\n", encoding="utf-8")
+        (base / "tracked.txt").write_text("original\n", encoding="utf-8")
+        git_run(
+            git_path, ["add", "README.md", "tracked.txt"], base, environment, "FIXTURE_WORKTREE_BASE_ADD_FAILED"
+        )
+        git_run(
+            git_path,
+            ["commit", "--quiet", "-m", "worktree base"],
+            base,
+            environment,
+            "FIXTURE_WORKTREE_BASE_COMMIT_FAILED",
+        )
+    else:
+        git_run(git_path, ["worktree", "prune"], base, environment, "FIXTURE_WORKTREE_BASE_PRUNE_FAILED")
+    return base
+
+
+def add_linked_worktree(
+    git_path: str,
+    fixtures_root: Path,
+    path: Path,
+    environment: Dict[str, str],
+    branch: str,
+) -> None:
+    base = worktree_base_repository(git_path, fixtures_root, environment)
+    git_run(
+        git_path,
+        ["worktree", "add", "--quiet", "-b", branch, str(path), "main"],
+        base,
+        environment,
+        "FIXTURE_WORKTREE_ADD_FAILED",
+    )
+
+
+def build_worktree_clean_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    add_linked_worktree(git_path, path.parent, path, environment, "worktree-clean")
+    status = git_porcelain_status(git_path, path, environment, "FIXTURE_WORKTREE_CLEAN_STATUS_FAILED")
+    if status:
+        raise PlaygroundError("FIXTURE_WORKTREE_CLEAN_DIRTY", "expected a clean worktree, found %r" % status)
+    return {
+        "repository": "work-tree",
+        "linked_worktree": True,
+        "branch": "worktree-clean",
+        "head": git_head(git_path, path, environment, "FIXTURE_WORKTREE_CLEAN_HEAD_FAILED"),
+        "staged_paths": [],
+        "unstaged_paths": [],
+        "untracked_paths": [],
+        "unmerged_paths": [],
+    }
+
+
+def build_worktree_dirty_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    add_linked_worktree(git_path, path.parent, path, environment, "worktree-dirty")
+    ground_truth = make_dirty_working_tree(git_path, path, environment, "FIXTURE_WORKTREE_DIRTY")
+    ground_truth.update(
+        {
+            "repository": "work-tree",
+            "linked_worktree": True,
+            "branch": "worktree-dirty",
+            "head": git_head(git_path, path, environment, "FIXTURE_WORKTREE_DIRTY_HEAD_FAILED"),
+        }
+    )
+    return ground_truth
+
+
+def build_conflict_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    init_simple_repository(git_path, path, environment, "FIXTURE_CONFLICT_INIT_FAILED")
+    (path / "contested.txt").write_text("line1\n", encoding="utf-8")
+    git_run(git_path, ["add", "contested.txt"], path, environment, "FIXTURE_CONFLICT_ADD_FAILED")
+    git_run(
+        git_path, ["commit", "--quiet", "-m", "conflict base"], path, environment, "FIXTURE_CONFLICT_COMMIT_FAILED"
+    )
+    git_run(git_path, ["branch", "incoming"], path, environment, "FIXTURE_CONFLICT_BRANCH_FAILED")
+    (path / "contested.txt").write_text("ours\n", encoding="utf-8")
+    git_run(git_path, ["commit", "--quiet", "-am", "ours"], path, environment, "FIXTURE_CONFLICT_OURS_FAILED")
+    git_run(git_path, ["checkout", "--quiet", "incoming"], path, environment, "FIXTURE_CONFLICT_CHECKOUT_FAILED")
+    if test_failpoint() == "sabotage-conflict":
+        # Touch a different file so the merge succeeds and the premise gate must refuse.
+        (path / "unrelated.txt").write_text("theirs\n", encoding="utf-8")
+        git_run(git_path, ["add", "unrelated.txt"], path, environment, "FIXTURE_CONFLICT_THEIRS_FAILED")
+        git_run(git_path, ["commit", "--quiet", "-m", "theirs"], path, environment, "FIXTURE_CONFLICT_THEIRS_FAILED")
+    else:
+        (path / "contested.txt").write_text("theirs\n", encoding="utf-8")
+        git_run(git_path, ["commit", "--quiet", "-am", "theirs"], path, environment, "FIXTURE_CONFLICT_THEIRS_FAILED")
+    git_run(git_path, ["checkout", "--quiet", "main"], path, environment, "FIXTURE_CONFLICT_RETURN_FAILED")
+    merge = git_run(git_path, ["merge", "--no-edit", "incoming"], path, environment, "", allow_failure=True)
+    unmerged = git_run(
+        git_path, ["diff", "--name-only", "--diff-filter=U"], path, environment, "FIXTURE_CONFLICT_UNMERGED_FAILED"
+    ).stdout.split()
+    if merge.returncode == 0 or not unmerged:
+        raise PlaygroundError("FIXTURE_CONFLICT_MISSING", "merge did not produce unmerged index entries")
+    return {
+        "repository": "work-tree",
+        "linked_worktree": False,
+        "branch": "main",
+        "unmerged_paths": unmerged,
+        "untracked_paths": [],
+    }
+
+
+def build_diverged_stash_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    origin = path.parent / (path.name + "-origin.git")
+    peer = path.parent / (path.name + "-peer")
+    git_run(
+        git_path,
+        ["init", "--quiet", "--bare", "--initial-branch=main", str(origin)],
+        path.parent,
+        environment,
+        "FIXTURE_DIVERGED_ORIGIN_FAILED",
+    )
+    git_run(
+        git_path, ["clone", "--quiet", str(origin), str(peer)], path.parent, environment, "FIXTURE_DIVERGED_PEER_FAILED"
+    )
+    # A clone of an empty bare repository may name its unborn branch from local
+    # defaults; pin it to main so the push below targets the measured branch.
+    git_run(git_path, ["symbolic-ref", "HEAD", "refs/heads/main"], peer, environment, "FIXTURE_DIVERGED_PEER_FAILED")
+    set_repository_identity(git_path, peer, environment)
+    (peer / "shared.txt").write_text("base\n", encoding="utf-8")
+    git_run(git_path, ["add", "shared.txt"], peer, environment, "FIXTURE_DIVERGED_BASE_ADD_FAILED")
+    git_run(git_path, ["commit", "--quiet", "-m", "base"], peer, environment, "FIXTURE_DIVERGED_BASE_COMMIT_FAILED")
+    git_run(git_path, ["push", "--quiet", "origin", "main"], peer, environment, "FIXTURE_DIVERGED_BASE_PUSH_FAILED")
+
+    git_run(
+        git_path, ["clone", "--quiet", str(origin), str(path)], path.parent, environment, "FIXTURE_DIVERGED_CLONE_FAILED"
+    )
+    set_repository_identity(git_path, path, environment)
+
+    (peer / "shared.txt").write_text("remote-only\n", encoding="utf-8")
+    git_run(
+        git_path, ["commit", "--quiet", "-am", "remote-only commit"], peer, environment, "FIXTURE_DIVERGED_REMOTE_COMMIT_FAILED"
+    )
+    git_run(git_path, ["push", "--quiet", "origin", "main"], peer, environment, "FIXTURE_DIVERGED_REMOTE_PUSH_FAILED")
+
+    if test_failpoint() != "sabotage-diverged":
+        (path / "local-only.txt").write_text("local-only\n", encoding="utf-8")
+        git_run(git_path, ["add", "local-only.txt"], path, environment, "FIXTURE_DIVERGED_LOCAL_ADD_FAILED")
+        git_run(
+            git_path, ["commit", "--quiet", "-m", "local-only commit"], path, environment, "FIXTURE_DIVERGED_LOCAL_COMMIT_FAILED"
+        )
+
+    git_run(git_path, ["fetch", "--quiet", "origin"], path, environment, "FIXTURE_DIVERGED_FETCH_FAILED")
+    counts = git_run(
+        git_path,
+        ["rev-list", "--left-right", "--count", "origin/main...HEAD"],
+        path,
+        environment,
+        "FIXTURE_DIVERGED_COUNT_FAILED",
+    ).stdout.split()
+    if len(counts) != 2:
+        raise PlaygroundError("FIXTURE_DIVERGENCE_MISSING", "could not measure ahead/behind counts")
+    behind, ahead = int(counts[0]), int(counts[1])
+
+    (path / "uncommitted.txt").write_text("uncommitted\n", encoding="utf-8")
+    git_run(git_path, ["add", "uncommitted.txt"], path, environment, "FIXTURE_DIVERGED_STASH_ADD_FAILED")
+    git_run(
+        git_path,
+        ["stash", "push", "--quiet", "-m", "diverged-stash fixture"],
+        path,
+        environment,
+        "FIXTURE_DIVERGED_STASH_PUSH_FAILED",
+    )
+    stash_lines = [
+        line
+        for line in git_run(
+            git_path, ["stash", "list"], path, environment, "FIXTURE_DIVERGED_STASH_LIST_FAILED"
+        ).stdout.splitlines()
+        if line
+    ]
+    if ahead < 1 or behind < 1 or not stash_lines:
+        raise PlaygroundError(
+            "FIXTURE_DIVERGENCE_MISSING",
+            "expected positive ahead/behind counts and a nonempty stash, found ahead=%d behind=%d stash=%r"
+            % (ahead, behind, stash_lines),
+        )
+    return {
+        "repository": "work-tree",
+        "linked_worktree": False,
+        "branch": "main",
+        "head": git_head(git_path, path, environment, "FIXTURE_DIVERGED_HEAD_FAILED"),
+        "ahead": ahead,
+        "behind": behind,
+        "stash_count": len(stash_lines),
+        "staged_paths": [],
+        "unstaged_paths": [],
+        "untracked_paths": [],
+        "unmerged_paths": [],
+    }
+
+
+def build_detached_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    init_simple_repository(git_path, path, environment, "FIXTURE_DETACHED_INIT_FAILED")
+    (path / "first.txt").write_text("first\n", encoding="utf-8")
+    git_run(git_path, ["add", "first.txt"], path, environment, "FIXTURE_DETACHED_ADD_FIRST_FAILED")
+    git_run(
+        git_path, ["commit", "--quiet", "-m", "first commit"], path, environment, "FIXTURE_DETACHED_COMMIT_FIRST_FAILED"
+    )
+    target = git_head(git_path, path, environment, "FIXTURE_DETACHED_HEAD_FAILED")
+    (path / "second.txt").write_text("second\n", encoding="utf-8")
+    git_run(git_path, ["add", "second.txt"], path, environment, "FIXTURE_DETACHED_ADD_SECOND_FAILED")
+    git_run(
+        git_path,
+        ["commit", "--quiet", "-m", "second commit"],
+        path,
+        environment,
+        "FIXTURE_DETACHED_COMMIT_SECOND_FAILED",
+    )
+    if test_failpoint() != "sabotage-detached":
+        git_run(
+            git_path, ["checkout", "--quiet", "--detach", target], path, environment, "FIXTURE_DETACHED_CHECKOUT_FAILED"
+        )
+    symbolic = git_run(git_path, ["symbolic-ref", "-q", "HEAD"], path, environment, "", allow_failure=True)
+    current = git_head(git_path, path, environment, "FIXTURE_DETACHED_VERIFY_HEAD_FAILED")
+    if symbolic.returncode == 0 or current != target:
+        raise PlaygroundError("FIXTURE_DETACHED_INVALID", "expected a detached HEAD at the recorded commit")
+    return {
+        "repository": "work-tree",
+        "linked_worktree": False,
+        "branch": None,
+        "head": target,
+        "staged_paths": [],
+        "unstaged_paths": [],
+        "untracked_paths": [],
+        "unmerged_paths": [],
+    }
+
+
+def build_non_git_fixture(git_path: str, path: Path, environment: Dict[str, str]) -> Dict[str, Any]:
+    path.mkdir(parents=True)
+    if test_failpoint() == "sabotage-non-git":
+        # Plant repository metadata one level above so the contamination gate must refuse.
+        git_run(git_path, ["init", "--quiet", str(path.parent)], path.parent, environment, "FIXTURE_NON_GIT_SABOTAGE_FAILED")
+    probe = git_run(git_path, ["rev-parse", "--show-toplevel"], path, environment, "", allow_failure=True)
+    if probe.returncode == 0:
+        raise PlaygroundError("FIXTURE_NON_GIT_CONTAMINATED", "expected no Git parent within the disposable root")
+    return {"repository": "none"}
+
+
+LOCAL_FIXTURE_BUILDERS = {
+    "checkout-clean": build_checkout_clean_fixture,
+    "checkout-dirty": build_checkout_dirty_fixture,
+    "worktree-clean": build_worktree_clean_fixture,
+    "worktree-dirty": build_worktree_dirty_fixture,
+    "conflict": build_conflict_fixture,
+    "diverged-stash": build_diverged_stash_fixture,
+    "detached": build_detached_fixture,
+    "non-git": build_non_git_fixture,
+}
+
+
+def build_local_fixture_catalog(
+    mutation: Mutation,
+    environments: Dict[str, Dict[str, str]],
+    executable_paths: Dict[str, str],
+) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    run_dir = mutation.run_dir
+    git_path = executable_paths["git"]
+    environment = environments["local-fixtures"]
+    fixtures_root = local_fixtures_root(run_dir)
+    ensure_private_directory(fixtures_root)
+    manifest["local_fixtures"] = {}
+
+    for name in LOCAL_FIXTURES:
+        if test_failpoint() == "fixture-%s" % name:
+            raise PlaygroundError(
+                "INJECTED_FIXTURE_%s" % name.upper().replace("-", "_"),
+                "injected crash at the %s fixture-construction boundary" % name,
+            )
+        fixture_path = fixtures_root / name
+        expected = LOCAL_FIXTURE_BUILDERS[name](git_path, fixture_path, environment)
+        record = measure_fixture_ground_truth(git_path, name, fixture_path, environment)
+        for key, value in expected.items():
+            if record.get(key) != value:
+                raise PlaygroundError(
+                    "FIXTURE_%s_PREMISE_DRIFT" % name.upper().replace("-", "_"),
+                    "measured %s=%r, expected %r" % (key, record.get(key), value),
+                )
+        atomic_write_json(ground_truth_directory(run_dir) / ("%s.json" % name), record, "ground-truth")
+        manifest["local_fixtures"][name] = {
+            "path": str(fixture_path),
+            "ground_truth": "ground-truth/%s.json" % name,
+            "built_at": record["measured_at"],
+        }
+        mutation.persist("local-fixture-%s" % name)
+
+    catalog = [
+        {"label": name, "path": str(fixtures_root / name), "ground_truth": "ground-truth/%s.json" % name}
+        for name in LOCAL_FIXTURES
+    ]
+    manifest["fixture_assignments"] = {
+        profile_id: catalog for profile_id in PROFILE_IDS if profile_id != "viewer"
+    }
+    viewer_workspace = run_dir / "runtime" / "profiles" / "viewer" / "comparison"
+    ensure_private_directory(viewer_workspace)
+    manifest["viewer_workspace"] = str(viewer_workspace)
+    mutation.persist("fixture-assignments")
+
+
 def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     try:
         executable_paths, fixture, audit_digest, herdr_identity = preflight(arguments, source)
@@ -953,6 +1496,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
         with Mutation(root, run_id) as mutation:
             manifest = mutation.manifest
             assert manifest is not None
+            build_local_fixture_catalog(mutation, environments, executable_paths)
             target = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS") if test_mode() else None
             if not target:
                 manifest["lifecycle_state"] = "startup-failed-cleaned"

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -192,10 +192,14 @@ def fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 def atomic_write_json(path: Path, value: Dict[str, Any], label: str = "record") -> None:
     global _atomic_pause_used
     ensure_private_directory(path.parent)
-    payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    payload = (canonical_json(value) + "\n").encode("utf-8")
     failpoint = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT", "") if test_mode() else ""
     injected = failpoint.startswith("intent-") and label == "intent"
     kind = failpoint[len("intent-") :] if injected else ""
@@ -361,7 +365,7 @@ def output_record(
 
 
 def print_json(value: Dict[str, Any]) -> None:
-    print(json.dumps(value, sort_keys=True, separators=(",", ":")))
+    print(canonical_json(value))
 
 
 def error_result(error: PlaygroundError, manifest: Optional[Dict[str, Any]] = None) -> int:
@@ -462,7 +466,7 @@ def load_audit_attestation(path: str) -> Tuple[str, Dict[str, Dict[str, Any]]]:
             raise PlaygroundError(
                 "AUDIT_ATTESTATION_INVALID", "audit is absent, stale, or unapproved for %s" % candidate
             )
-    canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    canonical = canonical_json(value).encode("utf-8")
     digest = hashlib.sha256(canonical).hexdigest()
     return digest, {name: dict(candidates[name]) for name in CANDIDATE_REVISIONS}
 
@@ -503,7 +507,7 @@ def preflight(
             "%s is not on the approved PATH; recorded toolchain status: %s; install it temporarily for "
             "this trial (a scratch rustup/npm/jq/gh prefix removed afterward) or point PATH at an "
             "already-configured toolchain install — never add it to the managed Brewfile"
-            % (first, json.dumps(toolchain_status, sort_keys=True, separators=(",", ":"))),
+            % (first, canonical_json(toolchain_status)),
         )
 
     approved_herdr = os.path.realpath(arguments.approved_herdr)
@@ -804,9 +808,7 @@ def append_diagnostic(run_dir: Path, code: str, message: str) -> None:
     removed alongside `runtime/` once teardown succeeds."""
     path = diagnostics_log_path(run_dir)
     ensure_private_directory(path.parent)
-    line = json.dumps(
-        {"at": utc_now(), "code": code, "message": redact_text(message)}, sort_keys=True, separators=(",", ":")
-    )
+    line = canonical_json({"at": utc_now(), "code": code, "message": redact_text(message)})
     descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
     try:
         os.write(descriptor, (line + "\n").encode("utf-8"))
@@ -1264,8 +1266,8 @@ def measure_fixture_ground_truth(
         record["repository"] = "none"
         return record
     record["repository"] = "work-tree"
-    git_dir = git_run(git_path, ["rev-parse", "--git-dir"], path, environment, code).stdout.strip()
-    common_dir = git_run(git_path, ["rev-parse", "--git-common-dir"], path, environment, code).stdout.strip()
+    dirs = git_run(git_path, ["rev-parse", "--git-dir", "--git-common-dir"], path, environment, code).stdout.splitlines()
+    git_dir, common_dir = dirs[0].strip(), dirs[1].strip()
     record["linked_worktree"] = os.path.realpath(os.path.join(str(path), git_dir)) != os.path.realpath(
         os.path.join(str(path), common_dir)
     )
@@ -1675,7 +1677,8 @@ def build_local_fixture_catalog(
 
 
 def identity_component_valid(value: str) -> bool:
-    return bool(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value))
+    # Same grammar as run IDs: one identifier charset, so the two cannot drift.
+    return bool(RUN_ID.fullmatch(value))
 
 
 def repository_state_directory(root: Path, ownership: Dict[str, str]) -> Path:
@@ -4727,7 +4730,6 @@ def perform_view(root: Path, run_id: str, source: Dict[str, str]) -> int:
                         manifest["error"] = playground_error_json(error)
                         viewable_error = error
                 mutation.finish()
-            manifest = read_manifest(root, run_id)
         else:
             viewable_error = PlaygroundError(
                 "RUN_NOT_VIEWABLE", "view requires an active run; current state is %s" % manifest["lifecycle_state"]
@@ -4827,14 +4829,7 @@ def write_inventory(run_dir: Path, rows: List[Dict[str, Any]]) -> None:
             cells.append(format_r11_cell(field, row.get(field)))
         safe_cells = [str(cell).replace("|", "/").replace("\n", " ") for cell in cells]
         lines.append("| " + " | ".join(safe_cells) + " |")
-    path = run_dir / "inventory.md"
-    ensure_private_directory(path.parent)
-    descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        os.write(descriptor, ("\n".join(lines) + "\n").encode("utf-8"))
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
+    write_private_text(run_dir / "inventory.md", "\n".join(lines) + "\n")
 
 
 def capture_snapshot(
@@ -5147,7 +5142,6 @@ def command_snapshot(arguments: argparse.Namespace, source: Dict[str, str]) -> i
             mutation.finish()
     except PlaygroundError as error:
         return error_result(error)
-    manifest = read_manifest(root, arguments.run_id)
     output = output_record(manifest)
     output["result"] = result
     print_json(output)
@@ -5186,6 +5180,53 @@ def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> 
             )
         )
         return error.status
+
+
+def wait_start_marker_interruptible(root: Path, run_id: str, source: Dict[str, str]) -> Optional[int]:
+    """Block on the start marker; on interrupt, stop the run and return the
+    command's exit status. Returns None when the wait completed uninterrupted."""
+    try:
+        wait_for_test_marker(
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
+            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
+        )
+    except KeyboardInterrupt:
+        stopped, stop_status = stop_run(root, run_id, source)
+        print_json(
+            output_record(
+                stopped,
+                "START_INTERRUPTED",
+                "start was interrupted and verified teardown ran",
+                "status %s" % run_id,
+            )
+        )
+        return 130 if stop_status == 0 else stop_status
+    return None
+
+
+def handle_startup_failure(
+    mutation: "Mutation", root: Path, run_dir: Path, run_id: str, error: PlaygroundError, source: Dict[str, str]
+) -> int:
+    """Shared recovery for a provisioning failure before first readiness."""
+    if error.code.startswith("INJECTED_"):
+        # Injected crash boundary: leave the durable state exactly as a real
+        # crash would, for recovery through stop.
+        current = read_manifest(root, run_id)
+        print_json(output_record(current, error.code, error.message, "stop %s" % run_id))
+        return error.status
+    # Startup failed before first readiness: automatic cleanup that settles
+    # every dispatch identity and releases the lease.
+    manifest = mutation.manifest
+    assert manifest is not None
+    manifest["error"] = playground_error_json(error)
+    append_diagnostic(run_dir, error.code, error.message)
+    final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
+    mutation.finish()
+    if cleanup_status == 0:
+        print_json(output_record(final_manifest, error.code, error.message, "status %s" % run_id))
+    else:
+        print_json(output_record(final_manifest))
+    return error.status
 
 
 def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
@@ -5251,25 +5292,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
             except PlaygroundError as error:
                 remote_error = error
             if remote_error is not None:
-                if remote_error.code.startswith("INJECTED_"):
-                    # Injected crash boundary: leave the durable state exactly as
-                    # a real crash would, for recovery through stop.
-                    current = read_manifest(root, run_id)
-                    print_json(output_record(current, remote_error.code, remote_error.message, "stop %s" % run_id))
-                    return remote_error.status
-                # Startup failed before first readiness: automatic cleanup that
-                # settles every dispatch identity and releases the lease.
-                manifest["error"] = playground_error_json(remote_error)
-                append_diagnostic(run_dir, remote_error.code, remote_error.message)
-                final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
-                mutation.finish()
-                if cleanup_status == 0:
-                    print_json(
-                        output_record(final_manifest, remote_error.code, remote_error.message, "status %s" % run_id)
-                    )
-                else:
-                    print_json(output_record(final_manifest))
-                return remote_error.status
+                return handle_startup_failure(mutation, root, run_dir, run_id, remote_error, source)
 
             target = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS") if test_mode() else None
             if target:
@@ -5293,29 +5316,9 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 except PlaygroundError as error:
                     candidate_error = error
                 if candidate_error is not None:
-                    if candidate_error.code.startswith("INJECTED_"):
-                        # Injected crash boundary: leave durable state exactly
-                        # as a real crash would, for recovery through stop.
-                        current = read_manifest(root, run_id)
-                        print_json(
-                            output_record(current, candidate_error.code, candidate_error.message, "stop %s" % run_id)
-                        )
-                        return candidate_error.status
                     # A candidate activation failure triggers cleanup for all
                     # earlier profiles and preserves its diagnostics.
-                    manifest["error"] = playground_error_json(candidate_error)
-                    append_diagnostic(run_dir, candidate_error.code, candidate_error.message)
-                    final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
-                    mutation.finish()
-                    if cleanup_status == 0:
-                        print_json(
-                            output_record(
-                                final_manifest, candidate_error.code, candidate_error.message, "status %s" % run_id
-                            )
-                        )
-                    else:
-                        print_json(output_record(final_manifest))
-                    return candidate_error.status
+                    return handle_startup_failure(mutation, root, run_dir, run_id, candidate_error, source)
                 manifest["lifecycle_state"] = "active-ready"
                 manifest["error"] = None
                 manifest["next_command"] = "view %s" % run_id
@@ -5330,22 +5333,9 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 if interactive_mode(source):
                     pending_view = True
                 else:
-                    try:
-                        wait_for_test_marker(
-                            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
-                            "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
-                        )
-                    except KeyboardInterrupt:
-                        stopped, stop_status = stop_run(root, run_id, source)
-                        print_json(
-                            output_record(
-                                stopped,
-                                "START_INTERRUPTED",
-                                "start was interrupted and verified teardown ran",
-                                "status %s" % run_id,
-                            )
-                        )
-                        return 130 if stop_status == 0 else stop_status
+                    interrupted = wait_start_marker_interruptible(root, run_id, source)
+                    if interrupted is not None:
+                        return interrupted
                     manifest = read_manifest(root, run_id)
                     print_json(output_record(manifest))
                     return 0
@@ -5353,22 +5343,9 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
         if pending_view:
             return perform_view(root, run_id, source)
 
-        try:
-            wait_for_test_marker(
-                "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER",
-                "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
-            )
-        except KeyboardInterrupt:
-            stopped, stop_status = stop_run(root, run_id, source)
-            print_json(
-                output_record(
-                    stopped,
-                    "START_INTERRUPTED",
-                    "start was interrupted and verified teardown ran",
-                    "status %s" % run_id,
-                )
-            )
-            return 130 if stop_status == 0 else stop_status
+        interrupted = wait_start_marker_interruptible(root, run_id, source)
+        if interrupted is not None:
+            return interrupted
 
         manifest = read_manifest(root, run_id)
         print_json(output_record(manifest))
@@ -5417,6 +5394,15 @@ def adopt_claim(run_dir: Path, intent: Dict[str, Any]) -> Optional[Dict[str, Any
     return claim
 
 
+def wait_process_dead(pid: int, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not process_alive(pid):
+            return True
+        time.sleep(0.01)
+    return False
+
+
 def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
     verdict, reason = verify_process(record)
     if verdict == "gone":
@@ -5433,12 +5419,9 @@ def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]
         return True, None
     except (PermissionError, OSError):
         return False, "PROCESS_SIGNAL_FAILED"
-    deadline = time.monotonic() + 2
-    while time.monotonic() < deadline:
-        if not process_alive(pid):
-            record["status"] = "stopped"
-            return True, None
-        time.sleep(0.01)
+    if wait_process_dead(pid):
+        record["status"] = "stopped"
+        return True, None
     verdict, _ = verify_process(record)
     if verdict == "gone":
         record["status"] = "stopped"
@@ -5451,12 +5434,9 @@ def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]
         pass
     except (PermissionError, OSError):
         return False, "PROCESS_SIGNAL_FAILED"
-    deadline = time.monotonic() + 2
-    while time.monotonic() < deadline:
-        if not process_alive(pid):
-            record["status"] = "stopped"
-            return True, None
-        time.sleep(0.01)
+    if wait_process_dead(pid):
+        record["status"] = "stopped"
+        return True, None
     return False, "PROCESS_STOP_TIMEOUT"
 
 

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -54,6 +54,45 @@ LOCAL_FIXTURES = (
     "detached",
     "non-git",
 )
+LEASE_REF = "refs/heads/herdr-playground/lease"
+PLAYGROUND_NAMESPACE = "herdr-playground/"
+MARKER_FILE = ".herdr-git-status-playground.json"
+WORKFLOW_FILE = ".github/workflows/herdr-git-status-playground.yml"
+WORKFLOW_NAME = APP_NAME
+# Approved and changes-requested review states are deferred by decision R9 and
+# are intentionally absent from this catalog.
+GITHUB_FIXTURES = ("no-pr", "draft", "checks-failed", "checks-passed", "merge-conflict")
+PR_FIXTURES = {
+    "draft": {"draft": True, "conclusion": "success"},
+    "checks-passed": {"draft": False, "conclusion": "success"},
+    "checks-failed": {"draft": False, "conclusion": "failure"},
+}
+# Inert by construction: no third-party actions, no PR-triggered execution,
+# empty permissions, bounded runtime. Bootstrap hashes this exact text and
+# treats any remote divergence as drift.
+WORKFLOW_CONTENT = """\
+# Owned by herdr-git-status-playground bootstrap; edits outside bootstrap are drift.
+name: herdr-git-status-playground
+on:
+  push:
+    branches:
+      - "herdr-playground/**"
+  workflow_dispatch: {}
+permissions: {}
+concurrency:
+  group: herdr-git-status-playground-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  verdict:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: deterministic verdict
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            herdr-playground/checks-failed/*) exit 1 ;;
+          esac
+"""
 
 
 class PlaygroundError(Exception):
@@ -1448,6 +1487,1014 @@ def build_local_fixture_catalog(
     mutation.persist("fixture-assignments")
 
 
+def identity_component_valid(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value))
+
+
+def repository_state_directory(root: Path, ownership: Dict[str, str]) -> Path:
+    directory = root / "repository"
+    ensure_private_directory(directory)
+    for part in (ownership["host"], ownership["owner"], ownership["name"]):
+        if not identity_component_valid(part):
+            raise PlaygroundError(
+                "FIXTURE_OWNERSHIP_UNPROVED", "repository identity component %r is not addressable" % part
+            )
+        directory = directory / part
+        ensure_private_directory(directory)
+    return directory
+
+
+def host_installation_id(root: Path) -> str:
+    path = root / "host-installation-id"
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+        if value:
+            return value
+    except FileNotFoundError:
+        pass
+    value = secrets.token_hex(8)
+    try:
+        descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return path.read_text(encoding="utf-8").strip()
+    try:
+        os.write(descriptor, (value + "\n").encode("utf-8"))
+    finally:
+        os.close(descriptor)
+    return value
+
+
+def poll_sleep() -> None:
+    time.sleep(0.01 if test_mode() else 2.0)
+
+
+class BootstrapContext:
+    """Scrubbed controller environments plus durable per-repository state for
+    one bootstrap operation. The temporary work directory (including the run-
+    private credential file) is removed by cleanup(); the repository record and
+    fixture checkouts persist under the state root."""
+
+    def __init__(
+        self,
+        root: Path,
+        ownership: Dict[str, str],
+        executable_paths: Dict[str, str],
+        source: Dict[str, str],
+    ):
+        self.root = root
+        self.ownership = ownership
+        self.host = ownership["host"]
+        self.owner = ownership["owner"]
+        self.name = ownership["name"]
+        self.repository_id = ownership["repository_id"]
+        self.url = canonical_remote(ownership)
+        self.git = executable_paths["git"]
+        self.gh = executable_paths["gh"]
+        self.record_dir = repository_state_directory(root, ownership)
+        self.record_path = self.record_dir / "repository.json"
+        self.host_id = host_installation_id(root)
+        self.work = Path(tempfile.mkdtemp(prefix=".%s-bootstrap-" % APP_NAME))
+        os.chmod(str(self.work), 0o700)
+        token = os.environ["HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"]
+        credential_path = self.work / "git-credentials"
+        descriptor = os.open(str(credential_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(
+                descriptor,
+                ("https://x-access-token:%s@%s/%s/%s.git\n" % (token, self.host, self.owner, self.name)).encode(
+                    "utf-8"
+                ),
+            )
+        finally:
+            os.close(descriptor)
+        git_environment = minimal_environment(source, executable_paths, self.work)
+        git_environment.update(
+            {
+                "GIT_CONFIG_SYSTEM": "/dev/null",
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": str(self.work / ".gitconfig"),
+                "GIT_TERMINAL_PROMPT": "0",
+                "GIT_ASKPASS": "/usr/bin/false",
+                "GIT_SSH_COMMAND": "ssh -o BatchMode=yes -o IdentityAgent=none",
+                "GIT_AUTHOR_NAME": FIXTURE_AUTHOR_NAME,
+                "GIT_AUTHOR_EMAIL": FIXTURE_AUTHOR_EMAIL,
+                "GIT_COMMITTER_NAME": FIXTURE_AUTHOR_NAME,
+                "GIT_COMMITTER_EMAIL": FIXTURE_AUTHOR_EMAIL,
+                "GIT_CONFIG_COUNT": "2",
+                "GIT_CONFIG_KEY_0": "credential.helper",
+                "GIT_CONFIG_VALUE_0": "store --file=%s" % credential_path,
+                "GIT_CONFIG_KEY_1": "credential.useHttpPath",
+                "GIT_CONFIG_VALUE_1": "true",
+                "HERDR_PLAYGROUND_CANONICAL_REMOTE": self.url,
+            }
+        )
+        self.git_env = git_environment
+        gh_environment = minimal_environment(source, executable_paths, self.work)
+        gh_environment.update({"GH_CONFIG_DIR": str(self.work / "gh"), "GH_TOKEN": token})
+        self.gh_env = gh_environment
+        record_test_environments({"bootstrap-git": git_environment, "bootstrap-gh": gh_environment})
+        self.scratch = self.work / "scratch"
+        git_run(
+            self.git,
+            ["init", "--quiet", "--initial-branch=scratch", str(self.scratch)],
+            self.work,
+            git_environment,
+            "BOOTSTRAP_SCRATCH_FAILED",
+        )
+        self.record: Optional[Dict[str, Any]] = None
+        self.mutations: List[Dict[str, Any]] = []
+        self.mutated = False
+        self.lease_sha: Optional[str] = None
+        self.operation_id = ""
+
+    def cleanup(self) -> None:
+        shutil.rmtree(str(self.work), ignore_errors=True)
+
+    def persist_record(self) -> None:
+        if self.record is not None:
+            atomic_write_json(self.record_path, self.record, "repository-record")
+
+
+def gh_api(
+    ctx: BootstrapContext, path: str, code: str, fields: Optional[List[Tuple[str, str]]] = None
+) -> Any:
+    arguments = [ctx.gh, "api", "--hostname", ctx.host, path]
+    for flag, pair in fields or []:
+        arguments.extend([flag, pair])
+    try:
+        completed = subprocess.run(
+            arguments,
+            cwd=str(ctx.work),
+            env=ctx.gh_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PlaygroundError(code, str(error))
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "status %d" % completed.returncode
+        raise PlaygroundError(code, detail)
+    try:
+        return json.loads(completed.stdout)
+    except ValueError as error:
+        raise PlaygroundError(code, "invalid API response: %s" % error)
+
+
+def repo_path(ctx: BootstrapContext, suffix: str = "") -> str:
+    return "repos/%s/%s%s" % (ctx.owner, ctx.name, suffix)
+
+
+def resolve_repository(ctx: BootstrapContext) -> Dict[str, Any]:
+    """Resolve canonical host/owner/name to the immutable repository ID; called
+    again immediately before every mutation so redirects and identity drift
+    fail closed."""
+    payload = gh_api(ctx, repo_path(ctx), "REPOSITORY_IDENTITY_UNRESOLVED")
+    if payload.get("node_id") != ctx.repository_id:
+        raise PlaygroundError(
+            "REPOSITORY_ID_MISMATCH",
+            "resolved repository ID %r does not match the requested target %r"
+            % (payload.get("node_id"), ctx.repository_id),
+        )
+    if payload.get("full_name") != "%s/%s" % (ctx.owner, ctx.name):
+        raise PlaygroundError(
+            "REPOSITORY_ID_MISMATCH",
+            "repository resolution was redirected to %r" % payload.get("full_name"),
+        )
+    return payload
+
+
+def require_write_permission(ctx: BootstrapContext, payload: Dict[str, Any]) -> None:
+    permissions = payload.get("permissions") or {}
+    if permissions.get("push") is not True:
+        raise PlaygroundError(
+            "REPOSITORY_PERMISSION_INSUFFICIENT",
+            "the controller credential lacks write permission on %s/%s/%s" % (ctx.host, ctx.owner, ctx.name),
+        )
+
+
+def policy_preflight(ctx: BootstrapContext) -> None:
+    if gh_api(ctx, repo_path(ctx, "/actions/secrets"), "REPOSITORY_POLICY_DRIFT").get("total_count", 0):
+        raise PlaygroundError("REPOSITORY_POLICY_DRIFT", "the repository declares Actions secret material")
+    if gh_api(ctx, repo_path(ctx, "/environments"), "REPOSITORY_POLICY_DRIFT").get("total_count", 0):
+        raise PlaygroundError("REPOSITORY_POLICY_DRIFT", "the repository declares deployment environments")
+    if gh_api(ctx, repo_path(ctx, "/actions/permissions"), "REPOSITORY_POLICY_DRIFT").get("enabled") is not True:
+        raise PlaygroundError("REPOSITORY_POLICY_DRIFT", "repository Actions policy is not enabled")
+
+
+def ls_remote(ctx: BootstrapContext) -> Dict[str, str]:
+    completed = git_run(ctx.git, ["ls-remote", ctx.url], ctx.scratch, ctx.git_env, "REMOTE_REFS_UNREADABLE")
+    refs: Dict[str, str] = {}
+    for line in completed.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, _, refname = line.partition("\t")
+        refs[refname.strip()] = sha.strip()
+    return refs
+
+
+def build_commit(
+    ctx: BootstrapContext, files: Dict[str, str], message: str, base_ref: Optional[str] = None
+) -> Tuple[Path, str]:
+    workspace = Path(tempfile.mkdtemp(prefix="commit-", dir=str(ctx.work)))
+    code = "BOOTSTRAP_COMMIT_FAILED"
+    git_run(ctx.git, ["init", "--quiet", "--initial-branch=work", str(workspace)], ctx.work, ctx.git_env, code)
+    if base_ref:
+        git_run(ctx.git, ["fetch", "--quiet", ctx.url, base_ref], workspace, ctx.git_env, code)
+        git_run(ctx.git, ["checkout", "--quiet", "FETCH_HEAD"], workspace, ctx.git_env, code)
+    for name, contents in files.items():
+        path = workspace / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+    git_run(ctx.git, ["add", "-A"], workspace, ctx.git_env, code)
+    git_run(ctx.git, ["commit", "--quiet", "-m", message], workspace, ctx.git_env, code)
+    sha = git_run(ctx.git, ["rev-parse", "HEAD"], workspace, ctx.git_env, code).stdout.strip()
+    return workspace, sha
+
+
+def push_ref(
+    ctx: BootstrapContext,
+    workspace: Path,
+    refname: str,
+    new_sha: str,
+    expected: str,
+    fixture: str,
+    code: str,
+) -> None:
+    resolve_repository(ctx)
+    ctx.mutations.append(
+        {
+            "fixture": fixture,
+            "ref": refname,
+            "expected": expected,
+            "new_sha": new_sha,
+            "recorded_at": utc_now(),
+        }
+    )
+    ctx.persist_record()
+    ctx.mutated = True
+    completed = git_run(
+        ctx.git,
+        [
+            "push",
+            "--quiet",
+            ctx.url,
+            "%s:%s" % (new_sha, refname),
+            "--force-with-lease=%s:%s" % (refname, expected),
+        ],
+        workspace,
+        ctx.git_env,
+        code,
+        allow_failure=True,
+    )
+    if completed.returncode != 0:
+        raise PlaygroundError(
+            code, "compare-and-swap update of %s was rejected: %s" % (refname, completed.stderr.strip())
+        )
+    if ls_remote(ctx).get(refname) != new_sha:
+        raise PlaygroundError(code, "remote %s did not verify to the pushed object" % refname)
+
+
+def lease_payload(ctx: BootstrapContext, kind: str, operation_id: str) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "host": ctx.host,
+        "owner": ctx.owner,
+        "name": ctx.name,
+        "repository_id": ctx.repository_id,
+        "operation_kind": kind,
+        "operation_id": operation_id,
+        "host_installation_id": ctx.host_id,
+        "owner_start_identity": process_start_identity(os.getpid()),
+        "lifecycle_state": "%s-in-progress" % kind,
+        "fixture_generation": None,
+        "workflow_intents": [],
+        "claimed_at": utc_now(),
+    }
+
+
+def acquire_lease(ctx: BootstrapContext, kind: str, operation_id: str, code: str) -> str:
+    workspace, sha = build_commit(
+        ctx,
+        {"lease.json": json.dumps(lease_payload(ctx, kind, operation_id), sort_keys=True) + "\n"},
+        "%s lease %s" % (kind, operation_id),
+    )
+    completed = git_run(
+        ctx.git,
+        ["push", "--quiet", ctx.url, "%s:%s" % (sha, LEASE_REF), "--force-with-lease=%s:" % LEASE_REF],
+        workspace,
+        ctx.git_env,
+        code,
+        allow_failure=True,
+    )
+    if completed.returncode != 0:
+        raise PlaygroundError(
+            code,
+            "the repository lease is already held; inspect it with: git ls-remote %s %s" % (ctx.url, LEASE_REF),
+        )
+    if ls_remote(ctx).get(LEASE_REF) != sha:
+        raise PlaygroundError(code, "the acquired lease did not verify on the remote")
+    resolve_repository(ctx)
+    return sha
+
+
+def read_lease(ctx: BootstrapContext) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    sha = ls_remote(ctx).get(LEASE_REF)
+    if sha is None:
+        return None, None
+    git_run(ctx.git, ["fetch", "--quiet", ctx.url, LEASE_REF], ctx.scratch, ctx.git_env, "REMOTE_REFS_UNREADABLE")
+    shown = git_run(ctx.git, ["show", "FETCH_HEAD:lease.json"], ctx.scratch, ctx.git_env, "", allow_failure=True)
+    if shown.returncode != 0:
+        return sha, None
+    try:
+        payload = json.loads(shown.stdout)
+    except ValueError:
+        return sha, None
+    return sha, payload if isinstance(payload, dict) else None
+
+
+def release_lease(ctx: BootstrapContext, owned_sha: str) -> None:
+    completed = git_run(
+        ctx.git,
+        ["push", "--quiet", ctx.url, ":%s" % LEASE_REF, "--force-with-lease=%s:%s" % (LEASE_REF, owned_sha)],
+        ctx.scratch,
+        ctx.git_env,
+        "LEASE_RELEASE_FAILED",
+        allow_failure=True,
+    )
+    if completed.returncode != 0 or LEASE_REF in ls_remote(ctx):
+        raise PlaygroundError("LEASE_RELEASE_FAILED", "the conditional lease delete did not verify")
+
+
+def marker_contents(ctx: BootstrapContext) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "host": ctx.host,
+        "owner": ctx.owner,
+        "name": ctx.name,
+        "repository_id": ctx.repository_id,
+        "namespace": PLAYGROUND_NAMESPACE,
+        "workflow_path": WORKFLOW_FILE,
+        "workflow_sha256": hashlib.sha256(WORKFLOW_CONTENT.encode("utf-8")).hexdigest(),
+    }
+
+
+def validate_remote_contract(ctx: BootstrapContext, payload: Dict[str, Any]) -> None:
+    record = ctx.record
+    assert record is not None
+    guidance = (
+        "inspect the owned files with: git fetch %s refs/heads/%s && git show FETCH_HEAD:%s; "
+        "repair externally, then rerun bootstrap" % (ctx.url, record["default_branch"], MARKER_FILE)
+    )
+    if payload.get("default_branch") != record["default_branch"]:
+        raise PlaygroundError(
+            "DEFAULT_BRANCH_MISMATCH",
+            "remote default branch %r differs from the recorded %r; inspect the repository settings before "
+            "rerunning bootstrap" % (payload.get("default_branch"), record["default_branch"]),
+        )
+    branch_ref = "refs/heads/%s" % record["default_branch"]
+    git_run(ctx.git, ["fetch", "--quiet", ctx.url, branch_ref], ctx.scratch, ctx.git_env, "REMOTE_REFS_UNREADABLE")
+    marker_blob = git_run(
+        ctx.git, ["show", "FETCH_HEAD:%s" % MARKER_FILE], ctx.scratch, ctx.git_env, "", allow_failure=True
+    )
+    if marker_blob.returncode != 0:
+        raise PlaygroundError("MARKER_INVALID", "the ownership marker %s is missing; %s" % (MARKER_FILE, guidance))
+    try:
+        marker = json.loads(marker_blob.stdout)
+        if not isinstance(marker, dict):
+            raise ValueError("marker is not an object")
+    except ValueError as error:
+        raise PlaygroundError("MARKER_INVALID", "the ownership marker is malformed (%s); %s" % (error, guidance))
+    for key in ("host", "owner", "name", "repository_id"):
+        if marker.get(key) != record[key]:
+            raise PlaygroundError(
+                "MARKER_IDENTITY_MISMATCH",
+                "marker %s %r differs from the recorded %r; %s" % (key, marker.get(key), record[key], guidance),
+            )
+    if marker.get("namespace") != record["namespace"]:
+        raise PlaygroundError(
+            "NAMESPACE_MISMATCH",
+            "marker namespace %r differs from the recorded %r; %s"
+            % (marker.get("namespace"), record["namespace"], guidance),
+        )
+    workflow_blob = git_run(
+        ctx.git, ["show", "FETCH_HEAD:%s" % WORKFLOW_FILE], ctx.scratch, ctx.git_env, "", allow_failure=True
+    )
+    if (
+        workflow_blob.returncode != 0
+        or hashlib.sha256(workflow_blob.stdout.encode("utf-8")).hexdigest() != record["workflow_sha256"]
+    ):
+        raise PlaygroundError(
+            "WORKFLOW_DRIFT", "the owned workflow %s changed outside bootstrap; %s" % (WORKFLOW_FILE, guidance)
+        )
+
+
+def audit_owned_namespace(ctx: BootstrapContext, remote_refs: Dict[str, str]) -> None:
+    record = ctx.record
+    assert record is not None
+    expected: Dict[str, set] = {}
+
+    def accept(branch: Optional[str], sha: Optional[str]) -> None:
+        if branch and sha:
+            expected.setdefault("refs/heads/%s" % branch, set()).add(sha)
+
+    for fixture in record["fixtures"].values():
+        accept(fixture.get("branch"), fixture.get("head_sha"))
+        accept(fixture.get("base_branch"), fixture.get("base_sha"))
+    recovery = record.get("recovery") or {}
+    for mutation in recovery.get("mutations", []):
+        expected.setdefault(mutation["ref"], set()).add(mutation["new_sha"])
+    retired = set(record.get("retired_branches", []))
+    for refname, sha in remote_refs.items():
+        if not refname.startswith("refs/heads/" + PLAYGROUND_NAMESPACE) or refname == LEASE_REF:
+            continue
+        if refname[len("refs/heads/"):] in retired:
+            continue
+        acceptable = expected.get(refname)
+        if acceptable is None:
+            raise PlaygroundError(
+                "OWNERSHIP_DRIFT",
+                "unrecorded ref %s exists inside the owned namespace; inspect it with: git ls-remote %s %s"
+                % (refname, ctx.url, refname),
+            )
+        if sha not in acceptable:
+            raise PlaygroundError(
+                "OWNERSHIP_DRIFT",
+                "%s moved to unrecorded commit %s; inspect the branch history before rerunning bootstrap"
+                % (refname, sha),
+            )
+    for fixture in record["fixtures"].values():
+        for branch in (fixture.get("branch"), fixture.get("base_branch")):
+            if branch and "refs/heads/%s" % branch not in remote_refs:
+                raise PlaygroundError(
+                    "OWNERSHIP_DRIFT",
+                    "recorded ref refs/heads/%s is missing from the remote; inspect the repository before "
+                    "rerunning bootstrap" % branch,
+                )
+
+
+def list_pulls(ctx: BootstrapContext, branch: str, state: str = "all") -> List[Dict[str, Any]]:
+    path = repo_path(ctx, "/pulls?state=%s&head=%s:%s" % (state, ctx.owner, branch))
+    pulls = gh_api(ctx, path, "PULL_REQUEST_QUERY_FAILED")
+    if not isinstance(pulls, list):
+        raise PlaygroundError("PULL_REQUEST_QUERY_FAILED", "unexpected pull-request list shape")
+    return pulls
+
+
+def create_pull(ctx: BootstrapContext, branch: str, base: str, title: str, draft: bool) -> Dict[str, Any]:
+    resolve_repository(ctx)
+    ctx.mutated = True
+    fields = [
+        ("-f", "title=%s" % title),
+        ("-f", "head=%s" % branch),
+        ("-f", "base=%s" % base),
+        ("-F", "draft=%s" % ("true" if draft else "false")),
+    ]
+    return gh_api(ctx, repo_path(ctx, "/pulls"), "PULL_REQUEST_CREATE_FAILED", fields)
+
+
+def wait_workflow_run(ctx: BootstrapContext, branch: str, sha: str, conclusion: str) -> Dict[str, Any]:
+    for _ in range(200):
+        payload = gh_api(ctx, repo_path(ctx, "/actions/runs?head_sha=%s" % sha), "WORKFLOW_RUN_QUERY_FAILED")
+        matches = [
+            run
+            for run in payload.get("workflow_runs", [])
+            if run.get("name") == WORKFLOW_NAME
+            and run.get("head_branch") == branch
+            and run.get("head_sha") == sha
+            and run.get("status") == "completed"
+        ]
+        if matches:
+            newest = max(matches, key=lambda run: run["id"])
+            if newest.get("conclusion") != conclusion:
+                raise PlaygroundError(
+                    "WORKFLOW_CONCLUSION_UNEXPECTED",
+                    "run %s concluded %r, expected %r" % (newest["id"], newest.get("conclusion"), conclusion),
+                )
+            return newest
+        poll_sleep()
+    raise PlaygroundError("WORKFLOW_RUN_MISSING", "no completed %s run for %s@%s" % (WORKFLOW_NAME, branch, sha))
+
+
+def verify_recorded_run(ctx: BootstrapContext, fixture_record: Dict[str, Any]) -> None:
+    payload = gh_api(
+        ctx,
+        repo_path(ctx, "/actions/runs?head_sha=%s" % fixture_record["head_sha"]),
+        "WORKFLOW_RUN_QUERY_FAILED",
+    )
+    for run in payload.get("workflow_runs", []):
+        if run.get("id") == fixture_record["workflow_run_id"]:
+            if (
+                run.get("name") == WORKFLOW_NAME
+                and run.get("head_branch") == fixture_record["branch"]
+                and run.get("conclusion") == fixture_record["workflow_conclusion"]
+            ):
+                return
+            break
+    raise PlaygroundError(
+        "OWNERSHIP_DRIFT",
+        "recorded workflow run %s for %s changed or vanished; inspect the repository Actions history"
+        % (fixture_record["workflow_run_id"], fixture_record["branch"]),
+    )
+
+
+def verify_recorded_pull(ctx: BootstrapContext, fixture_record: Dict[str, Any]) -> Dict[str, Any]:
+    pulls = list_pulls(ctx, fixture_record["branch"])
+    if len(pulls) != 1:
+        raise PlaygroundError(
+            "OWNERSHIP_DRIFT",
+            "expected exactly the recorded pull request on %s, found %d; inspect the pull-request history"
+            % (fixture_record["branch"], len(pulls)),
+        )
+    pull = pulls[0]
+    if not (
+        pull.get("number") == fixture_record["pr_number"]
+        and pull.get("node_id") == fixture_record["pr_id"]
+        and pull.get("state") == "open"
+        and pull.get("draft") == fixture_record["draft"]
+        and pull.get("head", {}).get("sha") == fixture_record["head_sha"]
+        and pull.get("user", {}).get("login") == fixture_record["author"]
+    ):
+        raise PlaygroundError(
+            "OWNERSHIP_DRIFT",
+            "the pull request on %s was replaced or edited outside bootstrap; inspect PR #%s"
+            % (fixture_record["branch"], fixture_record["pr_number"]),
+        )
+    return pull
+
+
+def ensure_branch(
+    ctx: BootstrapContext, name: str, branch: str, files: Dict[str, str]
+) -> str:
+    assert ctx.record is not None
+    refname = "refs/heads/%s" % branch
+    remote_sha = ls_remote(ctx).get(refname)
+    if remote_sha is not None:
+        if any(
+            mutation["fixture"] == name and mutation["ref"] == refname and mutation["new_sha"] == remote_sha
+            for mutation in ctx.mutations
+        ):
+            return remote_sha
+        raise PlaygroundError(
+            "OWNERSHIP_DRIFT",
+            "%s already exists with unrecorded commit %s; inspect it before rerunning bootstrap"
+            % (refname, remote_sha),
+        )
+    workspace, sha = build_commit(
+        ctx, files, "%s fixture" % name, base_ref="refs/heads/%s" % ctx.record["default_branch"]
+    )
+    push_ref(ctx, workspace, refname, sha, "", name, "FIXTURE_REF_CAS_FAILED")
+    return sha
+
+
+def adopt_or_create_pull(
+    ctx: BootstrapContext, name: str, branch: str, base: str, sha: str, draft: bool
+) -> Dict[str, Any]:
+    pulls = list_pulls(ctx, branch)
+    matching = [
+        pull
+        for pull in pulls
+        if pull.get("state") == "open" and pull.get("head", {}).get("sha") == sha and pull.get("draft") == draft
+    ]
+    if len(matching) > 1 or len(pulls) > len(matching):
+        raise PlaygroundError(
+            "OWNERSHIP_DRIFT",
+            "unexpected pull-request history on %s; inspect it before rerunning bootstrap" % branch,
+        )
+    if matching:
+        return matching[0]
+    return create_pull(ctx, branch, base, "herdr playground %s fixture" % name, draft)
+
+
+def converge_no_pr(ctx: BootstrapContext) -> None:
+    assert ctx.record is not None
+    name = "no-pr"
+    fixture_record = ctx.record["fixtures"].get(name)
+    if fixture_record is not None:
+        if not list_pulls(ctx, fixture_record["branch"]):
+            return
+        # Closed history reached the recorded branch: rotate to a fresh version
+        # instead of reusing a branch that has ever had a pull request.
+        ctx.record.setdefault("retired_branches", []).append(fixture_record["branch"])
+        start_version = fixture_record["version"] + 1
+    else:
+        start_version = 1
+    remote_refs = ls_remote(ctx)
+    for version in range(start_version, start_version + 100):
+        branch = "%sno-pr/v%d" % (PLAYGROUND_NAMESPACE, version)
+        refname = "refs/heads/%s" % branch
+        if list_pulls(ctx, branch):
+            continue
+        remote_sha = remote_refs.get(refname)
+        adopted = remote_sha is not None and any(
+            mutation["fixture"] == name and mutation["ref"] == refname and mutation["new_sha"] == remote_sha
+            for mutation in ctx.mutations
+        )
+        if remote_sha is not None and not adopted:
+            continue
+        sha = remote_sha
+        if sha is None:
+            workspace, sha = build_commit(
+                ctx,
+                {"fixtures/no-pr.txt": "herdr playground no-pr fixture %s\n" % branch},
+                "no-pr fixture v%d" % version,
+                base_ref="refs/heads/%s" % ctx.record["default_branch"],
+            )
+            push_ref(ctx, workspace, refname, sha, "", name, "FIXTURE_REF_CAS_FAILED")
+        if list_pulls(ctx, branch):
+            raise PlaygroundError(
+                "OWNERSHIP_DRIFT", "pull-request history appeared on %s during bootstrap; inspect it" % branch
+            )
+        ctx.record["fixtures"][name] = {"branch": branch, "head_sha": sha, "version": version}
+        return
+    raise PlaygroundError("FIXTURE_REF_CAS_FAILED", "could not find an unused no-pr branch version")
+
+
+def converge_pr_fixture(ctx: BootstrapContext, name: str) -> None:
+    assert ctx.record is not None
+    definition = PR_FIXTURES[name]
+    fixture_record = ctx.record["fixtures"].get(name)
+    if fixture_record is not None:
+        verify_recorded_pull(ctx, fixture_record)
+        verify_recorded_run(ctx, fixture_record)
+        return
+    branch = "%s%s/head" % (PLAYGROUND_NAMESPACE, name)
+    sha = ensure_branch(
+        ctx, name, branch, {"fixtures/%s.txt" % name: "herdr playground %s fixture\n" % name}
+    )
+    run = wait_workflow_run(ctx, branch, sha, definition["conclusion"])
+    pull = adopt_or_create_pull(ctx, name, branch, ctx.record["default_branch"], sha, definition["draft"])
+    ctx.record["fixtures"][name] = {
+        "branch": branch,
+        "head_sha": sha,
+        "base_branch": ctx.record["default_branch"],
+        "pr_number": pull["number"],
+        "pr_id": pull["node_id"],
+        "author": pull["user"]["login"],
+        "draft": definition["draft"],
+        "workflow_run_id": run["id"],
+        "workflow_conclusion": run["conclusion"],
+    }
+
+
+def converge_merge_conflict(ctx: BootstrapContext) -> None:
+    assert ctx.record is not None
+    name = "merge-conflict"
+    fixture_record = ctx.record["fixtures"].get(name)
+    if fixture_record is not None:
+        verify_recorded_pull(ctx, fixture_record)
+        return
+    base_branch = PLAYGROUND_NAMESPACE + "merge-conflict/base"
+    head_branch = PLAYGROUND_NAMESPACE + "merge-conflict/head"
+    base_sha = ensure_branch(ctx, name, base_branch, {"fixtures/conflict.txt": "base side\n"})
+    head_sha = ensure_branch(ctx, name, head_branch, {"fixtures/conflict.txt": "head side\n"})
+    pull = adopt_or_create_pull(ctx, name, head_branch, base_branch, head_sha, False)
+    settled = None
+    for _ in range(200):
+        current = gh_api(ctx, repo_path(ctx, "/pulls/%d" % pull["number"]), "PULL_REQUEST_QUERY_FAILED")
+        if current.get("mergeable") is not None:
+            settled = current
+            break
+        poll_sleep()
+    if settled is None:
+        raise PlaygroundError(
+            "MERGEABILITY_UNSETTLED", "GitHub did not settle mergeability for PR #%s" % pull["number"]
+        )
+    if settled.get("mergeable") is not False or settled.get("mergeable_state") != "dirty":
+        raise PlaygroundError(
+            "MERGE_CONFLICT_NOT_CONFLICTING",
+            "PR #%s settled as mergeable=%r state=%r"
+            % (pull["number"], settled.get("mergeable"), settled.get("mergeable_state")),
+        )
+    ctx.record["fixtures"][name] = {
+        "branch": head_branch,
+        "head_sha": head_sha,
+        "base_branch": base_branch,
+        "base_sha": base_sha,
+        "pr_number": pull["number"],
+        "pr_id": pull["node_id"],
+        "author": pull["user"]["login"],
+        "draft": False,
+        "mergeable": settled["mergeable"],
+        "mergeable_state": settled["mergeable_state"],
+    }
+
+
+def converge_github_fixture(ctx: BootstrapContext, name: str) -> None:
+    if name == "no-pr":
+        converge_no_pr(ctx)
+    elif name == "merge-conflict":
+        converge_merge_conflict(ctx)
+    else:
+        converge_pr_fixture(ctx, name)
+
+
+def ensure_fixture_checkout(ctx: BootstrapContext, name: str, fixture_record: Dict[str, Any]) -> None:
+    checkouts = ctx.record_dir / "checkouts"
+    ensure_private_directory(checkouts)
+    destination = checkouts / name
+    branch = fixture_record["branch"]
+    head_sha = fixture_record["head_sha"]
+    code = "FIXTURE_CHECKOUT_FAILED"
+
+    def verified() -> bool:
+        try:
+            origin = git_run(ctx.git, ["remote", "get-url", "origin"], destination, ctx.git_env, code).stdout.strip()
+            current = git_run(ctx.git, ["symbolic-ref", "--short", "HEAD"], destination, ctx.git_env, code).stdout.strip()
+            head = git_run(ctx.git, ["rev-parse", "HEAD"], destination, ctx.git_env, code).stdout.strip()
+        except PlaygroundError:
+            return False
+        return origin == ctx.url and current == branch and head == head_sha
+
+    if destination.exists():
+        if not verified():
+            shutil.rmtree(str(destination))
+    if not destination.exists():
+        git_run(ctx.git, ["clone", "--quiet", ctx.url, str(destination)], ctx.work, ctx.git_env, code)
+        git_run(ctx.git, ["checkout", "--quiet", branch], destination, ctx.git_env, code)
+        if not verified():
+            raise PlaygroundError(code, "the %s checkout did not verify origin, branch, and head" % name)
+    fixture_record["checkout"] = {
+        "path": str(destination),
+        "origin": ctx.url,
+        "branch": branch,
+        "head_sha": head_sha,
+    }
+
+
+def bootstrap_result(
+    ctx: Optional[BootstrapContext],
+    initialized: bool,
+    lease_state: str,
+    error: Optional[Dict[str, str]] = None,
+    next_command: Optional[str] = None,
+    fixtures: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    repository = None
+    if ctx is not None:
+        repository = {
+            "host": ctx.host,
+            "owner": ctx.owner,
+            "name": ctx.name,
+            "repository_id": ctx.repository_id,
+        }
+    return {
+        "command": "bootstrap",
+        "initialized": initialized,
+        "repository": repository,
+        "fixtures": fixtures,
+        "lease": lease_state,
+        "error": error,
+        "next_command": next_command,
+    }
+
+
+def playground_error_json(error: PlaygroundError) -> Dict[str, str]:
+    return {"code": error.code, "message": error.message}
+
+
+def bootstrap_initialize(ctx: BootstrapContext, payload: Dict[str, Any]) -> int:
+    if ctx.record_path.exists():
+        raise PlaygroundError(
+            "BOOTSTRAP_ALREADY_INITIALIZED",
+            "this repository is already initialized; run bootstrap without --initialize",
+        )
+    refs = ls_remote(ctx)
+    # A concurrent initializer's lease is contested below, not unrelated content.
+    if any(refname != LEASE_REF for refname in refs):
+        raise PlaygroundError(
+            "REPOSITORY_NOT_EMPTY",
+            "explicit initialization only claims an empty repository; %s/%s/%s holds unrelated content"
+            % (ctx.host, ctx.owner, ctx.name),
+        )
+    default_branch = payload.get("default_branch") or "main"
+    operation_id = secrets.token_hex(8)
+    lease_sha = acquire_lease(ctx, "initialize", operation_id, "INITIALIZE_LEASE_LOST")
+    try:
+        if test_failpoint() == "bootstrap-pre-mutation":
+            raise PlaygroundError(
+                "INJECTED_BOOTSTRAP_PRE_MUTATION", "injected failure after lease acquisition, before mutation"
+            )
+        marker = marker_contents(ctx)
+        workspace, sha = build_commit(
+            ctx,
+            {
+                MARKER_FILE: json.dumps(marker, indent=2, sort_keys=True) + "\n",
+                WORKFLOW_FILE: WORKFLOW_CONTENT,
+            },
+            "initialize herdr playground ownership",
+        )
+        push_ref(ctx, workspace, "refs/heads/%s" % default_branch, sha, "", "default-branch", "INITIALIZE_BRANCH_CONFLICT")
+        ctx.record = {
+            "schema_version": SCHEMA_VERSION,
+            "host": ctx.host,
+            "owner": ctx.owner,
+            "name": ctx.name,
+            "repository_id": ctx.repository_id,
+            "default_branch": default_branch,
+            "namespace": PLAYGROUND_NAMESPACE,
+            "workflow_sha256": marker["workflow_sha256"],
+            "host_installation_id": ctx.host_id,
+            "initialized_at": utc_now(),
+            "fixtures": {},
+            "retired_branches": [],
+            "recovery": None,
+        }
+        ctx.persist_record()
+    except PlaygroundError as error:
+        if ctx.mutated:
+            atomic_write_json(
+                ctx.record_dir / "initialize-recovery.json",
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "operation_id": operation_id,
+                    "lease_sha": lease_sha,
+                    "mutations": ctx.mutations,
+                    "error": playground_error_json(error),
+                },
+                "initialize-recovery",
+            )
+            print_json(
+                bootstrap_result(
+                    ctx,
+                    False,
+                    "retained",
+                    error=playground_error_json(error),
+                    next_command="inspect the retained lease and recovery record, then rerun bootstrap --initialize",
+                )
+            )
+            return error.status
+        release_lease(ctx, lease_sha)
+        print_json(
+            bootstrap_result(
+                ctx,
+                False,
+                "released",
+                error=playground_error_json(error),
+                next_command="fix the reported condition and rerun bootstrap --initialize",
+            )
+        )
+        return error.status
+    release_lease(ctx, lease_sha)
+    print_json(bootstrap_result(ctx, True, "released", fixtures={}, next_command="bootstrap"))
+    return 0
+
+
+def bootstrap_converge(ctx: BootstrapContext, payload: Dict[str, Any]) -> int:
+    try:
+        ctx.record = read_json(ctx.record_path)
+    except PlaygroundError as error:
+        if error.code == "RUN_NOT_FOUND":
+            raise PlaygroundError(
+                "BOOTSTRAP_NOT_INITIALIZED",
+                "no repository record exists; run bootstrap --initialize against the empty dedicated repository",
+            )
+        raise
+    record = ctx.record
+    for key in ("host", "owner", "name", "repository_id"):
+        if record.get(key) != ctx.ownership[key]:
+            raise PlaygroundError(
+                "BOOTSTRAP_IDENTITY_MISMATCH",
+                "the persisted repository record does not match the requested canonical identity",
+            )
+    validate_remote_contract(ctx, payload)
+    remote_refs = ls_remote(ctx)
+    audit_owned_namespace(ctx, remote_refs)
+
+    recovery = record.get("recovery")
+    remote_lease_sha = remote_refs.get(LEASE_REF)
+    if remote_lease_sha is not None:
+        _, lease_doc = read_lease(ctx)
+        if (
+            lease_doc is not None
+            and recovery
+            and lease_doc.get("operation_id") == recovery.get("operation_id")
+            and lease_doc.get("host_installation_id") == ctx.host_id
+        ):
+            ctx.lease_sha = remote_lease_sha
+            ctx.operation_id = recovery["operation_id"]
+            ctx.mutations = recovery.setdefault("mutations", [])
+        else:
+            holder = lease_doc or {}
+            raise PlaygroundError(
+                "REPOSITORY_LEASE_HELD",
+                "the repository lease is held at %s by operation %r on host %r; inspect it with: "
+                "git ls-remote %s %s && git fetch %s %s && git show FETCH_HEAD:lease.json; "
+                "no automated takeover is performed"
+                % (
+                    remote_lease_sha,
+                    holder.get("operation_id"),
+                    holder.get("host_installation_id"),
+                    ctx.url,
+                    LEASE_REF,
+                    ctx.url,
+                    LEASE_REF,
+                ),
+            )
+    else:
+        ctx.operation_id = secrets.token_hex(8)
+        ctx.lease_sha = acquire_lease(ctx, "bootstrap", ctx.operation_id, "REPOSITORY_LEASE_HELD")
+        record["recovery"] = {
+            "operation_kind": "bootstrap",
+            "operation_id": ctx.operation_id,
+            "started_at": utc_now(),
+            "lease_sha": ctx.lease_sha,
+            "mutations": [],
+        }
+        ctx.mutations = record["recovery"]["mutations"]
+        ctx.persist_record()
+    resumed_mutations = bool(ctx.mutations)
+    try:
+        if test_failpoint() == "bootstrap-pre-mutation":
+            raise PlaygroundError(
+                "INJECTED_BOOTSTRAP_PRE_MUTATION", "injected failure after lease acquisition, before mutation"
+            )
+        for name in GITHUB_FIXTURES:
+            converge_github_fixture(ctx, name)
+            ctx.persist_record()
+            if test_failpoint() == "bootstrap-partial-%s" % name:
+                raise PlaygroundError(
+                    "INJECTED_BOOTSTRAP_PARTIAL", "injected failure after the %s fixture converged" % name
+                )
+        for name in GITHUB_FIXTURES:
+            ensure_fixture_checkout(ctx, name, record["fixtures"][name])
+        ctx.persist_record()
+    except PlaygroundError as error:
+        if ctx.mutated or resumed_mutations:
+            record["recovery"]["phase"] = "mutation-incomplete"
+            record["recovery"]["error"] = playground_error_json(error)
+            ctx.persist_record()
+            print_json(
+                bootstrap_result(
+                    ctx,
+                    True,
+                    "retained",
+                    error=playground_error_json(error),
+                    next_command="rerun bootstrap to resume the recorded operation",
+                )
+            )
+            return error.status
+        record["recovery"] = None
+        ctx.persist_record()
+        release_lease(ctx, ctx.lease_sha)
+        print_json(
+            bootstrap_result(
+                ctx,
+                True,
+                "released",
+                error=playground_error_json(error),
+                next_command="fix the reported condition and rerun bootstrap",
+            )
+        )
+        return error.status
+    record["recovery"] = None
+    ctx.persist_record()
+    release_lease(ctx, ctx.lease_sha)
+    fixtures_summary = {name: dict(record["fixtures"][name]) for name in GITHUB_FIXTURES}
+    print_json(bootstrap_result(ctx, True, "released", fixtures=fixtures_summary, next_command="start"))
+    return 0
+
+
+def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
+    ctx: Optional[BootstrapContext] = None
+    try:
+        ownership = load_fixture_ownership(arguments.fixture_ownership)
+        if not os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"):
+            raise PlaygroundError(
+                "CREDENTIAL_AUTHORITY_INVALID", "bootstrap requires the scoped controller credential"
+            )
+        executable_paths: Dict[str, str] = {}
+        for name in ("git", "gh"):
+            resolved = resolve_executable(name, source.get("PATH", ""))
+            if resolved is None:
+                raise PlaygroundError("%s_NOT_FOUND" % name.upper(), "%s is not on the approved PATH" % name)
+            executable_paths[name] = resolved
+        root = state_root(source)
+        ensure_private_directory(root)
+        ctx = BootstrapContext(root, ownership, executable_paths, source)
+        try:
+            payload = resolve_repository(ctx)
+            require_write_permission(ctx, payload)
+            policy_preflight(ctx)
+            if arguments.initialize:
+                return bootstrap_initialize(ctx, payload)
+            return bootstrap_converge(ctx, payload)
+        finally:
+            ctx.cleanup()
+    except PlaygroundError as error:
+        print_json(
+            bootstrap_result(
+                ctx,
+                False,
+                "not-acquired",
+                error=playground_error_json(error),
+                next_command="fix the reported condition and rerun bootstrap",
+            )
+        )
+        return error.status
+
+
 def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     try:
         executable_paths, fixture, audit_digest, herdr_identity = preflight(arguments, source)
@@ -1778,6 +2825,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     bootstrap = subparsers.add_parser("bootstrap", help="initialize or validate the fixture repository")
     bootstrap.add_argument("--initialize", action="store_true")
+    bootstrap.add_argument("--fixture-ownership", required=True)
 
     start = subparsers.add_parser("start", help="preflight and allocate a recoverable run")
     start.add_argument("--approved-herdr", required=True)
@@ -1829,6 +2877,8 @@ def main() -> int:
             return command_stop(arguments, source)
         if arguments.command == "view":
             return command_view(arguments, source)
+        if arguments.command == "bootstrap":
+            return command_bootstrap(arguments, source)
         return command_not_implemented(arguments.command, arguments, source)
     except PlaygroundError as error:
         return error_result(error)

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -345,7 +345,7 @@ def output_record(
             "generation": 0,
             "lifecycle_state": "not-allocated",
             "effective_state": "not-allocated",
-            "error": {"code": code, "message": message} if code else None,
+            "error": {"code": code, "message": redact_text(message)} if code else None,
             "next_command": next_command or "fix preflight and rerun start",
         }
     return {
@@ -353,7 +353,7 @@ def output_record(
         "generation": manifest["generation"],
         "lifecycle_state": manifest["lifecycle_state"],
         "effective_state": effective_state(manifest),
-        "error": {"code": code, "message": message}
+        "error": {"code": code, "message": redact_text(message)}
         if code
         else manifest.get("error"),
         "next_command": next_command if next_command is not None else manifest.get("next_command"),
@@ -480,14 +480,31 @@ def preflight(
             "separate controller-write and candidate-read credentials are required",
         )
 
+    # Record every optional toolchain's presence before failing (KTD11): the
+    # operator preparing a real trial needs to see the whole picture in one
+    # pass, not just whichever tool alphabetically failed first.
     dependency_names = ("cargo", "node", "jq", "gh", "git", "python3", "herdr")
     executable_paths: Dict[str, str] = {}
+    toolchain_status: Dict[str, str] = {}
+    missing_dependencies: List[str] = []
     search_path = source.get("PATH", "")
     for name in dependency_names:
         resolved = resolve_executable(name, search_path)
         if resolved is None:
-            raise PlaygroundError("%s_NOT_FOUND" % name.upper(), "%s is not on the approved PATH" % name)
-        executable_paths[name] = resolved
+            toolchain_status[name] = "missing"
+            missing_dependencies.append(name)
+        else:
+            toolchain_status[name] = "found"
+            executable_paths[name] = resolved
+    if missing_dependencies:
+        first = missing_dependencies[0]
+        raise PlaygroundError(
+            "%s_NOT_FOUND" % first.upper(),
+            "%s is not on the approved PATH; recorded toolchain status: %s; install it temporarily for "
+            "this trial (a scratch rustup/npm/jq/gh prefix removed afterward) or point PATH at an "
+            "already-configured toolchain install — never add it to the managed Brewfile"
+            % (first, json.dumps(toolchain_status, sort_keys=True, separators=(",", ":"))),
+        )
 
     approved_herdr = os.path.realpath(arguments.approved_herdr)
     if executable_paths["herdr"] != approved_herdr:
@@ -552,6 +569,70 @@ def live_herdr_roots(source: Dict[str, str]) -> List[Path]:
     state = Path(source.get("XDG_STATE_HOME") or home / ".local" / "state") / "herdr"
     data = Path(source.get("XDG_DATA_HOME") or home / ".local" / "share") / "herdr"
     return [path.resolve(strict=False) for path in (config, state, data)]
+
+
+def live_probe_environment(source: Dict[str, str], executable_paths: Dict[str, str]) -> Dict[str, str]:
+    """A read-only environment aimed at the ambient (live) Herdr roots rather
+    than a disposable profile home: only the resolved approved executables
+    plus standard utilities on PATH, and the caller's own HOME/XDG_* values so
+    the probe reads exactly what the live profile resolves to (KTD15)."""
+    directories: List[str] = []
+    for executable in executable_paths.values():
+        directory = str(Path(executable).parent)
+        if directory not in directories:
+            directories.append(directory)
+    for directory in ("/usr/bin", "/bin"):
+        if directory not in directories:
+            directories.append(directory)
+    home = Path(source.get("HOME") or str(Path.home()))
+    environment = {"PATH": os.pathsep.join(directories), "HOME": str(home)}
+    for key in ("XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_DATA_HOME"):
+        if source.get(key):
+            environment[key] = source[key]
+    for name in SAFE_INHERITED:
+        if name in source:
+            environment[name] = source[name]
+    if test_mode():
+        for name, value in os.environ.items():
+            if name.startswith("HGSP_"):
+                environment[name] = value
+    return environment
+
+
+def capture_live_invariant(source: Dict[str, str], executable_paths: Dict[str, str]) -> Dict[str, Any]:
+    """Read-only snapshot of the live Herdr profile the playground must never
+    mutate (KTD15): plugin registry, spaces/labels, and sidebar rows, plus the
+    live session socket's device/inode identity. Every probe is best-effort —
+    a live server that is not running fails every read-only probe the same
+    way before and after a well-behaved run, which is itself a valid, stable
+    invariant to compare."""
+    herdr_path = executable_paths.get("herdr")
+    if not herdr_path:
+        return {"socket_identity": None, "plugin_registry": None, "spaces": None, "sidebar_rows": None}
+    environment = live_probe_environment(source, executable_paths)
+    socket_path = live_herdr_roots(source)[1] / "session.sock"
+    socket_identity = None
+    if socket_path.exists():
+        info = socket_path.stat()
+        socket_identity = "%s:%s" % (info.st_dev, info.st_ino)
+    try:
+        registry = herdr_json(herdr_path, ["plugin", "registry"], environment, "LIVE_PROFILE_PROBE_FAILED")
+    except PlaygroundError:
+        registry = None
+    try:
+        spaces = herdr_json(herdr_path, ["space", "list"], environment, "LIVE_PROFILE_PROBE_FAILED")
+    except PlaygroundError:
+        spaces = None
+    try:
+        sidebar_rows = sidebar_snapshot(herdr_path, environment)
+    except PlaygroundError:
+        sidebar_rows = None
+    return {
+        "socket_identity": socket_identity,
+        "plugin_registry": registry,
+        "spaces": spaces,
+        "sidebar_rows": sidebar_rows,
+    }
 
 
 def is_within(path: Path, parent: Path) -> bool:
@@ -688,6 +769,50 @@ def redacted_environment(environment: Dict[str, str]) -> Dict[str, str]:
         else:
             redacted[name] = value
     return redacted
+
+
+def known_secret_values() -> List[str]:
+    """The scoped controller/candidate credential values (KTD17): the only
+    secrets the controller itself ever holds, so a value-based scrub for
+    these two catches a leak wherever it surfaces (config, environment,
+    subprocess stderr, or plugin output) without depending on the field it
+    landed in."""
+    values = []
+    for name in ("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN", "HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            values.append(value)
+    return values
+
+
+def redact_text(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return text
+    redacted = text
+    for secret in known_secret_values():
+        redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
+def diagnostics_log_path(run_dir: Path) -> Path:
+    return run_dir / "logs" / "controller.log"
+
+
+def append_diagnostic(run_dir: Path, code: str, message: str) -> None:
+    """Append a redacted diagnostic line to the run's raw log (KTD17): kept
+    only while the run has not reached a fully cleaned terminal state, and
+    removed alongside `runtime/` once teardown succeeds."""
+    path = diagnostics_log_path(run_dir)
+    ensure_private_directory(path.parent)
+    line = json.dumps(
+        {"at": utc_now(), "code": code, "message": redact_text(message)}, sort_keys=True, separators=(",", ":")
+    )
+    descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(descriptor, (line + "\n").encode("utf-8"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def record_test_environments(environments: Dict[str, Dict[str, str]]) -> None:
@@ -991,6 +1116,7 @@ def new_manifest(
     audit_digest: str,
     executable_paths: Dict[str, str],
     herdr_identity: Dict[str, str],
+    live_invariant_before: Dict[str, Any],
 ) -> Dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
@@ -1003,6 +1129,7 @@ def new_manifest(
         "audit_attestation_sha256": audit_digest,
         "dependencies": executable_paths,
         "herdr_identity": herdr_identity,
+        "live_invariant": {"before": live_invariant_before, "after": None, "match": None},
         "profiles": profiles,
         "launch_intents": {},
         "processes": {},
@@ -2344,7 +2471,7 @@ def bootstrap_result(
 
 
 def playground_error_json(error: PlaygroundError) -> Dict[str, str]:
-    return {"code": error.code, "message": error.message}
+    return {"code": error.code, "message": redact_text(error.message)}
 
 
 def bootstrap_initialize(ctx: BootstrapContext, payload: Dict[str, Any]) -> int:
@@ -3139,7 +3266,7 @@ def settle_remote(mutation: Mutation, source: Dict[str, str], unresolved: List[s
         ctx = BootstrapContext(mutation.root, manifest["fixture_repository"], executable_paths, source)
     except PlaygroundError as error:
         remote.setdefault("diagnostics", []).append(
-            {"at": utc_now(), "code": error.code, "message": error.message}
+            {"at": utc_now(), "code": error.code, "message": redact_text(error.message)}
         )
         unresolved.append(error.code)
         return
@@ -3185,7 +3312,7 @@ def settle_remote(mutation: Mutation, source: Dict[str, str], unresolved: List[s
                 )
         except PlaygroundError as error:
             remote.setdefault("diagnostics", []).append(
-                {"at": utc_now(), "code": error.code, "message": error.message}
+                {"at": utc_now(), "code": error.code, "message": redact_text(error.message)}
             )
             unresolved.append(error.code)
     finally:
@@ -3212,11 +3339,11 @@ def probe_remote_observation(mutation: Mutation, source: Dict[str, str]) -> None
         ctx = BootstrapContext(mutation.root, manifest["fixture_repository"], executable_paths, source)
     except PlaygroundError as error:
         remote.setdefault("diagnostics", []).append(
-            {"at": utc_now(), "code": error.code, "message": error.message}
+            {"at": utc_now(), "code": error.code, "message": redact_text(error.message)}
         )
         if manifest["lifecycle_state"] == "active-ready":
             manifest["lifecycle_state"] = "active-degraded"
-            manifest["error"] = {"code": error.code, "message": error.message}
+            manifest["error"] = {"code": error.code, "message": redact_text(error.message)}
         mutation.persist("remote-observation")
         return
     try:
@@ -3235,7 +3362,7 @@ def probe_remote_observation(mutation: Mutation, source: Dict[str, str]) -> None
                 if not valid:
                     degraded.append(("AUTHORITY_DRIFT", name))
             except PlaygroundError as error:
-                slices[name] = {"valid": False, "error": {"code": error.code, "message": error.message}}
+                slices[name] = {"valid": False, "error": {"code": error.code, "message": redact_text(error.message)}}
                 degraded.append((error.code, name))
         pending = remote.get("pending") or {}
         pending_active = False
@@ -3251,7 +3378,7 @@ def probe_remote_observation(mutation: Mutation, source: Dict[str, str]) -> None
         if pending_error is not None:
             slices[PENDING_FIXTURE] = {
                 "valid": False,
-                "error": {"code": pending_error.code, "message": pending_error.message},
+                "error": {"code": pending_error.code, "message": redact_text(pending_error.message)},
             }
         elif pending.get("state") == "ready" and not pending_active:
             degraded.append(("PENDING_COMPLETED_EARLY", PENDING_FIXTURE))
@@ -4269,6 +4396,27 @@ R11_FIELDS = (
     "hashes",
     "applicability",
 )
+# Every R11 field the worksheet must render, labeled for the header row. The
+# three OPERATOR_NOTE_FIELDS are the only free-text, human-entered columns;
+# every other column is an immutable controller measurement (R11/U7).
+R11_FIELD_LABELS = {
+    "capability_family": "capability family",
+    "baseline_signal": "baseline signal",
+    "candidate_visible_signal": "candidate-visible signal",
+    "companion_surface": "companion surface",
+    "ground_truth_classification": "ground truth",
+    "refresh_authority_state": "refresh/authority state",
+    "terminal_dimensions": "terminal dimensions",
+    "displaced_or_duplicated": "displaced/duplicated",
+    "readability_note": "readability note (operator)",
+    "dependency_note": "dependency note (operator)",
+    "error_link": "error link (operator)",
+    "lifecycle_note": "lifecycle",
+    "observation_id": "observation id",
+    "hashes": "evidence hashes",
+    "applicability": "applicability",
+}
+OPERATOR_NOTE_FIELDS = ("readability_note", "dependency_note", "error_link")
 
 
 def interactive_mode(source: Dict[str, str]) -> bool:
@@ -4635,21 +4783,50 @@ def ground_truth_for_fixture(mutation: Mutation, label: str) -> Dict[str, Any]:
     return {"kind": "local", "fixture": truth}
 
 
+def format_r11_cell(field: str, value: Any) -> str:
+    if value is None:
+        return ""
+    if field == "applicability":
+        state = value.get("state")
+        reason = value.get("reason")
+        return "%s (%s)" % (state, reason) if reason else state
+    if field == "hashes":
+        pairs = ["%s=%s" % (key, item[:12]) for key, item in sorted(value.items()) if item]
+        return ", ".join(pairs) if pairs else NOT_APPLICABLE
+    if field == "displaced_or_duplicated":
+        duplicated = ", ".join(value.get("duplicated") or []) or "none"
+        displaced = ", ".join(value.get("displaced") or []) or "none"
+        return "duplicated: %s; displaced: %s" % (duplicated, displaced)
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(item) for item in value) or NOT_APPLICABLE
+    if isinstance(value, dict):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
 def write_inventory(run_dir: Path, rows: List[Dict[str, Any]]) -> None:
-    lines = ["# Herdr Git status playground inventory", "", "Controller-measured fields are immutable; notes are operator free text.", ""]
-    lines.append("| candidate | fixture | applicability | candidate-visible | notes |")
-    lines.append("|---|---|---|---|---|")
+    """Project the durable evidence index into the human worksheet (U7): every
+    R11 category gets its own column so the later sidebar-design brainstorm
+    can read intended capability, ground truth, refresh/lifecycle behavior,
+    and evidence linkage without recomputing them from raw observations. Only
+    the three OPERATOR_NOTE_FIELDS columns are operator free text; every
+    other column is an immutable controller measurement."""
+    lines = [
+        "# Herdr Git status playground inventory",
+        "",
+        "Every column is a controller-generated measurement except the three "
+        "marked (operator), which are free-text notes and never a candidate ranking.",
+        "",
+    ]
+    headers = ["candidate", "fixture"] + [R11_FIELD_LABELS[field] for field in R11_FIELDS]
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("|" + "---|" * len(headers))
     for row in rows:
-        lines.append(
-            "| %s | %s | %s | %s | %s |"
-            % (
-                row["profile"],
-                row["fixture"],
-                row["applicability"]["state"],
-                ", ".join(row["candidate_visible_signal"]) or NOT_APPLICABLE,
-                row.get("readability_note") or "",
-            )
-        )
+        cells = [row["profile"], row["fixture"]]
+        for field in R11_FIELDS:
+            cells.append(format_r11_cell(field, row.get(field)))
+        safe_cells = [str(cell).replace("|", "/").replace("\n", " ") for cell in cells]
+        lines.append("| " + " | ".join(safe_cells) + " |")
     path = run_dir / "inventory.md"
     ensure_private_directory(path.parent)
     descriptor = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -4713,6 +4890,19 @@ def capture_snapshot(
     baseline = read_json(mutation.run_dir / "observations" / ("baseline-%s.json" % profile))["rows"]
     candidate_visible = [row for row in rows if row not in baseline]
     ground_truth = ground_truth_for_fixture(mutation, fixture)
+    # Classify every baseline signal against what the candidate still shows
+    # (KTD5/R11): "duplicated" baseline rows the candidate repeats verbatim,
+    # "displaced" baseline rows the candidate's view no longer carries. New
+    # candidate signals are already `candidate_visible` above.
+    baseline_set = set(baseline)
+    rows_set = set(rows)
+    displaced_or_duplicated = {
+        "duplicated": sorted(baseline_set & rows_set),
+        "displaced": sorted(baseline_set - rows_set),
+    }
+    notes = redact_text(notes)
+    dependency_note = redact_text(dependency_note)
+    error_link = redact_text(error_link)
 
     raw_observation = {
         "schema_version": SCHEMA_VERSION,
@@ -4770,7 +4960,7 @@ def capture_snapshot(
         "ground_truth_classification": ground_truth,
         "refresh_authority_state": "authority-checked" if ground_truth["kind"] == "github" else "n/a-local",
         "terminal_dimensions": viewer.get("pane_size"),
-        "displaced_or_duplicated": sorted(set(rows) & set(baseline) & set(candidate_visible)),
+        "displaced_or_duplicated": displaced_or_duplicated,
         "readability_note": notes,
         "dependency_note": dependency_note,
         "error_link": error_link,
@@ -5004,6 +5194,11 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     except PlaygroundError as error:
         return error_result(error)
 
+    # Captured before any playground-owned resource exists, over the ambient
+    # (live) roots the run must never touch, so a later after-check has an
+    # honest baseline (KTD15).
+    live_invariant_before = capture_live_invariant(source, executable_paths)
+
     root = state_root(source)
     run_dir: Optional[Path] = None
     manifest: Optional[Dict[str, Any]] = None
@@ -5017,6 +5212,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
             audit_digest,
             executable_paths,
             herdr_identity,
+            live_invariant_before,
         )
         atomic_write_json(run_dir / "manifest.json", manifest, "allocate")
         environments = build_environments(source, executable_paths, run_dir, profiles, fixture)
@@ -5064,6 +5260,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 # Startup failed before first readiness: automatic cleanup that
                 # settles every dispatch identity and releases the lease.
                 manifest["error"] = playground_error_json(remote_error)
+                append_diagnostic(run_dir, remote_error.code, remote_error.message)
                 final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
                 mutation.finish()
                 if cleanup_status == 0:
@@ -5107,6 +5304,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                     # A candidate activation failure triggers cleanup for all
                     # earlier profiles and preserves its diagnostics.
                     manifest["error"] = playground_error_json(candidate_error)
+                    append_diagnostic(run_dir, candidate_error.code, candidate_error.message)
                     final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
                     mutation.finish()
                     if cleanup_status == 0:
@@ -5262,6 +5460,31 @@ def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]
     return False, "PROCESS_STOP_TIMEOUT"
 
 
+def write_teardown_evidence(run_dir: Path, manifest: Dict[str, Any], final_state: str) -> None:
+    """Durable teardown projection (U7): adapter cleanup results, owned-process
+    verification, pending-run settlement, repository-lease release, and the
+    KTD15 live-profile after-check, in one evidence file that survives after
+    `runtime/` (and, on success, `logs/`) are removed."""
+    processes = {
+        intent_id: {"profile": process.get("profile"), "status": process.get("status")}
+        for intent_id, process in (manifest.get("processes") or {}).items()
+    }
+    remote = manifest.get("remote") or {}
+    evidence = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": manifest["run_id"],
+        "generation": manifest["generation"],
+        "final_state": final_state,
+        "candidate_cleanup": manifest.get("candidate_teardown", {}),
+        "owned_processes": processes,
+        "pending_run_settlement": remote.get("settlement"),
+        "repository_lease_release": (remote.get("lease") or {}).get("released"),
+        "live_profile_invariant": manifest.get("live_invariant"),
+        "recorded_at": utc_now(),
+    }
+    atomic_write_json(run_dir / "teardown.json", evidence, "teardown-evidence")
+
+
 def teardown_phases(
     mutation: Mutation, source: Dict[str, str], final_state: str
 ) -> Tuple[Dict[str, Any], int]:
@@ -5302,12 +5525,32 @@ def teardown_phases(
 
     settle_remote(mutation, source, unresolved)
 
+    # KTD15: prove the live Herdr profile this run must never touch is
+    # unchanged, immediately before the repository lease and disposable
+    # runtime are released. Only compares when a `before` snapshot exists —
+    # older/partial manifests without one skip the check rather than crash.
+    live_invariant = manifest.get("live_invariant") or {}
+    live_before = live_invariant.get("before")
+    if live_before is not None:
+        live_after = capture_live_invariant(source, manifest["dependencies"])
+        matches = live_before == live_after
+        live_invariant["after"] = live_after
+        live_invariant["match"] = matches
+        manifest["live_invariant"] = live_invariant
+        mutation.persist("live-invariant-check")
+        if not matches:
+            unresolved.append("LIVE_PROFILE_INVARIANT_MISMATCH")
+
     if unresolved:
         code = "PROCESS_IDENTITY_MISMATCH" if "PROCESS_IDENTITY_MISMATCH" in unresolved else unresolved[0]
         manifest["lifecycle_state"] = "cleanup-incomplete"
         manifest["error"] = {"code": code, "message": "owned resource cleanup could not be proved"}
         manifest["next_command"] = "stop %s" % run_id
+        append_diagnostic(
+            mutation.run_dir, code, "unresolved teardown conditions: %s" % ", ".join(unresolved)
+        )
         mutation.persist("cleanup-incomplete")
+        write_teardown_evidence(mutation.run_dir, manifest, "cleanup-incomplete")
         return manifest, 1
 
     manifest["lifecycle_state"] = final_state
@@ -5315,9 +5558,16 @@ def teardown_phases(
         manifest["error"] = None
     manifest["next_command"] = "status %s" % run_id
     mutation.persist(final_state)
+    write_teardown_evidence(mutation.run_dir, manifest, final_state)
     runtime = mutation.run_dir / "runtime"
     if runtime.exists():
         shutil.rmtree(str(runtime))
+        fsync_directory(mutation.run_dir)
+    # Raw controller diagnostics are discardable once cleanup fully succeeds
+    # (KTD17); the redacted teardown.json evidence above is what's retained.
+    logs_dir = mutation.run_dir / "logs"
+    if logs_dir.exists():
+        shutil.rmtree(str(logs_dir))
         fsync_directory(mutation.run_dir)
     return manifest, 0
 

--- a/home/dot_local/bin/executable_herdr-git-status-playground
+++ b/home/dot_local/bin/executable_herdr-git-status-playground
@@ -67,26 +67,54 @@ PR_FIXTURES = {
     "checks-passed": {"draft": False, "conclusion": "success"},
     "checks-failed": {"draft": False, "conclusion": "failure"},
 }
+PENDING_FIXTURE = "checks-pending"
+# The documented minimum observation window every remote candidate gets while
+# the pending run stays active, the dispatch hold that must exceed it, and the
+# workflow hard timeout that bounds the hold. 600 < 1800 <= 2400 < 45*60.
+PENDING_MIN_OBSERVATION_SECONDS = 600
+PENDING_HOLD_SECONDS = 1800
+PENDING_HOLD_CAP_SECONDS = 2400
+PENDING_WORKFLOW_TIMEOUT_MINUTES = 45
 # Inert by construction: no third-party actions, no PR-triggered execution,
 # empty permissions, bounded runtime. Bootstrap hashes this exact text and
-# treats any remote divergence as drift.
+# treats any remote divergence as drift. The dispatch path carries the run's
+# nonce into the run name so every playground dispatch is queryable by
+# repository/ref/head/workflow/event/nonce, and the hold input is validated
+# and capped below the hard job timeout.
 WORKFLOW_CONTENT = """\
 # Owned by herdr-git-status-playground bootstrap; edits outside bootstrap are drift.
 name: herdr-git-status-playground
+run-name: herdr-git-status-playground ${{ inputs.intent || github.ref_name }}
 on:
   push:
     branches:
       - "herdr-playground/**"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      intent:
+        description: nonce-bearing dispatch intent recorded by the controller
+        required: true
+        type: string
+      hold_seconds:
+        description: bounded pending hold in seconds
+        required: true
+        type: string
 permissions: {}
 concurrency:
-  group: herdr-git-status-playground-${{ github.ref }}
+  group: herdr-git-status-playground-${{ github.ref }}-${{ inputs.intent || 'push' }}
   cancel-in-progress: false
 jobs:
   verdict:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 45
     steps:
+      - name: bounded pending hold
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          hold="${{ inputs.hold_seconds }}"
+          case "$hold" in *[!0-9]*|'') exit 64 ;; esac
+          if [ "$hold" -gt 2400 ]; then exit 64; fi
+          sleep "$hold"
       - name: deterministic verdict
         run: |
           case "${GITHUB_REF_NAME}" in
@@ -950,6 +978,7 @@ def new_manifest(
         "profiles": profiles,
         "launch_intents": {},
         "processes": {},
+        "remote": None,
         "mutation_lease": None,
         "error": None,
         "next_command": "status %s" % run_id,
@@ -1616,9 +1645,15 @@ class BootstrapContext:
 
 
 def gh_api(
-    ctx: BootstrapContext, path: str, code: str, fields: Optional[List[Tuple[str, str]]] = None
+    ctx: BootstrapContext,
+    path: str,
+    code: str,
+    fields: Optional[List[Tuple[str, str]]] = None,
+    method: Optional[str] = None,
 ) -> Any:
     arguments = [ctx.gh, "api", "--hostname", ctx.host, path]
+    if method:
+        arguments.extend(["--method", method])
     for flag, pair in fields or []:
         arguments.extend([flag, pair])
     try:
@@ -1636,6 +1671,8 @@ def gh_api(
     if completed.returncode != 0:
         detail = completed.stderr.strip() or completed.stdout.strip() or "status %d" % completed.returncode
         raise PlaygroundError(code, detail)
+    if not completed.stdout.strip():
+        return None
     try:
         return json.loads(completed.stdout)
     except ValueError as error:
@@ -1756,7 +1793,14 @@ def push_ref(
         raise PlaygroundError(code, "remote %s did not verify to the pushed object" % refname)
 
 
-def lease_payload(ctx: BootstrapContext, kind: str, operation_id: str) -> Dict[str, Any]:
+def lease_payload(
+    ctx: BootstrapContext,
+    kind: str,
+    operation_id: str,
+    lifecycle_state: Optional[str] = None,
+    fixture_generation: Optional[int] = None,
+    workflow_intents: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     return {
         "schema_version": SCHEMA_VERSION,
         "host": ctx.host,
@@ -1767,17 +1811,26 @@ def lease_payload(ctx: BootstrapContext, kind: str, operation_id: str) -> Dict[s
         "operation_id": operation_id,
         "host_installation_id": ctx.host_id,
         "owner_start_identity": process_start_identity(os.getpid()),
-        "lifecycle_state": "%s-in-progress" % kind,
-        "fixture_generation": None,
-        "workflow_intents": [],
+        "lifecycle_state": lifecycle_state or "%s-in-progress" % kind,
+        "fixture_generation": fixture_generation,
+        "workflow_intents": workflow_intents or [],
         "claimed_at": utc_now(),
     }
 
 
-def acquire_lease(ctx: BootstrapContext, kind: str, operation_id: str, code: str) -> str:
+def acquire_lease(
+    ctx: BootstrapContext,
+    kind: str,
+    operation_id: str,
+    code: str,
+    lifecycle_state: Optional[str] = None,
+    fixture_generation: Optional[int] = None,
+    workflow_intents: Optional[List[str]] = None,
+) -> str:
+    payload = lease_payload(ctx, kind, operation_id, lifecycle_state, fixture_generation, workflow_intents)
     workspace, sha = build_commit(
         ctx,
-        {"lease.json": json.dumps(lease_payload(ctx, kind, operation_id), sort_keys=True) + "\n"},
+        {"lease.json": json.dumps(payload, sort_keys=True) + "\n"},
         "%s lease %s" % (kind, operation_id),
     )
     completed = git_run(
@@ -1814,17 +1867,21 @@ def read_lease(ctx: BootstrapContext) -> Tuple[Optional[str], Optional[Dict[str,
     return sha, payload if isinstance(payload, dict) else None
 
 
-def release_lease(ctx: BootstrapContext, owned_sha: str) -> None:
+def conditional_delete_ref(ctx: BootstrapContext, refname: str, owned_sha: str, code: str) -> None:
     completed = git_run(
         ctx.git,
-        ["push", "--quiet", ctx.url, ":%s" % LEASE_REF, "--force-with-lease=%s:%s" % (LEASE_REF, owned_sha)],
+        ["push", "--quiet", ctx.url, ":%s" % refname, "--force-with-lease=%s:%s" % (refname, owned_sha)],
         ctx.scratch,
         ctx.git_env,
-        "LEASE_RELEASE_FAILED",
+        code,
         allow_failure=True,
     )
-    if completed.returncode != 0 or LEASE_REF in ls_remote(ctx):
-        raise PlaygroundError("LEASE_RELEASE_FAILED", "the conditional lease delete did not verify")
+    if completed.returncode != 0 or refname in ls_remote(ctx):
+        raise PlaygroundError(code, "the conditional delete of %s did not verify" % refname)
+
+
+def release_lease(ctx: BootstrapContext, owned_sha: str) -> None:
+    conditional_delete_ref(ctx, LEASE_REF, owned_sha, "LEASE_RELEASE_FAILED")
 
 
 def marker_contents(ctx: BootstrapContext) -> Dict[str, Any]:
@@ -1905,6 +1962,11 @@ def audit_owned_namespace(ctx: BootstrapContext, remote_refs: Dict[str, str]) ->
     recovery = record.get("recovery") or {}
     for mutation in recovery.get("mutations", []):
         expected.setdefault(mutation["ref"], set()).add(mutation["new_sha"])
+    # Per-run transient refs (the checks-pending branch) are recorded before
+    # their push and removed by run teardown; a crashed run's leftover is
+    # recorded ownership, not foreign drift.
+    for refname, transient in (record.get("transient_refs") or {}).items():
+        expected.setdefault(refname, set()).add(transient["sha"])
     retired = set(record.get("retired_branches", []))
     for refname, sha in remote_refs.items():
         if not refname.startswith("refs/heads/" + PLAYGROUND_NAMESPACE) or refname == LEASE_REF:
@@ -2456,6 +2518,728 @@ def bootstrap_converge(ctx: BootstrapContext, payload: Dict[str, Any]) -> int:
     return 0
 
 
+# ---- Per-run remote generation and transient ownership (U4) ----------------
+
+
+def pending_branch_for(run_id: str) -> str:
+    return "%schecks-pending/%s" % (PLAYGROUND_NAMESPACE, run_id)
+
+
+def stage_attempts() -> Dict[str, int]:
+    """Bounded per-stage deadlines, measured in attempts so tests can prove
+    exhaustion with counters instead of wall-clock sleeps."""
+    if test_mode():
+        return {"promotion": 6, "readiness": 6, "settlement": 6, "authority": 6}
+    return {"promotion": 40, "readiness": 90, "settlement": 60, "authority": 40}
+
+
+def remote_backoff(attempt: int) -> None:
+    time.sleep((0.01 if test_mode() else 2.0) * min(attempt + 1, 5))
+
+
+def controller_remote_tools(source: Dict[str, str]) -> Dict[str, str]:
+    executable_paths: Dict[str, str] = {}
+    for name in ("git", "gh"):
+        resolved = resolve_executable(name, source.get("PATH", ""))
+        if resolved is None:
+            raise PlaygroundError("%s_NOT_FOUND" % name.upper(), "%s is not on the approved PATH" % name)
+        executable_paths[name] = resolved
+    return executable_paths
+
+
+def gh_run_by_id(ctx: BootstrapContext, run_number: int, code: str) -> Optional[Dict[str, Any]]:
+    try:
+        return gh_api(ctx, repo_path(ctx, "/actions/runs/%d" % run_number), code)
+    except PlaygroundError as error:
+        if "404" in error.message:
+            return None
+        raise
+
+
+def query_intent_runs(
+    ctx: BootstrapContext, pending: Dict[str, Any], intent: Dict[str, Any], code: str
+) -> List[Dict[str, Any]]:
+    """The unambiguous repository/ref/head/workflow/event/nonce recovery query.
+    Any nonce-bearing record that disagrees with the recorded dispatch identity
+    is a collision and fails closed instead of being adopted or ignored."""
+    payload = gh_api(ctx, repo_path(ctx, "/actions/runs"), code)
+    matches: List[Dict[str, Any]] = []
+    colliding: List[Any] = []
+    for run in payload.get("workflow_runs", []):
+        name = run.get("name") or ""
+        if intent["nonce"] not in name:
+            continue
+        if (
+            name == intent["run_name"]
+            and run.get("head_branch") == pending["branch"]
+            and run.get("head_sha") == pending["head_sha"]
+            and run.get("event") == "workflow_dispatch"
+            and isinstance(run.get("id"), int)
+        ):
+            matches.append(run)
+        else:
+            colliding.append(run.get("id"))
+    if colliding:
+        raise PlaygroundError(
+            "PENDING_NONCE_AMBIGUOUS",
+            "nonce %s appears on records that disagree with the recorded dispatch identity: %r"
+            % (intent["nonce"], sorted(colliding, key=str)),
+        )
+    return matches
+
+
+def mergeability_authority(ctx: BootstrapContext, pr_number: int) -> Dict[str, Any]:
+    for attempt in range(stage_attempts()["authority"]):
+        current = gh_api(ctx, repo_path(ctx, "/pulls/%d" % pr_number), "AUTHORITY_QUERY_FAILED")
+        if current.get("mergeable") is not None:
+            return current
+        remote_backoff(attempt)
+    raise PlaygroundError(
+        "AUTHORITY_UNSETTLED",
+        "mergeability for PR #%d stayed unknown through the bounded authority window; it cannot become stable "
+        "evidence" % pr_number,
+    )
+
+
+def fixture_authority(
+    ctx: BootstrapContext, name: str, fixture_record: Dict[str, Any], refs: Dict[str, str]
+) -> Dict[str, Any]:
+    identity: Dict[str, Any] = {
+        "ref": "refs/heads/%s" % fixture_record["branch"],
+        "ref_sha": refs.get("refs/heads/%s" % fixture_record["branch"]),
+    }
+    if "pr_number" in fixture_record:
+        pull = gh_api(ctx, repo_path(ctx, "/pulls/%d" % fixture_record["pr_number"]), "AUTHORITY_QUERY_FAILED")
+        identity["pull"] = {
+            "number": pull.get("number"),
+            "node_id": pull.get("node_id"),
+            "state": pull.get("state"),
+            "draft": pull.get("draft"),
+            "head_sha": pull.get("head", {}).get("sha"),
+        }
+        if name == "merge-conflict":
+            identity["pull"]["mergeable"] = pull.get("mergeable")
+            identity["pull"]["mergeable_state"] = pull.get("mergeable_state")
+    if "workflow_run_id" in fixture_record:
+        run = gh_run_by_id(ctx, fixture_record["workflow_run_id"], "AUTHORITY_QUERY_FAILED")
+        identity["workflow_run"] = (
+            None
+            if run is None
+            else {
+                "id": run.get("id"),
+                "head_sha": run.get("head_sha"),
+                "status": run.get("status"),
+                "conclusion": run.get("conclusion"),
+            }
+        )
+    return identity
+
+
+def authority_snapshot(ctx: BootstrapContext) -> Dict[str, Any]:
+    record = ctx.record
+    assert record is not None
+    refs = ls_remote(ctx)
+    fixtures: Dict[str, Any] = {}
+    for name in GITHUB_FIXTURES:
+        fixture_record = record["fixtures"].get(name)
+        if fixture_record is None:
+            raise PlaygroundError(
+                "AUTHORITY_DRIFT", "fixture %s is missing from the repository record; rerun bootstrap" % name
+            )
+        if name == "merge-conflict":
+            mergeability_authority(ctx, fixture_record["pr_number"])
+        identity = fixture_authority(ctx, name, fixture_record, refs)
+        if identity["ref_sha"] != fixture_record["head_sha"]:
+            raise PlaygroundError(
+                "AUTHORITY_DRIFT",
+                "fixture %s head moved to %r from the recorded %r; rerun bootstrap before starting a run"
+                % (name, identity["ref_sha"], fixture_record["head_sha"]),
+            )
+        fixtures[name] = identity
+    return {"captured_at": utc_now(), "repository_id": ctx.repository_id, "fixtures": fixtures}
+
+
+def snapshot_identity(snapshot: Optional[Dict[str, Any]]) -> Any:
+    return (snapshot or {}).get("fixtures")
+
+
+def lease_inspection_commands(ctx: BootstrapContext) -> str:
+    return (
+        "inspect it read-only with: git ls-remote %s %s && git fetch %s %s && git show FETCH_HEAD:lease.json"
+        % (ctx.url, LEASE_REF, ctx.url, LEASE_REF)
+    )
+
+
+def resolve_held_lease(ctx: BootstrapContext, root: Path) -> None:
+    """Fail closed on any held repository lease unless it provably belongs to a
+    terminal same-host run whose every ownership probe has settled."""
+    sha, doc = read_lease(ctx)
+    if sha is None:
+        return
+    inspect = lease_inspection_commands(ctx)
+    if not isinstance(doc, dict):
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_HELD",
+            "the repository lease at %s is unreadable; %s; no automated takeover is performed" % (sha, inspect),
+        )
+    if doc.get("host_installation_id") != ctx.host_id:
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_FOREIGN",
+            "the repository lease at %s belongs to foreign host installation %r running operation %r with workflow "
+            "intents %r; automation always refuses foreign takeover; %s; after inspecting, recover manually with: "
+            "gh run list --repo %s/%s, gh run cancel <run-id> --repo %s/%s, then git push %s :%s "
+            "--force-with-lease=%s:%s"
+            % (
+                sha,
+                doc.get("host_installation_id"),
+                doc.get("operation_id"),
+                doc.get("workflow_intents"),
+                inspect,
+                ctx.owner,
+                ctx.name,
+                ctx.owner,
+                ctx.name,
+                ctx.url,
+                LEASE_REF,
+                LEASE_REF,
+                sha,
+            ),
+        )
+    operation_id = doc.get("operation_id")
+    if doc.get("operation_kind") != "run" or not isinstance(operation_id, str):
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_HELD",
+            "the repository lease at %s is held by %s operation %r; %s"
+            % (sha, doc.get("operation_kind"), operation_id, inspect),
+        )
+    try:
+        other = read_manifest(root, operation_id)
+    except PlaygroundError:
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_HELD",
+            "the repository lease at %s names run %r, which has no readable local manifest; %s; no automated "
+            "takeover is performed" % (sha, operation_id, inspect),
+        )
+    if other["lifecycle_state"] in ACTIVE_STATES:
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_HELD",
+            "run %s still owns the repository lease in state %s; an exited command owner does not make it stale; "
+            "same-host recovery resumes that run (%s stop %s) and a new run stays blocked"
+            % (operation_id, other["lifecycle_state"], APP_NAME, operation_id),
+        )
+    remote = other.get("remote") or {}
+    pending = remote.get("pending") or {}
+    for intent in pending.get("intents", []):
+        run_ids = list(intent.get("run_ids") or [])
+        if not run_ids and intent.get("dispatched_at"):
+            run_ids = [run["id"] for run in query_intent_runs(ctx, pending, intent, "LEASE_PROBE_FAILED")]
+        for run_number in run_ids:
+            run = gh_run_by_id(ctx, run_number, "LEASE_PROBE_FAILED")
+            if run is not None and run.get("status") != "completed":
+                raise PlaygroundError(
+                    "REPOSITORY_LEASE_HELD",
+                    "leaked-lease probe found workflow run %d still active for terminal run %s; settle it with: "
+                    "%s stop %s" % (run_number, operation_id, APP_NAME, operation_id),
+                )
+    if pending.get("ref") and pending["ref"] in ls_remote(ctx):
+        raise PlaygroundError(
+            "REPOSITORY_LEASE_HELD",
+            "leaked-lease probe found transient ref %s still present for terminal run %s; settle it with: %s stop %s"
+            % (pending["ref"], operation_id, APP_NAME, operation_id),
+        )
+    release_lease(ctx, sha)
+
+
+def dispatch_pending(ctx: BootstrapContext, branch: str, nonce: str) -> None:
+    gh_api(
+        ctx,
+        repo_path(ctx, "/actions/workflows/%s/dispatches" % os.path.basename(WORKFLOW_FILE)),
+        "PENDING_DISPATCH_FAILED",
+        fields=[
+            ("-f", "ref=%s" % branch),
+            ("-f", "inputs[intent]=%s" % nonce),
+            ("-f", "inputs[hold_seconds]=%d" % PENDING_HOLD_SECONDS),
+        ],
+    )
+
+
+def await_pending_readiness(mutation: Mutation, ctx: BootstrapContext, intent: Dict[str, Any]) -> str:
+    """Bracket every readiness observation between authority snapshots anchored
+    to the run's generation; equal stale values never establish readiness."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    remote = manifest["remote"]
+    generation = remote["generation"]
+    for attempt in range(stage_attempts()["readiness"]):
+        before = authority_snapshot(ctx)
+        active: List[int] = []
+        statuses: Dict[str, Dict[str, Any]] = {}
+        for run_number in intent["run_ids"]:
+            run = gh_run_by_id(ctx, run_number, "PENDING_READINESS_QUERY_FAILED")
+            if run is None:
+                raise PlaygroundError(
+                    "PENDING_RUN_UNKNOWN", "promoted workflow run %d disappeared from the authority" % run_number
+                )
+            statuses[str(run_number)] = {"status": run.get("status"), "conclusion": run.get("conclusion")}
+            if run.get("status") in ("queued", "in_progress"):
+                active.append(run_number)
+        after = authority_snapshot(ctx)
+        anchored = snapshot_identity(generation["snapshot"])
+        if snapshot_identity(before) != anchored or snapshot_identity(after) != anchored:
+            remote.setdefault("diagnostics", []).append(
+                {
+                    "at": utc_now(),
+                    "code": "AUTHORITY_SLICE_INVALIDATED",
+                    "message": "authority identities changed during the readiness bracket",
+                }
+            )
+            mutation.persist("readiness-slice-invalidated")
+            remote_backoff(attempt)
+            continue
+        intent["readiness_statuses"] = statuses
+        if active:
+            return "ready"
+        if all(status["status"] == "completed" for status in statuses.values()):
+            return "completed-early"
+        remote_backoff(attempt)
+    raise PlaygroundError(
+        "PENDING_READINESS_DEADLINE",
+        "the pending run did not reach an observable pending state within the bounded readiness window",
+    )
+
+
+def dispatch_and_await_pending(mutation: Mutation, ctx: BootstrapContext) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    remote = manifest["remote"]
+    pending = remote["pending"]
+    attempts = stage_attempts()
+    for attempt_number in (1, 2):
+        nonce = secrets.token_hex(12)
+        intent = {
+            "attempt": attempt_number,
+            "nonce": nonce,
+            "run_name": "%s %s" % (WORKFLOW_NAME, nonce),
+            "hold_seconds": PENDING_HOLD_SECONDS,
+            "ref": pending["ref"],
+            "branch": pending["branch"],
+            "head_sha": pending["head_sha"],
+            "event": "workflow_dispatch",
+            "workflow": WORKFLOW_NAME,
+            "created_at": utc_now(),
+            "dispatched_at": None,
+            "run_ids": [],
+            "phase": "intent-committed",
+        }
+        pending["intents"].append(intent)
+        pending["state"] = "intent-committed"
+        # The unique dispatch intent is durable before the API call.
+        mutation.persist("pending-intent")
+        if test_failpoint() == "pending-before-dispatch":
+            raise PlaygroundError(
+                "INJECTED_PENDING_BEFORE_DISPATCH",
+                "injected crash after the durable dispatch intent, before the API call",
+            )
+        dispatch_pending(ctx, pending["branch"], nonce)
+        intent["dispatched_at"] = utc_now()
+        intent["phase"] = "dispatched"
+        pending["state"] = "dispatched"
+        mutation.persist("pending-dispatched")
+        if test_failpoint() == "pending-after-dispatch":
+            raise PlaygroundError(
+                "INJECTED_PENDING_AFTER_DISPATCH", "injected crash after dispatch, before numeric-ID promotion"
+            )
+        matches: List[Dict[str, Any]] = []
+        for attempt in range(attempts["promotion"]):
+            matches = query_intent_runs(ctx, pending, intent, "PENDING_PROMOTION_QUERY_FAILED")
+            if matches:
+                break
+            remote_backoff(attempt)
+        if not matches:
+            raise PlaygroundError(
+                "PENDING_PROMOTION_DEADLINE",
+                "no nonce-matched workflow run appeared for intent %s within the bounded promotion window" % nonce,
+            )
+        if test_failpoint() == "pending-before-promotion":
+            raise PlaygroundError(
+                "INJECTED_PENDING_BEFORE_PROMOTION",
+                "injected crash after the nonce query, before numeric-ID promotion",
+            )
+        run_ids = sorted(run["id"] for run in matches)
+        intent["run_ids"] = run_ids
+        intent["phase"] = "promoted"
+        generation = remote["generation"]
+        generation["pending_run_ids"] = sorted(set(generation["pending_run_ids"]) | set(run_ids))
+        # One atomic manifest replacement promotes every matched numeric ID
+        # into the generation.
+        mutation.persist("pending-promoted")
+        outcome = await_pending_readiness(mutation, ctx, intent)
+        if outcome == "ready":
+            pending["state"] = "ready"
+            pending["ready_at"] = utc_now()
+            pending["observation_window"] = {
+                "started_at": pending["ready_at"],
+                "min_seconds": PENDING_MIN_OBSERVATION_SECONDS,
+                "hold_seconds": PENDING_HOLD_SECONDS,
+                "workflow_timeout_minutes": PENDING_WORKFLOW_TIMEOUT_MINUTES,
+            }
+            mutation.persist("pending-ready")
+            return
+        if attempt_number == 1:
+            # One retrigger is allowed inside the overall deadline.
+            continue
+        raise PlaygroundError(
+            "PENDING_COMPLETED_EARLY",
+            "the pending workflow completed before first readiness on both dispatch attempts; it cannot silently "
+            "satisfy the pending fixture",
+        )
+    raise PlaygroundError("PENDING_COMPLETED_EARLY", "the pending workflow completed before first readiness")
+
+
+def provision_pending_fixture(mutation: Mutation, ctx: BootstrapContext) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None and ctx.record is not None
+    run_id = manifest["run_id"]
+    remote = manifest["remote"]
+    branch = pending_branch_for(run_id)
+    refname = "refs/heads/%s" % branch
+    workspace, sha = build_commit(
+        ctx,
+        {"fixtures/checks-pending.txt": "herdr playground checks-pending fixture for run %s\n" % run_id},
+        "checks-pending fixture for run %s" % run_id,
+        base_ref="refs/heads/%s" % ctx.record["default_branch"],
+    )
+    remote["pending"] = {
+        "fixture": PENDING_FIXTURE,
+        "ref": refname,
+        "branch": branch,
+        "head_sha": sha,
+        "hold_seconds": PENDING_HOLD_SECONDS,
+        "min_observation_seconds": PENDING_MIN_OBSERVATION_SECONDS,
+        "workflow_timeout_minutes": PENDING_WORKFLOW_TIMEOUT_MINUTES,
+        "intents": [],
+        "state": "ref-intent",
+        "ready_at": None,
+    }
+    mutation.persist("pending-ref-intent")
+    ctx.record.setdefault("transient_refs", {})[refname] = {
+        "run_id": run_id,
+        "sha": sha,
+        "recorded_at": utc_now(),
+    }
+    ctx.persist_record()
+    push_ref(ctx, workspace, refname, sha, "", PENDING_FIXTURE, "PENDING_REF_CAS_FAILED")
+    remote["pending"]["state"] = "ref-pushed"
+    mutation.persist("pending-ref-pushed")
+    dispatch_and_await_pending(mutation, ctx)
+
+
+def provision_remote_generation(
+    mutation: Mutation, source: Dict[str, str], executable_paths: Dict[str, str]
+) -> None:
+    """Bind the run to one fixture generation and one cancellable pending
+    workflow: lease, generation allocation, authority snapshot, durable
+    dispatch intent, dispatch, promotion, and bracketed readiness."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    root = mutation.root
+    ownership = manifest["fixture_repository"]
+    record_path = repository_state_directory(root, ownership) / "repository.json"
+    if not record_path.exists():
+        # The dedicated repository has not been bootstrapped on this host;
+        # remote candidates stay unavailable and later units enforce it.
+        manifest["remote"] = None
+        mutation.persist("remote-skipped")
+        return
+    ctx = BootstrapContext(
+        root, ownership, {"git": executable_paths["git"], "gh": executable_paths["gh"]}, source
+    )
+    try:
+        payload = resolve_repository(ctx)
+        require_write_permission(ctx, payload)
+        ctx.record = read_json(record_path)
+        for key in ("host", "owner", "name", "repository_id"):
+            if ctx.record.get(key) != ownership[key]:
+                raise PlaygroundError(
+                    "BOOTSTRAP_IDENTITY_MISMATCH",
+                    "the persisted repository record does not match the run's canonical identity",
+                )
+        resolve_held_lease(ctx, root)
+        generation_number = int(ctx.record.get("fixture_generation_counter", 0)) + 1
+        ctx.record["fixture_generation_counter"] = generation_number
+        ctx.persist_record()
+        lease_sha = acquire_lease(
+            ctx,
+            "run",
+            manifest["run_id"],
+            "REPOSITORY_LEASE_HELD",
+            lifecycle_state=manifest["lifecycle_state"],
+            fixture_generation=generation_number,
+            workflow_intents=["refs/heads/%s" % pending_branch_for(manifest["run_id"])],
+        )
+        attempts = stage_attempts()
+        manifest["remote"] = {
+            "repository": dict(ownership),
+            "lease": {
+                "ref": LEASE_REF,
+                "sha": lease_sha,
+                "operation_id": manifest["run_id"],
+                "acquired_at": utc_now(),
+                "released": None,
+            },
+            "generation": {
+                "number": generation_number,
+                "snapshot": None,
+                "deadlines": {
+                    "promotion_attempts": attempts["promotion"],
+                    "readiness_attempts": attempts["readiness"],
+                    "settlement_attempts": attempts["settlement"],
+                    "authority_attempts": attempts["authority"],
+                    "min_observation_seconds": PENDING_MIN_OBSERVATION_SECONDS,
+                    "hold_seconds": PENDING_HOLD_SECONDS,
+                    "workflow_timeout_minutes": PENDING_WORKFLOW_TIMEOUT_MINUTES,
+                },
+                "pending_run_ids": [],
+            },
+            "pending": None,
+            "observations": [],
+            "settlement": None,
+        }
+        mutation.persist("remote-lease")
+        if test_failpoint() == "run-lease-acquired":
+            raise PlaygroundError(
+                "INJECTED_RUN_LEASE_ACQUIRED", "injected crash after lease acquisition, before the snapshot"
+            )
+        snapshot = authority_snapshot(ctx)
+        manifest["remote"]["generation"]["snapshot"] = snapshot
+        mutation.persist("remote-snapshot")
+        provision_pending_fixture(mutation, ctx)
+    finally:
+        ctx.cleanup()
+
+
+def settle_pending_intents(ctx: BootstrapContext, remote: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Settle every exact recorded numeric run ID, resolving unpromoted intents
+    through the nonce query first; already-terminal matches count as settled,
+    cancellation is followed by bounded exact-ID polling to a terminal state."""
+    pending = remote.get("pending")
+    if not pending:
+        return []
+    attempts = stage_attempts()["settlement"]
+    evidence: List[Dict[str, Any]] = []
+    for intent in pending.get("intents", []):
+        run_ids = list(intent.get("run_ids") or [])
+        if not run_ids:
+            # Crash before promotion (or before dispatch): recover by the
+            # unambiguous query instead of assuming nothing was dispatched.
+            run_ids = sorted(
+                run["id"] for run in query_intent_runs(ctx, pending, intent, "PENDING_SETTLEMENT_QUERY_FAILED")
+            )
+            intent["run_ids"] = run_ids
+        for run_number in run_ids:
+            run = gh_run_by_id(ctx, run_number, "PENDING_SETTLEMENT_QUERY_FAILED")
+            if run is None:
+                raise PlaygroundError(
+                    "PENDING_RUN_UNKNOWN",
+                    "recorded workflow run %d cannot be read from the authority" % run_number,
+                )
+            already_terminal = run.get("status") == "completed"
+            cancelled = False
+            if not already_terminal:
+                gh_api(
+                    ctx,
+                    repo_path(ctx, "/actions/runs/%d/cancel" % run_number),
+                    "PENDING_CANCEL_FAILED",
+                    method="POST",
+                )
+                cancelled = True
+                terminal = False
+                for attempt in range(attempts):
+                    run = gh_run_by_id(ctx, run_number, "PENDING_SETTLEMENT_QUERY_FAILED")
+                    if run is None:
+                        raise PlaygroundError(
+                            "PENDING_RUN_UNKNOWN",
+                            "workflow run %d vanished while polling for a terminal state" % run_number,
+                        )
+                    if run.get("status") == "completed":
+                        terminal = True
+                        break
+                    remote_backoff(attempt)
+                if not terminal:
+                    raise PlaygroundError(
+                        "PENDING_STILL_ACTIVE",
+                        "workflow run %d stayed active through the bounded settlement window" % run_number,
+                    )
+            evidence.append(
+                {
+                    "run_id": run_number,
+                    "nonce": intent["nonce"],
+                    "already_terminal": already_terminal,
+                    "cancelled": cancelled,
+                    "final_status": run.get("status"),
+                    "conclusion": run.get("conclusion"),
+                    "settled_at": utc_now(),
+                }
+            )
+        intent["phase"] = "settled"
+    return evidence
+
+
+def settle_remote(mutation: Mutation, source: Dict[str, str], unresolved: List[str]) -> None:
+    manifest = mutation.manifest
+    assert manifest is not None
+    remote = manifest.get("remote")
+    if not remote:
+        return
+    if remote.get("settlement") is not None and remote["lease"].get("released") is not None:
+        return
+    if not os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"):
+        remote.setdefault("diagnostics", []).append(
+            {
+                "at": utc_now(),
+                "code": "CREDENTIAL_AUTHORITY_INVALID",
+                "message": "remote settlement requires the scoped controller credential",
+            }
+        )
+        unresolved.append("CREDENTIAL_AUTHORITY_INVALID")
+        return
+    try:
+        executable_paths = controller_remote_tools(source)
+        ctx = BootstrapContext(mutation.root, manifest["fixture_repository"], executable_paths, source)
+    except PlaygroundError as error:
+        remote.setdefault("diagnostics", []).append(
+            {"at": utc_now(), "code": error.code, "message": error.message}
+        )
+        unresolved.append(error.code)
+        return
+    try:
+        try:
+            resolve_repository(ctx)
+            if ctx.record_path.exists():
+                ctx.record = read_json(ctx.record_path)
+            evidence = settle_pending_intents(ctx, remote)
+            remote["settlement"] = {"runs": evidence, "completed_at": utc_now()}
+            pending = remote.get("pending")
+            if pending:
+                refname = pending["ref"]
+                current = ls_remote(ctx).get(refname)
+                if current is not None:
+                    if current != pending["head_sha"]:
+                        raise PlaygroundError(
+                            "OWNERSHIP_DRIFT",
+                            "transient ref %s moved to unrecorded commit %s; inspect it before retrying stop"
+                            % (refname, current),
+                        )
+                    conditional_delete_ref(ctx, refname, current, "PENDING_REF_CLEANUP_FAILED")
+                remote["settlement"]["transient_ref_deleted"] = True
+                if ctx.record is not None and refname in (ctx.record.get("transient_refs") or {}):
+                    del ctx.record["transient_refs"][refname]
+                    ctx.persist_record()
+            lease = remote["lease"]
+            sha, doc = read_lease(ctx)
+            if sha is None:
+                lease["released"] = {"at": utc_now(), "verified": "already-absent"}
+            elif sha == lease["sha"] or (
+                isinstance(doc, dict)
+                and doc.get("operation_id") == manifest["run_id"]
+                and doc.get("host_installation_id") == ctx.host_id
+            ):
+                release_lease(ctx, sha)
+                lease["released"] = {"at": utc_now(), "sha": sha, "verified": "conditional-delete"}
+            else:
+                raise PlaygroundError(
+                    "REPOSITORY_LEASE_FOREIGN",
+                    "the repository lease at %s is not owned by run %s; %s; no automated takeover is performed"
+                    % (sha, manifest["run_id"], lease_inspection_commands(ctx)),
+                )
+        except PlaygroundError as error:
+            remote.setdefault("diagnostics", []).append(
+                {"at": utc_now(), "code": error.code, "message": error.message}
+            )
+            unresolved.append(error.code)
+    finally:
+        ctx.cleanup()
+
+
+def probe_remote_observation(mutation: Mutation, source: Dict[str, str]) -> None:
+    """The mutating post-ready probe: bracket each fixture's authority slice
+    against the run generation, invalidate only drifted slices, and persist
+    degradation when the pending fixture or any authority probe fails."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    remote = manifest.get("remote")
+    if not remote or manifest["lifecycle_state"] not in ("active-ready", "active-degraded"):
+        return
+    degraded: List[Tuple[str, str]] = []
+    slices: Dict[str, Any] = {}
+    try:
+        executable_paths = controller_remote_tools(source)
+        if not os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN"):
+            raise PlaygroundError(
+                "CREDENTIAL_AUTHORITY_INVALID", "the observation probe requires the scoped controller credential"
+            )
+        ctx = BootstrapContext(mutation.root, manifest["fixture_repository"], executable_paths, source)
+    except PlaygroundError as error:
+        remote.setdefault("diagnostics", []).append(
+            {"at": utc_now(), "code": error.code, "message": error.message}
+        )
+        if manifest["lifecycle_state"] == "active-ready":
+            manifest["lifecycle_state"] = "active-degraded"
+            manifest["error"] = {"code": error.code, "message": error.message}
+        mutation.persist("remote-observation")
+        return
+    try:
+        recorded_fixtures = snapshot_identity(remote["generation"]["snapshot"]) or {}
+        for name, recorded in recorded_fixtures.items():
+            fixture_record = {"branch": recorded["ref"][len("refs/heads/"):], "head_sha": recorded["ref_sha"]}
+            if recorded.get("pull") is not None:
+                fixture_record["pr_number"] = recorded["pull"]["number"]
+            if recorded.get("workflow_run") is not None:
+                fixture_record["workflow_run_id"] = recorded["workflow_run"]["id"]
+            try:
+                before = fixture_authority(ctx, name, fixture_record, ls_remote(ctx))
+                after = fixture_authority(ctx, name, fixture_record, ls_remote(ctx))
+                valid = before == after == recorded
+                slices[name] = {"valid": valid, "before": before, "after": after}
+                if not valid:
+                    degraded.append(("AUTHORITY_DRIFT", name))
+            except PlaygroundError as error:
+                slices[name] = {"valid": False, "error": {"code": error.code, "message": error.message}}
+                degraded.append((error.code, name))
+        pending = remote.get("pending") or {}
+        pending_active = False
+        pending_error: Optional[PlaygroundError] = None
+        try:
+            for run_number in remote["generation"]["pending_run_ids"]:
+                run = gh_run_by_id(ctx, run_number, "AUTHORITY_QUERY_FAILED")
+                if run is not None and run.get("status") in ("queued", "in_progress"):
+                    pending_active = True
+        except PlaygroundError as error:
+            pending_error = error
+            degraded.append((error.code, PENDING_FIXTURE))
+        if pending_error is not None:
+            slices[PENDING_FIXTURE] = {
+                "valid": False,
+                "error": {"code": pending_error.code, "message": pending_error.message},
+            }
+        elif pending.get("state") == "ready" and not pending_active:
+            degraded.append(("PENDING_COMPLETED_EARLY", PENDING_FIXTURE))
+            slices[PENDING_FIXTURE] = {
+                "valid": False,
+                "detail": "the pending workflow completed early after active-ready",
+            }
+        else:
+            slices[PENDING_FIXTURE] = {"valid": True, "pending_active": pending_active}
+        remote.setdefault("observations", []).append({"captured_at": utc_now(), "slices": slices})
+        if degraded and manifest["lifecycle_state"] == "active-ready":
+            code, name = degraded[0]
+            manifest["lifecycle_state"] = "active-degraded"
+            manifest["error"] = {"code": code, "message": "the observation probe invalidated the %s slice" % name}
+        mutation.persist("remote-observation")
+    finally:
+        ctx.cleanup()
+
+
 def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     ctx: Optional[BootstrapContext] = None
     try:
@@ -2464,12 +3248,7 @@ def command_bootstrap(arguments: argparse.Namespace, source: Dict[str, str]) -> 
             raise PlaygroundError(
                 "CREDENTIAL_AUTHORITY_INVALID", "bootstrap requires the scoped controller credential"
             )
-        executable_paths: Dict[str, str] = {}
-        for name in ("git", "gh"):
-            resolved = resolve_executable(name, source.get("PATH", ""))
-            if resolved is None:
-                raise PlaygroundError("%s_NOT_FOUND" % name.upper(), "%s is not on the approved PATH" % name)
-            executable_paths[name] = resolved
+        executable_paths = controller_remote_tools(source)
         root = state_root(source)
         ensure_private_directory(root)
         ctx = BootstrapContext(root, ownership, executable_paths, source)
@@ -2544,21 +3323,41 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
             manifest = mutation.manifest
             assert manifest is not None
             build_local_fixture_catalog(mutation, environments, executable_paths)
+
+            remote_error: Optional[PlaygroundError] = None
+            try:
+                provision_remote_generation(mutation, source, executable_paths)
+            except PlaygroundError as error:
+                remote_error = error
+            if remote_error is not None:
+                if remote_error.code.startswith("INJECTED_"):
+                    # Injected crash boundary: leave the durable state exactly as
+                    # a real crash would, for recovery through stop.
+                    current = read_manifest(root, run_id)
+                    print_json(output_record(current, remote_error.code, remote_error.message, "stop %s" % run_id))
+                    return remote_error.status
+                # Startup failed before first readiness: automatic cleanup that
+                # settles every dispatch identity and releases the lease.
+                manifest["error"] = playground_error_json(remote_error)
+                final_manifest, cleanup_status = teardown_phases(mutation, source, "startup-failed-cleaned")
+                mutation.finish()
+                if cleanup_status == 0:
+                    print_json(
+                        output_record(final_manifest, remote_error.code, remote_error.message, "status %s" % run_id)
+                    )
+                else:
+                    print_json(output_record(final_manifest))
+                return remote_error.status
+
             target = os.environ.get("HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS") if test_mode() else None
             if not target:
-                manifest["lifecycle_state"] = "startup-failed-cleaned"
                 manifest["error"] = {
                     "code": "PROFILE_STARTUP_NOT_IMPLEMENTED",
                     "message": "candidate startup belongs to a later implementation unit",
                 }
-                manifest["next_command"] = "status %s" % run_id
-                mutation.persist("foundation-only")
-                runtime = run_dir / "runtime"
-                if runtime.exists():
-                    shutil.rmtree(str(runtime))
-                    fsync_directory(run_dir)
+                final_manifest, _ = teardown_phases(mutation, source, "startup-failed-cleaned")
                 mutation.finish()
-                print_json(output_record(manifest))
+                print_json(output_record(final_manifest))
                 return 1
 
             launch_error = start_foundation_process(mutation, environments["candidate-runtime"], target)
@@ -2581,7 +3380,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
                 "HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE",
             )
         except KeyboardInterrupt:
-            stopped, stop_status = stop_run(root, run_id)
+            stopped, stop_status = stop_run(root, run_id, source)
             print_json(
                 output_record(
                     stopped,
@@ -2606,7 +3405,7 @@ def command_start(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     except KeyboardInterrupt:
         if manifest is None or run_dir is None:
             return error_result(PlaygroundError("START_INTERRUPTED", "start was interrupted", 130))
-        stopped, stop_status = stop_run(root, manifest["run_id"])
+        stopped, stop_status = stop_run(root, manifest["run_id"], source)
         print_json(
             output_record(
                 stopped,
@@ -2682,56 +3481,72 @@ def terminate_owned_process(record: Dict[str, Any]) -> Tuple[bool, Optional[str]
     return False, "PROCESS_STOP_TIMEOUT"
 
 
-def stop_run(root: Path, run_id: str) -> Tuple[Dict[str, Any], int]:
+def teardown_phases(
+    mutation: Mutation, source: Dict[str, str], final_state: str
+) -> Tuple[Dict[str, Any], int]:
+    """Ordered continue-on-error teardown: stop owned processes, settle every
+    recorded pending workflow, delete the transient ref, conditionally release
+    the repository lease, then remove disposable runtime. Any unresolved
+    resource leaves cleanup-incomplete and retains the lease for retry."""
+    manifest = mutation.manifest
+    assert manifest is not None
+    run_id = manifest["run_id"]
+    manifest["lifecycle_state"] = "stopping"
+    manifest["next_command"] = "stop %s" % run_id
+    mutation.persist("stopping")
+    unresolved: List[str] = []
+
+    for intent_id, intent in manifest.get("launch_intents", {}).items():
+        process = manifest.get("processes", {}).get(intent_id)
+        if process is None:
+            process = adopt_claim(mutation.run_dir, intent)
+            if process is not None:
+                manifest["processes"][intent_id] = process
+        if process is None:
+            if intent.get("phase") == "intent-committed":
+                intent["phase"] = "cancelled-before-spawn"
+                continue
+            unresolved.append("PROCESS_IDENTITY_UNRESOLVED")
+            continue
+        stopped, code = terminate_owned_process(process)
+        if stopped:
+            intent["phase"] = "stopped"
+        elif code:
+            unresolved.append(code)
+
+    settle_remote(mutation, source, unresolved)
+
+    if unresolved:
+        code = "PROCESS_IDENTITY_MISMATCH" if "PROCESS_IDENTITY_MISMATCH" in unresolved else unresolved[0]
+        manifest["lifecycle_state"] = "cleanup-incomplete"
+        manifest["error"] = {"code": code, "message": "owned resource cleanup could not be proved"}
+        manifest["next_command"] = "stop %s" % run_id
+        mutation.persist("cleanup-incomplete")
+        return manifest, 1
+
+    manifest["lifecycle_state"] = final_state
+    if final_state == "stopped":
+        manifest["error"] = None
+    manifest["next_command"] = "status %s" % run_id
+    mutation.persist(final_state)
+    runtime = mutation.run_dir / "runtime"
+    if runtime.exists():
+        shutil.rmtree(str(runtime))
+        fsync_directory(mutation.run_dir)
+    return manifest, 0
+
+
+def stop_run(root: Path, run_id: str, source: Optional[Dict[str, str]] = None) -> Tuple[Dict[str, Any], int]:
+    if source is None:
+        source = dict(os.environ)
     current = read_manifest(root, run_id)
-    if current["lifecycle_state"] == "stopped":
+    if current["lifecycle_state"] in ("stopped", "startup-failed-cleaned"):
         return current, 0
     try:
         with Mutation(root, run_id) as mutation:
-            manifest = mutation.manifest
-            assert manifest is not None
-            manifest["lifecycle_state"] = "stopping"
-            manifest["next_command"] = "stop %s" % run_id
-            mutation.persist("stopping")
-            unresolved: List[str] = []
-
-            for intent_id, intent in manifest.get("launch_intents", {}).items():
-                process = manifest.get("processes", {}).get(intent_id)
-                if process is None:
-                    process = adopt_claim(mutation.run_dir, intent)
-                    if process is not None:
-                        manifest["processes"][intent_id] = process
-                if process is None:
-                    if intent.get("phase") == "intent-committed":
-                        intent["phase"] = "cancelled-before-spawn"
-                        continue
-                    unresolved.append("PROCESS_IDENTITY_UNRESOLVED")
-                    continue
-                stopped, code = terminate_owned_process(process)
-                if stopped:
-                    intent["phase"] = "stopped"
-                elif code:
-                    unresolved.append(code)
-
-            if unresolved:
-                code = "PROCESS_IDENTITY_MISMATCH" if "PROCESS_IDENTITY_MISMATCH" in unresolved else unresolved[0]
-                manifest["lifecycle_state"] = "cleanup-incomplete"
-                manifest["error"] = {"code": code, "message": "owned process cleanup could not be proved"}
-                manifest["next_command"] = "stop %s" % run_id
-                mutation.persist("cleanup-incomplete")
-                mutation.finish()
-                return manifest, 1
-
-            manifest["lifecycle_state"] = "stopped"
-            manifest["error"] = None
-            manifest["next_command"] = "status %s" % run_id
-            mutation.persist("stopped")
-            runtime = mutation.run_dir / "runtime"
-            if runtime.exists():
-                shutil.rmtree(str(runtime))
-                fsync_directory(mutation.run_dir)
+            manifest, status = teardown_phases(mutation, source, "stopped")
             mutation.finish()
-            return manifest, 0
+            return manifest, status
     except PlaygroundError as error:
         current = read_manifest(root, run_id)
         current["_operation_error"] = {"code": error.code, "message": error.message}
@@ -2741,7 +3556,7 @@ def stop_run(root: Path, run_id: str) -> Tuple[Dict[str, Any], int]:
 def command_stop(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     root = state_root(source)
     try:
-        manifest, status = stop_run(root, arguments.run_id)
+        manifest, status = stop_run(root, arguments.run_id, source)
     except PlaygroundError as error:
         return error_result(error)
     operation_error = manifest.pop("_operation_error", None)
@@ -2790,6 +3605,13 @@ def command_view(arguments: argparse.Namespace, source: Dict[str, str]) -> int:
     root = state_root(source)
     try:
         manifest = read_manifest(root, arguments.run_id)
+        if manifest.get("remote") and manifest["lifecycle_state"] in ("active-ready", "active-degraded"):
+            # view acquires the run lease and persists any resulting
+            # degradation before attaching.
+            with Mutation(root, arguments.run_id) as mutation:
+                probe_remote_observation(mutation, source)
+                mutation.finish()
+            manifest = read_manifest(root, arguments.run_id)
     except PlaygroundError as error:
         return error_result(error)
     try:

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -1,0 +1,226 @@
+# Herdr Git status playground Bats harness.
+# Load after helpers/common so SOURCE_ROOT and assertion helpers are available.
+
+HGSP_CONTROLLER="$SOURCE_ROOT/dot_local/bin/executable_herdr-git-status-playground"
+HGSP_PYTHON="$(command -v python3)"
+
+hgsp_teardown() {
+  local run_id manifest
+  if [[ -n "${HGSP_WORK:-}" ]]; then
+    : > "$HGSP_WORK/managed-release"
+    : > "$HGSP_WORK/start-release"
+    : > "$HGSP_WORK/view-release"
+    : > "$HGSP_WORK/atomic-release"
+    : > "$HGSP_WORK/lease-release"
+  fi
+  if [[ -x "$HGSP_CONTROLLER" && -d "${HGSP_STATE_ROOT:-}/runs" ]]; then
+    for manifest in "$HGSP_STATE_ROOT"/runs/*/manifest.json; do
+      [[ -f "$manifest" ]] || continue
+      run_id="${manifest%/manifest.json}"
+      run_id="${run_id##*/}"
+      env PATH="$HGSP_STUB:/bin" \
+        XDG_STATE_HOME="$HGSP_XDG_STATE" \
+        HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
+        HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG="$HGSP_ENV_LOG" \
+        "$HGSP_PYTHON" "$HGSP_CONTROLLER" stop "$run_id" >/dev/null 2>&1 || true
+    done
+  fi
+  if [[ -n "${HGSP_BG_PIDS:-}" ]]; then
+    local pid
+    for pid in $HGSP_BG_PIDS; do
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    done
+  fi
+  [[ -n "${HGSP_WORK:-}" ]] && rm -rf "$HGSP_WORK" || true
+  unset HGSP_WORK HGSP_STUB HGSP_STATE_ROOT HGSP_XDG_STATE HGSP_CALL_LOG
+  unset HGSP_ENV_LOG HGSP_RUN_IDS HGSP_BG_PIDS HGSP_LAST_RUN_ID
+}
+
+hgsp_setup() {
+  [[ -z "${HGSP_WORK:-}" ]] || hgsp_teardown
+  HGSP_WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/hgsp.XXXXXX")"
+  HGSP_STUB="$HGSP_WORK/stub"
+  HGSP_XDG_STATE="$HGSP_WORK/xdg-state"
+  HGSP_STATE_ROOT="$HGSP_XDG_STATE/herdr-git-status-playground"
+  HGSP_CALL_LOG="$HGSP_WORK/calls.log"
+  HGSP_ENV_LOG="$HGSP_WORK/environments.jsonl"
+  HGSP_RUN_IDS=""
+  HGSP_BG_PIDS=""
+  export HGSP_WORK HGSP_STUB HGSP_CALL_LOG
+  mkdir -p "$HGSP_STUB" "$HGSP_XDG_STATE"
+  : > "$HGSP_CALL_LOG"
+  : > "$HGSP_ENV_LOG"
+
+  local tool
+  for tool in cargo git gh jq node; do
+    cat > "$HGSP_STUB/$tool" <<'SH'
+#!/bin/sh
+tool=${0##*/}
+printf '%s|%s\n' "$tool" "$*" >> "$HGSP_CALL_LOG"
+case "$tool:$*" in
+  node:--version) printf 'v20.11.0\n' ;;
+  git:--version) printf 'git version 2.45.0\n' ;;
+  gh:--version) printf 'gh version 2.50.0\n' ;;
+  jq:--version) printf 'jq-1.7\n' ;;
+  cargo:--version) printf 'cargo 1.80.0\n' ;;
+  gh:auth\ status*) exit "${HGSP_GH_AUTH_STATUS:-0}" ;;
+esac
+exit 0
+SH
+    chmod +x "$HGSP_STUB/$tool"
+  done
+  ln -s "$HGSP_PYTHON" "$HGSP_STUB/python3"
+
+  cat > "$HGSP_STUB/herdr" <<'SH'
+#!/bin/sh
+printf 'herdr|%s\n' "$*" >> "$HGSP_CALL_LOG"
+if [ "$1" = --version ]; then
+  printf '%s\n' "${HGSP_HERDR_VERSION:-herdr 0.8.2}"
+  exit 0
+fi
+exit 97
+SH
+  chmod +x "$HGSP_STUB/herdr"
+
+  cat > "$HGSP_STUB/managed-probe" <<'SH'
+#!/bin/sh
+printf 'managed-probe|start|%s\n' "$$" >> "$HGSP_CALL_LOG"
+: > "$HGSP_WORK/managed-ready"
+trap 'printf "managed-probe|TERM|%s\n" "$$" >> "$HGSP_CALL_LOG"; exit 0' TERM INT HUP
+while [ ! -e "$HGSP_WORK/managed-release" ]; do
+  sleep 0.01
+done
+SH
+  chmod +x "$HGSP_STUB/managed-probe"
+
+  cat > "$HGSP_WORK/fixture-ownership.json" <<'JSON'
+{"host":"github.com","owner":"example","name":"herdr-status-fixtures","repository_id":"R_fixture_1","owned":true}
+JSON
+  cat > "$HGSP_WORK/audit-attestation.json" <<'JSON'
+{"candidates":{"ezcorp":{"revision":"f144c8dac2860e344b6b379d2bcfee229dcf10ad","tree":"tree-ezcorp"},"sfroment":{"revision":"b726977143adc2847dc25e3327bc0b1b4fc26455","tree":"tree-sfroment"},"krystof":{"revision":"fe6575a89de9006c35d9d0b9707397839d983cff","tree":"tree-krystof"},"jmarbutt":{"revision":"8a56c5dce0bd65e47eddc9a1d862ddae870cddc3","tree":"tree-jmarbutt"}}}
+JSON
+  cat > "$HGSP_WORK/inherited-environment.json" <<JSON
+{"DYLD_INSERT_LIBRARIES":"poison","DYLD_LIBRARY_PATH":"poison","LD_PRELOAD":"poison","LD_LIBRARY_PATH":"poison","PYTHONPATH":"poison","PYTHONHOME":"poison","PYTHONSTARTUP":"poison","NODE_OPTIONS":"poison","RUBYOPT":"poison","HTTP_PROXY":"http://credential@proxy","HTTPS_PROXY":"http://credential@proxy","ALL_PROXY":"http://credential@proxy","PATH":"$HGSP_STUB:/bin:$HGSP_WORK/poison-bin"}
+JSON
+  chmod 600 "$HGSP_WORK/fixture-ownership.json" "$HGSP_WORK/audit-attestation.json" \
+    "$HGSP_WORK/inherited-environment.json"
+}
+
+hgsp_env() {
+  env \
+    PATH="$HGSP_STUB:/bin:$HGSP_WORK/poison-bin" \
+    HOME="$HGSP_WORK/live-home" \
+    XDG_CONFIG_HOME="$HGSP_WORK/live-config" \
+    XDG_STATE_HOME="$HGSP_XDG_STATE" \
+    XDG_DATA_HOME="$HGSP_WORK/live-data" \
+    NO_COLOR=safe-control \
+    HERDR_ENV=poison HERDR_SESSION=poison HERDR_SOCKET_PATH="$HGSP_WORK/live.sock" \
+    HERDR_CLIENT_SOCKET_PATH="$HGSP_WORK/live-client.sock" HERDR_CONFIG_PATH="$HGSP_WORK/live-config.toml" \
+    GH_TOKEN=ambient-token GH_REPO=wrong/repo GH_HOST=wrong.example \
+    GITHUB_TOKEN=ambient-github-token GITHUB_REPOSITORY=wrong/repo \
+    SSH_AUTH_SOCK="$HGSP_WORK/agent.sock" GPG_AGENT_INFO=poison \
+    GIT_ASKPASS=poison SSH_ASKPASS=poison GIT_CONFIG_GLOBAL="$HGSP_WORK/live-gitconfig" \
+    HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN=controller-canary \
+    HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN=candidate-canary \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG="$HGSP_ENV_LOG" \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_PARENT_ENV="$HGSP_WORK/inherited-environment.json" \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS="$HGSP_STUB/managed-probe" \
+    "$HGSP_PYTHON" "$HGSP_CONTROLLER" "$@"
+}
+
+hgsp_start_args() {
+  printf '%s\n' \
+    --approved-herdr "$HGSP_STUB/herdr" \
+    --fixture-ownership "$HGSP_WORK/fixture-ownership.json" \
+    --audit-attestation "$HGSP_WORK/audit-attestation.json"
+}
+
+hgsp_start() {
+  local args=()
+  while IFS= read -r value; do args+=("$value"); done < <(hgsp_start_args)
+  hgsp_env start "${args[@]}" "$@"
+}
+
+hgsp_json_field() {
+  local json="$1" field="$2"
+  "$HGSP_PYTHON" -c 'import json,sys; value=json.loads(sys.argv[1]);
+for part in sys.argv[2].split("."): value=value[part]
+print("true" if value is True else "false" if value is False else value)' "$json" "$field"
+}
+
+hgsp_capture_run_id() {
+  HGSP_LAST_RUN_ID="$(hgsp_json_field "$output" run_id)"
+  HGSP_RUN_IDS="$HGSP_RUN_IDS $HGSP_LAST_RUN_ID"
+}
+
+hgsp_manifest() {
+  printf '%s/runs/%s/manifest.json\n' "$HGSP_STATE_ROOT" "$1"
+}
+
+hgsp_wait_for_file() {
+  local file="$1" attempts="${2:-500}"
+  while (( attempts > 0 )); do
+    [[ -e "$file" ]] && return 0
+    attempts=$((attempts - 1))
+    sleep 0.01
+  done
+  fail "timed out waiting for causal marker $file"
+}
+
+hgsp_assert_no_launch_or_mutation() {
+  run grep -E '^(managed-probe|gh\|api|gh\|pr|gh\|workflow|git\|push)' "$HGSP_CALL_LOG"
+  assert_failure
+}
+
+hgsp_patch_manifest() {
+  local run_id="$1" expression="$2"
+  "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$expression" <<'PY'
+import json
+import os
+import sys
+
+path, expression = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+exec(expression, {"manifest": manifest})
+temporary = path + ".fixture"
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(manifest, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.replace(temporary, path)
+PY
+}
+
+hgsp_set_manifest_lease() {
+  local run_id="$1" pid="$2" start_identity="$3"
+  "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$pid" "$start_identity" <<'PY'
+import json
+import os
+import sys
+
+path, pid, start_identity = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+manifest["mutation_lease"] = {
+    "owner_id": "fixture",
+    "pid": int(pid),
+    "start_identity": start_identity,
+    "claimed_at": "1970-01-01T00:00:00Z",
+}
+temporary = path + ".fixture"
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(manifest, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.replace(temporary, path)
+PY
+}
+
+hgsp_process_start_identity() {
+  "$HGSP_PYTHON" - "$1" <<'PY'
+import subprocess
+import sys
+print(subprocess.check_output(["ps", "-o", "lstart=", "-p", sys.argv[1]], text=True).strip())
+PY
+}

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -52,8 +52,28 @@ hgsp_setup() {
   : > "$HGSP_CALL_LOG"
   : > "$HGSP_ENV_LOG"
 
+  # Fixture construction needs real Git behavior; the stub answers preflight's
+  # --version probe itself and delegates fixture operations (identified by the
+  # fixtures environment's GIT_CEILING_DIRECTORIES) to the real binary, logging
+  # them under a distinct prefix so mutation-guard greps stay meaningful.
+  local real_git
+  real_git="$(command -v git)"
+  cat > "$HGSP_STUB/git" <<SH
+#!/bin/sh
+if [ -n "\${GIT_CEILING_DIRECTORIES:-}" ]; then
+  printf 'git-fixture|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+  exec "$real_git" "\$@"
+fi
+printf 'git|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+case "\$1" in
+  --version) printf 'git version 2.45.0\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$HGSP_STUB/git"
+
   local tool
-  for tool in cargo git gh jq node; do
+  for tool in cargo gh jq node; do
     cat > "$HGSP_STUB/$tool" <<'SH'
 #!/bin/sh
 tool=${0##*/}

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -135,6 +135,15 @@ SH
   cat > "$HGSP_STUB/gh" <<SH
 #!/bin/sh
 printf 'gh|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+if [ "\$1" = api ] && [ -n "\${HGSP_GH_API_FAIL:-}" ] && [ "\$GH_TOKEN" = candidate-canary ]; then
+  # F4 redaction knob: model a candidate-activation `gh api` call (scoped to
+  # the candidate token, never the controller token) that fails and echoes
+  # the credential it was handed into its own diagnostic stderr, so a
+  # regression test can prove the failure never reaches manifest.json
+  # unredacted (KTD17).
+  printf 'gh: api request failed for token %s\n' "\${GH_TOKEN:-}" >&2
+  exit 1
+fi
 if [ "\$1" = api ] && [ -f "\${0%/*}/gh-api-sim.py" ]; then
   exec "$HGSP_PYTHON" "\${0%/*}/gh-api-sim.py" "\$@"
 fi
@@ -169,6 +178,14 @@ case "\$profile" in
   *) profile=controller ;;
 esac
 printf 'herdr|%s|%s\n' "\$profile" "\$*" >> "\$HGSP_CALL_LOG"
+# F2 subprocess-timeout knob: sleep past the injected test-mode timeout
+# instead of returning, so a regression test can prove a hung herdr call
+# resolves through the timeout diagnostic rather than blocking forever.
+if [ -n "\${HGSP_HERDR_HANG_ARGS:-}" ]; then
+  case " \$* " in
+    *" \$HGSP_HERDR_HANG_ARGS "*) sleep "\${HGSP_HERDR_HANG_SECONDS:-5}" ;;
+  esac
+fi
 if [ "\$1" = --version ]; then
   printf '%s\n' "\${HGSP_HERDR_VERSION:-herdr 0.8.2}"
   exit 0

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -36,6 +36,7 @@ hgsp_teardown() {
   [[ -n "${HGSP_WORK:-}" ]] && rm -rf "$HGSP_WORK" || true
   unset HGSP_WORK HGSP_STUB HGSP_STATE_ROOT HGSP_XDG_STATE HGSP_CALL_LOG
   unset HGSP_ENV_LOG HGSP_RUN_IDS HGSP_BG_PIDS HGSP_LAST_RUN_ID HGSP_REMOTE_GIT
+  unset HGSP_BYSTANDER_PID
 }
 
 hgsp_setup() {
@@ -125,16 +126,451 @@ SH
   chmod +x "$HGSP_STUB/gh"
   ln -s "$HGSP_PYTHON" "$HGSP_STUB/python3"
 
-  cat > "$HGSP_STUB/herdr" <<'SH'
+  # Herdr stub: `--version` and the long-running `server run` stay in shell so
+  # the controller-owned server process image keeps the stub path in its
+  # command line; every other subcommand runs the stateful profile simulator.
+  cat > "$HGSP_STUB/herdr" <<SH
 #!/bin/sh
-printf 'herdr|%s\n' "$*" >> "$HGSP_CALL_LOG"
-if [ "$1" = --version ]; then
-  printf '%s\n' "${HGSP_HERDR_VERSION:-herdr 0.8.2}"
+profile="\${XDG_STATE_HOME:-}"
+case "\$profile" in
+  */runtime/profiles/*/state) profile="\${profile%/state}"; profile="\${profile##*/}" ;;
+  *) profile=controller ;;
+esac
+printf 'herdr|%s|%s\n' "\$profile" "\$*" >> "\$HGSP_CALL_LOG"
+if [ "\$1" = --version ]; then
+  printf '%s\n' "\${HGSP_HERDR_VERSION:-herdr 0.8.2}"
   exit 0
 fi
-exit 97
+if [ "\$1" = server ] && [ "\$2" = run ]; then
+  state="\$XDG_STATE_HOME/herdr"
+  mkdir -p "\$state"
+  : > "\$state/session.sock"
+  trap 'rm -f "\$state/session.sock"; exit 0' TERM INT HUP
+  while [ -d "\$state" ]; do sleep 0.05; done
+  rm -f "\$state/session.sock" 2>/dev/null
+  exit 0
+fi
+exec "$HGSP_PYTHON" "$HGSP_STUB/herdr-sim.py" "\$@"
 SH
   chmod +x "$HGSP_STUB/herdr"
+
+  cat > "$HGSP_STUB/plugin-daemon.py" <<'PY'
+"""Detached plugin daemon model: writes its own PID record and state file,
+then idles until its profile state directory (or, for jmarbutt, the profile
+socket) disappears. Spawned with start_new_session so pgid == pid."""
+import fcntl
+import json
+import os
+import signal
+import sys
+import time
+
+
+def locked_update(path, mutate):
+    with open(path, "r+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        value = json.load(handle)
+        mutate(value)
+        handle.seek(0)
+        handle.truncate()
+        json.dump(value, handle)
+        handle.write("\n")
+
+
+def main():
+    role, state_dir, socket_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+    # Model a plugin that drops the injected XDG variables: resolution falls
+    # back to HOME, which the guarded child environment points at the profile.
+    probe_environment = dict(os.environ)
+    for name in ("XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_DATA_HOME"):
+        probe_environment.pop(name, None)
+    resolved_home_root = os.path.join(probe_environment.get("HOME", os.path.expanduser("~")), ".config", "herdr")
+
+    plugin_dirs = {
+        "ezcorp": "plugins/ez-corp.git-status",
+        "krystof": "plugins/gitlab-ci-status",
+        "jmarbutt": "plugins/jmarbutt.spaces-pr-status",
+    }
+    records = {"ezcorp": "updater.pid", "krystof": "poller.pid", "jmarbutt": "daemon.json"}
+    plugin_dir = os.path.join(state_dir, plugin_dirs[role])
+    os.makedirs(plugin_dir, exist_ok=True)
+    pid = os.getpid()
+    record_path = os.path.join(plugin_dir, records[role])
+    with open(record_path, "w", encoding="utf-8") as handle:
+        if role == "jmarbutt":
+            json.dump({"pid": pid}, handle)
+            handle.write("\n")
+        else:
+            handle.write("%d\n" % pid)
+
+    state = {
+        "pid": pid,
+        "executable": os.path.realpath(__file__),
+        "socket": socket_path,
+        "resolved_home_root": resolved_home_root,
+        "role": role,
+    }
+    spaces_path = os.path.join(state_dir, "spaces.json")
+    if role == "ezcorp":
+        spaces = []
+        try:
+            with open(spaces_path, encoding="utf-8") as handle:
+                spaces = json.load(handle)
+        except (OSError, ValueError):
+            spaces = []
+        omitted = os.environ.get("HGSP_EZCORP_OMIT_SPACE")
+        state["spaces"] = [
+            entry["label"]
+            for entry in spaces
+            if not entry.get("worktree_child") and entry["label"] != omitted
+        ]
+        state["metadata_complete"] = True
+    if role == "krystof":
+        def decorate(spaces):
+            for entry in spaces:
+                if not entry["label_text"].endswith(" •ci"):
+                    entry["label_text"] = entry["label_text"] + " •ci"
+        try:
+            locked_update(spaces_path, decorate)
+        except (OSError, ValueError):
+            pass
+    with open(os.path.join(plugin_dir, "state.json"), "w", encoding="utf-8") as handle:
+        json.dump(state, handle)
+        handle.write("\n")
+
+    while os.path.isdir(state_dir):
+        if (
+            role == "jmarbutt"
+            and not os.environ.get("HGSP_JMARBUTT_STUCK")
+            and not os.path.exists(socket_path)
+        ):
+            break
+        time.sleep(0.05)
+
+
+main()
+PY
+
+  cat > "$HGSP_STUB/herdr-sim.py" <<'PY'
+"""Stateful Herdr profile simulator: plugin registry, spaces, labels, tokens,
+sidebar snapshots, and native plugin actions with their real hazards (a
+liveness-only PID record that native paths signal blindly)."""
+import fcntl
+import json
+import os
+import subprocess
+import sys
+import time
+
+STATE_DIR = os.path.join(os.environ.get("XDG_STATE_HOME", ""), "herdr")
+DATA_DIR = os.path.join(os.environ.get("XDG_DATA_HOME", ""), "herdr")
+CONFIG = os.path.join(os.environ.get("XDG_CONFIG_HOME", ""), "herdr", "config.toml")
+SOCKET = os.path.join(STATE_DIR, "session.sock")
+SPACES = os.path.join(STATE_DIR, "spaces.json")
+REGISTRY = os.path.join(DATA_DIR, "plugins", "registry.json")
+TREES = {
+    "ez-corp.git-status": "tree-ezcorp",
+    "git-detail": "tree-sfroment",
+    "gitlab-ci-status": "tree-krystof",
+    "jmarbutt.spaces-pr-status": "tree-jmarbutt",
+}
+PID_RECORDS = {
+    "ez-corp.git-status": "updater.pid",
+    "gitlab-ci-status": "poller.pid",
+    "jmarbutt.spaces-pr-status": "daemon.json",
+}
+DAEMON_ROLES = {
+    "ez-corp.git-status": "ezcorp",
+    "gitlab-ci-status": "krystof",
+    "jmarbutt.spaces-pr-status": "jmarbutt",
+}
+
+GIT_DETAIL_SCRIPT = r'''#!/bin/sh
+mode="${1:-watch}"
+state_dir="$XDG_STATE_HOME/herdr"
+if [ "$mode" = watch ]; then
+  trap 'exit 0' TERM INT HUP
+  if [ "${HGSP_GIT_DETAIL_MODE:-}" = leak ]; then
+    ( trap '' TERM; while [ -d "$state_dir" ]; do sleep 0.05; done ) &
+  fi
+  while [ -d "$state_dir" ]; do sleep 0.05; done
+  exit 0
+fi
+knob="${HGSP_GIT_DETAIL_MODE:-ok}"
+if [ "$knob" = early-exit ]; then exit 0; fi
+tab="$(printf '\t')"
+herdr space list --plain | while IFS="$tab" read -r label cwd; do
+  [ -n "$label" ] || continue
+  herdr pane cwd "$label" >/dev/null || continue
+  [ "$knob" = silent ] && continue
+  porcelain="$(GIT_CEILING_DIRECTORIES="${HGSP_WORK:-/}" git -C "$cwd" status --porcelain 2>/dev/null)" || continue
+  staged="$(printf '%s\n' "$porcelain" | grep -c '^[MADRC].')" || true
+  unstaged="$(printf '%s\n' "$porcelain" | grep -c '^.[MD]')" || true
+  untracked="$(printf '%s\n' "$porcelain" | grep -c '^??')" || true
+  value="git_detail=staged:$staged unstaged:$unstaged untracked:$untracked"
+  if [ "$knob" = swallow ]; then
+    herdr pane publish --inject-fail "$label" "$value" 2>/dev/null || true
+    continue
+  fi
+  herdr pane publish "$label" "$value"
+done
+exit 0
+'''
+
+
+def log(line):
+    path = os.environ.get("HGSP_CALL_LOG")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def fail(message, status=1):
+    sys.stderr.write("herdr: %s\n" % message)
+    raise SystemExit(status)
+
+
+def require_server():
+    if not os.path.exists(SOCKET):
+        fail("no running server for this profile (socket missing)")
+
+
+def load_json(path, default):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return default
+
+
+def save_json(path, value):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(value, handle)
+        handle.write("\n")
+
+
+def native_signal_record(plugin_id):
+    """The modelled hazard: native lifecycle paths trust a liveness-only PID
+    record and signal whatever process it names."""
+    record = os.path.join(STATE_DIR, "plugins", plugin_id, PID_RECORDS[plugin_id])
+    if not os.path.exists(record):
+        return
+    try:
+        with open(record, encoding="utf-8") as handle:
+            contents = handle.read().strip()
+        pid = json.loads(contents)["pid"] if contents.startswith("{") else int(contents)
+    except (OSError, ValueError, KeyError):
+        return
+    log("herdr-native-signal|%s|%s" % (plugin_id, pid))
+    try:
+        os.kill(int(pid), 15)
+    except (OSError, ProcessLookupError, PermissionError):
+        pass
+
+
+def spawn_daemon(plugin_id):
+    role = DAEMON_ROLES[plugin_id]
+    daemon = os.path.join(os.path.dirname(os.path.realpath(__file__)), "plugin-daemon.py")
+    with open(os.devnull, "rb") as null_in, open(os.devnull, "wb") as null_out:
+        subprocess.Popen(
+            [sys.executable, daemon, role, STATE_DIR, SOCKET],
+            stdin=null_in,
+            stdout=null_out,
+            stderr=null_out,
+            start_new_session=True,
+            close_fds=True,
+        )
+    state_path = os.path.join(STATE_DIR, "plugins", plugin_id, "state.json")
+    for _ in range(500):
+        if os.path.exists(state_path):
+            return
+        time.sleep(0.01)
+    fail("the %s daemon never registered" % plugin_id)
+
+
+def plugin_run(plugin_id, action):
+    injected = os.environ.get("HGSP_PLUGIN_FAIL", "")
+    if injected == "%s:%s" % (plugin_id, action):
+        fail("injected %s %s failure" % (plugin_id, action))
+    if plugin_id == "ez-corp.git-status" and action == "status-enable":
+        require_server()
+        native_signal_record(plugin_id)
+        if os.environ.get("HGSP_EZCORP_NO_DAEMON"):
+            return
+        spawn_daemon(plugin_id)
+        return
+    if plugin_id == "ez-corp.git-status" and action in ("status-disable", "metadata-cleanup"):
+        native_signal_record(plugin_id)
+        state_path = os.path.join(STATE_DIR, "plugins", plugin_id, "state.json")
+        try:
+            os.unlink(state_path)
+        except FileNotFoundError:
+            pass
+        return
+    if plugin_id == "gitlab-ci-status" and action == "start":
+        require_server()
+        if not load_json(SPACES, []):
+            fail("gitlab-ci-status start requires existing spaces")
+        native_signal_record(plugin_id)
+        spawn_daemon(plugin_id)
+        return
+    if plugin_id == "gitlab-ci-status" and action == "stop":
+        native_signal_record(plugin_id)
+        return
+    if plugin_id == "jmarbutt.spaces-pr-status" and action == "startup":
+        require_server()
+        native_signal_record(plugin_id)
+        spawn_daemon(plugin_id)
+        return
+    if plugin_id == "jmarbutt.spaces-pr-status" and action == "refresh":
+        require_server()
+        if not load_json(SPACES, []):
+            fail("refresh requires existing spaces")
+        record = load_json(os.path.join(STATE_DIR, "plugins", plugin_id, "daemon.json"), {})
+        pid = record.get("pid")
+        alive = False
+        if isinstance(pid, int):
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except (OSError, ProcessLookupError, PermissionError):
+                alive = False
+        if not alive:
+            fail("refresh requires a live daemon")
+        state_path = os.path.join(STATE_DIR, "plugins", plugin_id, "state.json")
+        state = load_json(state_path, {})
+        state["refreshed"] = True
+        state["refreshed_at"] = time.time()
+        save_json(state_path, state)
+        return
+    fail("unsupported plugin action %s %s" % (plugin_id, action))
+
+
+def main():
+    args = sys.argv[1:]
+    if args[:2] == ["plugin", "fetch"]:
+        plugin_id = args[2]
+        revision = args[args.index("--revision") + 1]
+        print(json.dumps({"plugin_id": plugin_id, "revision": revision, "tree": TREES.get(plugin_id, "")}))
+        return
+    if args[:2] == ["plugin", "install"]:
+        plugin_id = args[2]
+        revision = args[args.index("--revision") + 1]
+        registry = load_json(REGISTRY, [])
+        if any(entry["plugin_id"] == plugin_id for entry in registry):
+            fail("plugin %s is already installed" % plugin_id)
+        registry.append({"plugin_id": plugin_id, "revision": revision, "enabled": "--disabled" not in args})
+        save_json(REGISTRY, registry)
+        if plugin_id == "git-detail":
+            script = os.path.join(DATA_DIR, "plugins", "git-detail", "git-detail.sh")
+            os.makedirs(os.path.dirname(script), exist_ok=True)
+            with open(script, "w", encoding="utf-8") as handle:
+                handle.write(GIT_DETAIL_SCRIPT)
+            os.chmod(script, 0o700)
+        planted = os.environ.get("HGSP_PLANT_STALE_PID")
+        if planted and plugin_id in PID_RECORDS:
+            record = os.path.join(STATE_DIR, "plugins", plugin_id, PID_RECORDS[plugin_id])
+            os.makedirs(os.path.dirname(record), exist_ok=True)
+            with open(record, "w", encoding="utf-8") as handle:
+                if record.endswith(".json"):
+                    json.dump({"pid": int(planted)}, handle)
+                    handle.write("\n")
+                else:
+                    handle.write("%s\n" % planted)
+            log("herdr-stale-planted|%s|%s" % (plugin_id, planted))
+        return
+    if args[:2] == ["plugin", "registry"]:
+        print(json.dumps(load_json(REGISTRY, [])))
+        return
+    if args[:2] == ["plugin", "enable"]:
+        require_server()
+        registry = load_json(REGISTRY, [])
+        for entry in registry:
+            if entry["plugin_id"] == args[2]:
+                entry["enabled"] = True
+                save_json(REGISTRY, registry)
+                return
+        fail("plugin %s is not installed" % args[2])
+    if args[:2] == ["plugin", "run"]:
+        plugin_run(args[2], args[3])
+        return
+    if args[:2] == ["space", "create"]:
+        require_server()
+        label = args[2]
+        cwd = args[args.index("--cwd") + 1]
+        spaces = load_json(SPACES, [])
+        spaces.append(
+            {
+                "label": label,
+                "label_text": label,
+                "cwd": cwd,
+                "worktree_child": "--worktree-child" in args,
+                "tokens": {},
+            }
+        )
+        save_json(SPACES, spaces)
+        return
+    if args[:2] == ["space", "list"]:
+        require_server()
+        spaces = load_json(SPACES, [])
+        if "--plain" in args:
+            for entry in spaces:
+                sys.stdout.write("%s\t%s\n" % (entry["label"], entry["cwd"]))
+        else:
+            print(json.dumps(spaces))
+        return
+    if args[:3] == ["space", "label", "set"]:
+        require_server()
+        spaces = load_json(SPACES, [])
+        for entry in spaces:
+            if entry["label"] == args[3]:
+                entry["label_text"] = args[4]
+                save_json(SPACES, spaces)
+                return
+        fail("no space labelled %s" % args[3])
+    if args[:2] == ["pane", "cwd"]:
+        require_server()
+        for entry in load_json(SPACES, []):
+            if entry["label"] == args[2]:
+                print(entry["cwd"])
+                return
+        fail("no space labelled %s" % args[2])
+    if args[:2] == ["pane", "publish"]:
+        require_server()
+        rest = args[2:]
+        if rest and rest[0] == "--inject-fail":
+            fail("injected publication failure")
+        label = rest[0]
+        spaces = load_json(SPACES, [])
+        for entry in spaces:
+            if entry["label"] == label:
+                for pair in rest[1:]:
+                    key, _, value = pair.partition("=")
+                    entry["tokens"][key] = value
+                save_json(SPACES, spaces)
+                return
+        fail("no space labelled %s" % label)
+    if args[:2] == ["sidebar", "snapshot"]:
+        require_server()
+        try:
+            with open(CONFIG, encoding="utf-8") as handle:
+                lines = handle.read().splitlines()
+        except OSError:
+            fail("no sidebar configuration")
+        for line in lines:
+            if line.startswith('sidebar_row = "'):
+                sys.stdout.write(line[len('sidebar_row = "'):-1] + "\n")
+        return
+    if args[:2] == ["config", "reload"]:
+        require_server()
+        return
+    fail("unsupported herdr invocation: %r" % (args,), 97)
+
+
+main()
+PY
 
   cat > "$HGSP_STUB/managed-probe" <<'SH'
 #!/bin/sh
@@ -151,7 +587,7 @@ SH
 {"host":"github.com","owner":"example","name":"herdr-status-fixtures","repository_id":"R_fixture_1","owned":true}
 JSON
   cat > "$HGSP_WORK/audit-attestation.json" <<'JSON'
-{"candidates":{"ezcorp":{"revision":"f144c8dac2860e344b6b379d2bcfee229dcf10ad","tree":"tree-ezcorp"},"sfroment":{"revision":"b726977143adc2847dc25e3327bc0b1b4fc26455","tree":"tree-sfroment"},"krystof":{"revision":"fe6575a89de9006c35d9d0b9707397839d983cff","tree":"tree-krystof"},"jmarbutt":{"revision":"8a56c5dce0bd65e47eddc9a1d862ddae870cddc3","tree":"tree-jmarbutt"}}}
+{"candidates":{"ezcorp":{"revision":"f144c8dac2860e344b6b379d2bcfee229dcf10ad","tree":"tree-ezcorp","approved":true},"sfroment":{"revision":"b726977143adc2847dc25e3327bc0b1b4fc26455","tree":"tree-sfroment","approved":true},"krystof":{"revision":"fe6575a89de9006c35d9d0b9707397839d983cff","tree":"tree-krystof","approved":true},"jmarbutt":{"revision":"8a56c5dce0bd65e47eddc9a1d862ddae870cddc3","tree":"tree-jmarbutt","approved":true}}}
 JSON
   cat > "$HGSP_WORK/inherited-environment.json" <<JSON
 {"DYLD_INSERT_LIBRARIES":"poison","DYLD_LIBRARY_PATH":"poison","LD_PRELOAD":"poison","LD_LIBRARY_PATH":"poison","PYTHONPATH":"poison","PYTHONHOME":"poison","PYTHONSTARTUP":"poison","NODE_OPTIONS":"poison","RUBYOPT":"poison","HTTP_PROXY":"http://credential@proxy","HTTPS_PROXY":"http://credential@proxy","ALL_PROXY":"http://credential@proxy","PATH":"$HGSP_STUB:/bin:$HGSP_WORK/poison-bin"}
@@ -179,8 +615,27 @@ hgsp_env() {
     HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
     HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG="$HGSP_ENV_LOG" \
     HERDR_GIT_STATUS_PLAYGROUND_TEST_PARENT_ENV="$HGSP_WORK/inherited-environment.json" \
-    HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS="$HGSP_STUB/managed-probe" \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_PROCESS="${HGSP_TEST_PROCESS-$HGSP_STUB/managed-probe}" \
     "$HGSP_PYTHON" "$HGSP_CONTROLLER" "$@"
+}
+
+# Run the real candidate lifecycle instead of the U1 foundation test process.
+hgsp_candidate_start() {
+  HGSP_TEST_PROCESS= hgsp_start "$@"
+}
+
+hgsp_profile_root() {
+  printf '%s/runs/%s/runtime/profiles/%s\n' "$HGSP_STATE_ROOT" "$1" "$2"
+}
+
+# A live process no playground run owns; regressions that signal it kill it.
+# It leads its own process group so that a forged plugin record passes every
+# liveness-shaped check and only real identity agreement can reject it.
+hgsp_start_bystander() {
+  "$HGSP_PYTHON" -c 'import os,time; os.setsid(); time.sleep(600)' \
+    </dev/null >/dev/null 2>&1 3>&- &
+  HGSP_BYSTANDER_PID=$!
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $HGSP_BYSTANDER_PID"
 }
 
 hgsp_start_args() {

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -119,7 +119,16 @@ if [ "\$1" = api ] && [ -f "\${0%/*}/gh-api-sim.py" ]; then
 fi
 case "\$*" in
   --version) printf 'gh version 2.50.0\n' ;;
-  auth\ status*) exit "\${HGSP_GH_AUTH_STATUS:-0}" ;;
+  auth\ status*)
+    if [ -n "\${HGSP_LEAK_TOKEN_IN_STDERR:-}" ]; then
+      # Models a real-world hazard: a CLI that echoes the credential it was
+      # just handed into its own diagnostic stderr on failure. Proves the
+      # controller's redaction scrubs the value wherever it surfaces, not
+      # just in fields it deliberately writes (KTD17).
+      printf 'gh: authentication failed for token %s\n' "\${GH_TOKEN:-}" >&2
+    fi
+    exit "\${HGSP_GH_AUTH_STATUS:-0}"
+    ;;
 esac
 exit 0
 SH

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -34,7 +34,7 @@ hgsp_teardown() {
   fi
   [[ -n "${HGSP_WORK:-}" ]] && rm -rf "$HGSP_WORK" || true
   unset HGSP_WORK HGSP_STUB HGSP_STATE_ROOT HGSP_XDG_STATE HGSP_CALL_LOG
-  unset HGSP_ENV_LOG HGSP_RUN_IDS HGSP_BG_PIDS HGSP_LAST_RUN_ID
+  unset HGSP_ENV_LOG HGSP_RUN_IDS HGSP_BG_PIDS HGSP_LAST_RUN_ID HGSP_REMOTE_GIT
 }
 
 hgsp_setup() {
@@ -56,6 +56,10 @@ hgsp_setup() {
   # --version probe itself and delegates fixture operations (identified by the
   # fixtures environment's GIT_CEILING_DIRECTORIES) to the real binary, logging
   # them under a distinct prefix so mutation-guard greps stay meaningful.
+  # Once hgsp_github_setup installs the remote simulator, controller commands
+  # that address an https remote are routed through it (the `git|` prefix keeps
+  # mutation-guard greps meaningful) while purely local plumbing runs the real
+  # binary under the separate `git-local|` prefix.
   local real_git
   real_git="$(command -v git)"
   cat > "$HGSP_STUB/git" <<SH
@@ -64,10 +68,22 @@ if [ -n "\${GIT_CEILING_DIRECTORIES:-}" ]; then
   printf 'git-fixture|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
   exec "$real_git" "\$@"
 fi
+if [ "\$1" = --version ]; then
+  printf 'git|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+  printf 'git version 2.45.0\n'
+  exit 0
+fi
+if [ -f "\${0%/*}/git-remote-sim.py" ]; then
+  case " \$* " in
+    *" https://"*)
+      printf 'git|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+      exec "$HGSP_PYTHON" "\${0%/*}/git-remote-sim.py" "\$@"
+      ;;
+  esac
+  printf 'git-local|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+  exec "$real_git" "\$@"
+fi
 printf 'git|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
-case "\$1" in
-  --version) printf 'git version 2.45.0\n'; exit 0 ;;
-esac
 exit 0
 SH
   chmod +x "$HGSP_STUB/git"
@@ -90,6 +106,22 @@ exit 0
 SH
     chmod +x "$HGSP_STUB/$tool"
   done
+
+  # gh answers preflight probes itself; once hgsp_github_setup installs the API
+  # simulator, `gh api` calls run against the shared stateful GitHub model.
+  cat > "$HGSP_STUB/gh" <<SH
+#!/bin/sh
+printf 'gh|%s\n' "\$*" >> "\$HGSP_CALL_LOG"
+if [ "\$1" = api ] && [ -f "\${0%/*}/gh-api-sim.py" ]; then
+  exec "$HGSP_PYTHON" "\${0%/*}/gh-api-sim.py" "\$@"
+fi
+case "\$*" in
+  --version) printf 'gh version 2.50.0\n' ;;
+  auth\ status*) exit "\${HGSP_GH_AUTH_STATUS:-0}" ;;
+esac
+exit 0
+SH
+  chmod +x "$HGSP_STUB/gh"
   ln -s "$HGSP_PYTHON" "$HGSP_STUB/python3"
 
   cat > "$HGSP_STUB/herdr" <<'SH'
@@ -141,7 +173,7 @@ hgsp_env() {
     GITHUB_TOKEN=ambient-github-token GITHUB_REPOSITORY=wrong/repo \
     SSH_AUTH_SOCK="$HGSP_WORK/agent.sock" GPG_AGENT_INFO=poison \
     GIT_ASKPASS=poison SSH_ASKPASS=poison GIT_CONFIG_GLOBAL="$HGSP_WORK/live-gitconfig" \
-    HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN=controller-canary \
+    HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN="${HGSP_CONTROLLER_TOKEN:-controller-canary}" \
     HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN=candidate-canary \
     HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
     HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG="$HGSP_ENV_LOG" \
@@ -243,4 +275,524 @@ import subprocess
 import sys
 print(subprocess.check_output(["ps", "-o", "lstart=", "-p", sys.argv[1]], text=True).strip())
 PY
+}
+
+# ---- Stateful GitHub simulation (U3) ------------------------------------
+# The canonical fixture repository is a real local bare repository, so every
+# ref CAS (force-with-lease) uses genuine Git semantics; a JSON state file
+# layers the GitHub-only entities (repository identity, permissions, pull
+# requests, workflow runs, policy) on top of it.
+
+hgsp_real_git() {
+  env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1 \
+    GIT_TERMINAL_PROMPT=0 git "$@"
+}
+
+hgsp_remote_git() {
+  hgsp_real_git --git-dir "$HGSP_REMOTE_GIT" "$@"
+}
+
+hgsp_github_setup() {
+  HGSP_REMOTE_GIT="$HGSP_WORK/remote/fixture.git"
+  export HGSP_REMOTE_GIT
+  mkdir -p "$HGSP_WORK/remote"
+  hgsp_real_git init --quiet --bare --initial-branch=main "$HGSP_REMOTE_GIT"
+  local decoy seed
+  for decoy in decoy-host decoy-repo; do
+    hgsp_real_git init --quiet --bare --initial-branch=main "$HGSP_WORK/remote/$decoy.git"
+  done
+  seed="$(mktemp -d "$HGSP_WORK/seed.XXXXXX")"
+  hgsp_real_git init --quiet --initial-branch=main "$seed"
+  hgsp_real_git -C "$seed" -c user.name=Decoy -c user.email=decoy@example.invalid \
+    commit --quiet --allow-empty -m "decoy baseline"
+  hgsp_real_git -C "$seed" push --quiet "$HGSP_WORK/remote/decoy-host.git" main
+  hgsp_real_git -C "$seed" push --quiet "$HGSP_WORK/remote/decoy-repo.git" main
+  rm -rf "$seed"
+
+  "$HGSP_PYTHON" - "$HGSP_WORK" "$(command -v git)" <<'PY'
+import json
+import os
+import sys
+
+work, real_git = sys.argv[1:]
+
+
+def repository(name, node_id, url):
+    return {
+        "node_id": node_id,
+        "url": url,
+        "git_dir": os.path.join(work, "remote", name),
+        "default_branch": "main",
+        "secrets_total": 0,
+        "environments_total": 0,
+        "actions_enabled": True,
+        "pulls": [],
+        "next_pr_number": 1,
+        "workflow_runs": [],
+        "next_run_id": 9001,
+        "mergeable_settle_polls": 2,
+        "decoy_runs": False,
+    }
+
+
+state = {
+    "real_git": real_git,
+    "tokens": {"controller-canary": "write", "candidate-canary": "read"},
+    "repositories": {
+        "github.com/example/herdr-status-fixtures": repository(
+            "fixture.git", "R_fixture_1", "https://github.com/example/herdr-status-fixtures.git"
+        ),
+        "wrong.example/example/herdr-status-fixtures": repository(
+            "decoy-host.git", "R_decoy_host", "https://wrong.example/example/herdr-status-fixtures.git"
+        ),
+        "github.com/wrong/repo": repository(
+            "decoy-repo.git", "R_decoy_repo", "https://github.com/wrong/repo.git"
+        ),
+    },
+}
+path = os.path.join(work, "github-state.json")
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(state, handle, indent=1)
+    handle.write("\n")
+os.chmod(path, 0o600)
+PY
+
+  cat > "$HGSP_STUB/git-remote-sim.py" <<'PY'
+"""Route controller Git commands addressed to an https remote onto the local
+bare repository behind it, enforcing credential permissions and modelling the
+push-triggered GitHub Actions runs."""
+import fcntl
+import json
+import os
+import subprocess
+import sys
+
+LEASE_REF = "refs/heads/herdr-playground/lease"
+
+
+def log(line):
+    path = os.environ.get("HGSP_CALL_LOG")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def fail(message, status=128):
+    sys.stderr.write("fatal: %s\n" % message)
+    raise SystemExit(status)
+
+
+def credential_token(url):
+    store = None
+    for index in range(int(os.environ.get("GIT_CONFIG_COUNT", "0") or 0)):
+        if os.environ.get("GIT_CONFIG_KEY_%d" % index) == "credential.helper":
+            value = os.environ.get("GIT_CONFIG_VALUE_%d" % index, "")
+            if value.startswith("store --file="):
+                store = value[len("store --file="):]
+    if not store or not os.path.exists(store):
+        return None
+    host = url.split("/")[2]
+    for line in open(store, encoding="utf-8"):
+        line = line.strip()
+        if "@%s/" % host in line:
+            return line.split("://", 1)[1].split("@", 1)[0].split(":", 1)[1]
+    return None
+
+
+def record_push_effects(state, repo, real_git, argv, url):
+    positionals = [argument for argument in argv if not argument.startswith("-")]
+    for refspec in positionals[positionals.index(url) + 1:]:
+        if ":" not in refspec:
+            continue
+        source, ref = refspec.split(":", 1)
+        if not source:
+            log("git-push|%s|deleted" % ref)
+            continue
+        sha = subprocess.check_output(
+            [real_git, "--git-dir", repo["git_dir"], "rev-parse", ref], text=True
+        ).strip()
+        log("git-push|%s|%s" % (ref, sha))
+        if not ref.startswith("refs/heads/herdr-playground/") or ref == LEASE_REF:
+            continue
+        branch = ref[len("refs/heads/"):]
+        conclusion = "failure" if "checks-failed" in branch else "success"
+        runs = repo.setdefault("workflow_runs", [])
+
+        def add(name, head_sha, verdict):
+            runs.append(
+                {
+                    "id": repo["next_run_id"],
+                    "name": name,
+                    "head_branch": branch,
+                    "head_sha": head_sha,
+                    "status": "completed",
+                    "conclusion": verdict,
+                    "event": "push",
+                }
+            )
+            repo["next_run_id"] += 1
+
+        add("herdr-git-status-playground", sha, conclusion)
+        if repo.get("decoy_runs"):
+            flipped = "failure" if conclusion == "success" else "success"
+            add("herdr-git-status-playground-nightly", sha, flipped)
+            add("herdr-git-status-playground", "f" * 40, flipped)
+
+
+def main():
+    argv = sys.argv[1:]
+    work = os.environ.get("HGSP_WORK")
+    if not work:
+        fail("HGSP_WORK is not available to the git remote simulator")
+    with open(os.path.join(work, "github-state.json"), "r+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        state = json.load(handle)
+        real_git = state["real_git"]
+        url = next((argument for argument in argv if argument.startswith("https://")), None)
+        repo = None
+        for key, record in state["repositories"].items():
+            if record["url"] == url:
+                repo_key, repo = key, record
+                break
+        if repo is None:
+            fail("repository not found: %s" % url)
+        subcommand = next(argument for argument in argv if not argument.startswith("-"))
+        token = credential_token(url) or os.environ.get("HGSP_DIRECT_TOKEN")
+        permission = state["tokens"].get(token)
+        log("git-auth|%s|%s|token=%s" % (subcommand, repo_key, token or "-"))
+        if permission is None:
+            fail("authentication required for %s" % url)
+        if subcommand == "push" and permission != "write":
+            fail("write permission to %s denied for read-only credential" % repo_key, 128)
+        rewritten = [repo["git_dir"] if argument == url else argument for argument in argv]
+        completed = subprocess.run([real_git] + rewritten)
+        if completed.returncode == 0 and subcommand == "clone":
+            destination = [argument for argument in argv if not argument.startswith("-")][-1]
+            subprocess.run(
+                [real_git, "-C", destination, "remote", "set-url", "origin", url], check=True
+            )
+        if completed.returncode == 0 and subcommand == "push":
+            record_push_effects(state, repo, real_git, argv, url)
+        handle.seek(0)
+        handle.truncate()
+        json.dump(state, handle)
+        handle.write("\n")
+    raise SystemExit(completed.returncode)
+
+
+main()
+PY
+
+  cat > "$HGSP_STUB/gh-api-sim.py" <<'PY'
+"""Stateful `gh api` simulator over the shared GitHub model."""
+import fcntl
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from urllib.parse import parse_qs
+
+
+def log(line):
+    path = os.environ.get("HGSP_CALL_LOG")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def fail(message):
+    sys.stderr.write("gh: %s\n" % message)
+    raise SystemExit(1)
+
+
+def pr_json(pull):
+    return {
+        "number": pull["number"],
+        "node_id": pull["node_id"],
+        "state": pull["state"],
+        "draft": pull["draft"],
+        "head": {"ref": pull["head_ref"], "sha": pull["head_sha"]},
+        "base": {"ref": pull["base_ref"]},
+        "user": {"login": pull["user"]},
+        "mergeable": pull.get("mergeable"),
+        "mergeable_state": pull.get("mergeable_state", "unknown"),
+    }
+
+
+def isolated_env():
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+        }
+    )
+    return environment
+
+
+def compute_mergeable(real_git, git_dir, base_ref, head_sha):
+    scratch = tempfile.mkdtemp(prefix="hgsp-merge-")
+    environment = isolated_env()
+    try:
+        subprocess.run(
+            [real_git, "clone", "--quiet", git_dir, scratch], env=environment, check=True
+        )
+        subprocess.run(
+            [real_git, "-C", scratch, "checkout", "--quiet", base_ref],
+            env=environment,
+            check=True,
+        )
+        merge = subprocess.run(
+            [
+                real_git, "-C", scratch, "-c", "user.name=sim",
+                "-c", "user.email=sim@example.invalid",
+                "merge", "--no-commit", "--no-ff", head_sha,
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if merge.returncode == 0:
+            return True, "clean"
+        unmerged = subprocess.check_output(
+            [real_git, "-C", scratch, "ls-files", "-u"], env=environment, text=True
+        )
+        return (False, "dirty") if unmerged.strip() else (True, "clean")
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def main():
+    args = sys.argv[1:]
+    if not args or args[0] != "api":
+        fail("unsupported invocation")
+    host = "github.com"
+    fields = {}
+    path = None
+    method = None
+    index = 1
+    while index < len(args):
+        argument = args[index]
+        if argument == "--hostname":
+            host = args[index + 1]
+            index += 2
+        elif argument in ("-f", "-F"):
+            key, _, value = args[index + 1].partition("=")
+            if argument == "-F" and value in ("true", "false"):
+                value = value == "true"
+            fields[key] = value
+            index += 2
+        elif argument in ("--method", "-X"):
+            method = args[index + 1]
+            index += 2
+        else:
+            path = argument
+            index += 1
+    if method is None:
+        method = "POST" if fields else "GET"
+    token = os.environ.get("GH_TOKEN", "")
+    route, _, query = (path or "").partition("?")
+    route = route.strip("/")
+    params = parse_qs(query)
+    log(
+        "gh-sim|method=%s|host=%s|path=%s|token=%s|ghrepo=%s|ghhost=%s"
+        % (
+            method, host, route, token or "-",
+            os.environ.get("GH_REPO", "-"), os.environ.get("GH_HOST", "-"),
+        )
+    )
+    work = os.environ.get("HGSP_WORK")
+    if not work:
+        fail("HGSP_WORK is not available to the gh simulator")
+    with open(os.path.join(work, "github-state.json"), "r+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        state = json.load(handle)
+        permission = state["tokens"].get(token)
+        if permission is None:
+            fail("HTTP 401: authentication failed")
+        parts = route.split("/")
+        if parts[0] != "repos" or len(parts) < 3:
+            fail("HTTP 404: unsupported path %s" % route)
+        repo = state["repositories"].get("%s/%s/%s" % (host, parts[1], parts[2]))
+        if repo is None:
+            fail("HTTP 404: repository %s/%s on %s" % (parts[1], parts[2], host))
+        real_git = state["real_git"]
+        tail = parts[3:]
+        if not tail:
+            out = {
+                "node_id": repo["node_id"],
+                "full_name": "%s/%s" % (parts[1], parts[2]),
+                "default_branch": repo["default_branch"],
+                "permissions": {
+                    "push": permission == "write",
+                    "pull": True,
+                    "admin": permission == "write",
+                },
+            }
+        elif tail == ["actions", "secrets"]:
+            out = {"total_count": repo.get("secrets_total", 0)}
+        elif tail == ["environments"]:
+            out = {"total_count": repo.get("environments_total", 0)}
+        elif tail == ["actions", "permissions"]:
+            out = {"enabled": repo.get("actions_enabled", True), "allowed_actions": "all"}
+        elif tail == ["actions", "runs"]:
+            runs = repo.get("workflow_runs", [])
+            head_sha = params.get("head_sha", [None])[0]
+            if head_sha:
+                runs = [run for run in runs if run["head_sha"] == head_sha]
+            out = {"total_count": len(runs), "workflow_runs": runs}
+        elif tail == ["pulls"] and method == "GET":
+            pulls = repo.get("pulls", [])
+            state_param = params.get("state", ["open"])[0]
+            if state_param != "all":
+                pulls = [pull for pull in pulls if pull["state"] == state_param]
+            head = params.get("head", [None])[0]
+            if head:
+                branch = head.partition(":")[2]
+                pulls = [pull for pull in pulls if pull["head_ref"] == branch]
+            out = [pr_json(pull) for pull in pulls]
+        elif tail == ["pulls"] and method == "POST":
+            if permission != "write":
+                fail("HTTP 403: write permission required")
+            probe = subprocess.run(
+                [
+                    real_git, "--git-dir", repo["git_dir"], "rev-parse",
+                    "refs/heads/%s" % fields["head"],
+                ],
+                env=isolated_env(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if probe.returncode != 0:
+                fail("HTTP 422: head ref %s does not exist" % fields["head"])
+            pull = {
+                "number": repo["next_pr_number"],
+                "node_id": "PR_%s_%d" % (repo["node_id"], repo["next_pr_number"]),
+                "state": "open",
+                "draft": bool(fields.get("draft", False)),
+                "head_ref": fields["head"],
+                "head_sha": probe.stdout.strip(),
+                "base_ref": fields["base"],
+                "user": "playground-controller",
+                "mergeable": None,
+                "mergeable_state": "unknown",
+                "mergeable_polls_remaining": repo.get("mergeable_settle_polls", 2),
+                "title": fields.get("title", ""),
+            }
+            repo["next_pr_number"] += 1
+            repo.setdefault("pulls", []).append(pull)
+            out = pr_json(pull)
+        elif len(tail) == 2 and tail[0] == "pulls":
+            number = int(tail[1])
+            pull = next(
+                (entry for entry in repo.get("pulls", []) if entry["number"] == number), None
+            )
+            if pull is None:
+                fail("HTTP 404: pull %d" % number)
+            if pull.get("mergeable") is None:
+                remaining = pull.get("mergeable_polls_remaining", 0)
+                if remaining > 0:
+                    pull["mergeable_polls_remaining"] = remaining - 1
+                else:
+                    mergeable, mergeable_state = compute_mergeable(
+                        real_git, repo["git_dir"], pull["base_ref"], pull["head_sha"]
+                    )
+                    pull["mergeable"] = mergeable
+                    pull["mergeable_state"] = mergeable_state
+            out = pr_json(pull)
+        else:
+            fail("HTTP 404: unsupported path %s" % route)
+        handle.seek(0)
+        handle.truncate()
+        json.dump(state, handle)
+        handle.write("\n")
+    print(json.dumps(out))
+
+
+main()
+PY
+}
+
+hgsp_bootstrap() {
+  hgsp_env bootstrap --fixture-ownership "$HGSP_WORK/fixture-ownership.json" "$@"
+}
+
+hgsp_initialize() {
+  hgsp_bootstrap --initialize "$@"
+}
+
+hgsp_patch_github_state() {
+  "$HGSP_PYTHON" - "$HGSP_WORK/github-state.json" "$1" <<'PY'
+import json
+import os
+import sys
+
+path, expression = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    state = json.load(handle)
+exec(expression, {"state": state, "repo": state["repositories"]["github.com/example/herdr-status-fixtures"]})
+temporary = path + ".patch"
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(state, handle)
+    handle.write("\n")
+os.replace(temporary, path)
+PY
+}
+
+hgsp_github_query() {
+  "$HGSP_PYTHON" - "$HGSP_WORK/github-state.json" "$1" <<'PY'
+import json
+import sys
+
+path, expression = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    state = json.load(handle)
+value = eval(expression, {"state": state, "repo": state["repositories"]["github.com/example/herdr-status-fixtures"]})
+print("true" if value is True else "false" if value is False else value)
+PY
+}
+
+hgsp_repo_record() {
+  printf '%s/repository/github.com/example/herdr-status-fixtures/repository.json\n' "$HGSP_STATE_ROOT"
+}
+
+hgsp_record_field() {
+  hgsp_json_field "$(cat "$(hgsp_repo_record)")" "$1"
+}
+
+# Rewrite one file on the remote default branch through real Git, bypassing
+# the simulator, to model drift performed outside the controller.
+hgsp_rewrite_default_file() {
+  local file="$1" scratch
+  scratch="$(mktemp -d "$HGSP_WORK/tamper.XXXXXX")"
+  hgsp_real_git clone --quiet "$HGSP_REMOTE_GIT" "$scratch/clone"
+  mkdir -p "$scratch/clone/$(dirname "$file")"
+  cat > "$scratch/clone/$file"
+  hgsp_real_git -C "$scratch/clone" -c user.name=Drift -c user.email=drift@example.invalid add -A
+  hgsp_real_git -C "$scratch/clone" -c user.name=Drift -c user.email=drift@example.invalid \
+    commit --quiet -m "external rewrite of $file"
+  hgsp_real_git -C "$scratch/clone" push --quiet origin HEAD
+  rm -rf "$scratch"
+}
+
+# Push one commit to an arbitrary remote ref through real Git, bypassing the
+# simulator, to model foreign leases, unrelated branches, and drifted heads.
+hgsp_seed_remote_ref() {
+  local ref="$1" message="${2:-seeded}" base="${3:-}" scratch
+  scratch="$(mktemp -d "$HGSP_WORK/seed-ref.XXXXXX")"
+  hgsp_real_git init --quiet --initial-branch=seed "$scratch"
+  if [[ -n "$base" ]]; then
+    hgsp_real_git -C "$scratch" fetch --quiet "$HGSP_REMOTE_GIT" "$base"
+    hgsp_real_git -C "$scratch" checkout --quiet -b seeded FETCH_HEAD
+  fi
+  printf '%s\n' "$message" > "$scratch/seeded.txt"
+  hgsp_real_git -C "$scratch" add seeded.txt
+  hgsp_real_git -C "$scratch" -c user.name=Foreign -c user.email=foreign@example.invalid \
+    commit --quiet -m "$message"
+  hgsp_real_git -C "$scratch" push --quiet "$HGSP_REMOTE_GIT" "HEAD:$ref"
+  rm -rf "$scratch"
 }

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -34,7 +34,7 @@ hgsp_teardown() {
     done
   fi
   [[ -n "${HGSP_WORK:-}" ]] && rm -rf "$HGSP_WORK" || true
-  unset HGSP_WORK HGSP_STUB HGSP_STATE_ROOT HGSP_XDG_STATE HGSP_CALL_LOG
+  unset HGSP_WORK HGSP_STUB HGSP_STATE_ROOT HGSP_XDG_STATE HGSP_CALL_LOG HGSP_SYSBIN
   unset HGSP_ENV_LOG HGSP_RUN_IDS HGSP_BG_PIDS HGSP_LAST_RUN_ID HGSP_REMOTE_GIT
   unset HGSP_BYSTANDER_PID
 }
@@ -47,12 +47,33 @@ hgsp_setup() {
   HGSP_STATE_ROOT="$HGSP_XDG_STATE/herdr-git-status-playground"
   HGSP_CALL_LOG="$HGSP_WORK/calls.log"
   HGSP_ENV_LOG="$HGSP_WORK/environments.jsonl"
+  HGSP_SYSBIN="$HGSP_WORK/sysbin"
   HGSP_RUN_IDS=""
   HGSP_BG_PIDS=""
   export HGSP_WORK HGSP_STUB HGSP_CALL_LOG
-  mkdir -p "$HGSP_STUB" "$HGSP_XDG_STATE"
+  mkdir -p "$HGSP_STUB" "$HGSP_XDG_STATE" "$HGSP_SYSBIN"
   : > "$HGSP_CALL_LOG"
   : > "$HGSP_ENV_LOG"
+
+  # A curated stand-in for /bin: every real system utility (sleep, mkdir, rm,
+  # ...) that the stub shell scripts need, minus the seven dependency names
+  # the playground preflight resolves. Linux base images apt-install git
+  # (Homebrew bootstrap needs it) so plain "/bin" contains a real, working
+  # git; PATH="$HGSP_STUB:/bin:..." would then let "missing dependency" tests
+  # resolve the renamed-away stub tool straight through to that real binary
+  # (via /bin -> /usr/bin on Linux) instead of finding it absent, which
+  # macOS's git-free /bin never exposed. Using this directory instead keeps
+  # every non-dependency utility on PATH while making the seven managed tools
+  # truly unresolvable once their stub is renamed away, on every platform.
+  local sysbin_entry sysbin_name
+  for sysbin_entry in /bin/*; do
+    [[ -e "$sysbin_entry" ]] || continue
+    sysbin_name="${sysbin_entry##*/}"
+    case "$sysbin_name" in
+      cargo | node | jq | gh | git | python3 | herdr) continue ;;
+    esac
+    ln -s "$sysbin_entry" "$HGSP_SYSBIN/$sysbin_name" 2>/dev/null || true
+  done
 
   # Fixture construction needs real Git behavior; the stub answers preflight's
   # --version probe itself and delegates fixture operations (identified by the
@@ -689,7 +710,7 @@ JSON
 {"candidates":{"ezcorp":{"revision":"f144c8dac2860e344b6b379d2bcfee229dcf10ad","tree":"tree-ezcorp","approved":true},"sfroment":{"revision":"b726977143adc2847dc25e3327bc0b1b4fc26455","tree":"tree-sfroment","approved":true},"krystof":{"revision":"fe6575a89de9006c35d9d0b9707397839d983cff","tree":"tree-krystof","approved":true},"jmarbutt":{"revision":"8a56c5dce0bd65e47eddc9a1d862ddae870cddc3","tree":"tree-jmarbutt","approved":true}}}
 JSON
   cat > "$HGSP_WORK/inherited-environment.json" <<JSON
-{"DYLD_INSERT_LIBRARIES":"poison","DYLD_LIBRARY_PATH":"poison","LD_PRELOAD":"poison","LD_LIBRARY_PATH":"poison","PYTHONPATH":"poison","PYTHONHOME":"poison","PYTHONSTARTUP":"poison","NODE_OPTIONS":"poison","RUBYOPT":"poison","HTTP_PROXY":"http://credential@proxy","HTTPS_PROXY":"http://credential@proxy","ALL_PROXY":"http://credential@proxy","PATH":"$HGSP_STUB:/bin:$HGSP_WORK/poison-bin"}
+{"DYLD_INSERT_LIBRARIES":"poison","DYLD_LIBRARY_PATH":"poison","LD_PRELOAD":"poison","LD_LIBRARY_PATH":"poison","PYTHONPATH":"poison","PYTHONHOME":"poison","PYTHONSTARTUP":"poison","NODE_OPTIONS":"poison","RUBYOPT":"poison","HTTP_PROXY":"http://credential@proxy","HTTPS_PROXY":"http://credential@proxy","ALL_PROXY":"http://credential@proxy","PATH":"$HGSP_STUB:$HGSP_SYSBIN:$HGSP_WORK/poison-bin"}
 JSON
   chmod 600 "$HGSP_WORK/fixture-ownership.json" "$HGSP_WORK/audit-attestation.json" \
     "$HGSP_WORK/inherited-environment.json"
@@ -697,7 +718,7 @@ JSON
 
 hgsp_env() {
   env \
-    PATH="$HGSP_STUB:/bin:$HGSP_WORK/poison-bin" \
+    PATH="$HGSP_STUB:$HGSP_SYSBIN:$HGSP_WORK/poison-bin" \
     HOME="$HGSP_WORK/live-home" \
     XDG_CONFIG_HOME="$HGSP_WORK/live-config" \
     XDG_STATE_HOME="$HGSP_XDG_STATE" \

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -1,7 +1,7 @@
 # Herdr Git status playground Bats harness.
 # Load after helpers/common so SOURCE_ROOT and assertion helpers are available.
 
-HGSP_CONTROLLER="$SOURCE_ROOT/dot_local/bin/executable_herdr-git-status-playground"
+HGSP_CONTROLLER="${HGSP_CONTROLLER_OVERRIDE:-$SOURCE_ROOT/dot_local/bin/executable_herdr-git-status-playground}"
 HGSP_PYTHON="$(command -v python3)"
 
 hgsp_teardown() {
@@ -22,6 +22,7 @@ hgsp_teardown() {
         XDG_STATE_HOME="$HGSP_XDG_STATE" \
         HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
         HERDR_GIT_STATUS_PLAYGROUND_TEST_LOG="$HGSP_ENV_LOG" \
+        HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN=controller-canary \
         "$HGSP_PYTHON" "$HGSP_CONTROLLER" stop "$run_id" >/dev/null 2>&1 || true
     done
   fi
@@ -533,6 +534,27 @@ def isolated_env():
     return environment
 
 
+def mature(repo, run):
+    """Advance one run per observation: poll-count driven early completion and
+    cancellation, so tests prove ordering with counters, not wall clocks."""
+    if run.get("status") == "completed":
+        return
+    polls = run.get("complete_after_polls")
+    if polls is not None:
+        if polls <= 0:
+            run["status"] = "completed"
+            run["conclusion"] = "success"
+            return
+        run["complete_after_polls"] = polls - 1
+    if run.get("cancel_requested") and not run.get("uncancellable"):
+        remaining = run.get("cancel_pending_polls", 1)
+        if remaining <= 0:
+            run["status"] = "completed"
+            run["conclusion"] = "cancelled"
+        else:
+            run["cancel_pending_polls"] = remaining - 1
+
+
 def compute_mergeable(real_git, git_dir, base_ref, head_sha):
     scratch = tempfile.mkdtemp(prefix="hgsp-merge-")
     environment = isolated_env()
@@ -613,6 +635,11 @@ def main():
         permission = state["tokens"].get(token)
         if permission is None:
             fail("HTTP 401: authentication failed")
+        remaining = state.get("api_fail_after")
+        if remaining is not None:
+            if remaining <= 0:
+                fail(state.get("api_fail_message", "HTTP 403: API rate limit exceeded"))
+            state["api_fail_after"] = remaining - 1
         parts = route.split("/")
         if parts[0] != "repos" or len(parts) < 3:
             fail("HTTP 404: unsupported path %s" % route)
@@ -643,7 +670,73 @@ def main():
             head_sha = params.get("head_sha", [None])[0]
             if head_sha:
                 runs = [run for run in runs if run["head_sha"] == head_sha]
+            event = params.get("event", [None])[0]
+            if event:
+                runs = [run for run in runs if run.get("event") == event]
+            branch = params.get("branch", [None])[0]
+            if branch:
+                runs = [run for run in runs if run.get("head_branch") == branch]
+            for run in runs:
+                mature(repo, run)
             out = {"total_count": len(runs), "workflow_runs": runs}
+        elif len(tail) == 3 and tail[:2] == ["actions", "runs"] and tail[2].isdigit():
+            run = next(
+                (entry for entry in repo.get("workflow_runs", []) if entry["id"] == int(tail[2])), None
+            )
+            if run is None:
+                fail("HTTP 404: workflow run %s" % tail[2])
+            mature(repo, run)
+            out = dict(run)
+        elif len(tail) == 4 and tail[:2] == ["actions", "runs"] and tail[3] == "cancel":
+            if permission != "write":
+                fail("HTTP 403: write permission required")
+            run = next(
+                (entry for entry in repo.get("workflow_runs", []) if entry["id"] == int(tail[2])), None
+            )
+            if run is None:
+                fail("HTTP 404: workflow run %s" % tail[2])
+            log("gh-cancel|run=%s" % tail[2])
+            if run.get("status") == "completed":
+                fail("HTTP 409: cannot cancel a completed workflow run")
+            run["cancel_requested"] = True
+            run.setdefault("cancel_pending_polls", repo.get("cancel_pending_polls", 1))
+            out = None
+        elif len(tail) == 4 and tail[:2] == ["actions", "workflows"] and tail[3] == "dispatches":
+            if permission != "write":
+                fail("HTTP 403: write permission required")
+            ref = fields.get("ref")
+            probe = subprocess.run(
+                [real_git, "--git-dir", repo["git_dir"], "rev-parse", "refs/heads/%s" % ref],
+                env=isolated_env(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if probe.returncode != 0:
+                fail("HTTP 422: no ref %s" % ref)
+            if repo.get("dispatch_creates_run") is False:
+                out = None
+            else:
+                queue = repo.get("dispatch_complete_after_polls_queue") or []
+                complete_after = queue.pop(0) if queue else None
+                run = {
+                    "id": repo["next_run_id"],
+                    "name": "herdr-git-status-playground %s" % fields.get("inputs[intent]", ""),
+                    "head_branch": ref,
+                    "head_sha": probe.stdout.strip(),
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "event": "workflow_dispatch",
+                    "hold_seconds": fields.get("inputs[hold_seconds]"),
+                    "complete_after_polls": complete_after,
+                }
+                repo["next_run_id"] += 1
+                repo.setdefault("workflow_runs", []).append(run)
+                log(
+                    "gh-dispatch|ref=%s|intent=%s|hold=%s|run=%d"
+                    % (ref, fields.get("inputs[intent]", ""), fields.get("inputs[hold_seconds]", ""), run["id"])
+                )
+                out = None
         elif tail == ["pulls"] and method == "GET":
             pulls = repo.get("pulls", [])
             state_param = params.get("state", ["open"])[0]
@@ -710,7 +803,8 @@ def main():
         handle.truncate()
         json.dump(state, handle)
         handle.write("\n")
-    print(json.dumps(out))
+    if out is not None:
+        print(json.dumps(out))
 
 
 main()
@@ -762,6 +856,49 @@ hgsp_repo_record() {
 
 hgsp_record_field() {
   hgsp_json_field "$(cat "$(hgsp_repo_record)")" "$1"
+}
+
+# One-call remote foundation for run-level (U4) cases: simulator, explicit
+# initialization, and a converged durable fixture catalog.
+hgsp_remote_ready() {
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+}
+
+hgsp_host_installation_id() {
+  cat "$HGSP_STATE_ROOT/host-installation-id"
+}
+
+hgsp_manifest_query() {
+  local run_id="$1" expression="$2"
+  "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$expression" <<'PY'
+import json
+import sys
+
+path, expression = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+value = eval(expression, {"manifest": manifest, "remote": manifest.get("remote")})
+print("true" if value is True else "false" if value is False else value)
+PY
+}
+
+# Force-write a lease commit with the given lease.json payload through real
+# Git, bypassing the simulator, to model exited-owner, leaked, and foreign
+# repository leases.
+hgsp_seed_lease() {
+  local payload="$1" scratch
+  scratch="$(mktemp -d "$HGSP_WORK/lease.XXXXXX")"
+  hgsp_real_git init --quiet --initial-branch=seed "$scratch"
+  printf '%s\n' "$payload" > "$scratch/lease.json"
+  hgsp_real_git -C "$scratch" add lease.json
+  hgsp_real_git -C "$scratch" -c user.name=Holder -c user.email=holder@example.invalid \
+    commit --quiet -m "seeded lease"
+  hgsp_real_git -C "$scratch" push --quiet --force "$HGSP_REMOTE_GIT" "HEAD:refs/heads/herdr-playground/lease"
+  rm -rf "$scratch"
 }
 
 # Rewrite one file on the remote default branch through real Git, bypassing

--- a/tests/helpers/herdr_git_status_playground.bash
+++ b/tests/helpers/herdr_git_status_playground.bash
@@ -126,9 +126,11 @@ SH
   chmod +x "$HGSP_STUB/gh"
   ln -s "$HGSP_PYTHON" "$HGSP_STUB/python3"
 
-  # Herdr stub: `--version` and the long-running `server run` stay in shell so
-  # the controller-owned server process image keeps the stub path in its
-  # command line; every other subcommand runs the stateful profile simulator.
+  # Herdr stub: `--version`, the long-running `server run`, and the long-lived
+  # `client attach` all stay in shell (never exec into python) so the
+  # controller-owned process image keeps the stub path in its command line,
+  # matching what verify_process's identity check requires; every other
+  # subcommand runs the stateful profile simulator and exits immediately.
   cat > "$HGSP_STUB/herdr" <<SH
 #!/bin/sh
 profile="\${XDG_STATE_HOME:-}"
@@ -148,6 +150,17 @@ if [ "\$1" = server ] && [ "\$2" = run ]; then
   trap 'rm -f "\$state/session.sock"; exit 0' TERM INT HUP
   while [ -d "\$state" ]; do sleep 0.05; done
   rm -f "\$state/session.sock" 2>/dev/null
+  exit 0
+fi
+if [ "\$1" = client ] && [ "\$2" = attach ]; then
+  socket="\$("$HGSP_PYTHON" "$HGSP_STUB/herdr-sim.py" "\$@")"
+  status=\$?
+  if [ "\$status" -ne 0 ]; then
+    exit "\$status"
+  fi
+  state="\$XDG_STATE_HOME/herdr"
+  trap 'exit 0' TERM INT HUP
+  while [ -e "\$socket" ] && [ -d "\$state" ]; do sleep 0.05; done
   exit 0
 fi
 exec "$HGSP_PYTHON" "$HGSP_STUB/herdr-sim.py" "\$@"
@@ -566,6 +579,83 @@ def main():
     if args[:2] == ["config", "reload"]:
         require_server()
         return
+    if args[:2] == ["space", "focus"]:
+        require_server()
+        label = args[2]
+        if not any(entry["label"] == label for entry in load_json(SPACES, [])):
+            fail("no space labelled %s" % label)
+        focus_path = os.path.join(STATE_DIR, "focus.json")
+        current = load_json(focus_path, {"generation": 0})
+        save_json(
+            focus_path,
+            {
+                "label": label,
+                "generation": current.get("generation", 0) + 1,
+                "previous_label": current.get("label"),
+                "previous_generation": current.get("generation"),
+            },
+        )
+        return
+    if args[:2] == ["space", "current"]:
+        require_server()
+        current = load_json(os.path.join(STATE_DIR, "focus.json"), None)
+        if current is None:
+            fail("no fixture has been focused yet")
+        # Test knob: model a client that echoes a cached read from before the
+        # most recent focus switch, so causal-freshness tests can prove that
+        # an equal stale value is rejected rather than trusted (KTD7).
+        if os.environ.get("HGSP_STALE_FOCUS_READ") and current.get("previous_label") is not None:
+            print(json.dumps({"label": current["previous_label"], "generation": current["previous_generation"]}))
+        else:
+            print(json.dumps({"label": current["label"], "generation": current["generation"]}))
+        return
+    if args[:2] == ["workspace", "create"]:
+        require_server()
+        name = args[2]
+        cwd = args[args.index("--cwd") + 1]
+        workspace_path = os.path.join(STATE_DIR, "workspace.json")
+        if os.path.exists(workspace_path):
+            fail("workspace %s already exists" % name)
+        save_json(workspace_path, {"name": name, "cwd": cwd, "panes": {}})
+        return
+    if args[:2] == ["workspace", "layout"]:
+        require_server()
+        name = args[2]
+        panes_count = int(args[args.index("--panes") + 1])
+        columns = int(args[args.index("--columns") + 1])
+        rows = int(args[args.index("--rows") + 1])
+        if panes_count != 4 or columns % 2 != 0 or rows % 2 != 0:
+            fail("only an even 2x2 layout is supported")
+        workspace_path = os.path.join(STATE_DIR, "workspace.json")
+        workspace = load_json(workspace_path, None)
+        if workspace is None or workspace.get("name") != name:
+            fail("no workspace named %s" % name)
+        width, height = columns // 2, rows // 2
+        workspace["layout"] = {"columns": columns, "rows": rows, "width": width, "height": height}
+        save_json(workspace_path, workspace)
+        print(json.dumps({"panes": [{"width": width, "height": height} for _ in range(panes_count)]}))
+        return
+    if args[:2] == ["client", "attach"]:
+        # Registration only: the sh wrapper that invoked this owns the
+        # long-lived idle loop and signal handling, so the recorded launch
+        # identity (the stub path) stays in the process image, matching the
+        # server-run pattern's identity contract (KTD9's process-verification
+        # relies on the stub path appearing in the live process command).
+        socket_path = args[args.index("--socket") + 1]
+        pane_id = args[args.index("--pane") + 1]
+        header = json.loads(args[args.index("--header") + 1])
+        if "--nested" not in args or "--no-auto-start" not in args:
+            fail("nested client attach requires --nested and --no-auto-start")
+        if not os.path.exists(socket_path):
+            fail("candidate socket is unavailable: %s" % socket_path)
+        workspace_path = os.path.join(STATE_DIR, "workspace.json")
+        workspace = load_json(workspace_path, None)
+        if workspace is None:
+            fail("no viewer workspace to attach into")
+        workspace.setdefault("panes", {})[pane_id] = {"header": header, "socket": socket_path}
+        save_json(workspace_path, workspace)
+        print(socket_path)
+        return
     fail("unsupported herdr invocation: %r" % (args,), 97)
 
 
@@ -680,6 +770,33 @@ hgsp_wait_for_file() {
 hgsp_assert_no_launch_or_mutation() {
   run grep -E '^(managed-probe|gh\|api|gh\|pr|gh\|workflow|git\|push)' "$HGSP_CALL_LOG"
   assert_failure
+}
+
+hgsp_evidence_index() {
+  printf '%s/runs/%s/evidence-index.json\n' "$HGSP_STATE_ROOT" "$1"
+}
+
+# Mutate the run's evidence-index.json in place through a Python expression
+# bound to `rows` (the list); used to fabricate finalize-time edge cases
+# (missing/duplicate/corrupted records) without recapturing real evidence.
+hgsp_patch_evidence_index() {
+  local run_id="$1" expression="$2"
+  "$HGSP_PYTHON" - "$(hgsp_evidence_index "$run_id")" "$expression" <<'PY'
+import json
+import os
+import sys
+
+path, expression = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    index = json.load(handle)
+rows = index["rows"]
+exec(expression, {"index": index, "rows": rows})
+temporary = path + ".fixture"
+with open(temporary, "w", encoding="utf-8") as handle:
+    json.dump(index, handle, sort_keys=True, separators=(",", ":"))
+    handle.write("\n")
+os.replace(temporary, path)
+PY
 }
 
 hgsp_patch_manifest() {

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -33,6 +33,18 @@ teardown() {
   assert_file_not_exists "$HGSP_STATE_ROOT"
 }
 
+@test "herdr-git-status-playground turns an unmodeled internal error into well-formed JSON, not a bare traceback" {
+  hgsp_setup
+
+  # #then a genuine bug (not a modeled PlaygroundError) still yields parseable
+  # JSON on stdout with an INTERNAL_ERROR code, never a raw traceback
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=internal-error run hgsp_env status --all
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" INTERNAL_ERROR
+  assert_output --partial "injected internal error for INTERNAL_ERROR boundary coverage"
+  refute_output --partial "Traceback"
+}
+
 @test "herdr-git-status-playground isolates profiles and child environments" {
   hgsp_setup
   run hgsp_start
@@ -277,7 +289,7 @@ PY
 
 @test "herdr-git-status-playground crash boundaries preserve recoverable intents" {
   hgsp_setup
-  local point run_id manifest
+  local point run_id manifest claim_path wrapper_pid
   for point in before-spawn after-spawn before-identity-commit; do
     HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="$point" run hgsp_start
     assert_failure 1
@@ -294,6 +306,18 @@ assert next(iter(manifest["launch_intents"].values()))["phase"] in {"intent-comm
 PY
     assert_success
 
+    # #then after-spawn and before-identity-commit leave a real launch-wrapper
+    # process parked on its unclaimed gate; capture its PID from the claim
+    # before stop so we can prove it was actually reaped, not just forgotten.
+    wrapper_pid=""
+    if [[ "$point" != before-spawn ]]; then
+      claim_path="$HGSP_STATE_ROOT/runs/$run_id/runtime/launch/foundation-supervisor/claim.json"
+      [[ -f "$claim_path" ]] || fail "expected a wrapper claim at $claim_path for $point"
+      wrapper_pid="$("$HGSP_PYTHON" -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["pid"])' "$claim_path")"
+      run kill -0 "$wrapper_pid"
+      assert_success
+    fi
+
     run hgsp_env status "$run_id"
     assert_success
     assert_equal "$(hgsp_json_field "$output" run_id)" "$run_id"
@@ -304,6 +328,12 @@ PY
       assert_success
     fi
     assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+
+    # #then stop actually reaped the forgotten wrapper, not merely marked it done
+    if [[ -n "$wrapper_pid" ]]; then
+      run kill -0 "$wrapper_pid"
+      assert_failure
+    fi
   done
 }
 
@@ -701,7 +731,10 @@ PY
     assert_file_exists "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID/ground-truth/$control.json"
     run hgsp_env stop "$HGSP_LAST_RUN_ID"
     assert_success
-    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+    # A sabotaged start now cleans itself up (startup-failed-cleaned is the
+    # terminal state per the automatic-cleanup contract); stop stays
+    # idempotent on that terminal state instead of converting it to stopped.
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
   done
 }
 
@@ -1926,6 +1959,106 @@ PY
     assert_failure
   done
   run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground survives a teardown-time quarantine failure instead of wedging in stopping" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-ready
+
+  # #then an injected quarantine failure for ezcorp still reaches
+  # cleanup-incomplete (not a hang stuck in "stopping"), and records the
+  # injected code among the unresolved teardown conditions.
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="quarantine-teardown-ezcorp" run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" INJECTED_QUARANTINE_TEARDOWN_FAILURE
+  assert_equal \
+    "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["ezcorp"]["pid_record_quarantined"]')" \
+    false
+
+  # #then a later stop, without the injected failure, still settles the run
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground bounds a hung external command with a timeout instead of blocking forever" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then a herdr call that hangs past the (injected, tiny) subprocess timeout
+  # fails with a timeout diagnostic instead of blocking the command forever
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_SUBPROCESS_TIMEOUT_SECONDS=1 \
+    HGSP_HERDR_HANG_ARGS="sidebar snapshot" \
+    HGSP_HERDR_HANG_SECONDS=5 \
+    run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" SIDEBAR_SNAPSHOT_FAILED
+  assert_regex "$(hgsp_json_field "$output" error.message)" "timed out after"
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+
+  # #then teardown itself never hung on the timeout: the run already settled
+  run hgsp_env stop "$HGSP_LAST_RUN_ID"
+  assert_success
+}
+
+@test "herdr-git-status-playground routes a local fixture catalog failure through startup cleanup, not a silent provisioning ghost" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then a non-injected fixture-build failure is wrapped like the remote
+  # provisioning failure just below it: automatic cleanup runs and the run
+  # reaches a terminal state instead of a silent, uncleaned "provisioning" ghost
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="sabotage-dirty" run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" FIXTURE_CHECKOUT_DIRTY_INCOMPLETE
+  local lifecycle_state
+  lifecycle_state="$(hgsp_json_field "$output" lifecycle_state)"
+  [[ "$lifecycle_state" == startup-failed-cleaned || "$lifecycle_state" == cleanup-incomplete ]] \
+    || fail "expected a terminal cleanup state, got $lifecycle_state"
+
+  # #then the error is durably persisted, not left for the caller to lose
+  assert_equal \
+    "$(hgsp_manifest_query "$HGSP_LAST_RUN_ID" 'manifest["error"]["code"]')" \
+    FIXTURE_CHECKOUT_DIRTY_INCOMPLETE
+}
+
+@test "herdr-git-status-playground redacts a leaked credential from a candidate-activation failure in the durable manifest" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then a `gh api` failure during candidate auth probing that echoes the
+  # candidate credential into its own stderr never reaches manifest.json
+  # unredacted (KTD17)
+  HGSP_GH_API_FAIL=1 run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" CANDIDATE_AUTH_UNPROVED
+
+  run grep -r candidate-canary "$HGSP_STATE_ROOT"
+  assert_failure
+
+  assert_equal \
+    "$(hgsp_manifest_query "$HGSP_LAST_RUN_ID" 'manifest["candidate_diagnostics"]["krystof"]["code"]')" \
+    CANDIDATE_AUTH_UNPROVED
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$HGSP_LAST_RUN_ID")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+message = manifest["candidate_diagnostics"]["krystof"]["message"]
+assert "candidate-canary" not in message, message
+assert "<redacted>" in message, message
+PY
   assert_success
 }
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -469,6 +469,290 @@ SH
 }
 
 # ===========================================
+# herdr-git-status-playground local fixtures (U2)
+# ===========================================
+
+@test "herdr-git-status-playground core fixtures match independent Git measurement" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run "$HGSP_PYTHON" - "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+run_dir = sys.argv[1]
+
+
+def load(name):
+    with open(os.path.join(run_dir, "ground-truth", name + ".json"), encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def git(path, *arguments, check=True):
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    completed = subprocess.run(
+        ["git", "-C", path] + list(arguments),
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if check:
+        assert completed.returncode == 0, (path, arguments, completed.stderr)
+    return completed
+
+
+# #then clean fixtures stay clean after every harness metadata write
+for name in ("checkout-clean", "worktree-clean"):
+    record = load(name)
+    assert git(record["path"], "status", "--porcelain=v1").stdout == "", name
+    head = git(record["path"], "rev-parse", "HEAD").stdout.strip()
+    assert record["head"] == head, (name, record["head"], head)
+    for family in ("staged_paths", "unstaged_paths", "untracked_paths", "unmerged_paths"):
+        assert record[family] == [], (name, family, record[family])
+
+# #then the worktree fixture is a real linked worktree by Git metadata
+worktree = load("worktree-clean")
+git_dir = git(worktree["path"], "rev-parse", "--git-dir").stdout.strip()
+common_dir = git(worktree["path"], "rev-parse", "--git-common-dir").stdout.strip()
+resolved = [os.path.realpath(os.path.join(worktree["path"], value)) for value in (git_dir, common_dir)]
+assert resolved[0] != resolved[1], resolved
+assert worktree["linked_worktree"] is True
+assert load("checkout-clean")["linked_worktree"] is False
+
+# #then both mixed-dirty fixtures hold one staged, one unstaged, one untracked path
+for name in ("checkout-dirty", "worktree-dirty"):
+    record = load(name)
+    lines = sorted(line for line in git(record["path"], "status", "--porcelain=v1").stdout.splitlines() if line)
+    assert lines == sorted(["A  staged.txt", " M tracked.txt", "?? untracked.txt"]), (name, lines)
+    assert record["staged_paths"] == ["staged.txt"], record
+    assert record["unstaged_paths"] == ["tracked.txt"], record
+    assert record["untracked_paths"] == ["untracked.txt"], record
+assert load("worktree-dirty")["linked_worktree"] is True
+assert load("checkout-dirty")["linked_worktree"] is False
+PY
+  assert_success
+}
+
+@test "herdr-git-status-playground diagnostic fixtures attribute state without missing families" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run "$HGSP_PYTHON" - "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+run_dir = sys.argv[1]
+
+
+def load(name):
+    with open(os.path.join(run_dir, "ground-truth", name + ".json"), encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def git(path, *arguments, check=True):
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    completed = subprocess.run(
+        ["git", "-C", path] + list(arguments),
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if check:
+        assert completed.returncode == 0, (path, arguments, completed.stderr)
+    return completed
+
+
+# #then the conflict fixture holds verified unmerged index entries
+conflict = load("conflict")
+unmerged = sorted({line.split("\t")[-1] for line in git(conflict["path"], "ls-files", "-u").stdout.splitlines()})
+assert unmerged == ["contested.txt"], unmerged
+assert conflict["unmerged_paths"] == ["contested.txt"], conflict
+
+# #then the diverged fixture proves positive ahead and behind counts and a nonempty stash
+diverged = load("diverged-stash")
+counts = git(diverged["path"], "rev-list", "--left-right", "--count", "origin/main...HEAD").stdout.split()
+behind, ahead = int(counts[0]), int(counts[1])
+assert ahead >= 1 and behind >= 1, counts
+assert diverged["ahead"] == ahead and diverged["behind"] == behind, diverged
+stash_lines = [line for line in git(diverged["path"], "stash", "list").stdout.splitlines() if line]
+assert stash_lines and diverged["stash_count"] == len(stash_lines), (diverged, stash_lines)
+
+# #then the detached fixture records the expected commit and no symbolic branch
+detached = load("detached")
+assert git(detached["path"], "symbolic-ref", "-q", "HEAD", check=False).returncode != 0
+head = git(detached["path"], "rev-parse", "HEAD").stdout.strip()
+assert detached["head"] == head and detached["branch"] is None, detached
+
+# #then the non-git fixture has no Git parent within the disposable root
+non_git = load("non-git")
+assert git(non_git["path"], "rev-parse", "--git-dir", check=False).returncode != 0
+probe = os.path.realpath(non_git["path"])
+boundary = os.path.realpath(run_dir)
+while True:
+    assert not os.path.exists(os.path.join(probe, ".git")), probe
+    if probe == boundary:
+        break
+    probe = os.path.dirname(probe)
+
+# #then every record shares one schema; unsupported families read not applicable, never missing
+order = ["checkout-clean", "checkout-dirty", "worktree-clean", "worktree-dirty",
+         "conflict", "diverged-stash", "detached", "non-git"]
+records = {name: load(name) for name in order}
+key_sets = {frozenset(record) for record in records.values()}
+assert len(key_sets) == 1, key_sets
+assert records["non-git"]["repository"] == "none"
+for key, value in records["non-git"].items():
+    if key in ("schema_version", "label", "path", "measured_at", "repository"):
+        continue
+    assert value == "not applicable", (key, value)
+for name in ("checkout-clean", "conflict", "detached"):
+    assert records[name]["ahead"] == "not applicable", name
+    assert records[name]["behind"] == "not applicable", name
+assert isinstance(records["diverged-stash"]["ahead"], int)
+assert isinstance(records["diverged-stash"]["behind"], int)
+PY
+  assert_success
+}
+
+@test "herdr-git-status-playground refuses ground truth when one premise property is sabotaged" {
+  hgsp_setup
+  local entry point expected_code sabotaged control
+  for entry in \
+    "dirty:FIXTURE_CHECKOUT_DIRTY_INCOMPLETE:checkout-dirty:checkout-clean" \
+    "conflict:FIXTURE_CONFLICT_MISSING:conflict:worktree-dirty" \
+    "diverged:FIXTURE_DIVERGENCE_MISSING:diverged-stash:conflict" \
+    "detached:FIXTURE_DETACHED_INVALID:detached:diverged-stash" \
+    "non-git:FIXTURE_NON_GIT_CONTAMINATED:non-git:detached"; do
+    IFS=: read -r point expected_code sabotaged control <<< "$entry"
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="sabotage-$point" run hgsp_start
+    assert_failure 1
+    hgsp_capture_run_id
+    assert_equal "$(hgsp_json_field "$output" error.code)" "$expected_code"
+    assert_file_not_exists "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID/ground-truth/$sabotaged.json"
+    assert_file_exists "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID/ground-truth/$control.json"
+    run hgsp_env stop "$HGSP_LAST_RUN_ID"
+    assert_success
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  done
+}
+
+@test "herdr-git-status-playground fixture interruption never publishes partial ground truth" {
+  hgsp_setup
+  local fixtures="checkout-clean checkout-dirty worktree-clean worktree-dirty conflict diverged-stash detached non-git"
+  local index=0 name run_id expected_code
+  for name in $fixtures; do
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="fixture-$name" run hgsp_start
+    assert_failure 1
+    hgsp_capture_run_id
+    run_id="$HGSP_LAST_RUN_ID"
+    expected_code="INJECTED_FIXTURE_$(printf '%s' "$name" | tr '[:lower:]-' '[:upper:]_')"
+    assert_equal "$(hgsp_json_field "$output" error.code)" "$expected_code"
+    run "$HGSP_PYTHON" - "$HGSP_STATE_ROOT/runs/$run_id" "$index" <<'PY'
+import json
+import os
+import sys
+
+run_dir, index = sys.argv[1], int(sys.argv[2])
+order = ["checkout-clean", "checkout-dirty", "worktree-clean", "worktree-dirty",
+         "conflict", "diverged-stash", "detached", "non-git"]
+directory = os.path.join(run_dir, "ground-truth")
+present = sorted(os.listdir(directory)) if os.path.isdir(directory) else []
+assert present == sorted(name + ".json" for name in order[:index]), (present, index)
+with open(os.path.join(run_dir, "manifest.json"), encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert sorted(manifest.get("local_fixtures", {})) == sorted(order[:index]), manifest.get("local_fixtures")
+assert "fixture_assignments" not in manifest
+PY
+    assert_success
+    run hgsp_env stop "$run_id"
+    assert_success
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+    index=$((index + 1))
+  done
+
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run "$HGSP_PYTHON" - "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID" <<'PY'
+import json
+import os
+import sys
+
+run_dir = sys.argv[1]
+order = ["checkout-clean", "checkout-dirty", "worktree-clean", "worktree-dirty",
+         "conflict", "diverged-stash", "detached", "non-git"]
+present = sorted(os.listdir(os.path.join(run_dir, "ground-truth")))
+assert present == sorted(name + ".json" for name in order), present
+with open(os.path.join(run_dir, "manifest.json"), encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert sorted(manifest["local_fixtures"]) == sorted(order)
+assert "fixture_assignments" in manifest
+PY
+  assert_success
+}
+
+@test "herdr-git-status-playground assigns identical ordered catalogs to candidates and a workspace to the viewer" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run "$HGSP_PYTHON" - "$HGSP_STATE_ROOT/runs/$HGSP_LAST_RUN_ID" <<'PY'
+import json
+import os
+import sys
+
+run_dir = sys.argv[1]
+with open(os.path.join(run_dir, "manifest.json"), encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assignments = manifest["fixture_assignments"]
+assert sorted(assignments) == ["ezcorp", "jmarbutt", "krystof", "sfroment"], sorted(assignments)
+order = ["checkout-clean", "checkout-dirty", "worktree-clean", "worktree-dirty",
+         "conflict", "diverged-stash", "detached", "non-git"]
+reference = assignments["ezcorp"]
+assert [entry["label"] for entry in reference] == order, reference
+canonical = json.dumps(reference, sort_keys=True)
+for profile_id, catalog in assignments.items():
+    assert json.dumps(catalog, sort_keys=True) == canonical, profile_id
+for entry in reference:
+    assert os.path.isdir(entry["path"]), entry
+    assert os.path.basename(entry["path"]) == entry["label"], entry
+workspace = os.path.realpath(manifest["viewer_workspace"])
+viewer_root = os.path.realpath(os.path.dirname(manifest["profiles"]["viewer"]["home"]))
+assert os.path.commonpath([workspace, viewer_root]) == viewer_root, (workspace, viewer_root)
+assert os.path.isdir(workspace)
+fixture_paths = {os.path.realpath(entry["path"]) for entry in reference}
+assert workspace not in fixture_paths
+for path in fixture_paths:
+    assert os.path.commonpath([path, workspace]) != workspace, (path, workspace)
+PY
+  assert_success
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -753,6 +753,492 @@ PY
 }
 
 # ===========================================
+# herdr-git-status-playground GitHub fixtures (U3)
+# ===========================================
+
+@test "herdr-git-status-playground initialization refuses foreign, nonempty, unauthorized, and mismatched repositories" {
+  hgsp_setup
+  hgsp_github_setup
+
+  printf '%s\n' '{"host":"github.com","owner":"example","name":"my-mac-setup","repository_id":"R_fixture_1","owned":true}' > "$HGSP_WORK/fixture-ownership.json"
+  run hgsp_initialize
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" FIXTURE_OWNERSHIP_UNPROVED
+
+  printf '%s\n' '{"host":"github.com","owner":"example","name":"herdr-status-fixtures","repository_id":"R_other","owned":true}' > "$HGSP_WORK/fixture-ownership.json"
+  run hgsp_initialize
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_ID_MISMATCH
+
+  printf '%s\n' '{"host":"github.com","owner":"example","name":"herdr-status-fixtures","repository_id":"R_fixture_1","owned":true}' > "$HGSP_WORK/fixture-ownership.json"
+  hgsp_patch_github_state 'state["tokens"]["controller-canary"] = "read"'
+  run hgsp_initialize
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_PERMISSION_INSUFFICIENT
+  hgsp_patch_github_state 'state["tokens"]["controller-canary"] = "write"'
+
+  hgsp_seed_remote_ref refs/heads/unrelated-topic "unrelated operator content"
+  run hgsp_initialize
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_NOT_EMPTY
+  run hgsp_remote_git rev-parse refs/heads/main
+  assert_failure
+  assert_file_not_exists "$(hgsp_repo_record)"
+
+  # #then the nearby valid control reaches the success path once the repository is empty
+  hgsp_remote_git update-ref -d refs/heads/unrelated-topic
+  run hgsp_initialize
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" initialized)" true
+  assert_file_exists "$(hgsp_repo_record)"
+}
+
+@test "herdr-git-status-playground first initialization claims atomically and a concurrent initializer loses without mutation" {
+  hgsp_setup
+  hgsp_github_setup
+  hgsp_seed_remote_ref refs/heads/herdr-playground/lease "foreign concurrent lease"
+  run hgsp_initialize
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" INITIALIZE_LEASE_LOST
+  run hgsp_remote_git rev-parse refs/heads/main
+  assert_failure
+  assert_file_not_exists "$(hgsp_repo_record)"
+
+  hgsp_remote_git update-ref -d refs/heads/herdr-playground/lease
+  run hgsp_initialize
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lease)" released
+  # #then the lease acquisition demanded the absent-ref compare-and-swap form
+  run grep -E -- '--force-with-lease=refs/heads/herdr-playground/lease:$' "$HGSP_CALL_LOG"
+  assert_success
+  # #then one atomic claim created the default branch with marker plus workflow
+  run hgsp_remote_git rev-list --count refs/heads/main
+  assert_success
+  assert_output 1
+  run hgsp_remote_git show refs/heads/main:.herdr-git-status-playground.json
+  assert_success
+  local marker="$output"
+  assert_equal "$(hgsp_json_field "$marker" repository_id)" R_fixture_1
+  assert_equal "$(hgsp_json_field "$marker" host)" github.com
+  assert_equal "$(hgsp_json_field "$marker" namespace)" "herdr-playground/"
+  run hgsp_remote_git show refs/heads/main:.github/workflows/herdr-git-status-playground.yml
+  assert_success
+  # #then the exact lease was verified and conditionally deleted
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  # #then durable controller state never retains a credential canary
+  run grep -r controller-canary "$HGSP_STATE_ROOT"
+  assert_failure
+  run grep -r candidate-canary "$HGSP_STATE_ROOT"
+  assert_failure
+}
+
+@test "herdr-git-status-playground installs an inert pinned workflow and blocks bootstrap on policy drift" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  hgsp_remote_git show refs/heads/main:.github/workflows/herdr-git-status-playground.yml > "$HGSP_WORK/installed-workflow.yml"
+  run "$HGSP_PYTHON" - "$HGSP_WORK/installed-workflow.yml" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+assert "permissions: {}" in text, text
+assert "timeout-minutes:" in text
+assert "concurrency:" in text
+for forbidden in ("secret", "environment", "pull_request", "issue_comment", "workflow_run", "repository_dispatch", "schedule"):
+    assert forbidden not in text, forbidden
+assert "push:" in text and "workflow_dispatch:" in text
+for line in text.splitlines():
+    if "uses:" in line:
+        pinned = line.split("@")[-1].strip().strip('"')
+        assert re.fullmatch(r"[0-9a-f]{40}", pinned), line
+PY
+  assert_success
+
+  hgsp_patch_github_state 'repo["secrets_total"] = 1'
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_POLICY_DRIFT
+  assert_equal "$(hgsp_json_field "$output" lease)" not-acquired
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  hgsp_patch_github_state 'repo["secrets_total"] = 0'
+
+  hgsp_patch_github_state 'repo["environments_total"] = 2'
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_POLICY_DRIFT
+  hgsp_patch_github_state 'repo["environments_total"] = 0'
+
+  # #then the nearby control converges once policy drift is repaired
+  run hgsp_bootstrap
+  assert_success
+}
+
+@test "herdr-git-status-playground repeated bootstrap converges without duplicates or unrelated branch changes" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  hgsp_seed_remote_ref refs/heads/unrelated-topic "operator branch outside the namespace"
+  local unrelated_sha
+  unrelated_sha="$(hgsp_remote_git rev-parse refs/heads/unrelated-topic)"
+
+  run hgsp_bootstrap
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lease)" released
+  assert_equal "$(hgsp_github_query 'len(repo["pulls"])')" 4
+  cp "$(hgsp_repo_record)" "$HGSP_WORK/first-record.json"
+
+  run hgsp_bootstrap
+  assert_success
+  assert_equal "$(hgsp_github_query 'len(repo["pulls"])')" 4
+  assert_equal "$(hgsp_github_query 'len([p for p in repo["pulls"] if p["state"] == "open"])')" 4
+  run "$HGSP_PYTHON" -c 'import json,sys; a=json.load(open(sys.argv[1]))["fixtures"]; b=json.load(open(sys.argv[2]))["fixtures"]; assert a==b, (a,b)' \
+    "$HGSP_WORK/first-record.json" "$(hgsp_repo_record)"
+  assert_success
+  assert_equal "$(hgsp_remote_git rev-parse refs/heads/unrelated-topic)" "$unrelated_sha"
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+}
+
+@test "herdr-git-status-playground releases its lease on clean outcomes and retains it across partial mutation" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=bootstrap-pre-mutation run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" INJECTED_BOOTSTRAP_PRE_MUTATION
+  assert_equal "$(hgsp_json_field "$output" lease)" released
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  assert_equal "$(hgsp_record_field recovery)" None
+
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=bootstrap-partial-draft run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" INJECTED_BOOTSTRAP_PARTIAL
+  assert_equal "$(hgsp_json_field "$output" lease)" retained
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_success
+  run "$HGSP_PYTHON" - "$(hgsp_repo_record)" <<'PY'
+import json
+import sys
+
+record = json.load(open(sys.argv[1], encoding="utf-8"))
+recovery = record["recovery"]
+assert recovery and recovery["operation_kind"] == "bootstrap", recovery
+assert recovery["operation_id"], recovery
+mutations = recovery["mutations"]
+assert mutations, recovery
+for mutation in mutations:
+    assert mutation["ref"].startswith("refs/heads/herdr-playground/"), mutation
+    assert len(mutation["new_sha"]) == 40, mutation
+    assert "fixture" in mutation and "expected" in mutation, mutation
+PY
+  assert_success
+
+  # #then resuming converges forward through matched compare-and-swap state
+  run hgsp_bootstrap
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lease)" released
+  assert_equal "$(hgsp_github_query 'len(repo["pulls"])')" 4
+  assert_equal "$(hgsp_github_query 'len([p for p in repo["pulls"] if p["state"] == "open"])')" 4
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  assert_equal "$(hgsp_record_field recovery)" None
+
+  # #then a foreign lease fails closed with exact inspection guidance
+  hgsp_seed_remote_ref refs/heads/herdr-playground/lease "foreign holder"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_HELD
+  assert_output --partial "git ls-remote"
+  hgsp_remote_git update-ref -d refs/heads/herdr-playground/lease
+  run hgsp_bootstrap
+  assert_success
+}
+
+@test "herdr-git-status-playground ambient selectors cannot redirect queries or mutations" {
+  hgsp_setup
+  hgsp_github_setup
+  local decoy_host_sha decoy_repo_sha poison_cwd
+  decoy_host_sha="$(hgsp_real_git --git-dir "$HGSP_WORK/remote/decoy-host.git" rev-parse main)"
+  decoy_repo_sha="$(hgsp_real_git --git-dir "$HGSP_WORK/remote/decoy-repo.git" rev-parse main)"
+  poison_cwd="$HGSP_WORK/poison-cwd"
+  hgsp_real_git init --quiet --initial-branch=main "$poison_cwd"
+  hgsp_real_git -C "$poison_cwd" remote add origin "https://wrong.example/example/herdr-status-fixtures.git"
+
+  cd "$poison_cwd"
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+  cd "$BATS_TEST_DIRNAME"
+
+  run "$HGSP_PYTHON" - "$HGSP_CALL_LOG" <<'PY'
+import sys
+
+lines = [line.strip() for line in open(sys.argv[1], encoding="utf-8") if line.startswith("gh-sim|")]
+assert lines
+for line in lines:
+    fields = dict(part.split("=", 1) for part in line.split("|")[1:])
+    assert fields["host"] == "github.com", line
+    assert fields["path"].startswith("repos/example/herdr-status-fixtures"), line
+    assert fields["ghrepo"] == "-", line
+    assert fields["ghhost"] == "-", line
+PY
+  assert_success
+  assert_equal "$(hgsp_real_git --git-dir "$HGSP_WORK/remote/decoy-host.git" rev-parse main)" "$decoy_host_sha"
+  assert_equal "$(hgsp_real_git --git-dir "$HGSP_WORK/remote/decoy-repo.git" rev-parse main)" "$decoy_repo_sha"
+  run "$HGSP_PYTHON" -c 'import json,sys; s=json.load(open(sys.argv[1]))["repositories"]; assert not s["wrong.example/example/herdr-status-fixtures"]["pulls"]; assert not s["github.com/wrong/repo"]["pulls"]' "$HGSP_WORK/github-state.json"
+  assert_success
+  run grep -E 'git-auth\|[a-z-]+\|(wrong\.example|github\.com/wrong)' "$HGSP_CALL_LOG"
+  assert_failure
+}
+
+@test "herdr-git-status-playground blocks startup on marker, workflow, default-branch, and namespace drift" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  local original_marker original_workflow
+  original_marker="$(hgsp_remote_git show refs/heads/main:.herdr-git-status-playground.json)"
+  original_workflow="$(hgsp_remote_git show refs/heads/main:.github/workflows/herdr-git-status-playground.yml)"
+
+  hgsp_patch_github_state 'repo["default_branch"] = "trunk"'
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" DEFAULT_BRANCH_MISMATCH
+  assert_output --partial "inspect"
+  hgsp_patch_github_state 'repo["default_branch"] = "main"'
+
+  printf 'not json at all\n' | hgsp_rewrite_default_file .herdr-git-status-playground.json
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" MARKER_INVALID
+  assert_output --partial "inspect"
+
+  "$HGSP_PYTHON" -c 'import json,sys; marker=json.loads(sys.argv[1]); marker["namespace"]="other/"; print(json.dumps(marker))' "$original_marker" \
+    | hgsp_rewrite_default_file .herdr-git-status-playground.json
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" NAMESPACE_MISMATCH
+  printf '%s\n' "$original_marker" | hgsp_rewrite_default_file .herdr-git-status-playground.json
+
+  printf '%s\n# drifted outside the controller\n' "$original_workflow" | hgsp_rewrite_default_file .github/workflows/herdr-git-status-playground.yml
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" WORKFLOW_DRIFT
+  assert_output --partial "inspect"
+  printf '%s\n' "$original_workflow" | hgsp_rewrite_default_file .github/workflows/herdr-git-status-playground.yml
+
+  # #then the nearby control converges after external repair
+  run hgsp_bootstrap
+  assert_success
+}
+
+@test "herdr-git-status-playground no-pr fixture rotates away from closed pull-request history" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+  local v1_branch
+  v1_branch="$(hgsp_record_field fixtures.no-pr.branch)"
+  assert_equal "$v1_branch" "herdr-playground/no-pr/v1"
+
+  hgsp_patch_github_state "repo['pulls'].append({'number': repo['next_pr_number'], 'node_id': 'PR_history', 'state': 'closed', 'draft': False, 'head_ref': '$v1_branch', 'head_sha': '0'*40, 'base_ref': 'main', 'user': 'playground-controller', 'mergeable': None, 'mergeable_state': 'unknown'}); repo['next_pr_number'] += 1"
+  run hgsp_bootstrap
+  assert_success
+  local v2_branch
+  v2_branch="$(hgsp_record_field fixtures.no-pr.branch)"
+  assert_equal "$v2_branch" "herdr-playground/no-pr/v2"
+  run "$HGSP_PYTHON" -c 'import json,sys; repo=json.load(open(sys.argv[1]))["repositories"]["github.com/example/herdr-status-fixtures"]; assert not [p for p in repo["pulls"] if p["head_ref"] == sys.argv[2]], "rotated branch has history"' \
+    "$HGSP_WORK/github-state.json" "$v2_branch"
+  assert_success
+  assert_equal "$(hgsp_github_query 'len([p for p in repo["pulls"] if p["state"] == "closed"])')" 1
+  assert_equal "$(hgsp_record_field fixtures.no-pr.checkout.branch)" "$v2_branch"
+
+  # #then the retired branch does not read as foreign drift on the next pass
+  run hgsp_bootstrap
+  assert_success
+  assert_equal "$(hgsp_record_field fixtures.no-pr.branch)" "$v2_branch"
+}
+
+@test "herdr-git-status-playground selects exact workflow records and settles mergeability authority" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  hgsp_patch_github_state 'repo["decoy_runs"] = True'
+  hgsp_patch_github_state "repo['workflow_runs'].append({'id': 8000, 'name': 'herdr-git-status-playground', 'head_branch': 'herdr-playground/checks-passed/head', 'head_sha': 'e'*40, 'status': 'completed', 'conclusion': 'failure', 'event': 'push'})"
+  run hgsp_bootstrap
+  assert_success
+  run "$HGSP_PYTHON" - "$(hgsp_repo_record)" "$HGSP_WORK/github-state.json" <<'PY'
+import json
+import sys
+
+record = json.load(open(sys.argv[1], encoding="utf-8"))
+repo = json.load(open(sys.argv[2], encoding="utf-8"))["repositories"]["github.com/example/herdr-status-fixtures"]
+runs = {run["id"]: run for run in repo["workflow_runs"]}
+for name, conclusion in (("checks-passed", "success"), ("checks-failed", "failure"), ("draft", "success")):
+    fixture = record["fixtures"][name]
+    run = runs[fixture["workflow_run_id"]]
+    assert run["name"] == "herdr-git-status-playground", run
+    assert run["head_branch"] == fixture["branch"], (run, fixture)
+    assert run["head_sha"] == fixture["head_sha"], (run, fixture)
+    assert run["conclusion"] == conclusion, run
+conflict = record["fixtures"]["merge-conflict"]
+assert conflict["mergeable"] is False, conflict
+assert conflict["mergeable_state"] == "dirty", conflict
+pull = [p for p in repo["pulls"] if p["number"] == conflict["pr_number"]][0]
+assert pull["mergeable"] is False and pull["mergeable_state"] == "dirty", pull
+PY
+  assert_success
+  # #then mergeability was polled until the authority settled, never assumed
+  run grep -cF "path=repos/example/herdr-status-fixtures/pulls/$(hgsp_record_field fixtures.merge-conflict.pr_number)|" "$HGSP_CALL_LOG"
+  assert_success
+  [[ "$output" -ge 3 ]]
+}
+
+@test "herdr-git-status-playground treats unrecorded owned-namespace changes as drift, never overwriting" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+
+  hgsp_seed_remote_ref refs/heads/herdr-playground/draft/head "unrecorded commit" refs/heads/herdr-playground/draft/head
+  local drifted_sha
+  drifted_sha="$(hgsp_remote_git rev-parse refs/heads/herdr-playground/draft/head)"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" OWNERSHIP_DRIFT
+  assert_equal "$(hgsp_remote_git rev-parse refs/heads/herdr-playground/draft/head)" "$drifted_sha"
+  hgsp_remote_git update-ref refs/heads/herdr-playground/draft/head "$(hgsp_record_field fixtures.draft.head_sha)"
+  run hgsp_bootstrap
+  assert_success
+
+  hgsp_patch_github_state "[p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/draft/head'][0].update({'user': 'intruder'})"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" OWNERSHIP_DRIFT
+  hgsp_patch_github_state "[p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/draft/head'][0].update({'user': 'playground-controller'})"
+
+  hgsp_patch_github_state "pr = [p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/checks-passed/head'][0]; pr['state'] = 'closed'; repo['pulls'].append(dict(pr, number=repo['next_pr_number'], node_id='PR_replaced', state='open')); repo['next_pr_number'] += 1"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" OWNERSHIP_DRIFT
+  hgsp_patch_github_state "repo['pulls'] = [p for p in repo['pulls'] if p['node_id'] != 'PR_replaced']; [p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/checks-passed/head'][0].update({'state': 'open'})"
+
+  local run_id
+  run_id="$(hgsp_record_field fixtures.checks-passed.workflow_run_id)"
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $run_id][0]['conclusion'] = 'failure'"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" OWNERSHIP_DRIFT
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $run_id][0]['conclusion'] = 'success'"
+
+  hgsp_seed_remote_ref refs/heads/herdr-playground/foreign "foreign namespace branch"
+  run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" OWNERSHIP_DRIFT
+  hgsp_remote_git update-ref -d refs/heads/herdr-playground/foreign
+
+  # #then the nearby control converges once drift is externally resolved
+  run hgsp_bootstrap
+  assert_success
+}
+
+@test "herdr-git-status-playground records verified fixture checkouts under controller-only credentials" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+
+  # #then every remote fixture has a recorded checkout with exact origin, branch, and head
+  run "$HGSP_PYTHON" - "$(hgsp_repo_record)" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+record = json.load(open(sys.argv[1], encoding="utf-8"))
+environment = dict(os.environ)
+environment.update(
+    {
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
+)
+
+
+def git(path, *arguments):
+    return subprocess.check_output(["git", "-C", path] + list(arguments), env=environment, text=True).strip()
+
+
+fixtures = record["fixtures"]
+assert sorted(fixtures) == ["checks-failed", "checks-passed", "draft", "merge-conflict", "no-pr"], sorted(fixtures)
+for name, fixture in fixtures.items():
+    checkout = fixture["checkout"]
+    path = checkout["path"]
+    assert os.path.isdir(path), path
+    assert git(path, "remote", "get-url", "origin") == "https://github.com/example/herdr-status-fixtures.git", name
+    assert git(path, "symbolic-ref", "--short", "HEAD") == checkout["branch"] == fixture["branch"], name
+    assert git(path, "rev-parse", "HEAD") == checkout["head_sha"] == fixture["head_sha"], name
+PY
+  assert_success
+
+  # #then bootstrap authenticated exclusively with the scoped controller credential
+  run "$HGSP_PYTHON" - "$HGSP_CALL_LOG" <<'PY'
+import sys
+
+lines = [line.strip() for line in open(sys.argv[1], encoding="utf-8")]
+gh = [line for line in lines if line.startswith("gh-sim|")]
+auth = [line for line in lines if line.startswith("git-auth|")]
+assert gh and auth
+for line in gh + auth:
+    assert "candidate-canary" not in line, line
+    assert "token=controller-canary" in line, line
+PY
+  assert_success
+  run grep -r candidate-canary "$HGSP_STATE_ROOT"
+  assert_failure
+  run grep -r controller-canary "$HGSP_STATE_ROOT"
+  assert_failure
+
+  # #then the candidate-read credential cannot mutate the repository
+  local refs_before
+  refs_before="$(hgsp_remote_git for-each-ref)"
+  HGSP_CONTROLLER_TOKEN=candidate-canary run hgsp_bootstrap
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_PERMISSION_INSUFFICIENT
+  assert_equal "$(hgsp_remote_git for-each-ref)" "$refs_before"
+}
+
+@test "herdr-git-status-playground defers approved and changes-requested states silently" {
+  hgsp_setup
+  hgsp_github_setup
+  run hgsp_initialize
+  assert_success
+  run hgsp_bootstrap
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" error)" None
+  summary="$output" "$HGSP_PYTHON" -c 'import json,os; out=json.loads(os.environ["summary"]); assert sorted(out["fixtures"]) == ["checks-failed", "checks-passed", "draft", "merge-conflict", "no-pr"], out; text=json.dumps(out).lower(); assert "approved" not in text; assert "changes-requested" not in text; assert "changes_requested" not in text'
+  run grep -iE 'approved|changes.requested' "$(hgsp_repo_record)"
+  assert_failure
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -2171,6 +2171,523 @@ PY
 }
 
 # ===========================================
+# herdr-git-status-playground comparison viewer and evidence snapshots (U6)
+# ===========================================
+
+@test "herdr-git-status-playground creates an isolated viewer with four equal panes identifying run, candidate, profile, and fixture" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  run hgsp_env view "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-ready
+
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+viewer = manifest["viewer"]
+assert viewer["attached_at"], viewer
+assert viewer["diagnostic"] is False, viewer
+panes = viewer["panes"]
+assert set(panes) == {"ezcorp", "sfroment", "krystof", "jmarbutt"}, panes
+size = viewer["pane_size"]
+assert size["width"] > 0 and size["height"] > 0, size
+for name, pane in panes.items():
+    header = pane["header"]
+    assert header["run_id"] == manifest["run_id"], header
+    assert isinstance(header["generation"], int) and header["generation"] >= 0, header
+    assert header["candidate"] == manifest["candidates"][name]["revision"], header
+    assert header["profile"] == name, header
+    assert header["fixture"] == "checkout-clean", header
+PY
+  assert_success
+
+  # #then the viewer never touched, and cannot reach, the live socket
+  run "$HGSP_PYTHON" - "$HGSP_ENV_LOG" <<'PY'
+import json
+import sys
+
+records = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+by_class = {record["class"]: record["environment"] for record in records}
+child = by_class["viewer-attach"]
+assert "HERDR_SOCKET_PATH" not in child, child
+assert "HERDR_CLIENT_SOCKET_PATH" not in child, child
+assert "HERDR_ENV" not in child, child
+PY
+  assert_success
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground enforces minimum equal terminal dimensions and marks a shrunk view diagnostic until restored" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  # #given a terminal below the documented minimum, before any viewer exists
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEWER_DIMENSIONS=40x10 run hgsp_env view "$run_id"
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" VIEWER_DIMENSIONS_TOO_SMALL
+  run "$HGSP_PYTHON" -c "import json,sys; m=json.load(open(sys.argv[1])); assert m['viewer'] is None, m['viewer']" \
+    "$(hgsp_manifest "$run_id")"
+  assert_success
+
+  # #given an acceptable size, the viewer attaches cleanly
+  run hgsp_env view "$run_id"
+  assert_success
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["viewer"]["diagnostic"]')" false
+
+  # #when the terminal later shrinks below the minimum
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEWER_DIMENSIONS=40x10 run hgsp_env view "$run_id"
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" VIEWER_DIMENSIONS_TOO_SMALL
+  # #then the view is marked diagnostic rather than silently kept equal
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["viewer"]["diagnostic"]')" true
+
+  # #then restoring an equal-region size clears the diagnostic
+  run hgsp_env view "$run_id"
+  assert_success
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["viewer"]["diagnostic"]')" false
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground refuses to attach a missing candidate socket and never spawns a replacement server" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  local jmarbutt_pid
+  jmarbutt_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["server-jmarbutt"]["pid"]')"
+
+  # #given the jmarbutt candidate server is gone before the viewer ever attaches
+  kill -TERM "$jmarbutt_pid"
+  for _ in $(seq 1 200); do
+    kill -0 "$jmarbutt_pid" 2>/dev/null || break
+    sleep 0.01
+  done
+
+  run hgsp_env view "$run_id"
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" VIEWER_ATTACH_SOCKET_MISSING
+
+  # #then the three unaffected candidates attached and jmarbutt never got a replacement server
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+panes = (manifest.get("viewer") or {}).get("panes") or {}
+assert set(panes) == {"ezcorp", "sfroment", "krystof"}, panes
+assert "client-jmarbutt" not in manifest["processes"], sorted(manifest["processes"])
+PY
+  assert_success
+  run grep -F 'herdr|jmarbutt|server run' "$HGSP_CALL_LOG"
+  assert_success
+  assert_equal "${#lines[@]}" 1
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground attaches the viewer only from an interactive active-ready start, and a degraded run still allows an explicit view" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #when start runs interactively it reaches active-ready already viewing
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_INTERACTIVE=1 run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["viewer"]["attached_at"] is not None')" true
+  run hgsp_env stop "$run_id"
+  assert_success
+
+  # #given a plain (non-interactive) start
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  # #then it returned without requiring a TTY and never auto-attached a viewer
+  run "$HGSP_PYTHON" -c "import json,sys; m=json.load(open(sys.argv[1])); assert m['viewer'] is None, m['viewer']" \
+    "$(hgsp_manifest "$run_id")"
+  assert_success
+
+  # #when the run is later marked degraded
+  hgsp_patch_manifest "$run_id" 'manifest["lifecycle_state"] = "active-degraded"'
+  # #then finalize refuses acceptance from a degraded run
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_REQUIRES_ACTIVE_READY
+  # #but an explicit view still attaches it, diagnostic evidence rather than blocked
+  run hgsp_env view "$run_id"
+  assert_success
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["viewer"]["attached_at"] is not None')" true
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground rejects a stale fixture-focus reading and an observation that predates activation" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  # #given a real switch away from the provisioning default fixture
+  run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-dirty
+  assert_success
+
+  # #when the ezcorp profile echoes its cached pre-switch focus instead of a fresh read
+  HGSP_STALE_FOCUS_READ=1 run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-dirty
+  # #then the stale-but-plausible value cannot establish readiness
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" SNAPSHOT_FIXTURE_MISMATCH
+
+  # #given an observation timestamped before the candidate's own activation
+  hgsp_patch_manifest "$run_id" 'manifest["candidates"]["ezcorp"]["ready_at"] = "2999-01-01T00:00:00Z"'
+  run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-dirty
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" SNAPSHOT_NOT_CAUSAL
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground snapshot output attributes run, candidate, profile, fixture, ground truth, and readiness" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  run hgsp_env snapshot "$run_id" --profile krystof --fixture checkout-clean --notes "clean sidebar reads as clean"
+  assert_success
+  run "$HGSP_PYTHON" - "$output" <<'PY'
+import json
+import sys
+
+record = json.loads(sys.argv[1])
+row = record["result"]
+assert row["run_id"] == record["run_id"], row
+assert row["profile"] == "krystof", row
+assert row["fixture"] == "checkout-clean", row
+assert row["candidate"] == "fe6575a89de9006c35d9d0b9707397839d983cff", row
+assert row["ground_truth_classification"]["kind"] == "local", row
+assert row["ground_truth_classification"]["fixture"]["repository"] == "work-tree", row
+assert row["captured_at"], row
+assert row["lifecycle_note"] == "active-ready", row
+assert row["readability_note"] == "clean sidebar reads as clean", row
+PY
+  assert_success
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground indexes screenshot and raw-observation hashes against the visible pane identity" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  run hgsp_env view "$run_id"
+  assert_success
+
+  local screenshot="$HGSP_WORK/pane.png"
+  printf 'not a real image, just fixture bytes' > "$screenshot"
+
+  run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-clean --screenshot "$screenshot"
+  assert_success
+
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$HGSP_STATE_ROOT" "$run_id" "$screenshot" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+manifest_path, state_root, run_id, screenshot = sys.argv[1:]
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+run_dir = os.path.join(state_root, "runs", run_id)
+index = json.load(open(os.path.join(run_dir, "evidence-index.json"), encoding="utf-8"))
+row = next(r for r in index["rows"] if r["profile"] == "ezcorp" and r["fixture"] == "checkout-clean")
+header = row["header"]
+assert header["run_id"] == manifest["run_id"] == row["run_id"], row
+assert header["candidate"] == row["candidate"], row
+assert header["profile"] == row["profile"] == "ezcorp", row
+assert header["fixture"] == row["fixture"] == "checkout-clean", row
+expected_screenshot = hashlib.sha256(open(screenshot, "rb").read()).hexdigest()
+assert row["hashes"]["screenshot_sha256"] == expected_screenshot, row["hashes"]
+raw_path = os.path.join(run_dir, "observations", "snapshot-ezcorp-checkout-clean-%s.json" % row["observation_id"])
+expected_raw = hashlib.sha256(open(raw_path, "rb").read()).hexdigest()
+assert row["hashes"]["raw_observation_sha256"] == expected_raw, row["hashes"]
+assert row["screenshot_path"] and os.path.exists(os.path.join(run_dir, row["screenshot_path"])), row
+PY
+  assert_success
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground finalize rejects missing, duplicate, stale, misattributed, and incomplete evidence" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  local candidates=(ezcorp sfroment krystof jmarbutt)
+  local fixtures=(
+    checkout-clean checkout-dirty worktree-clean worktree-dirty conflict diverged-stash detached non-git
+    gh-no-pr gh-draft gh-checks-failed gh-checks-passed gh-merge-conflict
+  )
+  local name label
+  for label in "${fixtures[@]}"; do
+    for name in "${candidates[@]}"; do
+      run hgsp_env snapshot "$run_id" --profile "$name" --fixture "$label"
+      assert_success
+    done
+  done
+
+  # #then full, non-duplicated coverage of every candidate-fixture pair finalizes
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" result.row_count)" 52
+
+  # #given one candidate-fixture pair is recorded twice
+  hgsp_patch_evidence_index "$run_id" 'rows.append(dict(rows[0]))'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_DUPLICATE_RECORD
+
+  # #given that duplicate is undone but a different pair is then missing entirely
+  hgsp_patch_evidence_index "$run_id" '
+rows.pop()
+index["stashed_row"] = rows.pop()
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_MISSING_RECORD
+
+  # #given the missing pair is restored, coverage is complete again
+  hgsp_patch_evidence_index "$run_id" 'rows.append(index.pop("stashed_row"))'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  # #given one row is missing a required R11 field
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "checkout-clean":
+        index["stashed_note"] = row.pop("dependency_note")
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_MISSING_FIELDS
+
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "checkout-clean":
+        row["dependency_note"] = index.pop("stashed_note")
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  # #given a GitHub fixture row's recorded authority has drifted since capture
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "gh-checks-passed":
+        index["stashed_sha"] = row["ground_truth_classification"]["fixture"]["head_sha"]
+        row["ground_truth_classification"]["fixture"]["head_sha"] = "f" * 40
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_STALE_AUTHORITY
+
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "gh-checks-passed":
+        row["ground_truth_classification"]["fixture"]["head_sha"] = index.pop("stashed_sha")
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  # #given a screenshot is attributed on a row with no visible pane header to attribute it to
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "checkout-clean":
+        row["screenshot_path"] = "observations/fake-screenshot.png"
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_SCREENSHOT_IDENTITY_MISMATCH
+
+  hgsp_patch_evidence_index "$run_id" '
+for row in rows:
+    if row["profile"] == "ezcorp" and row["fixture"] == "checkout-clean":
+        row["screenshot_path"] = None
+        break
+'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  # #given the viewer panes are recorded as an unequal split
+  hgsp_patch_manifest "$run_id" \
+    'manifest["viewer"] = {"dimensions": {"columns": 81, "rows": 24}, "diagnostic": False, "panes": {}}'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_UNEQUAL_PANES
+
+  hgsp_patch_manifest "$run_id" 'manifest["viewer"] = None'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  # #given the run's recorded current fixture disagrees with live candidate focus
+  hgsp_patch_manifest "$run_id" 'manifest["current_fixture"] = "checkout-dirty"'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_failure
+  assert_equal "$(hgsp_json_field "$output" error.code)" FINALIZE_WRONG_ACTIVE_FIXTURE
+
+  hgsp_patch_manifest "$run_id" 'manifest["current_fixture"] = "gh-merge-conflict"'
+  run hgsp_env snapshot "$run_id" --finalize
+  assert_success
+
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground a dead nested client does not block status, snapshot, or stop" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  run hgsp_env view "$run_id"
+  assert_success
+  local client_pid
+  client_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["client-krystof"]["pid"]')"
+
+  kill -KILL "$client_pid"
+  for _ in $(seq 1 200); do
+    kill -0 "$client_pid" 2>/dev/null || break
+    sleep 0.01
+  done
+
+  # #then status still reports, now degraded since an owned process is gone
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" effective_state)" active-degraded
+
+  # #and snapshot for another candidate still succeeds
+  run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-clean
+  assert_success
+
+  # #and stop still succeeds
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground view and snapshot join the same run-mutation barrier a concurrent stop cannot bypass" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  local marker="$HGSP_WORK/lease-held" release="$HGSP_WORK/lease-release"
+
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_MARKER="$marker" \
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_RELEASE="$release" \
+    hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-clean > "$HGSP_WORK/snapshot.out" 2>&1 &
+  local holder_pid=$!
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $holder_pid"
+  hgsp_wait_for_file "$marker"
+
+  # #when a concurrent stop arrives while snapshot still owns the lease
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" RUN_BUSY
+  # #then the lifecycle state and ownership records are unharmed, not regressed
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-ready
+
+  : > "$release"
+  wait "$holder_pid"
+  HGSP_BG_PIDS=""
+
+  # #then stop now succeeds cleanly once the lease is free
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground ordered teardown continues after one viewer-owned failure, retains runtime, and clears it once resolved" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  run hgsp_env view "$run_id"
+  assert_success
+
+  # #given the viewer server's own record is corrupted (mismatched identity).
+  # Deliberately not a nested client: every client's idle loop watches its
+  # candidate's own socket, which the same teardown pass tears down a few
+  # launch-intent entries earlier, so a corrupted client can race its own
+  # candidate's shutdown and exit on its own before its turn is even checked.
+  # The viewer server has no such dependency, so its corruption deterministically
+  # survives to its own turn in the generic teardown loop.
+  hgsp_patch_manifest "$run_id" "manifest['processes']['server-viewer']['start_identity']='mismatched'"
+
+  # #when stop runs, it still settles every other safe phase (candidates, panes)
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_MISMATCH
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["ezcorp"]["completed"]')" true
+  # #then the disposable runtime is retained, not removed, while incomplete
+  [[ -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]]
+
+  # #given the corrupted record is corrected (models an operator recovering identity)
+  local pid start_identity
+  pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["server-viewer"]["pid"]')"
+  start_identity="$(hgsp_process_start_identity "$pid")"
+  hgsp_patch_manifest "$run_id" "manifest['processes']['server-viewer']['start_identity']='$start_identity'"
+
+  # #then repeated stop now settles everything and removes the runtime
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  [[ ! -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]]
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -406,6 +406,15 @@ PY
   hgsp_capture_run_id
   run_id="$HGSP_LAST_RUN_ID"
   generation="$(hgsp_json_field "$output" generation)"
+  # Captured now (not grepped from the shared call log later): the earlier
+  # start's own foundation process is torn down correctly above and may or
+  # may not win its race to log a TERM line before this run even begins, so
+  # a bare "no TERM anywhere in the log" check is a coin flip on whether that
+  # unrelated, already-verified teardown happened to get logged in time.
+  # Binding to this run's own recorded pid keeps the assertion about exactly
+  # what the test claims: view's detach never signals *this* run's process.
+  local probe_pid
+  probe_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["foundation-supervisor"]["pid"]')"
   marker="$HGSP_WORK/view-waiting"
   HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_MARKER="$marker" \
   HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_RELEASE="$HGSP_WORK/view-release" \
@@ -422,7 +431,7 @@ PY
   run hgsp_env status "$run_id"
   assert_success
   assert_equal "$(hgsp_json_field "$output" generation)" "$generation"
-  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  run grep "managed-probe|TERM|$probe_pid\$" "$HGSP_CALL_LOG"
   assert_failure
 }
 
@@ -1572,6 +1581,13 @@ PY
 
   # #then a dispatch that never materializes exhausts the bounded promotion window
   hgsp_patch_github_state 'repo["dispatch_creates_run"] = False'
+  # hgsp_remote_ready's own bootstrap (initialize, then converge) already
+  # verifies each PR fixture's workflow run, logging the same
+  # actions/runs-listing calls the promotion loop below uses; counting from
+  # this offset keeps the bound below scoped to only the queries this one
+  # start's promotion loop issues, not bootstrap's unrelated baseline traffic.
+  local query_log_offset
+  query_log_offset="$(wc -l < "$HGSP_CALL_LOG")"
   run hgsp_start
   assert_failure 1
   hgsp_capture_run_id
@@ -1584,8 +1600,11 @@ PY
   # #then the promotion loop stayed within the recorded bounded deadline
   local bound queries
   bound="$(hgsp_manifest_query "$run_id" 'remote["generation"]["deadlines"]["promotion_attempts"]')"
-  queries="$(grep -c 'path=repos/example/herdr-status-fixtures/actions/runs|' "$HGSP_CALL_LOG")"
-  [[ "$queries" -le $((bound + 2)) ]]
+  queries="$(tail -n "+$((query_log_offset + 1))" "$HGSP_CALL_LOG" \
+    | grep -c 'path=repos/example/herdr-status-fixtures/actions/runs|')"
+  if (( queries > bound + 2 )); then
+    fail "promotion loop issued $queries actions/runs queries, expected at most $((bound + 2))"
+  fi
   run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
   assert_failure
   hgsp_patch_github_state 'repo["dispatch_creates_run"] = True'

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -2,6 +2,7 @@
 
 load 'helpers/common'
 load 'helpers/herdr_task_sync'
+load 'helpers/herdr_git_status_playground'
 
 setup() {
   unset HERDR_CHILD_NAME
@@ -9,9 +10,462 @@ setup() {
 }
 
 teardown() {
+  hgsp_teardown
   hts_teardown
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
   [[ -n "${CHILD_STUB:-}" ]] && rm -rf "$CHILD_STUB" || true
+}
+
+# ===========================================
+# herdr-git-status-playground controller (U1)
+# ===========================================
+
+@test "herdr-git-status-playground rejects invalid CLI input without state" {
+  hgsp_setup
+  run hgsp_env
+  assert_failure 2
+  assert_output --partial "usage:"
+  assert_file_not_exists "$HGSP_STATE_ROOT"
+
+  run hgsp_env status --unknown
+  assert_failure 2
+  assert_output --partial "unrecognized arguments"
+  assert_file_not_exists "$HGSP_STATE_ROOT"
+}
+
+@test "herdr-git-status-playground isolates profiles and child environments" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" provisioning
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+
+  run "$HGSP_PYTHON" - "$HGSP_ENV_LOG" "$(hgsp_manifest "$HGSP_LAST_RUN_ID")" "$HGSP_WORK" <<'PY'
+import json
+import os
+import sys
+
+env_log, manifest_path, work = sys.argv[1:]
+records = [json.loads(line) for line in open(env_log, encoding="utf-8") if line.strip()]
+by_class = {record["class"]: record["environment"] for record in records}
+required = {"controller-git", "controller-gh", "candidate-build", "candidate-runtime", "viewer"}
+assert required <= by_class.keys(), by_class.keys()
+poisoned = {
+    "HERDR_ENV", "HERDR_SESSION", "HERDR_SOCKET_PATH", "HERDR_CLIENT_SOCKET_PATH",
+    "HERDR_CONFIG_PATH", "GH_REPO", "GH_HOST", "GITHUB_REPOSITORY", "GITHUB_TOKEN",
+    "SSH_AUTH_SOCK", "GPG_AGENT_INFO", "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH",
+    "LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP",
+    "NODE_OPTIONS", "RUBYOPT", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "SSH_ASKPASS",
+}
+for name, child in by_class.items():
+    assert poisoned.isdisjoint(child), (name, poisoned & child.keys())
+    assert child["NO_COLOR"] == "safe-control", (name, child)
+    assert work + "/poison-bin" not in child["PATH"], (name, child["PATH"])
+assert "GH_TOKEN" not in by_class["candidate-build"]
+assert "GH_TOKEN" not in by_class["viewer"]
+assert by_class["controller-gh"]["GH_TOKEN"] == "<redacted>"
+assert by_class["candidate-runtime"]["GH_TOKEN"] == "<redacted>"
+git = by_class["controller-git"]
+assert git["GIT_CONFIG_SYSTEM"] == "/dev/null"
+assert git["GIT_TERMINAL_PROMPT"] == "0"
+assert git["HOME"].startswith(work + "/xdg-state/herdr-git-status-playground/runs/")
+assert git["GIT_CONFIG_GLOBAL"].startswith(git["HOME"])
+assert git["HERDR_PLAYGROUND_CANONICAL_REMOTE"] == "https://github.com/example/herdr-status-fixtures.git"
+assert git["GIT_CONFIG_KEY_0"] == "credential.helper"
+controller_root = os.path.dirname(git["HOME"])
+assert git["GIT_CONFIG_VALUE_0"].startswith("store --file=" + controller_root + "/")
+assert not os.path.exists(git["GIT_CONFIG_VALUE_0"].removeprefix("store --file="))
+assert git["GIT_ASKPASS"] != "poison"
+with open(manifest_path, encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert manifest["canonical_remote"] == "https://github.com/example/herdr-status-fixtures.git"
+profiles = manifest["profiles"]
+assert len(profiles) == 5
+keys = ("home", "config_home", "state_home", "data_home", "socket")
+for key in keys:
+    values = [profile[key] for profile in profiles.values()]
+    assert len(values) == len(set(values)), (key, values)
+live_roots = [work + "/live-config/herdr", work + "/xdg-state/herdr", work + "/live-data/herdr"]
+for profile in profiles.values():
+    for key in keys:
+        path = os.path.realpath(profile[key])
+        assert all(os.path.commonpath([path, root]) != root for root in live_roots), (path, live_roots)
+run_root = os.path.dirname(manifest_path)
+for directory, _, files in os.walk(run_root):
+    for name in files:
+        contents = open(os.path.join(directory, name), "rb").read()
+        assert b"controller-canary" not in contents, os.path.join(directory, name)
+        assert b"candidate-canary" not in contents, os.path.join(directory, name)
+PY
+  assert_success
+}
+
+@test "herdr-git-status-playground rejects every missing dependency before launch" {
+  hgsp_setup
+  local tool expected
+  for tool in cargo node jq gh git python3; do
+    mv "$HGSP_STUB/$tool" "$HGSP_STUB/$tool.off"
+    run hgsp_start
+    assert_failure 1
+    expected="$(printf '%s' "$tool" | tr '[:lower:]' '[:upper:]')_NOT_FOUND"
+    assert_equal "$(hgsp_json_field "$output" error.code)" "$expected"
+    hgsp_assert_no_launch_or_mutation
+    mv "$HGSP_STUB/$tool.off" "$HGSP_STUB/$tool"
+  done
+}
+
+@test "herdr-git-status-playground pins Herdr 0.8.2 to its approved path" {
+  hgsp_setup
+  mv "$HGSP_STUB/herdr" "$HGSP_STUB/herdr.off"
+  run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" HERDR_NOT_FOUND
+  hgsp_assert_no_launch_or_mutation
+  mv "$HGSP_STUB/herdr.off" "$HGSP_STUB/herdr"
+
+  HGSP_HERDR_VERSION='herdr 0.8.3' run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" HERDR_VERSION_UNAPPROVED
+  hgsp_assert_no_launch_or_mutation
+
+  cp "$HGSP_STUB/herdr" "$HGSP_STUB/herdr-approved"
+  chmod +x "$HGSP_STUB/herdr-approved"
+  local args=()
+  while IFS= read -r value; do args+=("$value"); done < <(hgsp_start_args)
+  args[1]="$HGSP_STUB/herdr-approved"
+  run hgsp_env start "${args[@]}"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" HERDR_PATH_CHANGED
+  hgsp_assert_no_launch_or_mutation
+
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  hgsp_wait_for_file "$HGSP_WORK/managed-ready"
+  run grep '^managed-probe|start|' "$HGSP_CALL_LOG"
+  assert_success
+}
+
+@test "herdr-git-status-playground rejects unproved ownership audit and auth" {
+  hgsp_setup
+  local valid_fixture valid_audit
+  valid_fixture="$HGSP_WORK/fixture-ownership.json"
+  valid_audit="$HGSP_WORK/audit-attestation.json"
+
+  printf '%s\n' '{"host":"github.com","owner":"example","name":"my-mac-setup","repository_id":"R_wrong","owned":true}' > "$valid_fixture"
+  run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" FIXTURE_OWNERSHIP_UNPROVED
+  hgsp_assert_no_launch_or_mutation
+
+  hgsp_setup
+  printf '%s\n' '{"candidates":{}}' > "$HGSP_WORK/audit-attestation.json"
+  run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUDIT_ATTESTATION_INVALID
+  hgsp_assert_no_launch_or_mutation
+
+  hgsp_setup
+  HGSP_GH_AUTH_STATUS=1 run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" CONTROLLER_AUTH_FAILED
+  hgsp_assert_no_launch_or_mutation
+
+  hgsp_setup
+  valid_fixture="$HGSP_WORK/fixture-ownership.json"
+  valid_audit="$HGSP_WORK/audit-attestation.json"
+  run env PATH="$HGSP_STUB:/bin" XDG_STATE_HOME="$HGSP_XDG_STATE" \
+    HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN=same \
+    HERDR_GIT_STATUS_PLAYGROUND_CANDIDATE_TOKEN=same \
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_MODE=1 \
+    "$HGSP_PYTHON" "$HGSP_CONTROLLER" start \
+    --approved-herdr "$HGSP_STUB/herdr" --fixture-ownership "$valid_fixture" \
+    --audit-attestation "$valid_audit"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" CREDENTIAL_AUTHORITY_INVALID
+  hgsp_assert_no_launch_or_mutation
+}
+
+@test "herdr-git-status-playground atomically replaces private manifests" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local manifest marker release background_output
+  manifest="$(hgsp_manifest "$HGSP_LAST_RUN_ID")"
+  marker="$HGSP_WORK/atomic-ready"
+  release="$HGSP_WORK/atomic-release"
+
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_ATOMIC_MARKER="$marker" \
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_ATOMIC_RELEASE="$release" \
+    hgsp_env stop "$HGSP_LAST_RUN_ID" > "$HGSP_WORK/stop.out" 2>&1 &
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $!"
+  hgsp_wait_for_file "$marker"
+  run "$HGSP_PYTHON" - "$manifest" <<'PY'
+import json,sys
+for _ in range(500):
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        value = json.load(handle)
+    assert isinstance(value["generation"], int)
+    assert value["run_id"]
+PY
+  assert_success
+  : > "$release"
+  wait ${HGSP_BG_PIDS##* }
+  HGSP_BG_PIDS=""
+  background_output="$(<"$HGSP_WORK/stop.out")"
+  assert_equal "$(hgsp_json_field "$background_output" lifecycle_state)" stopped
+  run "$HGSP_PYTHON" -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$manifest"
+  assert_success
+  assert_output 600
+}
+
+@test "herdr-git-status-playground blocks spawn when intent persistence fails" {
+  hgsp_setup
+  local point
+  for point in permission write space replace; do
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="intent-$point" run hgsp_start
+    assert_failure 1
+    hgsp_capture_run_id
+    local expected
+    expected="INTENT_$(printf '%s' "$point" | tr '[:lower:]' '[:upper:]')_FAILED"
+    assert_equal "$(hgsp_json_field "$output" error.code)" "$expected"
+    assert_equal "$(hgsp_json_field "$output" next_command)" "stop $HGSP_LAST_RUN_ID"
+    hgsp_assert_no_launch_or_mutation
+    run "$HGSP_PYTHON" -m json.tool "$(hgsp_manifest "$HGSP_LAST_RUN_ID")"
+    assert_success
+  done
+}
+
+@test "herdr-git-status-playground crash boundaries preserve recoverable intents" {
+  hgsp_setup
+  local point run_id manifest
+  for point in before-spawn after-spawn before-identity-commit; do
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="$point" run hgsp_start
+    assert_failure 1
+    hgsp_capture_run_id
+    run_id="$HGSP_LAST_RUN_ID"
+    manifest="$(hgsp_manifest "$run_id")"
+    assert_equal "$(hgsp_json_field "$output" run_id)" "$run_id"
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" provisioning
+    run "$HGSP_PYTHON" - "$manifest" <<'PY'
+import json,sys
+manifest=json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["launch_intents"]
+assert next(iter(manifest["launch_intents"].values()))["phase"] in {"intent-committed", "spawn-attempted"}
+PY
+    assert_success
+
+    run hgsp_env status "$run_id"
+    assert_success
+    assert_equal "$(hgsp_json_field "$output" run_id)" "$run_id"
+    run hgsp_env stop "$run_id"
+    if [[ "$point" == after-spawn || "$point" == before-identity-commit ]]; then
+      assert_success
+    else
+      assert_success
+    fi
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  done
+}
+
+@test "herdr-git-status-playground serializes mutations without elapsed-time lease stealing" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id marker release first_pid current_start generation
+  run_id="$HGSP_LAST_RUN_ID"
+  marker="$HGSP_WORK/lease-held"
+  release="$HGSP_WORK/lease-release"
+  generation="$(hgsp_json_field "$output" generation)"
+
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_MARKER="$marker" \
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_LEASE_RELEASE="$release" \
+    hgsp_env stop "$run_id" > "$HGSP_WORK/first-stop.out" 2>&1 &
+  first_pid=$!
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $first_pid"
+  hgsp_wait_for_file "$marker"
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" RUN_BUSY
+  run hgsp_env status "$run_id"
+  assert_success
+  [[ "$(hgsp_json_field "$output" generation)" -gt "$generation" ]]
+  : > "$release"
+  wait "$first_pid"
+  HGSP_BG_PIDS=""
+
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  current_start="$(hgsp_process_start_identity "$$")"
+  hgsp_set_manifest_lease "$run_id" "$$" "$current_start"
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" RUN_BUSY
+
+  hgsp_patch_manifest "$run_id" "manifest['mutation_lease']['start_identity']='mismatched-start-identity'"
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground discovers and stops partial runs by ID" {
+  hgsp_setup
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=after-spawn run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  run hgsp_env status --all
+  assert_success
+  run_id="$run_id" "$HGSP_PYTHON" -c 'import json,os,sys; rows=json.loads(sys.argv[1])["runs"]; assert os.environ["run_id"] in [row["run_id"] for row in rows]' "$output"
+  assert_success
+
+  local manifest_before manifest_after
+  manifest_before="$($HGSP_PYTHON -c 'import hashlib,os,sys; p=sys.argv[1]; print(hashlib.sha256(open(p,"rb").read()).hexdigest(), os.stat(p).st_mtime_ns)' "$(hgsp_manifest "$run_id")")"
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" effective_state)" provisioning
+  manifest_after="$($HGSP_PYTHON -c 'import hashlib,os,sys; p=sys.argv[1]; print(hashlib.sha256(open(p,"rb").read()).hexdigest(), os.stat(p).st_mtime_ns)' "$(hgsp_manifest "$run_id")")"
+  assert_equal "$manifest_after" "$manifest_before"
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_file_not_exists "$HGSP_STATE_ROOT/runs/$run_id/runtime"
+
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground interruption tears down start but only detaches view" {
+  hgsp_setup
+  local marker="$HGSP_WORK/start-waiting" start_pid run_id generation
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_START_MARKER="$marker" \
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_START_RELEASE="$HGSP_WORK/start-release" \
+    hgsp_start > "$HGSP_WORK/start.out" 2>&1 &
+  start_pid=$!
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $start_pid"
+  hgsp_wait_for_file "$marker"
+  local controller_pid
+  controller_pid="$(<"$marker")"
+  kill -INT "$controller_pid"
+  wait "$start_pid" || true
+  HGSP_BG_PIDS=""
+  local start_output="$(<"$HGSP_WORK/start.out")"
+  run_id="$(hgsp_json_field "$start_output" run_id)"
+  HGSP_RUN_IDS="$HGSP_RUN_IDS $run_id"
+  assert_equal "$(hgsp_json_field "$start_output" error.code)" START_INTERRUPTED
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  generation="$(hgsp_json_field "$output" generation)"
+  marker="$HGSP_WORK/view-waiting"
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_MARKER="$marker" \
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_VIEW_RELEASE="$HGSP_WORK/view-release" \
+    hgsp_env view "$run_id" > "$HGSP_WORK/view.out" 2>&1 &
+  local view_pid=$!
+  HGSP_BG_PIDS="$HGSP_BG_PIDS $view_pid"
+  hgsp_wait_for_file "$marker"
+  controller_pid="$(<"$marker")"
+  kill -HUP "$controller_pid"
+  wait "$view_pid" || true
+  HGSP_BG_PIDS=""
+  local view_output="$(<"$HGSP_WORK/view.out")"
+  assert_equal "$(hgsp_json_field "$view_output" error.code)" VIEW_DETACHED
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" generation)" "$generation"
+  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  assert_failure
+}
+
+@test "herdr-git-status-playground never signals unknown or mismatched processes" {
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  hgsp_wait_for_file "$HGSP_WORK/managed-ready"
+  local unknown_pid
+  unknown_pid="$($HGSP_PYTHON -c 'import json,sys; print(next(iter(json.load(open(sys.argv[1]))["processes"].values()))["pid"])' "$(hgsp_manifest "$run_id")")"
+  hgsp_patch_manifest "$run_id" "manifest['processes']={}; next(iter(manifest['launch_intents'].values()))['claim']='runtime/launch/foundation-supervisor/missing-claim.json'"
+
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_UNRESOLVED
+  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  assert_failure
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_UNRESOLVED
+  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  assert_failure
+  run hgsp_env status --all
+  assert_success
+  run_id="$run_id" "$HGSP_PYTHON" -c 'import json,os,sys; assert os.environ["run_id"] in [row["run_id"] for row in json.loads(sys.argv[1])["runs"]]' "$output"
+  assert_success
+  : > "$HGSP_WORK/managed-release"
+  run "$HGSP_PYTHON" - "$unknown_pid" <<'PY'
+import os,sys,time
+pid=int(sys.argv[1])
+for _ in range(500):
+    try: os.kill(pid, 0)
+    except ProcessLookupError: break
+    time.sleep(0.01)
+else: raise SystemExit("unrecorded fixture process did not exit after causal release")
+PY
+  assert_success
+
+  hgsp_setup
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  hgsp_wait_for_file "$HGSP_WORK/managed-ready"
+  hgsp_patch_manifest "$run_id" "next(iter(manifest['processes'].values()))['start_identity']='mismatched'"
+
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_MISMATCH
+  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  assert_failure
+
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_MISMATCH
+  run grep 'managed-probe|TERM' "$HGSP_CALL_LOG"
+  assert_failure
+  : > "$HGSP_WORK/managed-release"
+}
+
+@test "herdr-git-status-playground extensionless Python is excluded from shellcheck by shebang" {
+  hgsp_setup
+  local stubdir="$HGSP_WORK/lint-stub"
+  mkdir -p "$stubdir"
+  cat > "$stubdir/shellcheck" <<'SH'
+#!/bin/sh
+for argument in "$@"; do
+  case "$argument" in
+    *executable_herdr-git-status-playground) exit 99 ;;
+  esac
+done
+exit 0
+SH
+  chmod +x "$stubdir/shellcheck"
+  run env PATH="$stubdir:$PATH" make -C "$BATS_TEST_DIRNAME/.." lint
+  assert_success
 }
 
 # ===========================================

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1239,6 +1239,467 @@ PY
 }
 
 # ===========================================
+# herdr-git-status-playground remote generation (U4)
+# ===========================================
+
+@test "herdr-git-status-playground run binds a leased generation with a durable nonce-bearing pending dispatch" {
+  hgsp_setup
+  hgsp_remote_ready
+  hgsp_patch_github_state 'repo["decoy_runs"] = True'
+
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_a="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  hgsp_wait_for_file "$HGSP_WORK/managed-ready"
+
+  # #then the run is bound to the repository lease and its own fixture generation
+  assert_equal "$(hgsp_manifest_query "$run_a" 'remote["generation"]["number"]')" 1
+  assert_equal "$(hgsp_manifest_query "$run_a" 'remote["lease"]["operation_id"]')" "$run_a"
+  assert_equal "$(hgsp_manifest_query "$run_a" 'remote["lease"]["sha"]')" \
+    "$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)"
+  assert_equal "$(hgsp_manifest_query "$run_a" 'len(remote["generation"]["snapshot"]["fixtures"])')" 5
+  # #then per-stage deadlines are recorded inside the generation
+  assert_equal "$(hgsp_manifest_query "$run_a" 'sorted(remote["generation"]["deadlines"])')" \
+    "['authority_attempts', 'hold_seconds', 'min_observation_seconds', 'promotion_attempts', 'readiness_attempts', 'settlement_attempts', 'workflow_timeout_minutes']"
+  # #then the pending intent is nonce-bearing and its hold exceeds the documented window under the hard timeout
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_a")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+pending = manifest["remote"]["pending"]
+assert pending["state"] == "ready", pending["state"]
+assert pending["hold_seconds"] > pending["min_observation_seconds"], pending
+assert pending["hold_seconds"] <= pending["workflow_timeout_minutes"] * 60, pending
+intents = pending["intents"]
+assert len(intents) == 1, intents
+intent = intents[0]
+assert intent["nonce"] and intent["nonce"] in intent["run_name"], intent
+assert intent["dispatched_at"], intent
+assert intent["run_ids"], intent
+assert manifest["remote"]["generation"]["pending_run_ids"] == intent["run_ids"], manifest["remote"]["generation"]
+assert pending["observation_window"]["min_seconds"] == pending["min_observation_seconds"]
+PY
+  assert_success
+  run grep -E '^gh-dispatch\|.*\|hold=1800\|' "$HGSP_CALL_LOG"
+  assert_success
+  local dispatched
+  dispatched="$(grep '^gh-dispatch|' "$HGSP_CALL_LOG" | sed 's/.*run=//')"
+  # #then decoy and push records on the same head stay excluded from the promotion
+  run "$HGSP_PYTHON" - "$HGSP_WORK/github-state.json" "$run_a" "$dispatched" <<'PY'
+import json
+import sys
+
+repo = json.load(open(sys.argv[1], encoding="utf-8"))["repositories"]["github.com/example/herdr-status-fixtures"]
+branch = "herdr-playground/checks-pending/%s" % sys.argv[2]
+on_branch = [run for run in repo["workflow_runs"] if run["head_branch"] == branch]
+assert len(on_branch) >= 3, on_branch
+dispatch_runs = [run for run in on_branch if run.get("event") == "workflow_dispatch"]
+assert [run["id"] for run in dispatch_runs] == [int(sys.argv[3])], dispatch_runs
+PY
+  assert_success
+  assert_equal "$(hgsp_manifest_query "$run_a" 'remote["generation"]["pending_run_ids"]')" "[$dispatched]"
+
+  # #then a second run cannot acquire the same repository lease while this run is active
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_HELD
+  assert_output --partial "$run_a"
+  assert_output --partial "stop $run_a"
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  assert_equal "$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)" \
+    "$(hgsp_manifest_query "$run_a" 'remote["lease"]["sha"]')"
+
+  # #then teardown settles the exact run, deletes the transient ref, and releases the lease
+  run hgsp_env stop "$run_a"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_a")" "$dispatched" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+settlement = manifest["remote"]["settlement"]
+runs = settlement["runs"]
+assert [run["run_id"] for run in runs] == [int(sys.argv[2])], runs
+assert runs[0]["cancelled"] is True and runs[0]["already_terminal"] is False, runs
+assert runs[0]["final_status"] == "completed" and runs[0]["conclusion"] == "cancelled", runs
+assert settlement["transient_ref_deleted"] is True, settlement
+assert manifest["remote"]["lease"]["released"]["verified"] == "conditional-delete", manifest["remote"]["lease"]
+PY
+  assert_success
+  run hgsp_remote_git rev-parse "refs/heads/herdr-playground/checks-pending/$run_a"
+  assert_failure
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  assert_equal "$(hgsp_record_field transient_refs)" "{}"
+
+  # #then terminal cleanup allows a new run on the next generation
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  assert_equal "$(hgsp_manifest_query "$HGSP_LAST_RUN_ID" 'remote["generation"]["number"]')" 2
+  run hgsp_env stop "$HGSP_LAST_RUN_ID"
+  assert_success
+  # #then durable state never retains a credential canary
+  run grep -r controller-canary "$HGSP_STATE_ROOT"
+  assert_failure
+  run grep -r candidate-canary "$HGSP_STATE_ROOT"
+  assert_failure
+}
+
+@test "herdr-git-status-playground refuses stale-owner takeover and settles leaked or foreign leases safely" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_a="$HGSP_LAST_RUN_ID"
+  run hgsp_env stop "$run_a"
+  assert_success
+  local settled_run host_id
+  settled_run="$(hgsp_manifest_query "$run_a" 'remote["generation"]["pending_run_ids"][0]')"
+  host_id="$(hgsp_host_installation_id)"
+
+  # #then a leaked terminal-run lease survives while any ownership probe is unsettled
+  hgsp_seed_lease "{\"schema_version\":1,\"operation_kind\":\"run\",\"operation_id\":\"$run_a\",\"host_installation_id\":\"$host_id\",\"workflow_intents\":[\"refs/heads/herdr-playground/checks-pending/$run_a\"]}"
+  local leaked_sha
+  leaked_sha="$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)"
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $settled_run][0].update({'status': 'in_progress', 'conclusion': None, 'cancel_requested': False})"
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_HELD
+  assert_output --partial "still active"
+  assert_equal "$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)" "$leaked_sha"
+
+  # #then once every probe settles the leaked lease is conditionally deleted and a run proceeds
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $settled_run][0].update({'status': 'completed', 'conclusion': 'cancelled'})"
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_b="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  run hgsp_env stop "$run_b"
+  assert_success
+
+  # #then a lease naming an unknown local run refuses automation
+  hgsp_seed_lease "{\"schema_version\":1,\"operation_kind\":\"run\",\"operation_id\":\"run-unknown-0000\",\"host_installation_id\":\"$host_id\",\"workflow_intents\":[]}"
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_HELD
+  assert_output --partial "no readable local manifest"
+
+  # #then a foreign-host lease always reports exact read-only inspection and manual recovery
+  hgsp_seed_lease "{\"schema_version\":1,\"operation_kind\":\"run\",\"operation_id\":\"run-elsewhere-0000\",\"host_installation_id\":\"foreign-host\",\"workflow_intents\":[\"refs/heads/herdr-playground/checks-pending/run-elsewhere-0000\"]}"
+  local foreign_sha
+  foreign_sha="$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)"
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_FOREIGN
+  assert_output --partial "git ls-remote"
+  assert_output --partial "gh run cancel"
+  assert_output --partial "refuses foreign takeover"
+  assert_output --partial "foreign-host"
+  assert_output --partial "run-elsewhere-0000"
+  assert_equal "$(hgsp_remote_git rev-parse refs/heads/herdr-playground/lease)" "$foreign_sha"
+
+  # #then the nearby control starts once the operator frees the lease externally
+  hgsp_remote_git update-ref -d refs/heads/herdr-playground/lease
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  run hgsp_env stop "$HGSP_LAST_RUN_ID"
+  assert_success
+}
+
+@test "herdr-git-status-playground pending dispatch intents are durable and crashes recover by exact query" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then the nonce-bearing intent is durable before any API dispatch
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=pending-before-dispatch run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" INJECTED_PENDING_BEFORE_DISPATCH
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" provisioning
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["phase"]')" intent-committed
+  [[ -n "$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["nonce"]')" ]]
+  run grep '^gh-dispatch|' "$HGSP_CALL_LOG"
+  assert_failure
+  # #then recovery verifies by query instead of assuming, then releases the lease
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["settlement"]["runs"]')" "[]"
+  run hgsp_remote_git rev-parse "refs/heads/herdr-playground/checks-pending/$run_id"
+  assert_failure
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+
+  # #then crashes after dispatch and before promotion recover through the nonce query
+  local point dispatched
+  for point in pending-after-dispatch pending-before-promotion; do
+    HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT="$point" run hgsp_start
+    assert_failure 1
+    hgsp_capture_run_id
+    run_id="$HGSP_LAST_RUN_ID"
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" provisioning
+    assert_equal "$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["run_ids"]')" "[]"
+    dispatched="$(grep '^gh-dispatch|' "$HGSP_CALL_LOG" | tail -1 | sed 's/.*run=//')"
+    run hgsp_env stop "$run_id"
+    assert_success
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+    assert_equal "$(hgsp_manifest_query "$run_id" '[r["run_id"] for r in remote["settlement"]["runs"]]')" "[$dispatched]"
+    assert_equal "$(hgsp_manifest_query "$run_id" 'remote["settlement"]["runs"][0]["conclusion"]')" cancelled
+    run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+    assert_failure
+  done
+
+  # #then a forged nonce-bearing record that disagrees with the recorded identity fails closed
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=pending-after-dispatch run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  local nonce
+  nonce="$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["nonce"]')"
+  hgsp_patch_github_state "repo['workflow_runs'].append({'id': repo['next_run_id'], 'name': 'herdr-git-status-playground $nonce', 'head_branch': 'herdr-playground/checks-pending/$run_id', 'head_sha': 'a'*40, 'status': 'completed', 'conclusion': 'success', 'event': 'workflow_dispatch'}); repo['next_run_id'] += 1"
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_NONCE_AMBIGUOUS
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_success
+  # #then the nearby control settles the same stop once the forgery is gone
+  hgsp_patch_github_state "repo['workflow_runs'] = [r for r in repo['workflow_runs'] if r['head_sha'] != 'a'*40]"
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+@test "herdr-git-status-playground retriggers one early completion and settles every dispatch attempt" {
+  hgsp_setup
+  hgsp_remote_ready
+  hgsp_patch_github_state 'repo["dispatch_complete_after_polls_queue"] = [0]'
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  # #then the early-completed first attempt cannot satisfy the fixture and was retriggered once
+  assert_equal "$(hgsp_manifest_query "$run_id" 'len(remote["pending"]["intents"])')" 2
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["pending"]["state"]')" ready
+  assert_equal "$(hgsp_manifest_query "$run_id" 'len(remote["generation"]["pending_run_ids"])')" 2
+  # #then teardown settles every exact numeric run ID, not only the newest
+  run hgsp_env stop "$run_id"
+  assert_success
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+remote = manifest["remote"]
+expected = set(remote["generation"]["pending_run_ids"])
+settled = {run["run_id"]: run for run in remote["settlement"]["runs"]}
+assert set(settled) == expected and len(expected) == 2, (settled, expected)
+assert sorted(run["already_terminal"] for run in settled.values()) == [False, True], settled
+for run in settled.values():
+    assert run["final_status"] == "completed", run
+PY
+  assert_success
+
+  # #then a second early completion fails startup into automatic cleanup
+  hgsp_patch_github_state 'repo["dispatch_complete_after_polls_queue"] = [0, 0]'
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_COMPLETED_EARLY
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  assert_equal "$(hgsp_manifest_query "$run_id" 'len(remote["pending"]["intents"])')" 2
+  assert_equal "$(hgsp_manifest_query "$run_id" 'len(remote["settlement"]["runs"])')" 2
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+}
+
+@test "herdr-git-status-playground fails startup closed on promotion deadlines, drift, and unsettled authority" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then a dispatch that never materializes exhausts the bounded promotion window
+  hgsp_patch_github_state 'repo["dispatch_creates_run"] = False'
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_PROMOTION_DEADLINE
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  # #then every dispatch identity is preserved through automatic teardown
+  [[ -n "$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["nonce"]')" ]]
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["pending"]["intents"][0]["phase"]')" settled
+  # #then the promotion loop stayed within the recorded bounded deadline
+  local bound queries
+  bound="$(hgsp_manifest_query "$run_id" 'remote["generation"]["deadlines"]["promotion_attempts"]')"
+  queries="$(grep -c 'path=repos/example/herdr-status-fixtures/actions/runs|' "$HGSP_CALL_LOG")"
+  [[ "$queries" -le $((bound + 2)) ]]
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  hgsp_patch_github_state 'repo["dispatch_creates_run"] = True'
+
+  # #then a moved fixture head is authority drift, never readiness or evidence
+  local draft_sha
+  draft_sha="$(hgsp_remote_git rev-parse refs/heads/herdr-playground/draft/head)"
+  hgsp_seed_remote_ref refs/heads/herdr-playground/draft/head "moved head" refs/heads/herdr-playground/draft/head
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUTHORITY_DRIFT
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  assert_output --partial "draft"
+  hgsp_remote_git update-ref refs/heads/herdr-playground/draft/head "$draft_sha"
+
+  # #then persistent unknown mergeability can never become stable evidence
+  hgsp_patch_github_state "[p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/merge-conflict/head'][0].update({'mergeable': None, 'mergeable_state': 'unknown', 'mergeable_polls_remaining': 10**6})"
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUTHORITY_UNSETTLED
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  hgsp_patch_github_state "[p for p in repo['pulls'] if p['head_ref'] == 'herdr-playground/merge-conflict/head'][0].update({'mergeable': False, 'mergeable_state': 'dirty'})"
+
+  # #then the nearby control reaches readiness once authority settles
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" FOUNDATION_PROCESS_RUNNING
+  run hgsp_env stop "$HGSP_LAST_RUN_ID"
+  assert_success
+}
+
+@test "herdr-git-status-playground retains the repository lease when settlement cannot be proved" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  local pending_run
+  pending_run="$(hgsp_manifest_query "$run_id" 'remote["generation"]["pending_run_ids"][0]')"
+
+  # #then authentication failure leaves cleanup-incomplete with the lease retained
+  HGSP_CONTROLLER_TOKEN=expired-token run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_IDENTITY_UNRESOLVED
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_success
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["generation"]["pending_run_ids"][0]')" "$pending_run"
+
+  # #then an unknown recorded identity leaves cleanup-incomplete with the lease retained
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $pending_run][0]['id'] = 424242"
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_RUN_UNKNOWN
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_success
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == 424242][0]['id'] = $pending_run"
+
+  # #then a run that stays active through the bounded window leaves cleanup-incomplete
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $pending_run][0]['uncancellable'] = True"
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_STILL_ACTIVE
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_success
+
+  # #then a new run stays blocked while the cleanup-incomplete run retains the lease
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" REPOSITORY_LEASE_HELD
+  assert_output --partial "$run_id"
+  assert_output --partial "stop $run_id"
+
+  # #then the nearby control settles the retried stop once cancellation can take effect
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $pending_run][0]['uncancellable'] = False"
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  run hgsp_remote_git rev-parse refs/heads/herdr-playground/lease
+  assert_failure
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground observation probes invalidate only drifted slices and persist degradation" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  hgsp_patch_manifest "$run_id" "manifest['lifecycle_state']='active-ready'"
+
+  # #then moving one fixture head invalidates only that observation slice
+  local draft_sha
+  draft_sha="$(hgsp_remote_git rev-parse refs/heads/herdr-playground/draft/head)"
+  hgsp_seed_remote_ref refs/heads/herdr-playground/draft/head "post-ready drift" refs/heads/herdr-playground/draft/head
+  run hgsp_env view "$run_id"
+  assert_failure
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["lifecycle_state"] == "active-degraded", manifest["lifecycle_state"]
+slices = manifest["remote"]["observations"][-1]["slices"]
+assert slices["draft"]["valid"] is False, slices["draft"]
+for name in ("no-pr", "checks-failed", "checks-passed", "merge-conflict", "checks-pending"):
+    assert slices[name]["valid"] is True, (name, slices[name])
+assert manifest["error"]["code"] == "AUTHORITY_DRIFT", manifest["error"]
+PY
+  assert_success
+  hgsp_remote_git update-ref refs/heads/herdr-playground/draft/head "$draft_sha"
+
+  # #then early completion after active-ready persists active-degraded, never stable evidence
+  hgsp_patch_manifest "$run_id" "manifest['lifecycle_state']='active-ready'; manifest['error']=None"
+  local pending_run
+  pending_run="$(hgsp_manifest_query "$run_id" 'remote["generation"]["pending_run_ids"][0]')"
+  hgsp_patch_github_state "[r for r in repo['workflow_runs'] if r['id'] == $pending_run][0].update({'status': 'completed', 'conclusion': 'success'})"
+  run hgsp_env view "$run_id"
+  assert_failure
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-degraded
+  assert_equal "$(hgsp_json_field "$output" error.code)" PENDING_COMPLETED_EARLY
+  assert_equal "$(hgsp_manifest_query "$run_id" 'remote["observations"][-1]["slices"]["checks-pending"]["valid"]')" false
+
+  # #then authentication expiry degrades the run instead of reading as no-PR or stable
+  hgsp_patch_manifest "$run_id" "manifest['lifecycle_state']='active-ready'; manifest['error']=None"
+  hgsp_patch_github_state 'state["api_fail_after"] = 0; state["api_fail_message"] = "HTTP 401: Bad credentials"'
+  run hgsp_env view "$run_id"
+  assert_failure
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-degraded
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUTHORITY_QUERY_FAILED
+  hgsp_patch_github_state 'state["api_fail_after"] = None'
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -148,6 +148,42 @@ PY
   assert_success
 }
 
+# ===========================================
+# herdr-git-status-playground runbook, inventory, and real-trial scaffolding (U7)
+# ===========================================
+
+@test "herdr-git-status-playground real-trial preflight records every optional toolchain status with non-Brewfile remediation" {
+  hgsp_setup
+  mv "$HGSP_STUB/jq" "$HGSP_STUB/jq.off"
+  run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" JQ_NOT_FOUND
+  local message
+  message="$(hgsp_json_field "$output" error.message)"
+  # #then every optional toolchain's own status is recorded, not just jq's
+  [[ "$message" == *'"cargo":"found"'* ]] || fail "message missing cargo status: $message"
+  [[ "$message" == *'"node":"found"'* ]] || fail "message missing node status: $message"
+  [[ "$message" == *'"jq":"missing"'* ]] || fail "message missing jq status: $message"
+  [[ "$message" == *'"gh":"found"'* ]] || fail "message missing gh status: $message"
+  # #and remediation points at a temporary or already-configured toolchain, never the Brewfile
+  [[ "$message" == *"temporarily"* ]] || fail "message missing temporary-install remediation: $message"
+  [[ "$message" == *"never add it to the managed Brewfile"* ]] || fail "message missing Brewfile guardrail: $message"
+  hgsp_assert_no_launch_or_mutation
+  mv "$HGSP_STUB/jq.off" "$HGSP_STUB/jq"
+}
+
+@test "herdr-git-status-playground redacts a leaked credential value from preflight output" {
+  hgsp_setup
+  # #given the auth probe's own stderr echoes the controller credential back
+  HGSP_GH_AUTH_STATUS=1 HGSP_LEAK_TOKEN_IN_STDERR=1 run hgsp_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" CONTROLLER_AUTH_FAILED
+  # #then the raw credential never reaches the CLI's own JSON output
+  refute_output --partial "controller-canary"
+  assert_output --partial "<redacted>"
+  hgsp_assert_no_launch_or_mutation
+}
+
 @test "herdr-git-status-playground rejects unproved ownership audit and auth" {
   hgsp_setup
   local valid_fixture valid_audit
@@ -2672,7 +2708,13 @@ for row in rows:
   assert_equal "$(hgsp_json_field "$output" error.code)" PROCESS_IDENTITY_MISMATCH
   assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["ezcorp"]["completed"]')" true
   # #then the disposable runtime is retained, not removed, while incomplete
-  [[ -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]]
+  [[ -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]] || fail "runtime was removed while cleanup-incomplete"
+  # #and a redacted raw diagnostic is retained for recovery (KTD17)
+  [[ -f "$HGSP_STATE_ROOT/runs/$run_id/logs/controller.log" ]] || fail "no controller.log was written"
+  run grep PROCESS_IDENTITY_MISMATCH "$HGSP_STATE_ROOT/runs/$run_id/logs/controller.log"
+  assert_success
+  refute_output --partial "controller-canary"
+  refute_output --partial "candidate-canary"
 
   # #given the corrupted record is corrected (models an operator recovering identity)
   local pid start_identity
@@ -2684,7 +2726,94 @@ for row in rows:
   run hgsp_env stop "$run_id"
   assert_success
   assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
-  [[ ! -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]]
+  [[ ! -d "$HGSP_STATE_ROOT/runs/$run_id/runtime" ]] || fail "runtime survived a fully settled stop"
+  # #and the raw log is discarded now that teardown fully succeeded (KTD17)
+  [[ ! -d "$HGSP_STATE_ROOT/runs/$run_id/logs" ]] || fail "logs/ survived a fully settled stop"
+  # #and the durable teardown evidence projects the same final state (U7)
+  run "$HGSP_PYTHON" -c "
+import json
+with open('$HGSP_STATE_ROOT/runs/$run_id/teardown.json', encoding='utf-8') as handle:
+    evidence = json.load(handle)
+assert evidence['final_state'] == 'stopped', evidence
+assert evidence['owned_processes'], evidence
+assert evidence['live_profile_invariant']['match'] is True, evidence['live_profile_invariant']
+"
+  assert_success
+}
+
+@test "herdr-git-status-playground detects and blocks teardown on live-profile drift, then settles once reverted" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  # #then the before-invariant is captured up front, ahead of any candidate activity
+  local before
+  before="$(hgsp_manifest_query "$run_id" 'manifest["live_invariant"]["before"] is not None')"
+  assert_equal "$before" true
+
+  # #given the live Herdr profile changes underneath the run (an out-of-band
+  # plugin install this playground must never cause or tolerate)
+  mkdir -p "$HGSP_WORK/live-data/herdr/plugins"
+  printf '[{"plugin_id":"drift.plugin","revision":"x","enabled":true}]\n' \
+    > "$HGSP_WORK/live-data/herdr/plugins/registry.json"
+
+  # #when teardown runs, the after-check proves the live profile no longer matches
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" LIVE_PROFILE_INVARIANT_MISMATCH
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["live_invariant"]["match"]')" false
+
+  # #given the drift is reverted (models the operator confirming no drift occurred)
+  rm -f "$HGSP_WORK/live-data/herdr/plugins/registry.json"
+
+  # #then repeated stop settles cleanly and records a matching after-check
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["live_invariant"]["match"]')" true
+}
+
+@test "herdr-git-status-playground inventory worksheet carries every R11 category and marks operator notes" {
+  hgsp_setup
+  hgsp_remote_ready
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+
+  run hgsp_env snapshot "$run_id" --profile ezcorp --fixture checkout-clean \
+    --notes "clear and legible" --dependency-note "needs cargo" --error-link "run-42"
+  assert_success
+  run hgsp_env snapshot "$run_id" --profile sfroment --fixture non-git \
+    --applicability no-visible-signal --applicability-reason "sfroment renders nothing outside a Git worktree"
+  assert_success
+
+  local inventory="$HGSP_STATE_ROOT/runs/$run_id/inventory.md"
+  [[ -f "$inventory" ]] || fail "inventory.md was not written"
+  # #then every R11 category has its own labeled column
+  local label
+  for label in "capability family" "baseline signal" "candidate-visible signal" "companion surface" \
+    "ground truth" "refresh/authority state" "terminal dimensions" "displaced/duplicated" \
+    "readability note (operator)" "dependency note (operator)" "error link (operator)" "lifecycle" \
+    "observation id" "evidence hashes" "applicability"; do
+    run grep -F "$label" "$inventory"
+    assert_success
+  done
+  # #and the operator-entered notes are legible in the row, matching what was passed
+  run grep -F "clear and legible" "$inventory"
+  assert_success
+  run grep -F "needs cargo" "$inventory"
+  assert_success
+  # #and an explicit no-visible-signal record is a documented observation, not a rank
+  run grep -F "no-visible-signal (sfroment renders nothing outside a Git worktree)" "$inventory"
+  assert_success
+
+  run hgsp_env stop "$run_id"
+  assert_success
 }
 
 # ===========================================

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1700,6 +1700,477 @@ PY
 }
 
 # ===========================================
+# herdr-git-status-playground candidate adapters (U5)
+# ===========================================
+
+@test "herdr-git-status-playground installs pinned candidates into guarded profiles with clean baselines" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-ready
+
+  # #then each isolated registry contains exactly the pinned candidate
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$HGSP_STATE_ROOT" "$run_id" <<'PY'
+import json
+import os
+import sys
+
+manifest_path, state_root, run_id = sys.argv[1:]
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+revisions = {
+    "ezcorp": ("ez-corp.git-status", "f144c8dac2860e344b6b379d2bcfee229dcf10ad"),
+    "sfroment": ("git-detail", "b726977143adc2847dc25e3327bc0b1b4fc26455"),
+    "krystof": ("gitlab-ci-status", "fe6575a89de9006c35d9d0b9707397839d983cff"),
+    "jmarbutt": ("jmarbutt.spaces-pr-status", "8a56c5dce0bd65e47eddc9a1d862ddae870cddc3"),
+}
+for name, (plugin_id, revision) in revisions.items():
+    registry_path = os.path.join(
+        state_root, "runs", run_id, "runtime", "profiles", name, "data", "herdr", "plugins", "registry.json"
+    )
+    registry = json.load(open(registry_path, encoding="utf-8"))
+    assert len(registry) == 1, (name, registry)
+    assert registry[0]["plugin_id"] == plugin_id and registry[0]["revision"] == revision, (name, registry)
+    recorded = manifest["candidates"][name]["registry"]
+    assert recorded["plugin_id"] == plugin_id and recorded["revision"] == revision, recorded
+    assert recorded["enabled"] is False, recorded
+# #then the baseline holds only the shared rows and candidate rows appear post-baseline
+shared = ["state_icon", "workspace", "pane", "git_ref", "spaces_default"]
+run_dir = os.path.join(state_root, "runs", run_id)
+for name in revisions:
+    baseline = json.load(open(os.path.join(run_dir, "observations", "baseline-%s.json" % name), encoding="utf-8"))
+    assert baseline["rows"] == shared, (name, baseline["rows"])
+    activation = json.load(open(os.path.join(run_dir, "observations", "activation-%s.json" % name), encoding="utf-8"))
+    tokens = manifest["candidates"][name]["sidebar_tokens"]
+    assert activation["rows"][: len(shared)] == shared, activation["rows"]
+    for token in tokens:
+        assert token in activation["rows"], (name, token, activation["rows"])
+    config = open(
+        os.path.join(run_dir, "runtime", "profiles", name, "config", "herdr", "config.toml"), encoding="utf-8"
+    ).read()
+    for token in tokens:
+        assert 'sidebar_row = "%s"' % token in config, (name, token)
+# #then jmarbutt notifications are disabled for the comparison run
+jm_config = json.load(
+    open(
+        os.path.join(
+            run_dir, "runtime", "profiles", "jmarbutt", "data", "herdr", "plugins",
+            "jmarbutt.spaces-pr-status", "config.json",
+        ),
+        encoding="utf-8",
+    )
+)
+assert jm_config == {"notifications": False}, jm_config
+# #then every profile received the identical ordered catalog: 8 local + 5 GitHub
+catalog = manifest["space_catalog"]
+assert [entry["label"] for entry in catalog][:8] == [
+    "checkout-clean", "checkout-dirty", "worktree-clean", "worktree-dirty",
+    "conflict", "diverged-stash", "detached", "non-git",
+], catalog
+assert [entry["label"] for entry in catalog][8:] == [
+    "gh-no-pr", "gh-draft", "gh-checks-failed", "gh-checks-passed", "gh-merge-conflict",
+], catalog
+snapshots = [tuple(entry["label"] for entry in manifest["candidates"][name]["label_snapshot"]) for name in revisions]
+assert len(set(snapshots)) == 1 and len(snapshots[0]) == 13, snapshots
+# #then a plugin that drops injected variables still resolves inside its profile
+for name in ("ezcorp", "krystof", "jmarbutt"):
+    plugin_id = revisions[name][0]
+    state = json.load(
+        open(
+            os.path.join(run_dir, "runtime", "profiles", name, "state", "herdr", "plugins", plugin_id, "state.json"),
+            encoding="utf-8",
+        )
+    )
+    profile_root = os.path.join(run_dir, "runtime", "profiles", name)
+    assert state["resolved_home_root"].startswith(profile_root), (name, state["resolved_home_root"])
+PY
+  assert_success
+
+  # #then GitHub-dependent adapters proved a repository-scoped read with only the candidate credential
+  run "$HGSP_PYTHON" - "$HGSP_ENV_LOG" "$HGSP_CALL_LOG" <<'PY'
+import json
+import sys
+
+env_log, call_log = sys.argv[1:]
+records = [json.loads(line) for line in open(env_log, encoding="utf-8") if line.strip()]
+by_class = {record["class"]: record["environment"] for record in records}
+for name in ("ezcorp", "sfroment", "krystof", "jmarbutt"):
+    child = by_class["candidate-runtime-%s" % name]
+    assert "HERDR_GIT_STATUS_PLAYGROUND_CONTROLLER_TOKEN" not in child, (name, sorted(child))
+    if name in ("krystof", "jmarbutt"):
+        assert child.get("GH_TOKEN") == "<redacted>", (name, child.get("GH_TOKEN"))
+    else:
+        assert "GH_TOKEN" not in child, name
+probes = [
+    line
+    for line in open(call_log, encoding="utf-8")
+    if line.startswith("gh-sim|") and "token=candidate-canary" in line
+]
+assert len(probes) >= 2, probes
+for line in probes:
+    assert "path=repos/example/herdr-status-fixtures" in line, line
+PY
+  assert_success
+
+  # #then activation ordering held: server before enable, spaces before start and refresh
+  run "$HGSP_PYTHON" - "$HGSP_CALL_LOG" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+
+
+def first(prefix):
+    for index, line in enumerate(lines):
+        if line.startswith(prefix):
+            return index
+    raise AssertionError("missing call-log line %r" % prefix)
+
+
+def last(prefix):
+    found = [index for index, line in enumerate(lines) if line.startswith(prefix)]
+    assert found, "missing call-log line %r" % prefix
+    return found[-1]
+
+
+assert first("herdr|ezcorp|server run") < first("herdr|ezcorp|plugin enable ez-corp.git-status")
+assert first("herdr|ezcorp|plugin enable") < first("herdr|ezcorp|plugin run ez-corp.git-status status-enable")
+assert last("herdr|krystof|space create") < first("herdr|krystof|plugin run gitlab-ci-status start")
+assert last("herdr|jmarbutt|space create") < first("herdr|jmarbutt|plugin run jmarbutt.spaces-pr-status startup")
+assert first("herdr|jmarbutt|plugin run jmarbutt.spaces-pr-status startup") < first(
+    "herdr|jmarbutt|plugin run jmarbutt.spaces-pr-status refresh"
+)
+PY
+  assert_success
+
+  local ezcorp_pid krystof_pid jmarbutt_pid
+  ezcorp_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["candidate-ezcorp"]["pid"]')"
+  krystof_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["candidate-krystof"]["pid"]')"
+  jmarbutt_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["candidate-jmarbutt"]["pid"]')"
+
+  # #then teardown restores labels, closes the jmarbutt socket, and never invokes a signal-capable native stop
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["krystof"]["labels_restored"]')" true
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["jmarbutt"]["socket_closed"]')" true
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["jmarbutt"]["daemon_gone"]')" true
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["ezcorp"]["metadata_cleanup"]')" true
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["sfroment"]["group_quiescent"]')" true
+  run grep -E 'plugin run ez-corp.git-status status-disable|plugin run gitlab-ci-status stop' "$HGSP_CALL_LOG"
+  assert_failure
+  run grep 'herdr|krystof|space label set checkout-clean checkout-clean' "$HGSP_CALL_LOG"
+  assert_success
+  run grep 'herdr-native-signal' "$HGSP_CALL_LOG"
+  assert_failure
+  local pid
+  for pid in "$ezcorp_pid" "$krystof_pid" "$jmarbutt_pid"; do
+    run kill -0 "$pid"
+    assert_failure
+  done
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground audit attestation gates launch before any candidate build or server" {
+  hgsp_setup
+  hgsp_remote_ready
+  local attestation="$HGSP_WORK/audit-attestation.json"
+  local original
+  original="$(cat "$attestation")"
+
+  # #then an unapproved attestation blocks in preflight, before any run state
+  printf '%s\n' "$original" | sed 's/"approved":true/"approved":false/' > "$attestation"
+  run hgsp_candidate_start
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUDIT_ATTESTATION_INVALID
+  assert_equal "$(hgsp_json_field "$output" run_id)" None
+  run grep -E '^herdr\|[a-z]+\|(server run|plugin install|plugin enable|plugin fetch)' "$HGSP_CALL_LOG"
+  assert_failure
+
+  # #then a fetched tree that disagrees with the attestation blocks before any build or server
+  printf '%s\n' "$original" | sed 's/tree-ezcorp/tree-tampered/' > "$attestation"
+  run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" AUDIT_TREE_MISMATCH
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+  run grep -E '^herdr\|[a-z]+\|(server run|plugin install|plugin enable)' "$HGSP_CALL_LOG"
+  assert_failure
+
+  # #then the nearby control launches once the attestation matches again
+  printf '%s\n' "$original" > "$attestation"
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" active-ready
+  run hgsp_env stop "$HGSP_LAST_RUN_ID"
+  assert_success
+}
+
+@test "herdr-git-status-playground quarantines stale plugin PID records and never signals an unverified PID" {
+  hgsp_setup
+  hgsp_remote_ready
+  hgsp_start_bystander
+
+  # #then startup quarantines every planted record before a native path can read it
+  HGSP_PLANT_STALE_PID="$HGSP_BYSTANDER_PID" run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  run grep -c 'herdr-stale-planted' "$HGSP_CALL_LOG"
+  assert_output 3
+  run grep 'herdr-native-signal' "$HGSP_CALL_LOG"
+  assert_failure
+  run kill -0 "$HGSP_BYSTANDER_PID"
+  assert_success
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+stale = [entry for entry in manifest["quarantines"] if entry["reason"] == "stale-before-activation"]
+assert {entry["candidate"] for entry in stale} == {"ezcorp", "krystof", "jmarbutt"}, stale
+PY
+  assert_success
+
+  # #then repeated stop still never signals the unverified planted PID
+  run hgsp_env stop "$run_id"
+  assert_success
+  run kill -0 "$HGSP_BYSTANDER_PID"
+  assert_success
+  run hgsp_env stop "$run_id"
+  assert_success
+  run kill -0 "$HGSP_BYSTANDER_PID"
+  assert_success
+  run grep 'herdr-native-signal' "$HGSP_CALL_LOG"
+  assert_failure
+}
+
+@test "herdr-git-status-playground sfroment readiness needs traced publications, not exit status" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then a clean exit with no queries, silence, or a swallowed publication failure all fail startup
+  local mode ezcorp_pid
+  for mode in early-exit silent swallow; do
+    HGSP_GIT_DETAIL_MODE="$mode" run hgsp_candidate_start
+    assert_failure 1
+    hgsp_capture_run_id
+    assert_equal "$(hgsp_json_field "$output" error.code)" SFROMENT_READINESS_FAILED
+    assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+    # #then cleanup for the earlier ezcorp profile ran and preserved diagnostics
+    ezcorp_pid="$(hgsp_manifest_query "$HGSP_LAST_RUN_ID" 'manifest["processes"]["candidate-ezcorp"]["pid"]')"
+    run kill -0 "$ezcorp_pid"
+    assert_failure
+    assert_equal "$(hgsp_manifest_query "$HGSP_LAST_RUN_ID" '"sfroment" in manifest["candidate_diagnostics"]')" true
+  done
+
+  # #then the control run proves ground-truth-matching publications through the traced once path
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidates"]["sfroment"]["readiness"]["publications"]["checkout-dirty"]')" \
+    "staged:1 unstaged:1 untracked:1"
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidates"]["sfroment"]["readiness"]["publications"]["conflict"]')" \
+    "staged:0 unstaged:0 untracked:0"
+  assert_equal "$(hgsp_manifest_query "$run_id" '"non-git" in manifest["candidates"]["sfroment"]["readiness"]["publications"]')" false
+  [[ "$(hgsp_manifest_query "$run_id" 'manifest["candidates"]["sfroment"]["readiness"]["queries"]')" -ge 1 ]]
+
+  # #then losing the watcher after readiness degrades the active run
+  local watcher_pid
+  watcher_pid="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["watcher-sfroment"]["pid"]')"
+  kill -TERM "$watcher_pid"
+  run "$HGSP_PYTHON" - "$watcher_pid" <<'PY'
+import os
+import sys
+import time
+
+pid = int(sys.argv[1])
+for _ in range(500):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        break
+    time.sleep(0.01)
+else:
+    raise SystemExit("watcher survived TERM")
+PY
+  assert_success
+  run hgsp_env status "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" effective_state)" active-degraded
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground ezcorp records known worktree skips but fails unexplained gaps and lost ownership" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  # #then an updater that never registers fails ownership before first readiness
+  HGSP_EZCORP_NO_DAEMON=1 run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" CANDIDATE_OWNERSHIP_UNPROVED
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+
+  # #then an unexplained missing space is a readiness failure, not inventory
+  HGSP_EZCORP_OMIT_SPACE=checkout-clean run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  assert_equal "$(hgsp_json_field "$output" error.code)" CANDIDATE_READINESS_FAILED
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+
+  # #then the control run stays valid and records the known worktree-child skip as inventory
+  run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+candidate = manifest["candidates"]["ezcorp"]
+notes = candidate["notes"]
+assert notes == [{"known": "skips-worktree-child-spaces", "spaces": ["worktree-clean", "worktree-dirty"]}], notes
+reported = set(candidate["readiness"]["reported_spaces"])
+assert "worktree-clean" not in reported and "checkout-clean" in reported, reported
+PY
+  assert_success
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground adopts a crashed detachment only when every identity agrees" {
+  hgsp_setup
+  hgsp_remote_ready
+  hgsp_start_bystander
+
+  # #then a crash after ezcorp detachment recovers by adopting the fully matching daemon
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=candidate-ezcorp-detached run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" INJECTED_CANDIDATE_EZCORP_DETACHED
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" provisioning
+  local state_file daemon_pid
+  state_file="$(hgsp_profile_root "$run_id" ezcorp)/state/herdr/plugins/ez-corp.git-status/state.json"
+  daemon_pid="$(hgsp_json_field "$(cat "$state_file")" pid)"
+  run kill -0 "$daemon_pid"
+  assert_success
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["ezcorp"]["adoption"]')" adopted
+  run kill -0 "$daemon_pid"
+  assert_failure
+
+  # #then a forged plugin record never becomes an adoption target or a signal target
+  HERDR_GIT_STATUS_PLAYGROUND_TEST_FAILPOINT=candidate-jmarbutt-detached run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  run_id="$HGSP_LAST_RUN_ID"
+  state_file="$(hgsp_profile_root "$run_id" jmarbutt)/state/herdr/plugins/jmarbutt.spaces-pr-status/state.json"
+  local original_state
+  original_state="$(cat "$state_file")"
+  "$HGSP_PYTHON" - "$state_file" "$HGSP_BYSTANDER_PID" <<'PY'
+import json
+import sys
+
+path, pid = sys.argv[1:]
+state = json.load(open(path, encoding="utf-8"))
+state["pid"] = int(pid)
+json.dump(state, open(path, "w", encoding="utf-8"))
+PY
+  run hgsp_env stop "$run_id"
+  assert_failure 1
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" cleanup-incomplete
+  assert_equal "$(hgsp_json_field "$output" error.code)" DETACHED_RESOURCE_UNRESOLVED
+  run kill -0 "$HGSP_BYSTANDER_PID"
+  assert_success
+
+  # #then the nearby control settles once the plugin state agrees again
+  printf '%s\n' "$original_state" > "$state_file"
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  run kill -0 "$HGSP_BYSTANDER_PID"
+  assert_success
+}
+
+@test "herdr-git-status-playground activation failure cleans every earlier profile and keeps diagnostics" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  HGSP_PLUGIN_FAIL=gitlab-ci-status:start run hgsp_candidate_start
+  assert_failure 1
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  assert_equal "$(hgsp_json_field "$output" error.code)" CANDIDATE_ACTIVATION_FAILED
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" startup-failed-cleaned
+
+  run "$HGSP_PYTHON" - "$(hgsp_manifest "$run_id")" "$HGSP_STATE_ROOT" "$run_id" <<'PY'
+import json
+import os
+import sys
+
+manifest_path, state_root, run_id = sys.argv[1:]
+manifest = json.load(open(manifest_path, encoding="utf-8"))
+diagnostics = manifest["candidate_diagnostics"]["krystof"]
+assert diagnostics["code"] == "CANDIDATE_ACTIVATION_FAILED", diagnostics
+# every earlier owned process is verifiably gone
+for key in ("candidate-ezcorp", "watcher-sfroment", "server-ezcorp", "server-sfroment", "server-krystof", "server-jmarbutt"):
+    record = manifest["processes"][key]
+    try:
+        os.kill(record["pid"], 0)
+        alive = True
+    except ProcessLookupError:
+        alive = False
+    assert not alive, (key, record["pid"])
+run_dir = os.path.join(state_root, "runs", run_id)
+assert not os.path.exists(os.path.join(run_dir, "runtime")), "runtime survived automatic cleanup"
+for name in ("ezcorp", "sfroment", "krystof", "jmarbutt"):
+    assert os.path.exists(os.path.join(run_dir, "observations", "baseline-%s.json" % name)), name
+PY
+  assert_success
+  run hgsp_env stop "$run_id"
+  assert_success
+}
+
+@test "herdr-git-status-playground requires sfroment process-group quiescence before teardown passes" {
+  hgsp_setup
+  hgsp_remote_ready
+
+  HGSP_GIT_DETAIL_MODE=leak run hgsp_candidate_start
+  assert_success
+  hgsp_capture_run_id
+  local run_id="$HGSP_LAST_RUN_ID"
+  local group
+  group="$(hgsp_manifest_query "$run_id" 'manifest["processes"]["watcher-sfroment"]["process_group"]')"
+
+  run hgsp_env stop "$run_id"
+  assert_success
+  assert_equal "$(hgsp_json_field "$output" lifecycle_state)" stopped
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["sfroment"]["group_quiescent"]')" true
+  assert_equal "$(hgsp_manifest_query "$run_id" 'manifest["candidate_teardown"]["sfroment"]["escalated"]')" true
+  run "$HGSP_PYTHON" - "$group" <<'PY'
+import subprocess
+import sys
+
+pgid = sys.argv[1]
+output = subprocess.check_output(["/bin/ps", "-axo", "pid=,pgid="], text=True)
+members = [line for line in output.splitlines() if line.split()[1:] == [pgid]]
+assert not members, members
+PY
+  assert_success
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -825,6 +825,35 @@ se_fixture_repo() {
   assert_file_executable "$HOME/.local/bin/herdr-child"
 }
 
+# ===========================================
+# herdr-git-status-playground (deployed command, U7)
+# ===========================================
+
+# Guarded like the run-post-apply.sh case above: this host may not have run
+# `chezmoi apply` with this checkout yet, but CI/Docker (make test-ubuntu)
+# always has, so this proves the deployed command's help path there without
+# failing a local, unapplied dev checkout.
+@test "herdr-git-status-playground deployed help works without Herdr, GitHub, Cargo, or network access" {
+  local bin="$HOME/.local/bin/herdr-git-status-playground"
+  [[ -x "$bin" ]] || skip "playground executable is not deployed"
+  local python_bin restricted_path
+  python_bin="$(command -v python3)"
+  restricted_path="$(dirname "$python_bin")"
+
+  # #then --help succeeds with only python3 on PATH: no herdr, gh, cargo, git, jq
+  run env -i PATH="$restricted_path" HOME="$HOME" "$python_bin" "$bin" --help
+  assert_success
+  assert_output --partial "usage:"
+  assert_output --partial "bootstrap"
+  assert_output --partial "start"
+  assert_output --partial "snapshot"
+
+  # #and a missing subcommand fails on usage alone, before any preflight runs
+  run env -i PATH="$restricted_path" HOME="$HOME" "$python_bin" "$bin"
+  assert_failure 2
+  assert_output --partial "usage:"
+}
+
 @test "herdr-task-sync Claude Code hook is deployed and executable" {
   assert_file_exists "$HOME/.claude/hooks/herdr-task-sync-hook.sh"
   assert_file_executable "$HOME/.claude/hooks/herdr-task-sync-hook.sh"

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -840,8 +840,11 @@ se_fixture_repo() {
   python_bin="$(command -v python3)"
   restricted_path="$(dirname "$python_bin")"
 
-  # #then --help succeeds with only python3 on PATH: no herdr, gh, cargo, git, jq
-  run env -i PATH="$restricted_path" HOME="$HOME" "$python_bin" "$bin" --help
+  # #then --help succeeds with only python3 on PATH: no herdr, gh, cargo, git,
+  # jq. Invoke the deployed entrypoint directly (its own #!/usr/bin/env
+  # python3 shebang resolves the interpreter) so the restricted PATH governs
+  # the actual command, not an interpreter path resolved outside it.
+  run env -i PATH="$restricted_path" HOME="$HOME" "$bin" --help
   assert_success
   assert_output --partial "usage:"
   assert_output --partial "bootstrap"
@@ -849,7 +852,7 @@ se_fixture_repo() {
   assert_output --partial "snapshot"
 
   # #and a missing subcommand fails on usage alone, before any preflight runs
-  run env -i PATH="$restricted_path" HOME="$HOME" "$python_bin" "$bin"
+  run env -i PATH="$restricted_path" HOME="$HOME" "$bin"
   assert_failure 2
   assert_output --partial "usage:"
 }


### PR DESCRIPTION
## Summary

It is now possible to compare four pinned Herdr git-status sidebar plugin candidates (ezcorp, sfroment, krystof, jmarbutt) side by side in a fully isolated, disposable environment and walk away with an attributable evidence bundle — one observation per candidate/fixture pair — instead of ad-hoc impressions. The new `herdr-git-status-playground` CLI (stdlib-only Python, deployed by chezmoi to `~/.local/bin`) owns the whole lifecycle: provisioning, comparison viewing, evidence capture, and verified teardown.

This is the data-gathering precursor for the upcoming sidebar-design decision; the follow-on work is the operator-run authenticated macOS trial (documented in the runbook) and the design work that consumes the resulting inventory.

## What the controller guarantees

- **Never touches what it does not own.** Every spawned process is verified by start-identity (pid + start time + executable) before any signal; a live-profile invariant is captured before provisioning and re-checked at teardown, so the operator's real Herdr profile is provably untouched. Candidates run in isolated XDG profiles with per-class environment scrubbing and split controller-write / candidate-read credentials.
- **Crash-safe lifecycle.** Durable launch intents and manifests survive interruption at every injected boundary; `stop` is idempotent and recovers partial runs; startup failures clean up automatically (`startup-failed-cleaned`) or surface exactly what could not be proved (`cleanup-incomplete`). Every subprocess call is bounded by a timeout.
- **Shared GitHub fixtures without interference.** A dedicated fixture repository is claimed via an exact-ref lease with compare-and-swap semantics; each run binds a fresh fixture generation and a cancellable pending workflow, so concurrent or crashed runs cannot corrupt durable fixtures. Local fixtures (8 repo states) are measured against independent git ground truth before use.
- **Evidence you can trust.** Snapshots are causally bound to the currently-focused fixture; `--finalize` refuses incomplete coverage, duplicates, identity disagreements, or authority drift. Teardown writes a durable `teardown.json` projection; credentials are redacted in every persisted sink.

`docs/herdr-git-status-playground.md` documents prerequisites, fixture ownership, normal use, per-state recovery, and evidence interpretation.

## Design decisions

- **Single-file controller.** ~5,800 lines in one executable is a deliberate trade-off for chezmoi's single-file deployment; splitting into modules is recorded as a residual.
- **Local-only degraded mode.** `start` without a bootstrapped fixture repository proceeds with `remote: null` rather than failing; whether `finalize` should hard-reject remote-less runs is an open product question (residual #3).
- **Stateful stubs over mocks.** Tests exercise a real local bare repo, a JSON GitHub simulator, and a profile-aware herdr stub that keeps the stub path in the process image so identity verification is tested for real. No test contacts the network.

## Testing

- `bats tests/scripts.bats`: 259/259 on macOS (61 playground cases; red→green observed per behavior slice during development).
- `make test-ubuntu` (Docker: applies the checkout, full suite incl. idempotency): 431/431.
- `bats tests/smoke.bats`: 73/73; the deployed-help case runs for real in Docker and skips on an unapplied host.
- `make lint` clean.
- The authenticated macOS acceptance trial could not be run here (requires live Herdr 0.8.2 and repository credentials); the controller scaffolds its preflight and the runbook documents the procedure — that trial is the operator's follow-on step.

Code review: dual independent cross-model reviews (claude/sonnet run `20260827-014144-fc7acc9b`, opencode/gpt-5.6-terra run `peer-1787787514-66171`), both `status: complete`; the P0 and six further findings were applied on-branch (teardown-quarantine wedge, subprocess timeouts, provisioning-ghost cleanup, manifest redaction, INTERNAL_ERROR JSON handler, reaping proof, smoke entrypoint).

## Known Residuals

Recorded from review, deliberately not fixed here (all in `home/dot_local/bin/executable_herdr-git-status-playground` unless noted):

| # | Sev | Location | Finding |
|---|-----|----------|---------|
| 1 | P1 | whole file | Single ~5,800-line controller; module split is follow-up |
| 2 | P1 | `:3170` | run-lease-acquired crash failpoint lacks a dedicated test |
| 3 | P1 | `:3109` | Deliberate local-only mode: should `finalize` reject remote-less runs? |
| 4 | P1 | `:431` | Fixture-ownership file picks the host the controller token is sent to (no allowlist) |
| 5 | P1 | `:495` | PATH-resolved `gh` receives both credentials (no pinned path/identity) |
| 6 | P1 | `:4987` | Pending observation window recorded but not enforced at finalize |
| 7 | P1 | `:4993` | Finalize does not recompute raw-observation hashes |
| 8 | P1 | `:5361` | SIGTERM (unlike SIGINT) bypasses active-run cleanup |
| 9 | P1 | `:5422` | Teardown accepts leader exit while group children may survive |
| 10 | P2 | `tests/helpers/herdr_git_status_playground.bash:26` | Test teardown hides cleanup failures |

Also filed in-repo: `docs/issues/2026-08-27-001` (pre-existing load-sensitive `PROCESS_IDENTITY_MISMATCH` flake in full-suite runs) and `docs/issues/2026-08-27-002` (bare mid-test `[[ ]]` assertions are silently inert in bats — suite-wide audit needed).

## Post-Deploy Monitoring & Validation

No production/runtime service impact — this deploys a manually-invoked CLI via `chezmoi apply`.

- **Owner / window:** repository owner, before the first real trial.
- **Validate:** after apply, `herdr-git-status-playground --help` works offline; follow the runbook for the authenticated trial; inspect `evidence-index.json`, `inventory.md`, `teardown.json`, and the live-profile invariant comparison.
- **Healthy:** trial reaches `active-ready`, finalize passes coverage validation, teardown reaches `stopped`, live invariant matches before/after.
- **Failure / rollback:** any `cleanup-incomplete` state recovers via repeated `stop` per the runbook; worst case, revert the branch — the tool is additive and touches nothing outside its own state root.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
