### PR TITLE
test(mcp): cover tavily-mcp registering on its credential alone

### DIFF
--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -6390,6 +6390,37 @@ STUB
   assert_success
 }
 
+@test "Claude settings modifier registers tavily-mcp when only its credential resolves" {
+  local modifier="$SOURCE_ROOT/modify_dot_claude.json"
+  local stub_bin="$BATS_TEST_TMPDIR/claude-modifier-tavily-bin"
+
+  # The mirror of the test above. The two credentialed servers are built by
+  # different jq expressions -- one a headers object, one a URL carrying the key
+  # inline -- so covering one direction does not cover the other.
+  mkdir -p "$stub_bin"
+  cat > "$stub_bin/op" <<'STUB'
+#!/bin/sh
+case "$2" in
+  *Tavily*) echo "tavily-credential" ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$stub_bin/op"
+
+  run --separate-stderr env PATH="$stub_bin:$PATH" HOME=/stub/home bash "$modifier" \
+    <<< '{"mcpServers":{}}'
+
+  assert_success
+  assert_stderr --partial "Jina API Key"
+  refute_stderr --partial "Tavily API Key"
+  run jq -e '
+    ((.mcpServers | keys | sort) == ["deepwiki","executor","fff","tavily-mcp"])
+    and (.mcpServers["tavily-mcp"].url ==
+      "https://mcp.tavily.com/mcp/?tavilyApiKey=tavily-credential")
+  ' <<< "$output"
+  assert_success
+}
+
 @test "Claude settings modifier passes settings through untouched without jq" {
   local modifier="$SOURCE_ROOT/modify_dot_claude.json"
   local input='{"mcpServers":{"kept":{"type":"stdio"}}}'


### PR DESCRIPTION
## Summary

`tavily-mcp` can now be proven to register when only its own credential resolves. #88 made the two credentialed MCP servers independent of each other, but its coverage only ran the jina-resolves / tavily-empty direction. A regression that re-coupled the two keys would still pass in the other direction.

The two servers are not symmetric in the code: `jina` assembles a headers object, `tavily-mcp` builds a URL with the key inline (`home/modify_dot_claude.json`). Covering one branch does not cover the other.

## Validation

Red then green, both observed:

- Re-coupling the keys in the modifier's jq expression (`if $tavily_key == "" or $jina_key == ""`) fails this test.
- The shipped expression passes it.

`make test-ubuntu` — 403/403 on this branch.

## Provenance

This was the one testing gap raised by the OpenCode leg of the cross-model review on #88, which ran after that PR merged. Its verdict on the merged code was otherwise approve with no actionable findings.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
