### PR TITLE
fix(tests): stabilize herdr-child under parallel load

### DIFF
--- a/docs/issues/2026-08-27-006-herdr-child-launch-signal-test-fails-under-parallel-load-on-a-10-second-subprocess-timeout.md
+++ b/docs/issues/2026-08-27-006-herdr-child-launch-signal-test-fails-under-parallel-load-on-a-10-second-subprocess-timeout.md
@@ -1,12 +1,13 @@
 ---
 title: "herdr-child launch signal test fails under parallel load on a 10 second subprocess timeout"
-short_description: "The test 'herdr-child catchable launch signals preserve ownership after prompt submission' times out and fails when the suite runs in parallel, and passes when run alone."
+short_description: "Parallel Bats workers inherit SIGINT=SIG_IGN into the launch subprocess while callback coverage reads waiting-label before failure publication completes; the tests must normalize signal disposition and wait on failed.state."
 type: "bug"
 category: "testing-ci"
 tags: ["flaky-test"]
 date: "2026-08-27"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-28"
 ---
 
 ## Why this exists
@@ -24,3 +25,7 @@ Treat the whole herdr-child suite, not just the launch-signal test, as the unit 
 ## Open decisions
 
 None.
+
+## Resolution
+
+Normalized each tested signal disposition before spawning Bash so parallel Bats workers exercise the launcher traps, turned the post-barrier timeout into a 30-second cleanup hang guard, and waited for failed.state before asserting the preserved waiting label. Verified both scenarios with repeated --jobs 8 runs, three complete 254-test parallel runs, make test-suite, make lint, and make test-issues.

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1016,14 +1016,20 @@ import subprocess
 import time
 
 stub = Path(os.environ["CHILD_STUB"])
-proc = subprocess.Popen(
-    ["bash", os.environ["CHILD_SCRIPT"], "start", "--kind", "claude", "--name",
-     "child-" + os.environ["CHILD_SIGNAL_NAME"], "--detach", "--prompt", "test task"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    text=True,
-    env=os.environ.copy(),
-)
+child_signal = getattr(signal, "SIG" + os.environ["CHILD_SIGNAL"])
+# Parallel Bats workers ignore SIGINT; reset it while spawning so Bash can install the trap.
+previous_handler = signal.signal(child_signal, signal.SIG_DFL)
+try:
+    proc = subprocess.Popen(
+        ["bash", os.environ["CHILD_SCRIPT"], "start", "--kind", "claude", "--name",
+         "child-" + os.environ["CHILD_SIGNAL_NAME"], "--detach", "--prompt", "test task"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=os.environ.copy(),
+    )
+finally:
+    signal.signal(child_signal, previous_handler)
 for _ in range(1000):
     if (stub / "prompt-seen").exists():
         break
@@ -1032,13 +1038,14 @@ else:
     proc.kill()
     raise AssertionError("prompt submission never reached its barrier")
 
-proc.send_signal(getattr(signal, "SIG" + os.environ["CHILD_SIGNAL"]))
+proc.send_signal(child_signal)
 try:
-    stdout, stderr = proc.communicate(timeout=10)
+    # prompt-seen proves signal ordering; this only guards a stuck cleanup/exit path.
+    stdout, stderr = proc.communicate(timeout=30)
 except subprocess.TimeoutExpired:
     proc.kill()
     proc.wait()
-    raise AssertionError("launcher did not handle the catchable signal")
+    raise AssertionError("launcher exceeded the 30-second cleanup hang guard")
 if proc.returncode == 0:
     raise AssertionError("signaled launcher returned success")
 expected = '"supervision":{"status":"failed","reason":"launch-signal-' + os.environ["CHILD_SIGNAL"]
@@ -1524,11 +1531,16 @@ PY
 }
 
 @test "herdr-child callback delivery exhaustion keeps decision waiting and blocks reap" {
+  local generation run_dir
   child_lifecycle_stub_herdr
   export HERDR_CHILD_MAX_DELIVERY_RETRIES=3
   printf '20\n' > "$CHILD_STUB/prompt-fail-count"
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
+  run cat "$CHILD_STUB/generation"
+  assert_success
+  generation="$output"
+  run_dir="$CHILD_STUB/state/runs/$generation"
 
   run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p9 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" HERDR_CHILD_NAME=child-life \
@@ -1539,7 +1551,9 @@ PY
   assert_file_exists "$CHILD_STUB/waiting-label"
 
   printf 'blocked 11\n' > "$CHILD_STUB/child-state"
-  child_wait_for_log 'supervision_failure_reason=prompt-error'
+  child_wait_for_file "$run_dir/failed.state"
+  run grep -qx 'reason=prompt-error' "$run_dir/failed.state"
+  assert_success
   assert_file_exists "$CHILD_STUB/waiting-label"
   printf 'done\n' > "$CHILD_STUB/child-list-status"
   run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \


### PR DESCRIPTION
## Summary

`herdr-child` parallel coverage now exercises catchable signals reliably and waits for durable watcher completion instead of racing transient filesystem state.

Parallel Bats workers can inherit `SIGINT=SIG_IGN`, so the signal test temporarily normalizes the tested signal while spawning Bash and restores the worker's prior disposition immediately afterward. The existing `prompt-seen` barrier remains the causal ordering assertion, while 30 seconds serves only as a cleanup hang guard. Callback exhaustion coverage now waits for `failed.state` with `reason=prompt-error` before asserting that the waiting label survived.

The repository issue records the diagnosis, verification evidence, and resolution.

## Testing

- `make test-suite`
- `make lint`
- `make test-issues`
- 3 complete 254-test `bats --jobs 8 --no-parallelize-across-files tests/scripts.bats` runs
- Repeated focused parallel runs for both repaired scenarios

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/GPT--5.6_Sol-000000)
