### PR TITLE
fix(tests): enforce Bats conditional assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ lint:
 	find . -name "*.sh" -type f -not -path "./.git/*" -not -path "*/node_modules/*" | xargs shellcheck --severity=warning
 	find home -name "run_*" -type f 2>/dev/null | xargs shellcheck --severity=warning
 	find home -name "executable_*" -type f -not -name "*.py" 2>/dev/null | xargs shellcheck --severity=warning
+	python3 scripts/check_bats_assertions.py tests
 
 clean:
 	docker compose -f docker/docker-compose.yml down --rmi local --volumes --remove-orphans 2>/dev/null || true

--- a/docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md
+++ b/docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md
@@ -1,12 +1,13 @@
 ---
 title: "Bare mid-test [[ ]] assertions are silently inert in bats"
-short_description: "A bare [[ ... ]] check that is not the last statement of a bats test body does not fail the test under the local bash/bats combination (empirically confirmed twice during playground work), so pre-existing mid-test bracket assertions across the suite may be unenforced and need an audit converting them to '[[ ... ]] || fail'."
+short_description: "All 29 first-party standalone [[...]] checks now use explicit failure paths, and a tested lint checker rejects future bare [[...]] and ((...)) commands while excluding vendored suites and shell payloads."
 type: "bug"
 category: "testing-ci"
 tags: ["test-integrity"]
 date: "2026-08-27"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-28"
 ---
 
 ## Why this exists
@@ -25,3 +26,7 @@ Impact: false confidence — assertions that reviewers believe are enforced are 
 ## Open decisions
 
 None.
+
+## Resolution
+
+Converted all 29 first-party standalone double-bracket assertions to explicit failure paths, calibrated every conversion against an always-false mutation, added a recursive quote/heredoc/arithmetic-aware lint checker with behavioral fixtures, and verified make test-issues, make lint, 14 affected Bats tests, and make test-ubuntu (403 cases).

--- a/docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md
+++ b/docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md
@@ -1,0 +1,31 @@
+---
+title: "Bats assertion checker misses a second same-line conditional"
+short_description: "scripts/check_bats_assertions.py stops after the first recognized compound conditional on a physical line, so a later bare [[...]] or ((...)) command after a semicolon can bypass make lint."
+type: "bug"
+category: "testing-ci"
+tags: ["test-integrity","linting"]
+date: "2026-08-28"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The lint guard added for explicit Bats compound-condition assertions returns after the first recognized `[[ ... ]]` or `(( ... ))` command on each physical line. A later bare conditional on the same line is never inspected:
+
+```bash
+[[ 1 == 1 ]] || fail "first"; [[ 1 == 2 ]]
+:
+```
+
+Running `python3 scripts/check_bats_assertions.py` against this fixture exits zero. The second condition can therefore reproduce the false-green assertion class while `make lint` reports success.
+
+## Scope
+
+- Continue scanning after each handled conditional until every top-level command segment on the physical line has been classified.
+- Add a rejection fixture where an explicitly handled first conditional is followed by a bare second conditional.
+- Preserve accepted quoted text, heredoc payloads, arithmetic shifts, control flow, and vendored Bats libraries.
+
+## Open decisions
+
+None.

--- a/docs/solutions/test-failures/bats-mid-test-compound-conditionals-bypass-errexit.md
+++ b/docs/solutions/test-failures/bats-mid-test-compound-conditionals-bypass-errexit.md
@@ -1,0 +1,129 @@
+---
+title: Bats mid-test compound conditionals bypass errexit
+date: 2026-08-28
+category: test-failures
+module: testing
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "A Bats test remains green after a standalone [[ ... ]] or (( ... )) condition evaluates false before a later successful command"
+  - "Assertions that reviewers believe are enforced do not invoke the Bats ERR trap under macOS system Bash 3.2"
+root_cause: logic_error
+resolution_type: test_fix
+severity: high
+related_components:
+  - "development_workflow"
+  - "tooling"
+tags:
+  - bats
+  - bash-3-2
+  - errexit
+  - err-trap
+  - compound-conditionals
+  - test-integrity
+  - semantic-regression-tests
+  - linting
+---
+
+# Bats mid-test compound conditionals bypass errexit
+
+## Problem
+
+On macOS Bash 3.2, a false standalone `[[ ... ]]` or `(( ... ))` command in the middle of a Bats 1.14 test function can bypass Bats' implicit failure machinery. If a later command succeeds, the generated test function returns zero and Bats reports a false green.
+
+## Symptoms
+
+- A Bats test remained green after a mid-test `[[ ... ]]` condition was changed to an always-false expression.
+- The same assertion appeared enforced as the final command, then became inert when a successful command was added after it.
+- A query-bound assertion failed in Linux Docker but was provably unenforced under the repository's local macOS Bash 3.2 and Bats 1.14 combination.
+- The suite contained 29 first-party standalone compound conditionals whose apparent assertions depended on implicit shell behavior.
+
+This unsafe shape looks like an assertion but has no explicit failure path:
+
+```bash
+@test "returns the expected value" {
+  actual="$(produce_value)"
+  [[ "$actual" == "expected" ]]
+  printf 'checked\n'
+}
+```
+
+## What Didn't Work
+
+No separate failed implementation attempts were recorded. These implicit safeguards were insufficient:
+
+- Relying on Bats' `set -eET` and `ERR` trap did not enforce a false mid-function `[[ ... ]]` or `(( ... ))` under macOS Bash 3.2.
+- Relying on final-command position was fragile. A false compound conditional at the end failed empirically, but adding any later successful command changed the verdict to green.
+- ShellCheck could not enforce this Bats-specific semantic contract. The conditionals are valid shell syntax.
+- Linux-only behavior was not representative. The assertion could fail in Docker while remaining inert on the supported macOS shell.
+
+## Solution
+
+Convert standalone compound-conditional assertions to explicit failure paths with useful diagnostics:
+
+```bash
+# Before: a later successful command can erase this false status on Bash 3.2.
+[[ "$actual" == "expected" ]]
+
+# After: failure is explicit and reports the observed value.
+[[ "$actual" == "expected" ]] || fail "unexpected value: $actual"
+```
+
+Arithmetic assertions follow the same rule:
+
+```bash
+(( count > 0 )) || fail "expected a positive count: $count"
+```
+
+PR [#91](https://github.com/Seigiard/my-mac-setup/pull/91) converted all 29 first-party standalone checks and added `scripts/check_bats_assertions.py` to `make lint`. The checker recursively inspects first-party `.bats` files and rejects covered `[[ ... ]]` and `(( ... ))` command shapes without explicit status handling. It excludes vendored Bats libraries and distinguishes executable conditionals from quoted text, comments, heredocs, here-strings, arithmetic expansions, multiline conditionals, and normal `if` or `while` control flow.
+
+The current checker stops after the first recognized compound conditional on each physical line. [`2026-08-28-004`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) tracks extending it to inspect a later same-line conditional rather than overstating the guard as a complete shell parser.
+
+Behavioral tests in `tests/test_bats_assertion_contract.py` prove both sides of the checker contract. Unsafe fixtures return nonzero with file and line diagnostics, while explicit handlers, control flow, shell payloads, and vendored fixtures remain accepted. Each converted assertion was also calibrated with an always-false mutation and observed failing at its new handler before its real condition was restored.
+
+## Why This Works
+
+Bats preprocesses each `@test` block into a generated Bash function. Conceptually, the unsafe example becomes:
+
+```bash
+bats_test_function --description "returns the expected value" -- test_returns_the_expected_value
+test_returns_the_expected_value() {
+  actual="$(produce_value)"
+  [[ "$actual" == "expected" ]]
+  printf 'checked\n'
+}
+```
+
+`bats-exec-test` starts with `set -eET`, installs Bats' `ERR` trap, and invokes the generated function from `bats_perform_test`. The verified causal chain on macOS Bash 3.2 is:
+
+1. The generated function executes a false mid-function `[[ ... ]]` or `(( ... ))` command.
+2. Bash 3.2 neither exits nor invokes the inherited `ERR` trap for that compound conditional in this position.
+3. Execution continues to the next command.
+4. A later successful command becomes the function's final status.
+5. Bats reaches `BATS_TEST_COMPLETED=1` and reports the test as passing.
+
+With `[[ ... ]] || fail "..."`, false selects the explicit failure branch. `fail` returns nonzero with a useful diagnostic, so the test no longer depends on Bash preserving the compound conditional's intermediate status.
+
+This bug is specific to the compound conditional commands tested here. A false simple `[ ... ]` command in the same mid-function position was empirically observed to trigger `ERR` and `errexit` under macOS Bash 3.2. The lint guard therefore targets standalone `[[ ... ]]` and `(( ... ))`, not every `[` simple command. Explicit assertion helpers or `|| fail` are still preferable whenever a command is intended to communicate an assertion.
+
+## Prevention
+
+- Give every standalone `[[ ... ]]` and `(( ... ))` assertion an explicit handler such as `|| fail "diagnostic"`, or use an appropriate `assert_*` helper.
+- Keep `python3 scripts/check_bats_assertions.py tests` in `make lint` as defense in depth for its covered syntax, and preserve regression issues for any newly discovered parser gap.
+- Calibrate assertion changes by recreating the regression: observe an always-false form fail, restore the real condition, then observe the same test pass.
+- Keep rejection fixtures beside valid controls so the guard proves it recognizes executable conditionals without rejecting control flow, generated shell payloads, or vendored tests.
+- Run macOS and Linux gates because shell-version differences are part of the supported environment, not interchangeable evidence.
+
+Verification for the fix completed successfully:
+
+- `make test-issues`: 44 tests.
+- `make lint`.
+- All 14 affected Bats test bodies after restoring their real conditions.
+- `make test-ubuntu`: 403 cases with expected skips.
+
+## Related Issues
+
+- [`docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md`](../../issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md) records the repository issue and resolution.
+- [`docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) tracks the checker's known same-line false negative.
+- [PR #91: Enforce Bats conditional assertions](https://github.com/Seigiard/my-mac-setup/pull/91) contains the implementation and verification evidence.
+- [`semantic-regression-tests-over-source-shape.md`](../design-patterns/semantic-regression-tests-over-source-shape.md) defines the broader red/green calibration and behavioral-control pattern used here.

--- a/scripts/check_bats_assertions.py
+++ b/scripts/check_bats_assertions.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+import sys
+
+
+HEREDOC = re.compile(
+    r"(?<!<)<<(?P<strip_tabs>-?)(?!<)\s*"
+    r"(?P<quote>['\"]?)(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)"
+)
+
+
+def line_state_after(line, state=None, arithmetic_depth=0):
+    escaped = False
+    heredocs = []
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if escaped:
+            escaped = False
+        elif state == "'":
+            if character == "'":
+                state = None
+        elif character == "\\":
+            escaped = True
+        elif state == '"':
+            if character == '"':
+                state = None
+        elif character == "#" and (index == 0 or line[index - 1].isspace()):
+            break
+        elif line.startswith("$((", index):
+            arithmetic_depth += 1
+            index += 2
+        elif line.startswith("((", index):
+            arithmetic_depth += 1
+            index += 1
+        elif arithmetic_depth and line.startswith("))", index):
+            arithmetic_depth -= 1
+            index += 1
+        elif character == "<" and not arithmetic_depth:
+            match = HEREDOC.match(line, index)
+            if match:
+                heredocs.append(
+                    (match.group("delimiter"), bool(match.group("strip_tabs")))
+                )
+                index = match.end() - 1
+        elif character in ("'", '"'):
+            state = character
+        index += 1
+    return state, arithmetic_depth, heredocs
+
+
+def conditional_command(line):
+    state = None
+    escaped = False
+    arithmetic_depth = 0
+    command_start = True
+    index = 0
+
+    while index < len(line):
+        character = line[index]
+        if escaped:
+            escaped = False
+        elif state == "'":
+            if character == "'":
+                state = None
+        elif character == "\\":
+            escaped = True
+        elif state == '"':
+            if character == '"':
+                state = None
+        elif character == "#" and (index == 0 or line[index - 1].isspace()):
+            break
+        elif character in ("'", '"'):
+            state = character
+        elif line.startswith("$((", index):
+            arithmetic_depth += 1
+            command_start = False
+            index += 2
+        elif line.startswith("((", index):
+            if command_start:
+                return index, "((", "))"
+            arithmetic_depth += 1
+            index += 1
+        elif arithmetic_depth and line.startswith("))", index):
+            arithmetic_depth -= 1
+            index += 1
+        elif not arithmetic_depth and character == ";":
+            command_start = True
+        elif not character.isspace():
+            if command_start and line.startswith("[[", index) and (
+                index + 2 == len(line) or line[index + 2].isspace()
+            ):
+                return index, "[[", "]]"
+            command_start = False
+        index += 1
+
+    return None
+
+
+def unquoted_closing(line, start, closing, state=None):
+    escaped = False
+    index = start
+    while index < len(line):
+        character = line[index]
+        if escaped:
+            escaped = False
+        elif state == "'":
+            if character == "'":
+                state = None
+        elif character == "\\":
+            escaped = True
+        elif state == '"':
+            if character == '"':
+                state = None
+        elif character in ("'", '"'):
+            state = character
+        elif line.startswith(closing, index):
+            return index, state
+        index += 1
+    return -1, state
+
+
+def find_violations(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    violations = []
+    heredocs = []
+    quote_state = None
+    arithmetic_depth = 0
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if heredocs:
+            delimiter, strip_tabs = heredocs[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                heredocs.pop(0)
+            index += 1
+            continue
+
+        if quote_state:
+            quote_state, arithmetic_depth, _ = line_state_after(
+                line, quote_state, arithmetic_depth
+            )
+            index += 1
+            continue
+
+        conditional = conditional_command(line)
+
+        if conditional:
+            start_column, opening, closing = conditional
+            command_end = index
+            condition_quote = None
+            closing_column, condition_quote = unquoted_closing(
+                lines[command_end], start_column + len(opening), closing
+            )
+            while closing_column < 0 and command_end + 1 < len(lines):
+                command_end += 1
+                closing_column, condition_quote = unquoted_closing(
+                    lines[command_end], 0, closing, condition_quote
+                )
+
+            tail = ""
+            if closing_column >= 0:
+                tail = lines[command_end][closing_column + len(closing) :].strip()
+            handled = tail.startswith(("||", "&&"))
+            if tail == "\\" and command_end + 1 < len(lines):
+                handled = lines[command_end + 1].lstrip().startswith(("||", "&&"))
+            if not handled:
+                violations.append((index + 1, opening, closing))
+            for command_line in lines[index : command_end + 1]:
+                quote_state, arithmetic_depth, found_heredocs = line_state_after(
+                    command_line, quote_state, arithmetic_depth
+                )
+                heredocs.extend(found_heredocs)
+            index = command_end
+        else:
+            quote_state, arithmetic_depth, found_heredocs = line_state_after(
+                line, quote_state, arithmetic_depth
+            )
+            heredocs.extend(found_heredocs)
+
+        index += 1
+
+    return violations
+
+
+def main(argv):
+    tests_dir = Path(argv[1]) if len(argv) > 1 else Path("tests")
+    violations = []
+    for path in sorted(tests_dir.rglob("*.bats")):
+        if path.relative_to(tests_dir).parts[:2] == ("helpers", "bats-libs"):
+            continue
+        for line_number, opening, closing in find_violations(path):
+            violations.append(
+                f"{path}:{line_number}: bare {opening}...{closing} requires "
+                "explicit status handling"
+            )
+
+    if violations:
+        print("\n".join(violations))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -1892,10 +1892,10 @@ PY
   call2="$(sed -n '2p' "$CHILD_STUB/calls.log")"
   call3="$(sed -n '3p' "$CHILD_STUB/calls.log")"
   call4="$(sed -n '4p' "$CHILD_STUB/calls.log")"
-  [[ "$call1" == agent\ list* ]]
-  [[ "$call2" == pane\ split*HERDR_CHILD_NAME=child-a*HERDR_CHILD_PARENT_PANE=wT:p0* ]]
-  [[ "$call3" == agent\ start* ]]
-  [[ "$call4" == agent\ prompt*child-a*wT:p9*wT:p0*--wait*--timeout\ 5000* ]]
+  [[ "$call1" == agent\ list* ]] || fail "unexpected first herdr-child call: $call1"
+  [[ "$call2" == pane\ split*HERDR_CHILD_NAME=child-a*HERDR_CHILD_PARENT_PANE=wT:p0* ]] || fail "unexpected second herdr-child call: $call2"
+  [[ "$call3" == agent\ start* ]] || fail "unexpected third herdr-child call: $call3"
+  [[ "$call4" == agent\ prompt*child-a*wT:p9*wT:p0*--wait*--timeout\ 5000* ]] || fail "unexpected fourth herdr-child call: $call4"
 }
 
 @test "herdr-child tab mode records ownership before starting an attached child" {
@@ -1910,11 +1910,11 @@ PY
   call3="$(sed -n '3p' "$CHILD_STUB/calls.log")"
   call4="$(sed -n '4p' "$CHILD_STUB/calls.log")"
   call5="$(sed -n '5p' "$CHILD_STUB/calls.log")"
-  [[ "$call1" == agent\ list* ]]
-  [[ "$call2" == tab\ create*--workspace\ w1*HERDR_CHILD_NAME=child-a*HERDR_CHILD_PARENT_PANE=wT:p0*--label\ mylabel* ]]
-  [[ "$call3" == pane\ report-metadata\ wT:p9\ --source\ child-agent-tab*child-tab=wT:tA* ]]
-  [[ "$call4" == agent\ start* ]]
-  [[ "$call5" == agent\ prompt*--wait* ]]
+  [[ "$call1" == agent\ list* ]] || fail "unexpected first tab-mode call: $call1"
+  [[ "$call2" == tab\ create*--workspace\ w1*HERDR_CHILD_NAME=child-a*HERDR_CHILD_PARENT_PANE=wT:p0*--label\ mylabel* ]] || fail "unexpected second tab-mode call: $call2"
+  [[ "$call3" == pane\ report-metadata\ wT:p9\ --source\ child-agent-tab*child-tab=wT:tA* ]] || fail "unexpected third tab-mode call: $call3"
+  [[ "$call4" == agent\ start* ]] || fail "unexpected fourth tab-mode call: $call4"
+  [[ "$call5" == agent\ prompt*--wait* ]] || fail "unexpected fifth tab-mode call: $call5"
 }
 
 @test "herdr-child tab launch signal closes a parsed creation before ownership publication" {
@@ -2014,8 +2014,8 @@ PY
   local start_call prompt_call
   start_call="$(sed -n '3p' "$CHILD_STUB/calls.log")"
   prompt_call="$(sed -n '4p' "$CHILD_STUB/calls.log")"
-  [[ "$start_call" == *--timeout\ 300000* ]]
-  [[ "$prompt_call" == *--timeout\ 1800000* ]]
+  [[ "$start_call" == *--timeout\ 300000* ]] || fail "startup timeout was not capped: $start_call"
+  [[ "$prompt_call" == *--timeout\ 1800000* ]] || fail "prompt timeout was not preserved: $prompt_call"
 }
 
 @test "herdr-child retries only the pane-readiness start failure" {
@@ -2820,7 +2820,7 @@ PY
   assert_equal "$sanitized_one" "$sanitized_two"
   dir_one="$(hts_socket_dir "$socket_one")"
   dir_two="$(hts_socket_dir "$socket_two")"
-  [[ "$dir_one" != "$dir_two" ]]
+  [[ "$dir_one" != "$dir_two" ]] || fail "colliding socket names shared one harness directory: $dir_one"
   hts_set_pane "$socket_one" '{"pane_id":"pane-1","label":"one","tokens":{}}'
   hts_set_pane "$socket_two" '{"pane_id":"pane-1","label":"two","tokens":{}}'
 
@@ -2982,7 +2982,7 @@ PY
     hts_wait_for_quiescence "$control"
     assert_equal "$(hts_record_number "$control" generation)" \
       "$(hts_record_number "$control" committed_generation)"
-    [[ "$(hts_record_number "$control" presentation_generation)" -gt 0 ]]
+    [[ "$(hts_record_number "$control" presentation_generation)" -gt 0 ]] || fail "presentation generation was not positive for $mode"
   done
   task="$(hts_task_file "$HTS_DEFAULT_SOCKET" claude pane-transcript transcript-s)"
   assert_equal "$(hts_record_text "$task" first_prompt)" "transcript first"
@@ -3125,7 +3125,7 @@ PY
 
   HERDR_TASK_SYNC_TEST_NO_WORKER=1 hts_run --agent claude --session restart-s <<< 'restart request'
   [[ "$(hts_record_number "$control" generation)" -gt \
-    "$(hts_record_number "$control" committed_generation)" ]]
+    "$(hts_record_number "$control" committed_generation)" ]] || fail "restart fixture had no pending generation"
   hts_worker_run &
   first_worker=$!
   hts_wait_for_file "$HTS_WORK/models/pi/1/started"
@@ -3165,7 +3165,7 @@ PY
   HERDR_TASK_SYNC_TEST_NOW_SEQ=100 HERDR_TASK_SYNC_TEST_NO_WORKER=1 \
     hts_run --agent pi --session clock-s --set second-clock < /dev/null
   second_generation="$(hts_record_number "$control" generation)"
-  [[ "$second_generation" -gt "$first_generation" ]]
+  [[ "$second_generation" -gt "$first_generation" ]] || fail "generation did not advance after clock rollback"
   HERDR_TASK_SYNC_TEST_NOW_SEQ=100 HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1 hts_worker_run
   assert_equal "$(hts_record_number "$control" committed_generation)" "$second_generation"
   assert_equal "$(hts_record_number "$task" generation)" "$second_generation"
@@ -3179,7 +3179,7 @@ PY
     fail "task metadata sequence did not advance: first=$first_task_metadata second=$second_task_metadata generation=$second_generation"
   [[ "$second_presentation" -gt "$first_presentation" ]] || \
     fail "presentation generation did not advance: first=$first_presentation second=$second_presentation generation=$second_generation"
-  [[ "$second_high_water" -ge "$second_generation" ]]
+  [[ "$second_high_water" -ge "$second_generation" ]] || fail "task metadata high-water fell below generation"
 }
 
 @test "herdr-task-sync exact socket namespaces survive legacy sanitized-name collisions" {
@@ -3188,7 +3188,7 @@ PY
   local task_one task_two namespace_one namespace_two
   namespace_one="$(hts_namespace "$socket_one")"
   namespace_two="$(hts_namespace "$socket_two")"
-  [[ "$namespace_one" != "$namespace_two" ]]
+  [[ "$namespace_one" != "$namespace_two" ]] || fail "exact socket paths shared one namespace: $namespace_one"
 
   # This test owns task namespace isolation only. A successful task commit normally
   # starts a detached presentation pass, and that pass legitimately advances the
@@ -3207,9 +3207,9 @@ PY
   assert_equal "$(hts_record_text "$task_two" slug)" socket-two
   assert_equal "$(hts_record_text "$namespace_one/socket.state" socket_path)" "$socket_one"
   assert_equal "$(hts_record_text "$namespace_two/socket.state" socket_path)" "$socket_two"
-  [[ "$(hts_record_number "$namespace_one/reconcile.state" task_metadata_high_water)" -gt 0 ]]
+  [[ "$(hts_record_number "$namespace_one/reconcile.state" task_metadata_high_water)" -gt 0 ]] || fail "first socket task high-water was not positive"
   assert_equal "$(hts_record_number "$namespace_one/reconcile.state" location_metadata_high_water)" 0
-  [[ "$(hts_record_number "$namespace_two/reconcile.state" task_metadata_high_water)" -gt 0 ]]
+  [[ "$(hts_record_number "$namespace_two/reconcile.state" task_metadata_high_water)" -gt 0 ]] || fail "second socket task high-water was not positive"
   assert_equal "$(hts_record_number "$namespace_two/reconcile.state" location_metadata_high_water)" 0
   grep -q '^checkout_root=' "$namespace_one/reconcile.state"
   grep -q '^repository_anchor=' "$namespace_one/reconcile.state"
@@ -3321,7 +3321,7 @@ PY
   run hts_run_fail_open_guard hts_worker_run
   assert_success
   [[ "$(hts_record_number "$control" generation)" -gt \
-    "$(hts_record_number "$control" committed_generation)" ]]
+    "$(hts_record_number "$control" committed_generation)" ]] || fail "worker write failure committed its pending generation"
 
   hts_setup
   HERDR_TASK_SYNC_TEST_NO_WORKER=1 hts_run \
@@ -3342,7 +3342,7 @@ PY
   run hts_run_fail_open_guard hts_worker_run
   assert_success
   [[ "$(hts_record_number "$control" generation)" -gt \
-    "$(hts_record_number "$control" committed_generation)" ]]
+    "$(hts_record_number "$control" committed_generation)" ]] || fail "task write failure committed its pending generation"
   assert_dir_not_exists "$(hts_pane_state_dir "$HTS_DEFAULT_SOCKET" pane-1)/worker.claim"
 
   hts_setup
@@ -3384,7 +3384,7 @@ PY
   wait "$first_pid"
   hts_wait_for_task_slug "$task" invoked-first-committed-second
   hts_wait_for_quiescence "$control"
-  [[ "$(hts_record_number "$control" committed_generation)" -gt "$first_generation" ]]
+  [[ "$(hts_record_number "$control" committed_generation)" -gt "$first_generation" ]] || fail "later inbox commit did not advance generation"
 }
 
 @test "herdr-task-sync adapters return when a direct engine hangs" {
@@ -3886,7 +3886,7 @@ SH
   hts_wait_for_presentation_quiescence "$socket_two"
   assert_equal "$(jq -r '.panes[0].label' "$(hts_socket_state "$socket_one")")" one
   assert_equal "$(jq -r '.panes[0].label' "$(hts_socket_state "$socket_two")")" two
-  [[ "$(hts_namespace "$socket_one")" != "$(hts_namespace "$socket_two")" ]]
+  [[ "$(hts_namespace "$socket_one")" != "$(hts_namespace "$socket_two")" ]] || fail "presentation sockets shared one namespace"
 }
 
 @test "herdr-task-sync presentation recovers stale and half-created owner claims" {
@@ -4011,7 +4011,7 @@ EOF
   HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1 hts_run --agent pi --session restart-presentation --set restart-task < /dev/null
   local reconcile="$(hts_namespace "$HTS_DEFAULT_SOCKET")/reconcile.state"
   hts_wait_for_record_number "$reconcile" pending_generation 1
-  [[ "$(hts_record_number "$reconcile" pending_generation)" -gt "$(hts_record_number "$reconcile" completed_generation 2>/dev/null || printf 0)" ]]
+  [[ "$(hts_record_number "$reconcile" pending_generation)" -gt "$(hts_record_number "$reconcile" completed_generation 2>/dev/null || printf 0)" ]] || fail "presentation restart fixture had no pending intent"
   run hts_presentation_run
   assert_success
   hts_wait_for_presentation_quiescence "$HTS_DEFAULT_SOCKET"
@@ -4110,7 +4110,7 @@ EOF
   HERDR_TASK_SYNC_TEST_NOW_SEQ=1 hts_location_pass
   second_seq="$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)"
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  [[ "$second_seq" -gt "$first_seq" ]]
+  [[ "$second_seq" -gt "$first_seq" ]] || fail "detached location sequence did not advance"
   assert_equal "$(jq -r '.panes[0].tokens.repo' "$state")" repo.git
   assert_equal "$(jq -r '.panes[0].tokens.worktree' "$state")" repo
   # Detached HEAD keeps the location: commit icon plus 7-char short SHA, no
@@ -4126,7 +4126,7 @@ EOF
   # pane_inline is deferred by the plan and never published; the non-Git arm
   # clears any stale copy, so only the task token survives.
   assert_equal "$(jq -c '.panes[0].tokens' "$state")" '{"task":"kept-task"}'
-  [[ "$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)" -gt "$second_seq" ]]
+  [[ "$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)" -gt "$second_seq" ]] || fail "non-Git location sequence did not advance"
 }
 
 @test "herdr-task-sync location real probe shape pays the second sha call only when detached" {
@@ -4773,9 +4773,9 @@ EOF
   assert_success
   token_one="$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.worktree' "$state")"
   token_two="$(jq -r '.panes[] | select(.pane_id == "pane-3") | .tokens.worktree' "$state")"
-  [[ "$token_one" != "$token_two" ]]
-  [[ "$token_one" = *abcdef || "$token_two" = *abcdef ]]
-  [[ "$token_one" = *abcdef0 || "$token_two" = *abcdef1 ]]
+  [[ "$token_one" != "$token_two" ]] || fail "colliding worktree digests produced the same token: $token_one"
+  [[ "$token_one" = *abcdef || "$token_two" = *abcdef ]] || fail "neither worktree token retained the six-character digest"
+  [[ "$token_one" = *abcdef0 || "$token_two" = *abcdef1 ]] || fail "colliding digest prefixes were not extended"
 }
 
 @test "herdr-task-sync worktree token ordinal fallback is unique and stable under pane reordering" {

--- a/tests/test_bats_assertion_contract.py
+++ b/tests/test_bats_assertion_contract.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+CHECKER = REPOSITORY / "scripts" / "check_bats_assertions.py"
+
+
+class TestBatsAssertionContract(unittest.TestCase):
+    def run_checker(self, files):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tests_dir = Path(temp_dir) / "tests"
+            tests_dir.mkdir()
+            for relative_path, content in files.items():
+                path = tests_dir / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, str(CHECKER), str(tests_dir)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_rejects_bare_conditional_commands(self):
+        result = self.run_checker(
+            {
+                "unsafe.bats": """@test "conditional" {
+  local attempt=2
+  local delay=$(( 1 << attempt ))
+  printf '%s\n' 'quoted example: <<FAKE'
+  # Commented example: <<COMMENT
+  run cat <<<'a here-string is not a heredoc'
+  [[ 1 == 2 ]]
+  :
+}
+""",
+                "nested/unsafe.bats": """@test "arithmetic" {
+  (( 0 ))
+}
+""",
+                "nested/semicolon.bats": """@test "semicolon" {
+  run true; [[ 1 == 2 ]]
+  :
+}
+"""
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unsafe.bats:8: bare [[...]]", result.stdout)
+        self.assertIn("nested/unsafe.bats:2: bare ((...))", result.stdout)
+        self.assertIn("nested/semicolon.bats:2: bare [[...]]", result.stdout)
+
+    def test_accepts_explicit_handlers_control_flow_and_heredocs(self):
+        result = self.run_checker(
+            {
+                "safe.bats": """@test "safe forms" {
+  [[ 1 == 1 ]] || fail "expected equality"
+  [[ 1 == 1 ]] || fail "literal ]] remains safe"
+  [[ 1 == 1 ]] \\
+    || fail "expected multiline equality"
+  [[ -e /tmp/ready ]] && break
+  (( count > 0 )) || fail "expected a positive count"
+  if [[ -e /tmp/optional ]]; then
+    :
+  fi
+  while (( count > 0 )); do
+    break
+  done
+  cat <<'SCRIPT'
+  [[ generated == shell ]]
+  (( generated_arithmetic ))
+SCRIPT
+  cat <<PLAIN
+	PLAIN
+  [[ still_generated == shell ]]
+PLAIN
+  run jq -e '
+    ((.items | length) == 1)
+  ' <<< "$output"
+}
+""",
+                "helpers/bats-libs/vendor.bats": """@test "vendored" {
+  [[ 1 == 2 ]]
+  :
+}
+""",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_repository_has_no_implicit_conditional_assertions(self):
+        result = subprocess.run(
+            [sys.executable, str(CHECKER), str(REPOSITORY / "tests")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bats tests now fail reliably when any standalone `[[ ... ]]` or `(( ... ))` check is false, including on macOS Bash 3.2 where a mid-test compound conditional can bypass `errexit`.

All 29 first-party checks now have explicit failure paths. `make lint` also rejects covered regression shapes while distinguishing real assertions from quoted shell, heredocs, arithmetic shifts, control flow, and vendored Bats libraries.

The PR documents the Bash/Bats failure mechanism as a reusable learning. Repository issue `2026-08-28-004` preserves a separately discovered parser limitation where a second compound conditional on the same physical line can bypass the lint guard.

## Validation

- Calibrated all 29 conversions with an always-false mutation; each failed at its new handler.
- Ran the 14 affected Bats test bodies successfully after restoring their real conditions.
- `make test-issues` passed 44 tests.
- `make lint` passed.
- `make test-ubuntu` passed 403 cases with only expected skips.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
