### PR TITLE
fix(tests): scan all same-line Bats conditionals

### DIFF
--- a/docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md
+++ b/docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md
@@ -1,12 +1,13 @@
 ---
 title: "Bats assertion checker misses a second same-line conditional"
-short_description: "scripts/check_bats_assertions.py stops after the first recognized compound conditional on a physical line, so a later bare [[...]] or ((...)) command after a semicolon can bypass make lint."
+short_description: "The checker now resumes after each handled compound conditional and rejects later bare [[...]] or ((...)) commands on the same physical line without regressing accepted shell syntax."
 type: "bug"
 category: "testing-ci"
 tags: ["test-integrity","linting"]
 date: "2026-08-28"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-28"
 ---
 
 ## Why this exists
@@ -29,3 +30,7 @@ Running `python3 scripts/check_bats_assertions.py` against this fixture exits ze
 ## Open decisions
 
 None.
+
+## Resolution
+
+Changed the checker to resume scanning after each compound conditional closing token, added calibrated rejection fixtures for later same-line [[...]] and ((...)) commands plus an accepted handled control, and verified make test-issues and make lint.

--- a/docs/solutions/test-failures/bats-mid-test-compound-conditionals-bypass-errexit.md
+++ b/docs/solutions/test-failures/bats-mid-test-compound-conditionals-bypass-errexit.md
@@ -77,7 +77,7 @@ Arithmetic assertions follow the same rule:
 
 PR [#91](https://github.com/Seigiard/my-mac-setup/pull/91) converted all 29 first-party standalone checks and added `scripts/check_bats_assertions.py` to `make lint`. The checker recursively inspects first-party `.bats` files and rejects covered `[[ ... ]]` and `(( ... ))` command shapes without explicit status handling. It excludes vendored Bats libraries and distinguishes executable conditionals from quoted text, comments, heredocs, here-strings, arithmetic expansions, multiline conditionals, and normal `if` or `while` control flow.
 
-The current checker stops after the first recognized compound conditional on each physical line. [`2026-08-28-004`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) tracks extending it to inspect a later same-line conditional rather than overstating the guard as a complete shell parser.
+The checker resumes after each recognized compound conditional and inspects later same-line command segments. [`2026-08-28-004`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) records the regression coverage that prevents an explicitly handled first conditional from hiding a later bare conditional.
 
 Behavioral tests in `tests/test_bats_assertion_contract.py` prove both sides of the checker contract. Unsafe fixtures return nonzero with file and line diagnostics, while explicit handlers, control flow, shell payloads, and vendored fixtures remain accepted. Each converted assertion was also calibrated with an always-false mutation and observed failing at its new handler before its real condition was restored.
 
@@ -124,6 +124,6 @@ Verification for the fix completed successfully:
 ## Related Issues
 
 - [`docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md`](../../issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md) records the repository issue and resolution.
-- [`docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) tracks the checker's known same-line false negative.
+- [`docs/issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md`](../../issues/2026-08-28-004-bats-assertion-checker-misses-a-second-same-line-conditional.md) records the resolved same-line false negative.
 - [PR #91: Enforce Bats conditional assertions](https://github.com/Seigiard/my-mac-setup/pull/91) contains the implementation and verification evidence.
 - [`semantic-regression-tests-over-source-shape.md`](../design-patterns/semantic-regression-tests-over-source-shape.md) defines the broader red/green calibration and behavioral-control pattern used here.

--- a/scripts/check_bats_assertions.py
+++ b/scripts/check_bats_assertions.py
@@ -9,6 +9,14 @@ HEREDOC = re.compile(
     r"(?<!<)<<(?P<strip_tabs>-?)(?!<)\s*"
     r"(?P<quote>['\"]?)(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)"
 )
+CONTROL_FLOW = {"if": "then", "elif": "then", "while": "do", "until": "do"}
+
+
+def shell_word_at(line, index, word):
+    end = index + len(word)
+    return line.startswith(word, index) and (
+        end == len(line) or line[end].isspace() or line[end] == ";"
+    )
 
 
 def line_state_after(line, state=None, arithmetic_depth=0):
@@ -51,12 +59,13 @@ def line_state_after(line, state=None, arithmetic_depth=0):
     return state, arithmetic_depth, heredocs
 
 
-def conditional_command(line):
+def conditional_command(line, start=0):
     state = None
     escaped = False
     arithmetic_depth = 0
-    command_start = True
-    index = 0
+    control_terminator = None
+    command_start = start == 0
+    index = start
 
     while index < len(line):
         character = line[index]
@@ -74,23 +83,42 @@ def conditional_command(line):
             break
         elif character in ("'", '"'):
             state = character
+        elif command_start and control_terminator and shell_word_at(
+            line, index, control_terminator
+        ):
+            index += len(control_terminator) - 1
+            control_terminator = None
+        elif command_start and any(
+            shell_word_at(line, index, word) for word in CONTROL_FLOW
+        ):
+            word = next(
+                word for word in CONTROL_FLOW if shell_word_at(line, index, word)
+            )
+            control_terminator = CONTROL_FLOW[word]
+            index += len(word) - 1
         elif line.startswith("$((", index):
             arithmetic_depth += 1
             command_start = False
             index += 2
         elif line.startswith("((", index):
-            if command_start:
+            if command_start and not control_terminator:
                 return index, "((", "))"
             arithmetic_depth += 1
             index += 1
         elif arithmetic_depth and line.startswith("))", index):
             arithmetic_depth -= 1
             index += 1
+        elif not arithmetic_depth and line.startswith(("&&", "||"), index):
+            command_start = True
+            index += 1
         elif not arithmetic_depth and character == ";":
             command_start = True
         elif not character.isspace():
-            if command_start and line.startswith("[[", index) and (
-                index + 2 == len(line) or line[index + 2].isspace()
+            if (
+                command_start
+                and not control_terminator
+                and line.startswith("[[", index)
+                and (index + 2 == len(line) or line[index + 2].isspace())
             ):
                 return index, "[[", "]]"
             command_start = False
@@ -148,10 +176,12 @@ def find_violations(path):
             continue
 
         conditional = conditional_command(line)
-
-        if conditional:
+        command_end = index
+        scan_line = index
+        while conditional:
             start_column, opening, closing = conditional
-            command_end = index
+            conditional_line = scan_line
+            command_end = scan_line
             condition_quote = None
             closing_column, condition_quote = unquoted_closing(
                 lines[command_end], start_column + len(opening), closing
@@ -169,7 +199,15 @@ def find_violations(path):
             if tail == "\\" and command_end + 1 < len(lines):
                 handled = lines[command_end + 1].lstrip().startswith(("||", "&&"))
             if not handled:
-                violations.append((index + 1, opening, closing))
+                violations.append((conditional_line + 1, opening, closing))
+
+            if closing_column < 0:
+                break
+            scan_line = command_end
+            scan_column = closing_column + len(closing)
+            conditional = conditional_command(lines[scan_line], scan_column)
+
+        if command_end > index:
             for command_line in lines[index : command_end + 1]:
                 quote_state, arithmetic_depth, found_heredocs = line_state_after(
                     command_line, quote_state, arithmetic_depth

--- a/tests/test_bats_assertion_contract.py
+++ b/tests/test_bats_assertion_contract.py
@@ -46,6 +46,24 @@ class TestBatsAssertionContract(unittest.TestCase):
   run true; [[ 1 == 2 ]]
   :
 }
+""",
+                "nested/second-conditional.bats": """@test "second conditional" {
+  [[ 1 == 1 ]] || fail "first"; [[ 1 == 2 ]]
+  :
+}
+""",
+                "nested/second-arithmetic.bats": """@test "second arithmetic" {
+  (( 1 )) || fail "first"; (( 0 ))
+  :
+}
+""",
+                "nested/second-and.bats": """@test "second after and" {
+  [[ 1 == 1 ]] || fail "first" && [[ 1 == 2 ]]; :
+}
+""",
+                "nested/second-or.bats": """@test "second after or" {
+  (( 0 )) && fail "first" || (( 0 )); :
+}
 """
             }
         )
@@ -54,6 +72,10 @@ class TestBatsAssertionContract(unittest.TestCase):
         self.assertIn("unsafe.bats:8: bare [[...]]", result.stdout)
         self.assertIn("nested/unsafe.bats:2: bare ((...))", result.stdout)
         self.assertIn("nested/semicolon.bats:2: bare [[...]]", result.stdout)
+        self.assertIn("nested/second-conditional.bats:2: bare [[...]]", result.stdout)
+        self.assertIn("nested/second-arithmetic.bats:2: bare ((...))", result.stdout)
+        self.assertIn("nested/second-and.bats:2: bare [[...]]", result.stdout)
+        self.assertIn("nested/second-or.bats:2: bare ((...))", result.stdout)
 
     def test_accepts_explicit_handlers_control_flow_and_heredocs(self):
         result = self.run_checker(
@@ -65,10 +87,19 @@ class TestBatsAssertionContract(unittest.TestCase):
     || fail "expected multiline equality"
   [[ -e /tmp/ready ]] && break
   (( count > 0 )) || fail "expected a positive count"
+  [[ 1 == 1 ]] || fail "first"; [[ 2 == 2 ]] || fail "second"
+  [[ 1 == 1 ]] || fail "first" && [[ 2 == 2 ]] || fail "second"
+  (( 0 )) && fail "first" || (( 1 )) || fail "second"
   if [[ -e /tmp/optional ]]; then
     :
   fi
+  if true && [[ -e /tmp/optional ]]; then
+    :
+  fi
   while (( count > 0 )); do
+    break
+  done
+  while true && (( count > 0 )); do
     break
   done
   cat <<'SCRIPT'


### PR DESCRIPTION
## Summary

`make lint` now reports every bare `[[ ... ]]` or `(( ... ))` command on a physical line, even when an earlier conditional is handled or the commands are joined by `;`, `&&`, or `||`.

The resumed scan preserves accepted control flow, quoted text, heredocs, arithmetic expansions, and vendored Bats libraries. Repository issue `2026-08-28-004` now records the verified resolution instead of a known false-green path.

## Validation

- `make test-issues` passed 44 tests.
- `make lint` passed.
- `python3 -m unittest tests.test_bats_assertion_contract` passed 3 tests.
- Python compilation and `git diff --check` passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
