### PR TITLE
feat(herdr): expose configurable git status tokens

### DIFF
--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -61,12 +61,15 @@ ICON_WORKTREE="$(printf '\356\261\276')" # nf-cod-worktree U+EC7E
 ICON_COMMIT="$(printf '\356\253\274')"   # nf-cod-git_commit U+EAFC
 ICON_FOLDER="$(printf '\356\252\203')"   # nf-cod-folder U+EA83
 ICON_STALE="$(printf '\356\252\202')"    # nf-cod-history U+EA82
-# Counts glyphs of the $git_status grammar. Same codicon family and the
-# same octal rule as above; each was verified present in the installed
-# Nerd Font before being chosen.
-ICON_DIRTY="$(printf '\356\252\260')"    # nf-cod-diff_modified U+EAB0
-ICON_AHEAD="$(printf '\356\252\241')"    # nf-cod-arrow_up U+EAA1
-ICON_BEHIND="$(printf '\356\252\232')"   # nf-cod-arrow_down U+EA9A
+# Each Git count has its own metadata token, so sidebar rows can choose and
+# reorder them independently. Keep the arrows as octal UTF-8: literal glyphs
+# are too easy to damage when this script passes through tooling.
+ICON_PULL="$(printf '\342\207\243')" # U+21E3 DOWNWARDS DASHED ARROW
+ICON_PUSH="$(printf '\342\207\241')" # U+21E1 UPWARDS DASHED ARROW
+ICON_CONFLICT='~'
+ICON_STAGED='+'
+ICON_UNSTAGED='!'
+ICON_UNTRACKED='?'
 # Worktree-token width math (text_length's `wc -m`, text_prefix's `cut -c`)
 # must count codepoints: under a non-UTF-8 locale both count bytes, so a cap
 # can split a multibyte path component.
@@ -83,6 +86,7 @@ case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
     ;;
 esac
 FIELD_SEPARATOR=$'\037'
+STATUS_SEPARATOR=$'\036'
 WORKTREE_TOKEN_MAX_LEN=18
 # A budget is handed straight to `sleep` in the probe watchdog. A `sleep` that
 # rejects its argument returns immediately, so the watchdog would kill every
@@ -858,11 +862,11 @@ resolve_pane_location() {
 
 # Counts are volatile where identity is stable, so they get their own probe,
 # their own budget and their own outcome: a status timeout must never make
-# $git_ref lie. Outcomes are the chart's states — `fresh` carries the counts
-# string (empty when the checkout is clean), `stale` means the probe did not
-# answer in budget, `absent` means there is nothing to count.
+# $git_ref lie. Outcomes are the chart's states — `fresh` carries the internal
+# bundle of independent count tokens (empty when clean), `stale` means the
+# probe did not answer in budget, `absent` means there is nothing to count.
 resolve_pane_git_status() {
-  local root="$1" outfile errfile status dirty ahead behind
+  local root="$1" outfile errfile status counts pull push conflicts staged unstaged untracked
   [ -n "$root" ] || { printf 'absent\037'; return 0; }
   command -v git >/dev/null 2>&1 || { printf 'stale\037'; return 0; }
   outfile="$(mktemp "$(namespace_dir)/.git-status.XXXXXX" 2>/dev/null)" || {
@@ -890,15 +894,24 @@ resolve_pane_git_status() {
     printf 'stale\037'
     return 0
   fi
-  # porcelain v2 prints one line per path, so a path that is both staged and
-  # modified counts once. Header lines start with '#'.
-  dirty="$(grep -c -v '^#' "$outfile" 2>/dev/null || true)"
-  # `# branch.ab` is emitted only when the branch has an upstream; without one
-  # both counts stay empty and the formatter drops them.
-  ahead="$(sed -n 's/^# branch\.ab +\([0-9][0-9]*\) -[0-9][0-9]*$/\1/p' "$outfile" 2>/dev/null)"
-  behind="$(sed -n 's/^# branch\.ab +[0-9][0-9]* -\([0-9][0-9]*\)$/\1/p' "$outfile" 2>/dev/null)"
+  # Parse every category in one pass. For ordinary and renamed records, X is
+  # the staged state and Y is the unstaged state. A partially staged path
+  # intentionally increments both; unmerged paths get their own count only.
+  counts="$(awk '
+    /^# branch\.ab / { push = substr($3, 2) + 0; pull = substr($4, 2) + 0; next }
+    $1 == "u" { conflicts++; next }
+    $1 == "?" { untracked++; next }
+    $1 == "1" || $1 == "2" {
+      if (substr($2, 1, 1) != ".") staged++
+      if (substr($2, 2, 1) != ".") unstaged++
+    }
+    END { print pull + 0, push + 0, conflicts + 0, staged + 0, unstaged + 0, untracked + 0 }
+  ' "$outfile" 2>/dev/null)"
   rm -f "$outfile" "$errfile"
-  printf 'fresh\037%s' "$(git_status_for "$dirty" "$ahead" "$behind")"
+  IFS=' ' read -r pull push conflicts staged unstaged untracked <<EOF
+$counts
+EOF
+  printf 'fresh\037%s' "$(git_status_tokens_for "$pull" "$push" "$conflicts" "$staged" "$unstaged" "$untracked")"
 }
 
 # Panes routinely share a checkout, so the probe runs once per distinct root
@@ -1102,21 +1115,27 @@ git_ref_for() {
   printf '%s' "$label"
 }
 
-# The counts half of the grammar:
-#   $git_status = [<dirty-icon><n>] [<ahead-icon><n>] [<behind-icon><n>]
-# Order is fixed so cells of the acceptance matrix are judged consistently,
-# and a zero renders as nothing at all rather than as "0". A clean checkout
-# with no divergence therefore produces the empty string, which the publish
-# arm turns into a cleared token.
-git_status_for() {
-  local dirty="$1" ahead="$2" behind="$3" label=""
-  case "$dirty" in '' | *[!0-9]*) dirty=0 ;; esac
-  case "$ahead" in '' | *[!0-9]*) ahead=0 ;; esac
-  case "$behind" in '' | *[!0-9]*) behind=0 ;; esac
-  [ "$dirty" -eq 0 ] || label="$ICON_DIRTY$dirty"
-  [ "$ahead" -eq 0 ] || label="${label}${label:+ }$ICON_AHEAD$ahead"
-  [ "$behind" -eq 0 ] || label="${label}${label:+ }$ICON_BEHIND$behind"
-  printf '%s' "$label"
+# Internal transport for six independent metadata tokens. The record
+# separator preserves empty positions without turning the published values
+# back into one user-facing string. An all-zero status stays wholly empty.
+git_status_tokens_for() {
+  local pull="$1" push="$2" conflicts="$3" staged="$4" unstaged="$5" untracked="$6"
+  local git_pull="" git_push="" git_conflicts="" git_staged="" git_unstaged="" git_untracked=""
+  case "$pull" in '' | *[!0-9]*) pull=0 ;; esac
+  case "$push" in '' | *[!0-9]*) push=0 ;; esac
+  case "$conflicts" in '' | *[!0-9]*) conflicts=0 ;; esac
+  case "$staged" in '' | *[!0-9]*) staged=0 ;; esac
+  case "$unstaged" in '' | *[!0-9]*) unstaged=0 ;; esac
+  case "$untracked" in '' | *[!0-9]*) untracked=0 ;; esac
+  [ "$pull" -eq 0 ] || git_pull="$ICON_PULL$pull"
+  [ "$push" -eq 0 ] || git_push="$ICON_PUSH$push"
+  [ "$conflicts" -eq 0 ] || git_conflicts="$ICON_CONFLICT$conflicts"
+  [ "$staged" -eq 0 ] || git_staged="$ICON_STAGED$staged"
+  [ "$unstaged" -eq 0 ] || git_unstaged="$ICON_UNSTAGED$unstaged"
+  [ "$untracked" -eq 0 ] || git_untracked="$ICON_UNTRACKED$untracked"
+  [ -n "$git_pull$git_push$git_conflicts$git_staged$git_unstaged$git_untracked" ] || return 0
+  printf '%s\036%s\036%s\036%s\036%s\036%s' \
+    "$git_pull" "$git_push" "$git_conflicts" "$git_staged" "$git_unstaged" "$git_untracked"
 }
 
 native_session_matches_active() {
@@ -1288,12 +1307,13 @@ reconcile_presentation_pass() {
   local _current_worktree _worktree_token _git_ref _git_status status_row _status_outcome _status_counts
   local _ref _place _folder _workspace_name
   local final_payload final_label final_task final_tokens
-  local final_repo final_worktree final_branch final_location_status final_git_ref final_git_status
+  local git_pull git_push git_conflicts git_staged git_unstaged git_untracked
+  local final_repo final_worktree final_branch final_location_status final_git_ref final_git_status final_legacy_tokens
   local pane_baselines baseline_row
   local state_file retained_pane presented_pane_ids
   local location_pids="" location_results="" location_result_file location_pid
   local location_probe_results="" location_child_failed=0
-  local legacy_label_panes final_location_label
+  local legacy_token_panes final_location_label
   command -v jq >/dev/null 2>&1 || return 1
   snapshot="$(herdr api snapshot 2>/dev/null)" || return 1
   printf '%s' "$snapshot" | jq -e '
@@ -1310,12 +1330,16 @@ reconcile_presentation_pass() {
 
   pane_rows="$(printf '%s' "$snapshot" | jq -r '
     .result.snapshot.panes[]?
+    | (.tokens // {}) as $t
+    | [$t.git_pull // "", $t.git_push // "", $t.git_conflicts // "",
+       $t.git_staged // "", $t.git_unstaged // "", $t.git_untracked // ""] as $status
     | [(.pane_id // ""), (.terminal_id // ""), (.tab_id // ""),
-        (.workspace_id // ""), (.agent // ""), (.agent_session.agent // ""),
-       (.agent_session.value // ""), (.label // ""), (.tokens.task // ""),
-       (.tokens.repo // ""), (.tokens.worktree // ""), (.tokens.branch // ""),
-       (.tokens.location_status // ""), (.tokens.git_ref // ""),
-       (.tokens.git_status // ""), (@base64)]
+       (.workspace_id // ""), (.agent // ""), (.agent_session.agent // ""),
+       (.agent_session.value // ""), (.label // ""), ($t.task // ""),
+       ($t.repo // ""), ($t.worktree // ""), ($t.branch // ""),
+       ($t.location_status // ""), ($t.git_ref // ""),
+       (if any($status[]; . != "") then ($status | join("\u001e")) else "" end),
+       (@base64)]
     | join("\u001f")' 2>/dev/null | filter_records_of_width 16)"
 
   # The current_* baseline tokens are consumed only where a pane's newly
@@ -1332,9 +1356,9 @@ reconcile_presentation_pass() {
   # Naming those panes off the snapshot schedules the write without widening
   # the record. A stale sweep daemon of the old version rewriting its own
   # tokens after an upgrade is exactly how a pane reaches that state.
-  legacy_label_panes="$(printf '%s' "$snapshot" | jq -r '
+  legacy_token_panes="$(printf '%s' "$snapshot" | jq -r '
     .result.snapshot.panes[]?
-    | select((.tokens.location_label // "") != "")
+    | select(((.tokens.location_label // "") != "") or ((.tokens.git_status // "") != ""))
     | (.pane_id // "")' 2>/dev/null)"
 
   # Workspace names suppress the $git_ref folder qualifier when the worktree
@@ -1553,7 +1577,7 @@ EOF
     fi
     _git_ref="$(git_ref_for "$_place" "$_ref" "$_folder" "$_location_status")"
     # The one place an outcome becomes a token decision: `fresh` publishes
-    # its counts, and both `stale` and `absent` publish nothing, because a
+    # its count tokens, and both `stale` and `absent` publish nothing, because a
     # count that might be wrong is worse than no count at all.
     #
     # The root, not the identity outcome, is what gates this. A transient
@@ -1616,7 +1640,7 @@ EOF
     # retain as-is. Same gate as the publish arms below, so such a pass also
     # keeps the legacy token for now.
     if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
-      ! list_contains_line "$id" "$legacy_label_panes" || location_changed=1
+      ! list_contains_line "$id" "$legacy_token_panes" || location_changed=1
     fi
     if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
       [ "$current_repo" = "$repo" ] || location_changed=1
@@ -1639,17 +1663,23 @@ EOF
       # on every location change.
       final_tokens="$(printf '%s' "$final_payload" | jq -r '
         .result.pane.tokens
-        | [(.repo // ""), (.worktree // ""), (.branch // ""),
-           (.location_status // ""), (.git_ref // ""), (.git_status // ""),
-           (.location_label // "")]
+        | . as $t
+        | [$t.git_pull // "", $t.git_push // "", $t.git_conflicts // "",
+           $t.git_staged // "", $t.git_unstaged // "", $t.git_untracked // ""] as $status
+        | [($t.repo // ""), ($t.worktree // ""), ($t.branch // ""),
+           ($t.location_status // ""), ($t.git_ref // ""),
+           (if any($status[]; . != "") then ($status | join("\u001e")) else "" end),
+           (if (($t.git_status // "") != "") or (($t.location_label // "") != "") then "1" else "" end),
+           ($t.location_label // "")]
         | join("\u001f")' 2>/dev/null)"
       IFS="$FIELD_SEPARATOR" read -r final_repo final_worktree final_branch \
-        final_location_status final_git_ref final_git_status final_location_label <<EOF
+        final_location_status final_git_ref final_git_status final_legacy_tokens final_location_label <<EOF
 $final_tokens
 EOF
       location_changed=0
       if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
         [ -z "$final_location_label" ] || location_changed=1
+        [ -z "$final_legacy_tokens" ] || location_changed=1
       fi
       if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
         [ "$final_repo" = "$repo" ] || location_changed=1
@@ -1673,12 +1703,20 @@ EOF
         # once despite being deferred by the plan; the clear can be dropped a
         # release after no deployed version writes it anymore.
         if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
-          set -- "$@" --token "repo=$repo" --token "worktree=$worktree_token" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token location_label
+          set -- "$@" --token "repo=$repo" --token "worktree=$worktree_token" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token location_label --clear-token git_status
           if [ -n "$branch" ]; then set -- "$@" --token "branch=$branch"; else set -- "$@" --clear-token branch; fi
           if [ -n "$location_status" ]; then set -- "$@" --token "location_status=$location_status"; else set -- "$@" --clear-token location_status; fi
-          if [ -n "$git_status" ]; then set -- "$@" --token "git_status=$git_status"; else set -- "$@" --clear-token git_status; fi
+          IFS="$STATUS_SEPARATOR" read -r git_pull git_push git_conflicts git_staged git_unstaged git_untracked <<EOF
+$git_status
+EOF
+          if [ -n "$git_pull" ]; then set -- "$@" --token "git_pull=$git_pull"; else set -- "$@" --clear-token git_pull; fi
+          if [ -n "$git_push" ]; then set -- "$@" --token "git_push=$git_push"; else set -- "$@" --clear-token git_push; fi
+          if [ -n "$git_conflicts" ]; then set -- "$@" --token "git_conflicts=$git_conflicts"; else set -- "$@" --clear-token git_conflicts; fi
+          if [ -n "$git_staged" ]; then set -- "$@" --token "git_staged=$git_staged"; else set -- "$@" --clear-token git_staged; fi
+          if [ -n "$git_unstaged" ]; then set -- "$@" --token "git_unstaged=$git_unstaged"; else set -- "$@" --clear-token git_unstaged; fi
+          if [ -n "$git_untracked" ]; then set -- "$@" --token "git_untracked=$git_untracked"; else set -- "$@" --clear-token git_untracked; fi
         else
-          set -- "$@" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token git_status --clear-token location_label
+          set -- "$@" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token git_status --clear-token git_pull --clear-token git_push --clear-token git_conflicts --clear-token git_staged --clear-token git_unstaged --clear-token git_untracked --clear-token location_label
         fi
         "$@" >/dev/null 2>&1 || continue
       fi

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -56,10 +56,10 @@ sidebar_min_width = 32
 # The `pane` row renders the pane label, which herdr-task-sync
 # (~/.local/bin/herdr-task-sync) sets to `<agent-prefix>:<task-slug>`, or to the
 # prefix alone until a task slug exists. The same script rebuilds each tab label
-# from the labels of its panes. The second sidebar row renders the combined Git
-# location token without adding Git information back to tab labels.
+# from the labels of its panes. The second sidebar row composes independent Git
+# tokens, so their order can change without touching the publisher.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace", "pane"], ["$git_ref", "$git_status"]]
+rows = [["state_icon", "workspace", "pane"], ["$git_ref", "$git_pull", "$git_push", "$git_conflicts", "$git_staged", "$git_unstaged", "$git_untracked"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -32,12 +32,20 @@ HTS_ICON_COMMIT="$(hts_icon COMMIT)"
 HTS_ICON_FOLDER="$(hts_icon FOLDER)"
 # shellcheck disable=SC2034
 HTS_ICON_STALE="$(hts_icon STALE)"
+# Git status symbols are the user-facing contract, so tests define them
+# independently instead of inheriting whatever the engine happens to render.
 # shellcheck disable=SC2034
-HTS_ICON_DIRTY="$(hts_icon DIRTY)"
+HTS_GIT_BEHIND="$(printf '\342\207\243')"
 # shellcheck disable=SC2034
-HTS_ICON_AHEAD="$(hts_icon AHEAD)"
+HTS_GIT_AHEAD="$(printf '\342\207\241')"
 # shellcheck disable=SC2034
-HTS_ICON_BEHIND="$(hts_icon BEHIND)"
+HTS_GIT_CONFLICT='~'
+# shellcheck disable=SC2034
+HTS_GIT_STAGED='+'
+# shellcheck disable=SC2034
+HTS_GIT_UNSTAGED='!'
+# shellcheck disable=SC2034
+HTS_GIT_UNTRACKED='?'
 
 hts_teardown() {
   # Reap a background reader a failed test left running BEFORE deleting its

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -4839,12 +4839,13 @@ EOF
   assert_equal "$(jq -r '.panes[] | .tokens.repo' "$state" | sort)" $'integration-platform-connectors\ninternal-developer-tooling'
 }
 
-@test "herdr-task-sync location clears a retired location_label even when every published token already matches" {
+@test "herdr-task-sync clears retired aggregate tokens even when every published token already matches" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repository" common="$HTS_WORK/repository/.git" state
   mkdir -p "$common"
   hts_git_location_fixture "$root" "$root" "$common" refs/heads/topic
+  hts_git_status_fixture "$root" '1 .M N... 100644 100644 100644 1111111 1111111 one.txt'
   hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
   hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
   hts_set_process_label pane-1 worker
@@ -4852,23 +4853,27 @@ EOF
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic $HTS_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
-  # given: a stale daemon of the retired version puts location_label back while
-  # leaving every token this version compares untouched. It reports under the
-  # same source at the sequence the last pass used, which is what an old daemon
-  # sharing the generation counter does.
+  # given: a stale daemon of the retired version puts both aggregate tokens
+  # back while leaving every current token untouched. It reports under the same
+  # source at the sequence the last pass used, as a sharing old daemon would.
   local legacy_seq
   legacy_seq="$(jq -r '.metadata["pane-1"]["location-sync"].seq' "$state")"
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata pane-1 \
-    --source location-sync --seq "$legacy_seq" --token 'location_label=repository/topic'
+    --source location-sync --seq "$legacy_seq" --token 'location_label=repository/topic' \
+    --token 'git_status=old-dirty-1'
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].tokens.location_label' "$state")" repository/topic
+  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" old-dirty-1
   # when: the next pass computes identical tokens and would otherwise skip
   hts_location_pass
   # then: the legacy token is gone and the live tokens are unharmed
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
+  assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic $HTS_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" topic
 }
 
@@ -4879,11 +4884,14 @@ EOF
   mkdir -p "$root" "$common"
   hts_mark_linked_worktree "$root" "$common/worktrees/plain"
   hts_git_location_fixture "$root" "$root" "$common" refs/heads/plain
-  # Counts are dirty and diverged both ways so the guard sees every icon the
-  # formatters can emit, not just the identity ones.
-  hts_git_status_fixture "$root" "$(printf '%s\n%s' \
+  # Exercise every status symbol so the character guard covers the complete
+  # formatter rather than only identity and divergence.
+  hts_git_status_fixture "$root" "$(printf '%s\n%s\n%s\n%s\n%s' \
     '# branch.ab +3 -4' \
-    '1 .M N... 100644 100644 100644 1111111 1111111 one.txt')"
+    'u UU N... 100644 100644 100644 100644 1111111 2222222 3333333 conflict.txt' \
+    '1 M. N... 100644 100644 100644 1111111 1111111 staged.txt' \
+    '1 .M N... 100644 100644 100644 2222222 2222222 unstaged.txt' \
+    '? untracked.txt')"
   hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
   hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
   hts_set_process_label pane-1 plain-task
@@ -4893,20 +4901,25 @@ EOF
   assert_failure
   # After removing every approved codicon glyph, only plain ASCII (plus the
   # label separator and ellipsis) may remain in published labels and tokens.
-  run jq -e --arg icons "$HTS_ICON_BRANCH$HTS_ICON_WORKTREE$HTS_ICON_COMMIT$HTS_ICON_FOLDER$HTS_ICON_STALE$HTS_ICON_DIRTY$HTS_ICON_AHEAD$HTS_ICON_BEHIND" '
+  run jq -e --arg icons "$HTS_ICON_BRANCH$HTS_ICON_WORKTREE$HTS_ICON_COMMIT$HTS_ICON_FOLDER$HTS_ICON_STALE$HTS_GIT_BEHIND$HTS_GIT_AHEAD$HTS_GIT_CONFLICT$HTS_GIT_STAGED$HTS_GIT_UNSTAGED$HTS_GIT_UNTRACKED" '
     [.panes[0].label, .tabs[0].label, .panes[0].tokens.worktree,
-     .panes[0].tokens.git_ref, .panes[0].tokens.git_status]
+     .panes[0].tokens.git_ref, .panes[0].tokens.git_pull,
+     .panes[0].tokens.git_push, .panes[0].tokens.git_conflicts,
+     .panes[0].tokens.git_staged, .panes[0].tokens.git_unstaged,
+     .panes[0].tokens.git_untracked]
     | all(.[]; (. // "") | explode - ($icons | explode) | implode | test("^[A-Za-z0-9._:/ ~\u00b7\u2026-]*$"))
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" plain-task
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE plain $HTS_ICON_FOLDER plain-worktree"
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" "${HTS_ICON_DIRTY}1 ${HTS_ICON_AHEAD}3 ${HTS_ICON_BEHIND}4"
+  assert_equal "$(jq -r '[.panes[0].tokens | .git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | map(select(. != null)) | join(" ")' "$state")" \
+    "${HTS_GIT_BEHIND}4 ${HTS_GIT_AHEAD}3 ${HTS_GIT_CONFLICT}1 ${HTS_GIT_STAGED}1 ${HTS_GIT_UNSTAGED}1 ${HTS_GIT_UNTRACKED}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
   # pane_inline stays deferred per the label-system plan: no pass publishes it.
   assert_equal "$(jq -r '.panes[0].tokens.pane_inline // ""' "$state")" ""
 }
 
-@test "herdr-task-sync publishes dirty ahead and behind counts beside an unchanged git_ref" {
+@test "herdr-task-sync publishes staged unstaged ahead and behind counts beside an unchanged git_ref" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" state
@@ -4931,12 +4944,25 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
   # then: the counts render in the fixed order and identity is untouched
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" \
-    "${HTS_ICON_DIRTY}2 ${HTS_ICON_AHEAD}1 ${HTS_ICON_BEHIND}2"
+  assert_equal "$(jq -r '[.panes[0].tokens | .git_pull, .git_push, .git_staged, .git_unstaged] | map(select(. != null)) | join(" ")' "$state")" \
+    "${HTS_GIT_BEHIND}2 ${HTS_GIT_AHEAD}1 ${HTS_GIT_STAGED}1 ${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
+
+  # when: only one new untracked path remains on the next pass
+  hts_git_status_fixture "$root" '? later.txt'
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+
+  # then: every independently published stale category is cleared
+  run jq -e --arg untracked "${HTS_GIT_UNTRACKED}1" '
+    .panes[0].tokens
+    | (.git_pull == null and .git_push == null and .git_staged == null and
+       .git_unstaged == null and .git_untracked == $untracked)
+  ' "$state"
+  assert_success
 }
 
-@test "herdr-task-sync clean checkout carries no counts token and republishes when only the counts change" {
+@test "herdr-task-sync clean checkout carries no count tokens and republishes when only the counts change" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" state
@@ -4952,8 +4978,9 @@ EOF
   HERDR_TASK_SYNC_TEST_NOW_SEQ=2000 hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
-  # then: no counts token is published
-  assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
+  # then: no count tokens are published
+  run jq -e '.panes[0].tokens | [.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)' "$state"
+  assert_success
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
 
   # when: a file goes dirty and nothing about the identity changes
@@ -4962,22 +4989,25 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
   # then: the counts-only change still triggers a republish
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
 }
 
-@test "herdr-task-sync counts every changed path once whether it is staged, unstaged, both, or untracked" {
+@test "herdr-task-sync separates conflicts staged unstaged and untracked paths" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" state
   mkdir -p "$root/.git" "$common"
-  # given: one staged path, one unstaged path, one that is both, one untracked
+  # given: one staged path, one unstaged path, one ordinary path that is both,
+  # one renamed path that is both, one untracked, and one unmerged path
   hts_git_location_fixture "$root" "$root" "$common" refs/heads/topic
-  hts_git_status_fixture "$root" "$(printf '%s\n%s\n%s\n%s' \
+  hts_git_status_fixture "$root" "$(printf '%s\n%s\n%s\n%s\n%s\n%s' \
     '1 M. N... 100644 100644 100644 1111111 1111111 staged.txt' \
     '1 .M N... 100644 100644 100644 2222222 2222222 unstaged.txt' \
     '1 MM N... 100644 100644 100644 3333333 3333333 both.txt' \
-    '? untracked.txt')"
+    "$(printf '2 MM N... 100644 100644 100644 4444444 4444444 R100 renamed.txt\told.txt')" \
+    '? untracked.txt' \
+    'u UU N... 100644 100644 100644 100644 1111111 2222222 3333333 conflict.txt')"
   hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
   hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
   hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repo"}'
@@ -4987,8 +5017,10 @@ EOF
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
-  # then: four paths, and the partially staged one is not double counted
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" "${HTS_ICON_DIRTY}4"
+  # then: the partially staged path belongs to both actionable categories,
+  # while the unmerged path is reported only as a conflict
+  assert_equal "$(jq -r '[.panes[0].tokens | .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | map(select(. != null)) | join(" ")' "$state")" \
+    "${HTS_GIT_CONFLICT}1 ${HTS_GIT_STAGED}3 ${HTS_GIT_UNSTAGED}3 ${HTS_GIT_UNTRACKED}1"
 }
 
 @test "herdr-task-sync omits ahead and behind when the branch has no upstream" {
@@ -5011,13 +5043,16 @@ EOF
   # when: the location pass runs
   run hts_location_pass
 
-  # then: the dirty count stands alone and the pass stays quiet
+  # then: the unstaged count stands alone and the pass stays quiet
   assert_success
   refute_output --partial "dropped"
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_ICON_DIRTY}1"
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
+  run jq -e '.panes[0].tokens | (.git_pull == null and .git_push == null)' "$state"
+  assert_success
 }
 
-@test "herdr-task-sync clears the counts token when a pane leaves a Git checkout" {
+@test "herdr-task-sync clears the count tokens when a pane leaves a Git checkout" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" plain="$HTS_WORK/plain" state
@@ -5031,7 +5066,7 @@ EOF
   hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repo"}'
   hts_set_process_label pane-1 worker
   HERDR_TASK_SYNC_TEST_NOW_SEQ=3000 hts_location_pass
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
 
   # when: the pane moves to a directory that is not a checkout
   hts_set_pane_location "$HTS_DEFAULT_SOCKET" pane-1 "$plain" "$plain"
@@ -5039,11 +5074,11 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
   # then: the counts go with the rest of the location tokens
-  run jq -e '.panes[0].tokens | (.git_status == null and .git_ref == null and .repo == null)' "$state"
+  run jq -e '.panes[0].tokens | ([.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)) and (.git_ref == null and .repo == null)' "$state"
   assert_success
 }
 
-@test "herdr-task-sync status probe over budget drops the counts and leaves git_ref intact" {
+@test "herdr-task-sync status probe over budget drops the count tokens and leaves git_ref intact" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" fixture state
@@ -5060,7 +5095,7 @@ EOF
 
   # given: that count is published, so the next assertion has something to lose
   HERDR_TASK_SYNC_TEST_NOW_SEQ=3999 hts_location_pass
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
 
   # when: the status probe stalls past its own budget on the next pass
   hts_block_git_status "$root"
@@ -5069,14 +5104,15 @@ EOF
 
   # then: identity survives and the published count is cleared, not retained
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
-  assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
+  run jq -e '.panes[0].tokens | [.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)' "$state"
+  assert_success
 
   # when: the probe answers again
   : > "$fixture/release"
   HERDR_TASK_SYNC_TEST_NOW_SEQ=4001 hts_location_pass
 
   # then: the counts appear without manual repair
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
 }
 
 @test "herdr-task-sync agent pane follows the directory its own statusline reports, not its launch directory" {
@@ -5125,7 +5161,7 @@ EOF
   hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repo"}'
   hts_set_process_label pane-1 worker
   HERDR_TASK_SYNC_TEST_NOW_SEQ=6000 hts_location_pass
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
 
   # when: the identity probe stalls past its budget while the status probe
   # still answers for the retained root
@@ -5135,7 +5171,7 @@ EOF
 
   # then: the ref is marked stale, and the counts measured this pass survive
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic $HTS_ICON_STALE"
-  assert_equal "$(jq -r '.panes[0].tokens.git_status' "$state")" "${HTS_ICON_DIRTY}1"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
 }
 
 @test "herdr-task-sync counts untracked paths its way, not the user git config's way" {

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -934,7 +934,7 @@ assert_herdr_sidebar_deployment_contract() {
   # Tab labels stay names-only, while the sidebar keeps Git location on its
   # own row so branch/worktree context never competes with the agent name.
   # Identity and counts are separate tokens sharing that row.
-  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\], \["\$git_ref", "\$git_status"\]\]$'
+  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\], \["\$git_ref", "\$git_pull", "\$git_push", "\$git_conflicts", "\$git_staged", "\$git_unstaged", "\$git_untracked"\]\]$'
   run grep -E '\$location_label|\$location_status' "$config"
   assert_failure
   width="$(awk '


### PR DESCRIPTION
## Summary

Herdr previously exposed one aggregate `$git_status` value, which hid the distinction between conflicts, staged changes, unstaged changes, and untracked files. This change publishes each category independently so the sidebar can render and reorder the exact state as `⇣1 ⇡2 ~6 +7 !8 ?9`.

## Changes

- Parse porcelain-v2 status once into pull, push, conflict, staged, unstaged, and untracked counts.
- Publish non-zero categories as independent metadata tokens and clear stale category values on every transition.
- Clear the retired aggregate `$git_status` token during migration.
- Configure the sidebar order without coupling presentation to the publisher.
- Cover renamed records, conflicts, clean states, stale probes, migration, and independent token clearing.

## Validation

- `bats tests/scripts.bats --filter <10 affected herdr-task-sync cases>`: 10/10 passed.
- Renamed-record regression was verified red before restoring the parser and green afterward.
- `make lint`: passed.
- `make test-templates`: passed.
- `python3 scripts/issues validate`: passed.
- `git diff --check`: passed.
- Full `bats tests/scripts.bats`: reached 140/254 with no failures before the 180-second local timeout; the complete suite was not observed.

## Post-deploy monitoring

- Deploy through the existing chezmoi workflow; the managed onchange script reloads Herdr and restarts the sweep daemon.
- Healthy state: active Git panes expose only non-zero `$git_*` count tokens in the configured order, and `$git_status` remains absent.
- Failure signal: stale category tokens persist after repository state changes, renamed paths are omitted, or the retired aggregate token reappears.
- Rollback: revert this commit, sync the chezmoi source clone, and reapply the managed configuration.

![OpenCode](https://img.shields.io/badge/OpenCode-GPT--5.6--Sol-000000?logo=openai&logoColor=white)
