### PR TITLE
fix(review): keep peer reviews static and full-size

### DIFF
--- a/docs/issues/2026-08-28-001-peer-test-rules-duplicated-between-se-code-review-skill-md-and-the-smithers-workflow.md
+++ b/docs/issues/2026-08-28-001-peer-test-rules-duplicated-between-se-code-review-skill-md-and-the-smithers-workflow.md
@@ -1,0 +1,22 @@
+---
+title: "Peer test rules duplicated between se-code-review SKILL.md and the Smithers workflow"
+short_description: "The no-tests restriction and tautological-tests criterion exist as two independently editable copies"
+type: "chore"
+category: "se-pipeline"
+tags: ["se-code-review","duplication"]
+date: "2026-08-28"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The no-run-tests restriction and the 'Tautological tests considered harmful' criterion are inlined in two separate runtimes: home/private_dot_claude/skills/se-code-review/SKILL.md (shared review contract block) and home/private_dot_claude/dot_smithers/workflows/se-code-review.tsx (consultHardRules extraRules). Changing the rule requires two synchronized edits, and the copies have already drifted — the .tsx version drops the quotation marks that scope the criterion handed to the testing persona. Inlining is correct in both places because each dispatches a fresh-context agent that cannot reach a pointer, so the fix is a shared origin rather than a pointer.
+
+## Scope
+
+Give the two rule strings one origin the workflow imports and the skill quotes verbatim, or add a check that fails when the two copies diverge. Out of scope: changing what the rules say.
+
+## Open decisions
+
+Whether a Markdown skill can practically import from a TypeScript module, or whether a drift test is the cheaper mechanism.

--- a/docs/issues/2026-08-28-002-project-claude-md-restates-the-global-tautological-tests-rule.md
+++ b/docs/issues/2026-08-28-002-project-claude-md-restates-the-global-tautological-tests-rule.md
@@ -1,0 +1,22 @@
+---
+title: "Project CLAUDE.md restates the global tautological-tests rule"
+short_description: "The my-mac-setup test block duplicates two meanings now owned by the global CLAUDE.md"
+type: "chore"
+category: "repository-maintenance"
+tags: ["claude-md","duplication"]
+date: "2026-08-28"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+The global instructions at home/private_dot_claude/CLAUDE.md gained an 'adding or reviewing tests' block stating that a test must change verdict when the protected behavior breaks and that exact-text assertions are valid only against an externally consumed literal contract. The project CLAUDE.md test block already carries both meanings ('A regression test is complete only when it goes red for the intended regression and green for the corrected behavior' and 'Assert externally observable behavior. Assert literal source or rendered text only when consumers depend on that exact shape'). The global file has the broader scope and is the right owner, which makes the project lines the duplicate — two copies that can drift and that both spend context on every turn in this repo.
+
+## Scope
+
+Trim the overlapping lines from the project CLAUDE.md test block, keeping its repo-specific content (suite selection, MMS_DISPOSABLE_HOME, control fixtures) and its pointer to docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md. Verify the solutions doc itself does not become the third copy.
+
+## Open decisions
+
+Whether the solutions doc or the global CLAUDE.md should be the single authority once the project restatement is removed.

--- a/docs/issues/2026-08-28-003-peer-no-run-tests-restriction-has-no-completion-criterion-the-parent-can-check.md
+++ b/docs/issues/2026-08-28-003-peer-no-run-tests-restriction-has-no-completion-criterion-the-parent-can-check.md
@@ -1,0 +1,22 @@
+---
+title: "Peer no-run-tests restriction has no completion criterion the parent can check"
+short_description: "Nothing detects a peer or persona subagent that ran the test suite anyway"
+type: "follow-up"
+category: "se-pipeline"
+tags: ["se-code-review","verification"]
+date: "2026-08-28"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The se-code-review shared review contract instructs each peer to use static inspection only and to append that same restriction to every persona/reviewer subagent prompt. Compliance is therefore twice removed: parent -> peer -> persona subagent. The demand is stated but no check exists — neither the report validation in 'Dispatch fresh peers' nor 'Synthesize reports' can tell a compliant envelope from one produced by a peer that ran the suite. The restriction exists so the parent owns test execution after synthesis and accepted fixes; a silent violation costs wall-clock time on duplicate suite runs and can leave a mutated tree the parent then reviews as clean.
+
+## Scope
+
+Either require each peer to declare its tool usage in the report envelope so the parent can reject a violating one, or accept the restriction as best-effort and say so explicitly in the skill so no reader assumes it is enforced. Applies to se-code-review; check whether se-doc-review and se-simplify carry the same unenforced demand.
+
+## Open decisions
+
+Whether a self-declared tool-usage field is trustworthy enough to gate on, given the same agent is the one under restriction.

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -57,6 +57,13 @@ Every skill's own description already carries its triggers. These four lines res
 
 </important>
 
+<important if="you are adding or reviewing tests">
+
+- **Tautological tests considered harmful.** A test must change verdict when the protected behavior breaks. A test that mirrors newly added source, prompt, config, or fixture text cannot.
+- Replace a tautological test with behavioral coverage, or omit it when no regression is protected. Exact-text assertions are valid only against an externally consumed literal contract.
+
+</important>
+
 <important if="you encounter conflicting patterns or conventions in the codebase">
 
 Pick one (more recent / more tested), state why in one line, and flag the other for cleanup. Every site you touch in this task follows the one you picked.

--- a/home/private_dot_claude/dot_smithers/workflows/se-code-review.tsx
+++ b/home/private_dot_claude/dot_smithers/workflows/se-code-review.tsx
@@ -170,7 +170,11 @@ ${consultHardRules({
   noChangesRules: [
     "NO CHANGES, JUST REPORT: mode:agent is report-only. Do not create, edit, or delete ANY file, never commit, never push, never switch branches. The snapshot and the repo are read-only context.",
   ],
-  extraRules: [REVIEWER_BREVITY_RULE],
+  extraRules: [
+    REVIEWER_BREVITY_RULE,
+    "Use static inspection and non-test read-only tooling only. Do not run test suites or individual tests, directly or through persona/reviewer subagents. Append this test restriction to every persona/reviewer subagent prompt. The parent review owner runs tests after report synthesis and any accepted fixes.",
+    "When the `testing` persona is selected, append this criterion to its prompt: Tautological tests considered harmful. Flag tests that merely mirror newly added source, prompt, config, or fixture text and would stay green while the intended behavior is broken. Require behavioral replacement or removal. Exact-text assertions are valid only when they exercise an externally consumed literal contract.",
+  ],
   finalOutput: {
     kind: "rawObject",
     objectDescription: "the plugin's full mode:agent JSON review (status/verdict/findings/...)",

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -10,11 +10,11 @@ Resolve these values before launch:
 - `CLAUDE_PROMPT`: the calling skill's complete Claude dispatch brief.
 - `OPENCODE_PROMPT`: the calling skill's complete OpenCode dispatch brief.
 
-Require `HERDR_ENV=1`, `herdr`, `claude`, and `opencode`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
+Require `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`, `herdr`, `claude`, and `opencode`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
 
-The **cleanup boundary** begins when the report transport directory is created. Track each created pane ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every pane created by this run and removes its report transport files before control returns to the calling skill.
+The **cleanup boundary** begins when the report transport directory is created. Track each created tab ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every tab created by this run and removes its report transport files before control returns to the calling skill.
 
-## Create panes
+## Create tabs
 
 Use run-scoped agent names no longer than 32 characters:
 
@@ -29,18 +29,26 @@ CLAUDE_REPORT_PATH="$PEER_REPORT_DIR/claude.report"
 OPENCODE_REPORT_PATH="$PEER_REPORT_DIR/opencode.report"
 ```
 
-Create sibling panes rooted at the repository without taking focus:
+Create one full-size background tab per peer, rooted at the repository without taking focus:
 
 ```bash
-CLAUDE_PANE=$(herdr pane split --current --direction right --cwd "$REPO_ROOT" --no-focus \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+CLAUDE_TAB_STATE=$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" \
+  --cwd "$REPO_ROOT" --label "$CLAUDE_NAME" --no-focus)
+CLAUDE_TAB=$(printf '%s' "$CLAUDE_TAB_STATE" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
+CLAUDE_PANE=$(printf '%s' "$CLAUDE_TAB_STATE" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
 
-OPENCODE_PANE=$(herdr pane split "$CLAUDE_PANE" --direction down --cwd "$REPO_ROOT" --no-focus \
-  --env 'OPENCODE_CONFIG_CONTENT={"permission":"allow","agent":{"build":{"permission":"allow","reasoningEffort":"high"}}}' \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+OPENCODE_TAB_STATE=$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" \
+  --cwd "$REPO_ROOT" --label "$OPENCODE_NAME" --no-focus \
+  --env 'OPENCODE_CONFIG_CONTENT={"permission":"allow","agent":{"build":{"permission":"allow","reasoningEffort":"high"}}}')
+OPENCODE_TAB=$(printf '%s' "$OPENCODE_TAB_STATE" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
+OPENCODE_PANE=$(printf '%s' "$OPENCODE_TAB_STATE" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
 ```
 
-A freshly split pane can make its following `agent start` return `agent_pane_busy`. On that exact error, wait two seconds and retry the same start once. A failed retry enters the cleanup boundary. A generic startup timeout enters cleanup immediately without retry.
+A freshly created tab's root pane can make its following `agent start` return `agent_pane_busy`. On that exact error, wait two seconds and retry the same start once. A failed retry enters the cleanup boundary. A generic startup timeout enters cleanup immediately without retry.
 
 ## Start exact peers
 
@@ -140,12 +148,12 @@ A settled state is only a wake-up signal. Pane-backed reads can silently omit al
 
 ## Close and clean before synthesis
 
-After collecting every available report into memory, close both panes and remove the transport directory before synthesis:
+After collecting every available report into memory, close both tabs and remove the transport directory before synthesis:
 
 ```bash
 CLEANUP_ERRORS=""
-herdr pane close "$CLAUDE_PANE" || CLEANUP_ERRORS="$CLEANUP_ERRORS pane:$CLAUDE_PANE"
-herdr pane close "$OPENCODE_PANE" || CLEANUP_ERRORS="$CLEANUP_ERRORS pane:$OPENCODE_PANE"
+herdr tab close "$CLAUDE_TAB" || CLEANUP_ERRORS="$CLEANUP_ERRORS tab:$CLAUDE_TAB"
+herdr tab close "$OPENCODE_TAB" || CLEANUP_ERRORS="$CLEANUP_ERRORS tab:$OPENCODE_TAB"
 rm -f "$CLAUDE_REPORT_PATH" "$CLAUDE_REPORT_PATH.tmp" \
   "$OPENCODE_REPORT_PATH" "$OPENCODE_REPORT_PATH.tmp" \
   || CLEANUP_ERRORS="$CLEANUP_ERRORS reports:$PEER_REPORT_DIR"
@@ -153,4 +161,4 @@ rmdir "$PEER_REPORT_DIR" || CLEANUP_ERRORS="$CLEANUP_ERRORS directory:$PEER_REPO
 [ -z "$CLEANUP_ERRORS" ] || printf 'peer cleanup incomplete:%s\n' "$CLEANUP_ERRORS" >&2
 ```
 
-Pane closure and report-directory removal complete the cleanup boundary. Attempt every recorded pane closure and every cleanup command even when an earlier command fails; report any pane or transport path that remains.
+Tab closure and report-directory removal complete the cleanup boundary. Attempt every recorded tab closure and every cleanup command even when an earlier command fails; report any tab or transport path that remains.

--- a/home/private_dot_claude/skills/se-code-review/SKILL.md
+++ b/home/private_dot_claude/skills/se-code-review/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[mode:agent] [PR URL/number | branch | base:<ref>] [plan:<path>]
 
 Run the same `compound-engineering:ce-code-review` workflow through two fresh peer sessions.
 
-Both peers review the same current checkout independently in `mode:agent`. They return reports and never edit the checkout. After collecting their reports, close both panes before synthesis. Never resume or reuse either peer, and never retain one for another phase.
+Both peers review the same current checkout independently in `mode:agent`. They return reports and never edit the checkout. After collecting their reports, close both tabs before synthesis. Never resume or reuse either peer, and never retain one for another phase.
 
 ## Resolve arguments
 
@@ -25,43 +25,56 @@ Empty target arguments review the current branch against its detected base. Reco
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for pane creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
 
 Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
 
+### Shared review contract
+
+Append this block verbatim to both peer prompts:
+
+```text
+This is an independent report-only review. Do not edit repository files, stage
+changes, commit, push, switch branches, or ask interactive questions. The shared
+lifecycle's report transport file is the only permitted write.
+
+Use static inspection and non-test read-only tooling only. Do not run test suites
+or individual tests, directly or through persona/reviewer subagents. Append this
+test restriction to every persona/reviewer subagent prompt. The parent review
+owner runs tests after report synthesis and any accepted fixes.
+
+When the `testing` persona is selected, append this criterion to its prompt:
+"Tautological tests considered harmful. Flag tests that merely mirror newly added
+source, prompt, config, or fixture text and would stay green while the intended
+behavior is broken. Require behavioral replacement or removal. Exact-text
+assertions are valid only when they exercise an externally consumed literal
+contract."
+
+Run the complete reviewer selection, persona dispatch, validation, merge, and
+JSON output flow. Return the final raw JSON report.
+```
+
 ### Claude prompt
 
-Send Claude this prompt:
+Send Claude this invocation line, then the shared review contract verbatim:
 
 ```text
 Invoke `/compound-engineering:ce-code-review` with these exact arguments:
 
 mode:agent <resolved arguments>
-
-This is an independent report-only review. Do not edit repository files, stage
-changes, commit, push, switch branches, or ask interactive questions. The shared
-lifecycle's report transport file is the only permitted write.
-
-Run the complete reviewer selection, persona dispatch, validation, merge, and
-JSON output flow. Return the final raw JSON report.
 ```
 
 ### OpenCode prompt
+
+Send OpenCode this invocation line, then the shared review contract verbatim:
 
 ```text
 Use the `ce-code-review` skill with these exact arguments:
 
 mode:agent <resolved arguments>
-
-This is an independent report-only review. Do not edit repository files, stage
-changes, commit, push, switch branches, or ask interactive questions. The shared
-lifecycle's report transport file is the only permitted write.
-
-Run the complete reviewer selection, persona dispatch, validation, merge, and
-JSON output flow. Return the final raw JSON report.
 ```
 
-Execute the shared lifecycle through pane closure. Require a complete parseable JSON report from each peer. One failed or malformed peer degrades coverage; two failed peers fail the review. Do not pass peer context into `se-simplify`.
+Execute the shared lifecycle through tab closure. Require a complete parseable JSON report from each peer. One failed or malformed peer degrades coverage; two failed peers fail the review. Do not pass peer context into `se-simplify`.
 
 ## Synthesize reports
 

--- a/home/private_dot_claude/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_claude/skills/se-doc-review/SKILL.md
@@ -10,7 +10,7 @@ Run three independent `ce-doc-review` passes from one pre-review document state:
 
 - The local pass runs headless on the real document and may apply `safe_auto` fixes.
 - Two fresh peers run headless on an immutable copy and return report-only envelopes.
-- The parent synthesizes all available envelopes after both peer panes close.
+- The parent synthesizes all available envelopes after both peer tabs close.
 
 ## Resolve the document
 
@@ -24,7 +24,7 @@ Record whether the wrapper was invoked with `mode:headless`; delivery uses that 
 
 ## Scan and freeze peer input
 
-The external payload is the document itself. Unless `SE_SKIP_SECRET_SCAN` is set to a non-empty value other than `0`, require `gitleaks` and run this fail-closed scan before creating panes:
+The external payload is the document itself. Unless `SE_SKIP_SECRET_SCAN` is set to a non-empty value other than `0`, require `gitleaks` and run this fail-closed scan before creating tabs:
 
 ```bash
 gitleaks dir --no-banner --redact --exit-code 2 "$DOC_PATH"
@@ -44,7 +44,7 @@ Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. This keeps both peer
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It owns pane creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It owns tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
 
 Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
 
@@ -102,11 +102,11 @@ canonical schema. An empty review still includes Coverage with explicit zero
 counts. End with the exact line: Review complete
 ```
 
-After the shared lifecycle submits both prompts and before it waits, invoke the local `compound-engineering:ce-doc-review` with `mode:headless DOC_PATH`. The local pass is the only review allowed to mutate the document. Whether the local pass succeeds or fails, resume the shared lifecycle through peer read and pane closure.
+After the shared lifecycle submits both prompts and before it waits, invoke the local `compound-engineering:ce-doc-review` with `mode:headless DOC_PATH`. The local pass is the only review allowed to mutate the document. Whether the local pass succeeds or fails, resume the shared lifecycle through peer read and tab closure.
 
 Accept an envelope only when Coverage accounts for every attempted persona, its counts reconcile, every surviving finding is routed once with its required fields, and the terminal line is exact. A failed or malformed pass degrades coverage; synthesize any surviving envelopes. If all three passes fail, fail the review without modifying the document further.
 
-Remove the temporary document copy and its empty staging directory after pane closure or any earlier failure.
+Remove the temporary document copy and its empty staging directory after tab closure or any earlier failure.
 
 ## Synthesize envelopes
 

--- a/home/private_dot_claude/skills/se-simplify/SKILL.md
+++ b/home/private_dot_claude/skills/se-simplify/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[scope description]"
 
 Launch two fresh peer sessions to inspect the same simplification scope.
 
-Each peer uses the `ce-simplify-code` rubric to produce findings without editing. After collecting both reports, close both panes before synthesis. The parent applies the accepted set exactly once and verifies behavior.
+Each peer uses the `ce-simplify-code` rubric to produce findings without editing. After collecting both reports, close both tabs before synthesis. The parent applies the accepted set exactly once and verifies behavior.
 
 ## Resolve scope
 
@@ -23,7 +23,7 @@ Capture the pre-apply worktree state so simplify-owned edits can be distinguishe
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for pane creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
 
 Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
 
@@ -77,7 +77,7 @@ Write `Findings: none` when no item survives. End with the exact line:
 Simplify review complete
 ```
 
-Execute the shared lifecycle through pane closure. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; two failed peers fail the simplify run and apply nothing.
+Execute the shared lifecycle through tab closure. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; two failed peers fail the simplify run and apply nothing.
 
 ## Synthesize findings
 


### PR DESCRIPTION
## Summary

Review peers now stay focused on static analysis instead of duplicating the parent review owner's test runs. Testing personas also treat tautological tests that mirror implementation text without proving behavior as false confidence.

Claude and OpenCode peers for code review, document review, and simplification now launch in separate full-size background Herdr tabs. This removes the nested narrow split that could leave OpenCode on its splash screen, while preserving the existing dispatch, wait, report, and cleanup lifecycle.

Three repository issues record the remaining policy-duplication and enforceability follow-ups without expanding this change.

## Validation

- `git diff --check origin/main...HEAD`
- Confirmed the installed Herdr CLI supports tab creation, root panes, environment injection, and tab cleanup through its built-in command help.
- Test suites were not run; these changes affect agent instructions and workflow prompts.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.6_sol](https://img.shields.io/badge/GPT_5.6_sol-000000?logo=openai&logoColor=white)
