### PR TITLE
fix(mcp): register credential-free MCP servers without 1Password

### DIFF
--- a/docs/issues/2026-08-27-001-claude-mcp-modifier-drops-every-server-without-1password.md
+++ b/docs/issues/2026-08-27-001-claude-mcp-modifier-drops-every-server-without-1password.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "agent-platform"
 tags: ["mcp","chezmoi","onepassword"]
 date: "2026-08-27"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-28"
 ---
 
 ## Why this exists
@@ -47,3 +48,7 @@ instead of the current all-or-nothing behavior.
 Whether a machine with `op` present but not signed in should register the
 credential-free servers and skip the rest, or fail loudly so the missing
 sign-in is noticed.
+
+## Resolution
+
+Split the guard in home/modify_dot_claude.json: only a missing jq still passes stdin through, while deepwiki, fff, and executor are registered unconditionally and jina and tavily-mcp are added per credential, independently of each other. op present but answering nothing warns on stderr and skips that one server rather than failing the apply, so a missing sign-in stays visible without costing the rest of the apply. Covered in tests/scripts.bats by three cases: credential-free registration without op, per-credential independence with the stderr warning, and the surviving no-jq pass-through.

--- a/home/modify_dot_claude.json
+++ b/home/modify_dot_claude.json
@@ -1,30 +1,53 @@
 #!/bin/bash
-# Modify ~/.claude.json to inject MCP server API keys from 1Password.
-# Requires: jq, op (1Password CLI)
+# Modify ~/.claude.json to register the MCP servers, injecting the API keys the
+# credentialed ones need from 1Password.
+# Requires: jq. Optional: op (1Password CLI).
 
 existing=$(cat)
 
-if ! command -v op &>/dev/null || ! command -v jq &>/dev/null; then
+# Every server entry is built with jq, so without it there is no way to write
+# the file at all and stdin is the only safe answer.
+if ! command -v jq &>/dev/null; then
   echo "$existing"
   exit 0
 fi
 
-JINA_KEY=$(op read "op://Private/Jina API Key/credential" --account my.1password.com 2>/dev/null || echo "")
-TAVILY_KEY=$(op read "op://Private/Tavily API Key/credential" --account my.1password.com 2>/dev/null || echo "")
+# Empty means "do not register that server". A machine with no `op` at all is a
+# deliberate configuration (CI, Docker) and stays quiet; `op` present but
+# answering nothing is a missing sign-in, which is worth a word on stderr. It is
+# not worth a non-zero exit: chezmoi aborts the whole apply on one, which would
+# cost the user every other managed file over a single MCP server.
+read_credential() {
+  command -v op &>/dev/null || return 0
 
-if [ -z "$JINA_KEY" ] || [ -z "$TAVILY_KEY" ]; then
-  echo "$existing"
-  exit 0
-fi
+  local value
+  value=$(op read "op://Private/$1/credential" --account my.1password.com 2>/dev/null || echo "")
+  if [ -z "$value" ]; then
+    echo "modify_dot_claude.json: 1Password returned no $1; skipping its MCP server" >&2
+    return 0
+  fi
 
+  printf '%s' "$value"
+}
+
+JINA_KEY=$(read_credential "Jina API Key")
+TAVILY_KEY=$(read_credential "Tavily API Key")
+
+# deepwiki, fff, and executor carry no credential, so they are registered
+# unconditionally. jina and tavily-mcp are added per key, independently of each
+# other: one absent credential is no reason to withhold the other's server.
 echo "$existing" | jq \
   --arg jina_key "$JINA_KEY" \
   --arg tavily_key "$TAVILY_KEY" \
   --arg home "$HOME" \
-  '.mcpServers = {
+  '.mcpServers = ({
     "deepwiki": { "type": "http", "url": "https://mcp.deepwiki.com/mcp" },
-    "jina": { "type": "http", "url": "https://mcp.jina.ai/v1", "headers": { "Authorization": ("Bearer " + $jina_key) } },
-    "tavily-mcp": { "type": "http", "url": ("https://mcp.tavily.com/mcp/?tavilyApiKey=" + $tavily_key) },
     "fff": { "type": "stdio", "command": ($home + "/.local/bin/fff-mcp"), "args": [], "env": {} },
     "executor": { "type": "stdio", "command": ($home + "/.local/bin/executor"), "args": ["mcp"], "env": {} }
-  }'
+  }
+  + (if $jina_key == "" then {} else {
+      "jina": { "type": "http", "url": "https://mcp.jina.ai/v1", "headers": { "Authorization": ("Bearer " + $jina_key) } }
+    } end)
+  + (if $tavily_key == "" then {} else {
+      "tavily-mcp": { "type": "http", "url": ("https://mcp.tavily.com/mcp/?tavilyApiKey=" + $tavily_key) }
+    } end))'

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1,5 +1,10 @@
 #!/usr/bin/env bats
 
+# `run --separate-stderr` needs bats 1.5. Both CI jobs already assert that floor
+# before running this suite, so the declaration records the requirement rather
+# than raising it.
+bats_require_minimum_version 1.5.0
+
 load 'helpers/common'
 load 'helpers/herdr_task_sync'
 
@@ -6257,9 +6262,9 @@ se_fake_runtime() {
   local modifier="$SOURCE_ROOT/modify_dot_claude.json"
   local stub_bin="$BATS_TEST_TMPDIR/claude-modifier-bin"
 
-  # The modifier only rewrites .mcpServers when both `op` and `jq` resolve, so a
-  # run without a 1Password stub would pass its input straight through and prove
-  # nothing about the executor entry.
+  # executor registers with or without 1Password; the stub is here so one run
+  # also covers the credentialed servers, whose entries exist only when `op`
+  # answers.
   mkdir -p "$stub_bin"
   cat > "$stub_bin/op" <<'STUB'
 #!/bin/sh
@@ -6280,24 +6285,91 @@ STUB
       "args": ["mcp"],
       "env": {}
     })
+    and (.mcpServers["tavily-mcp"].url ==
+      "https://mcp.tavily.com/mcp/?tavilyApiKey=stub-credential")
     and (.mcpServers | has("stale") | not)
     and (.other == "preserved")
   ' <<< "$output"
   assert_success
 }
 
-@test "Claude settings modifier passes settings through untouched without 1Password" {
+@test "Claude settings modifier registers the credential-free MCP servers without 1Password" {
+  local modifier="$SOURCE_ROOT/modify_dot_claude.json"
+  local jq_bin="$BATS_TEST_TMPDIR/claude-modifier-jq-bin"
+
+  # Control for the test above. deepwiki, fff, and executor carry no credential,
+  # so a machine where `op` never resolves must still get them; only jina and
+  # tavily-mcp depend on 1Password and stay out rather than registering with an
+  # empty key. A bare `op` absence is how CI and Docker run, so it stays silent.
+  #
+  # PATH_WITHOUT_OP drops every directory that holds an `op`, jq included when
+  # the two share one. Re-front jq so this lands in the credential-free branch
+  # rather than the no-jq guard the test below owns.
+  mkdir -p "$jq_bin"
+  ln -s "$(command -v jq)" "$jq_bin/jq"
+
+  run --separate-stderr env PATH="$jq_bin:$PATH_WITHOUT_OP" HOME=/stub/home bash "$modifier" \
+    <<< '{"mcpServers":{"stale":{"type":"stdio"}},"other":"preserved"}'
+
+  assert_success
+  assert_stderr ""
+  run jq -e '
+    ((.mcpServers | keys | sort) == ["deepwiki","executor","fff"])
+    and (.mcpServers.executor.command == "/stub/home/.local/bin/executor")
+    and (.other == "preserved")
+  ' <<< "$output"
+  assert_success
+}
+
+@test "Claude settings modifier registers each credentialed MCP server independently" {
+  local modifier="$SOURCE_ROOT/modify_dot_claude.json"
+  local stub_bin="$BATS_TEST_TMPDIR/claude-modifier-partial-bin"
+
+  # One key resolves and the other comes back empty. The two servers must not
+  # share a fate: the credential that exists is no reason to withhold its server
+  # because the other one is missing.
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/op" <<'STUB'
+#!/bin/sh
+case "$2" in
+  *Jina*) echo "jina-credential" ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$stub_bin/op"
+
+  run --separate-stderr env PATH="$stub_bin:$PATH" HOME=/stub/home bash "$modifier" \
+    <<< '{"mcpServers":{}}'
+
+  assert_success
+  # `op` is installed yet answered nothing, which is a missing sign-in rather
+  # than a deliberately credential-free machine. Say so without failing the
+  # apply, and name the credential so the cause is readable.
+  assert_stderr --partial "Tavily API Key"
+  refute_stderr --partial "Jina API Key"
+  run jq -e '
+    ((.mcpServers | keys | sort) == ["deepwiki","executor","fff","jina"])
+    and (.mcpServers.jina.headers.Authorization == "Bearer jina-credential")
+  ' <<< "$output"
+  assert_success
+}
+
+@test "Claude settings modifier passes settings through untouched without jq" {
   local modifier="$SOURCE_ROOT/modify_dot_claude.json"
   local input='{"mcpServers":{"kept":{"type":"stdio"}}}'
+  local stub_bin="$BATS_TEST_TMPDIR/claude-modifier-nojq-bin"
 
-  # Control for the test above, and the documented cost of the `op` gate: on a
-  # machine without 1Password the modifier drops *every* server, executor
-  # included, rather than registering the ones that need no credential.
-  run env PATH="$PATH_WITHOUT_OP" bash "$modifier" <<< "$input"
+  # The modifier builds every server entry with jq, so a machine without it has
+  # no way to write the file. Echoing stdin unchanged is the only safe answer,
+  # and it is the one guard that must survive the credential-free split above.
+  mkdir -p "$stub_bin"
+  ln -s "$(command -v cat)" "$stub_bin/cat"
+  ln -s "$(command -v bash)" "$stub_bin/bash"
+
+  run env PATH="$stub_bin" bash "$modifier" <<< "$input"
 
   assert_success
-  run jq -e '.mcpServers == {"kept":{"type":"stdio"}}' <<< "$output"
-  assert_success
+  assert_output "$input"
 }
 
 # ===========================================


### PR DESCRIPTION
## Summary

On a machine without 1Password, Claude Code came up with **no** MCP servers at all. `deepwiki`, `fff`, and `executor` need no credential, but they were dropped alongside `jina` and `tavily-mcp`; they now register regardless. The two credentialed servers are also independent of each other now — one unreadable key no longer withholds the other's server.

`home/modify_dot_claude.json` kept its only `.mcpServers` assignment behind two guards, one on `op` **or** `jq` being absent and one on either credential being empty. Both echoed stdin unchanged, so the assignment never ran. Only the missing-`jq` case still does, since the script cannot build the JSON without it.

## Design decision: warn, do not fail the apply

When `op` is installed but returns nothing — a missing sign-in rather than a deliberately credential-free machine — the script names the credential on stderr and skips that one server. A non-zero exit from a `modify_` script aborts the entire `chezmoi apply`, which would cost every other managed file over one MCP server. A bare `op` absence stays silent, since that is how CI and Docker run.

This matches `home/private_dot_config/opencode/opencode.json.tmpl`, which already registers all five servers unconditionally and lets only the credentialed two degrade at runtime.

## Validation

- `make test-ubuntu` — 402/402. The container has no `op`, so it exercises the fixed path end to end through a real `chezmoi apply`.
- `tests/scripts.bats` on the host — 256/256. `make test-issues` — 41/41. `shellcheck` clean.

Four cases in `tests/scripts.bats` own the contract: credential-free registration without `op`, per-credential independence with the stderr warning, the surviving no-`jq` pass-through, and the both-keys control, which now also asserts the `tavily-mcp` URL that carries its key inline.

## Known residuals

- Both API keys still reach `jq` via `--arg`, which places the secret in the process argv for the duration of the call. This predates the change.
- `read_credential` discards `op`'s stderr with `2>/dev/null`, so an `op` failure unrelated to credentials leaves no signal.
- Every apply rewrites `.mcpServers` wholesale, so a transient `op` failure removes a previously registered credentialed server until the next successful apply.

Review coverage was degraded — one of the two cross-model peer review legs never executed, so only one model reviewed this.

Related: `docs/issues/2026-08-27-001-claude-mcp-modifier-drops-every-server-without-1password.md`, which this branch closes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
