### PR TITLE
fix(herdr): remove sidebar token separators

### DIFF
--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -38,6 +38,7 @@ PI_MODEL="${HERDR_TASK_SYNC_PI_MODEL:-openai-codex/gpt-5.4-mini}"
 CLAUDE_MODEL="${HERDR_TASK_SYNC_CLAUDE_MODEL:-claude-haiku-4-5-20251001}"
 SOURCE_ID="task-sync"
 LOCATION_SOURCE_ID="location-sync"
+SIDEBAR_SOURCE_ID="sidebar-sync"
 SLUG_MAX_LEN=40
 # R4 asks for 2-4 words. A wordier answer is prose, not a name — an engine that
 # explains itself instead of naming the session counts as a failed call, so the
@@ -70,6 +71,9 @@ ICON_CONFLICT='~'
 ICON_STAGED='+'
 ICON_UNSTAGED='!'
 ICON_UNTRACKED='?'
+# Herdr trims ordinary trailing whitespace from metadata values. Braille
+# pattern blank occupies one terminal cell without drawing a visible glyph.
+SIDEBAR_PADDING="$(printf '\342\240\200')" # U+2800 BRAILLE PATTERN BLANK
 # Worktree-token width math (text_length's `wc -m`, text_prefix's `cut -c`)
 # must count codepoints: under a non-UTF-8 locale both count bytes, so a cap
 # can split a multibyte path component.
@@ -1115,9 +1119,9 @@ git_ref_for() {
   printf '%s' "$label"
 }
 
-# Internal transport for six independent metadata tokens. The record
-# separator preserves empty positions without turning the published values
-# back into one user-facing string. An all-zero status stays wholly empty.
+# Internal transport for six Git status values. The record separator preserves
+# empty positions for both independent token publication and $git_line
+# aggregation. An all-zero status stays wholly empty.
 git_status_tokens_for() {
   local pull="$1" push="$2" conflicts="$3" staged="$4" unstaged="$5" untracked="$6"
   local git_pull="" git_push="" git_conflicts="" git_staged="" git_unstaged="" git_untracked=""
@@ -1136,6 +1140,25 @@ git_status_tokens_for() {
   [ -n "$git_pull$git_push$git_conflicts$git_staged$git_unstaged$git_untracked" ] || return 0
   printf '%s\036%s\036%s\036%s\036%s\036%s' \
     "$git_pull" "$git_push" "$git_conflicts" "$git_staged" "$git_unstaged" "$git_untracked"
+}
+
+sidebar_line_for() {
+  local line="" value
+  for value in "$@"; do
+    [ -n "$value" ] || continue
+    if [ -z "$line" ]; then line="$value"; else line="$line $value"; fi
+  done
+  printf '%s' "$line"
+}
+
+git_sidebar_line_for() {
+  local git_ref="$1" status="$2" pull push conflicts staged unstaged untracked line
+  IFS="$STATUS_SEPARATOR" read -r pull push conflicts staged unstaged untracked <<EOF
+$status
+EOF
+  line="$(sidebar_line_for "$git_ref" "$pull" "$push" "$conflicts" "$staged" "$unstaged" "$untracked")"
+  [ -z "$line" ] || line="$line$SIDEBAR_PADDING"
+  printf '%s' "$line"
 }
 
 native_session_matches_active() {
@@ -1257,7 +1280,7 @@ tab_target_matches() {
 }
 
 # Tab labels identify the panes only. Git location remains available through
-# each pane's metadata and the separate $git_ref sidebar row.
+# each pane's independent metadata and its aggregate $git_line sidebar row.
 compose_tab_intents() {
   local snapshot="$1" pane_presentations="$2" tab_intents=""
   local tab_rows tab_id workspace current index parts named
@@ -1309,7 +1332,8 @@ reconcile_presentation_pass() {
   local final_payload final_label final_task final_tokens
   local git_pull git_push git_conflicts git_staged git_unstaged git_untracked
   local final_repo final_worktree final_branch final_location_status final_git_ref final_git_status final_legacy_tokens
-  local pane_baselines baseline_row
+  local pane_baselines sidebar_baselines baseline_row sidebar_row
+  local current_agent_line current_git_line agent_line git_line sidebar_changed
   local state_file retained_pane presented_pane_ids
   local location_pids="" location_results="" location_result_file location_pid
   local location_probe_results="" location_child_failed=0
@@ -1349,6 +1373,10 @@ reconcile_presentation_pass() {
   # record keeps those records narrow.
   pane_baselines="$(printf '%s\n' "$pane_rows" | awk -F "$FIELD_SEPARATOR" \
     -v OFS="$FIELD_SEPARATOR" 'NF { print $1, $10, $11, $12, $13, $14, $15 }')"
+  sidebar_baselines="$(printf '%s' "$snapshot" | jq -r '
+    .result.snapshot.panes[]?
+    | [(.pane_id // ""), (.tokens.agent_line // ""), (.tokens.git_line // "")]
+    | join("\u001f")' 2>/dev/null | filter_records_of_width 3)"
 
   # location_label is the retired predecessor of git_ref. It is deliberately
   # absent from the presentation record, so a pane whose new tokens all match
@@ -1623,6 +1651,17 @@ EOF
     IFS="$FIELD_SEPARATOR" read -r current_repo current_worktree current_branch current_location_status current_git_ref current_git_status <<EOF
 $baseline_row
 EOF
+    sidebar_row="$(table_row_for "$id" "$sidebar_baselines")"
+    IFS="$FIELD_SEPARATOR" read -r current_agent_line current_git_line <<EOF
+$sidebar_row
+EOF
+    _workspace_name="$(table_value_for "$workspace" "$workspace_rows")"
+    agent_line="$(sidebar_line_for "$_workspace_name" "$intended")"
+    git_line="$(git_sidebar_line_for "$git_ref" "$git_status")"
+    sidebar_changed=0
+    if [ "$current_agent_line" != "$agent_line" ] || [ "$current_git_line" != "$git_line" ]; then
+      sidebar_changed=1
+    fi
     if [ -n "$slug" ] && [ "$current_task" != "$slug" ]; then
       presentation_generation_valid "$pass" || return 2
       final_payload="$(herdr pane get "$id" 2>/dev/null)" || continue
@@ -1651,8 +1690,10 @@ EOF
       # Counts move while identity stands still, so they have to join this
       # comparison or the token would freeze after its first write.
       [ "$current_git_status" = "$git_status" ] || location_changed=1
+    # Clear our location source before writing a new sidebar source. Otherwise
+    # Herdr can merge dormant location contributions back into a reused pane.
     elif [ "$location_outcome" = "non_git" ] && \
-      { [ -n "$current_repo" ] || [ -n "$current_worktree" ] || [ -n "$current_branch" ] || [ -n "$current_location_status" ] || [ -n "$current_git_ref" ] || [ -n "$current_git_status" ]; }; then
+      { [ -n "$current_repo" ] || [ -n "$current_worktree" ] || [ -n "$current_branch" ] || [ -n "$current_location_status" ] || [ -n "$current_git_ref" ] || [ -n "$current_git_status" ] || [ "$sidebar_changed" -eq 1 ]; }; then
       location_changed=1
     fi
     if [ "$location_changed" -eq 1 ]; then
@@ -1689,7 +1730,7 @@ EOF
         [ "$final_git_ref" = "$git_ref" ] || location_changed=1
         [ "$final_git_status" = "$git_status" ] || location_changed=1
       elif [ "$location_outcome" = "non_git" ] && \
-        { [ -n "$final_repo" ] || [ -n "$final_worktree" ] || [ -n "$final_branch" ] || [ -n "$final_location_status" ] || [ -n "$final_git_ref" ] || [ -n "$final_git_status" ]; }; then
+        { [ -n "$final_repo" ] || [ -n "$final_worktree" ] || [ -n "$final_branch" ] || [ -n "$final_location_status" ] || [ -n "$final_git_ref" ] || [ -n "$final_git_status" ] || [ "$sidebar_changed" -eq 1 ]; }; then
         location_changed=1
       fi
       if [ "$location_changed" -eq 1 ]; then
@@ -1720,6 +1761,16 @@ EOF
         fi
         "$@" >/dev/null 2>&1 || continue
       fi
+    fi
+    if [ "$sidebar_changed" -eq 1 ]; then
+      presentation_generation_valid "$pass" || return 2
+      final_payload="$(herdr pane get "$id" 2>/dev/null)" || continue
+      pane_target_matches "$final_payload" "$id" "$terminal" "$tab_id" "$agent_of" "$native_session" || continue
+      set -- herdr pane report-metadata "$id" --source "$SIDEBAR_SOURCE_ID" --seq "$pass"
+      if [ -n "$agent_line" ]; then set -- "$@" --token "agent_line=$agent_line"; else set -- "$@" --clear-token agent_line; fi
+      if [ -n "$git_line" ]; then set -- "$@" --token "git_line=$git_line"; else set -- "$@" --clear-token git_line; fi
+      presentation_generation_valid "$pass" || return 2
+      "$@" >/dev/null 2>&1 || continue
     fi
     [ "$current" != "$intended" ] || continue
     presentation_generation_valid "$pass" || return 2

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -53,13 +53,13 @@ description = "close pane, then tab, but keep workspace"
 prompt_new_tab_name = false
 sidebar_min_width = 32
 
-# The `pane` row renders the pane label, which herdr-task-sync
-# (~/.local/bin/herdr-task-sync) sets to `<agent-prefix>:<task-slug>`, or to the
-# prefix alone until a task slug exists. The same script rebuilds each tab label
-# from the labels of its panes. The second sidebar row composes independent Git
-# tokens, so their order can change without touching the publisher.
+# herdr-task-sync (~/.local/bin/herdr-task-sync) combines the workspace and pane
+# label into $agent_line, and Git identity plus counts into $git_line. One token
+# per row avoids Herdr's hardcoded middle-dot separator. The script still
+# publishes independent Git tokens for other consumers and rebuilds tab labels
+# from the individual pane labels.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace", "pane"], ["$git_ref", "$git_pull", "$git_push", "$git_conflicts", "$git_staged", "$git_unstaged", "$git_untracked"]]
+rows = [["state_icon", "$agent_line"], ["$git_line"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -46,6 +46,10 @@ HTS_GIT_STAGED='+'
 HTS_GIT_UNSTAGED='!'
 # shellcheck disable=SC2034
 HTS_GIT_UNTRACKED='?'
+# Herdr trims ordinary trailing whitespace from metadata. A blank braille cell
+# survives normalization and keeps the final Git count off the sidebar border.
+# shellcheck disable=SC2034
+HTS_SIDEBAR_PADDING="$(printf '\342\240\200')"
 
 hts_teardown() {
   # Reap a background reader a failed test left running BEFORE deleting its

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -3587,7 +3587,9 @@ SH
   assert_equal "$(jq -r '.panes[0].tokens.task' "$state")" newest-second
   assert_equal "$(jq -r '.panes[0].label' "$state")" cc:newest-second
   assert_equal "$(jq -r '.tabs[0].label' "$state")" cc:newest-second
-  run grep -c '^pane report-metadata' "$HTS_LOG"
+  run grep -c -- '--source task-sync' "$HTS_LOG"
+  assert_output "1"
+  run grep -c -- '--source sidebar-sync' "$HTS_LOG"
   assert_output "1"
 }
 
@@ -4124,8 +4126,8 @@ EOF
   HERDR_TASK_SYNC_TEST_NOW_SEQ=0 hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   # pane_inline is deferred by the plan and never published; the non-Git arm
-  # clears any stale copy, so only the task token survives.
-  assert_equal "$(jq -c '.panes[0].tokens' "$state")" '{"task":"kept-task"}'
+  # clears every Git token while the task and aggregate agent label survive.
+  assert_equal "$(jq -cS '.panes[0].tokens' "$state")" '{"agent_line":"repo worker","task":"kept-task"}'
   [[ "$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)" -gt "$second_seq" ]] || fail "non-Git location sequence did not advance"
 }
 
@@ -4457,9 +4459,10 @@ EOF
   # worktree token is the whole $git_ref.
   run jq -e \
     --arg ref_one "$HTS_ICON_BRANCH topic-one $HTS_ICON_FOLDER live-token $HTS_ICON_STALE" \
-    --arg ref_two "$HTS_ICON_FOLDER live-token $HTS_ICON_STALE" '
-    (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one})
-    and (.panes[] | select(.pane_id == "pane-2") | .tokens == {repo:"live-repo",worktree:"live-token",location_status:"stale",git_ref:$ref_two})
+    --arg ref_two "$HTS_ICON_FOLDER live-token $HTS_ICON_STALE" \
+    --arg pad "$HTS_SIDEBAR_PADDING" '
+    (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one,agent_line:"one",git_line:($ref_one + $pad)})
+    and (.panes[] | select(.pane_id == "pane-2") | .tokens == {repo:"live-repo",worktree:"live-token",location_status:"stale",git_ref:$ref_two,agent_line:"two",git_line:($ref_two + $pad)})
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "one · two · three"
@@ -4904,15 +4907,16 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   run grep -ER 'manual_owner|reclaim|label_ledger|server_epoch|takeover|prepare_rollback' "$(hts_namespace "$HTS_DEFAULT_SOCKET")"
   assert_failure
-  # After removing every approved codicon glyph, only plain ASCII (plus the
-  # label separator and ellipsis) may remain in published labels and tokens.
+  # After removing every approved codicon glyph, only plain ASCII plus the
+  # label separator, ellipsis, and blank-cell padding may remain.
   run jq -e --arg icons "$HTS_ICON_BRANCH$HTS_ICON_WORKTREE$HTS_ICON_COMMIT$HTS_ICON_FOLDER$HTS_ICON_STALE$HTS_GIT_BEHIND$HTS_GIT_AHEAD$HTS_GIT_CONFLICT$HTS_GIT_STAGED$HTS_GIT_UNSTAGED$HTS_GIT_UNTRACKED" '
     [.panes[0].label, .tabs[0].label, .panes[0].tokens.worktree,
+     .panes[0].tokens.agent_line, .panes[0].tokens.git_line,
      .panes[0].tokens.git_ref, .panes[0].tokens.git_pull,
      .panes[0].tokens.git_push, .panes[0].tokens.git_conflicts,
      .panes[0].tokens.git_staged, .panes[0].tokens.git_unstaged,
      .panes[0].tokens.git_untracked]
-    | all(.[]; (. // "") | explode - ($icons | explode) | implode | test("^[A-Za-z0-9._:/ ~\u00b7\u2026-]*$"))
+    | all(.[]; (. // "") | explode - ($icons | explode) | implode | test("^[A-Za-z0-9._:/ ~\u00b7\u2026\u2800-]*$"))
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" plain-task
@@ -4924,7 +4928,7 @@ EOF
   assert_equal "$(jq -r '.panes[0].tokens.pane_inline // ""' "$state")" ""
 }
 
-@test "herdr-task-sync publishes staged unstaged ahead and behind counts beside an unchanged git_ref" {
+@test "herdr-task-sync publishes separator-free sidebar lines in display order" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" state
@@ -4948,7 +4952,15 @@ EOF
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
-  # then: the counts render in the fixed order and identity is untouched
+  # then: the aggregate lines render in the fixed order without Herdr inserting
+  # separators, and the final blank cell keeps the count off the panel border
+  assert_equal "$(jq -r '.panes[0].tokens.agent_line' "$state")" "repo worker"
+  assert_equal "$(jq -r '.panes[0].tokens.git_line' "$state")" \
+    "$HTS_ICON_BRANCH topic $HTS_GIT_BEHIND"'2 '"$HTS_GIT_AHEAD"'1 +1 !1'"$HTS_SIDEBAR_PADDING"
+  run jq -e '.panes[0].tokens.git_line | contains("·") | not' "$state"
+  assert_success
+
+  # The independent source tokens remain available for other consumers.
   assert_equal "$(jq -r '[.panes[0].tokens | .git_pull, .git_push, .git_staged, .git_unstaged] | map(select(. != null)) | join(" ")' "$state")" \
     "${HTS_GIT_BEHIND}2 ${HTS_GIT_AHEAD}1 ${HTS_GIT_STAGED}1 ${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
@@ -4987,6 +4999,7 @@ EOF
   run jq -e '.panes[0].tokens | [.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)' "$state"
   assert_success
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
+  assert_equal "$(jq -r '.panes[0].tokens.git_line' "$state")" "$HTS_ICON_BRANCH topic$HTS_SIDEBAR_PADDING"
 
   # when: a file goes dirty and nothing about the identity changes
   hts_git_status_fixture "$root" '1 .M N... 100644 100644 100644 1111111 1111111 one.txt'
@@ -4996,6 +5009,7 @@ EOF
   # then: the counts-only change still triggers a republish
   assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
+  assert_equal "$(jq -r '.panes[0].tokens.git_line' "$state")" "$HTS_ICON_BRANCH topic ${HTS_GIT_UNSTAGED}1$HTS_SIDEBAR_PADDING"
 }
 
 @test "herdr-task-sync separates conflicts staged unstaged and untracked paths" {
@@ -5079,7 +5093,7 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
   # then: the counts go with the rest of the location tokens
-  run jq -e '.panes[0].tokens | ([.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)) and (.git_ref == null and .repo == null)' "$state"
+  run jq -e '.panes[0].tokens | ([.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)) and (.git_ref == null and .git_line == null and .repo == null)' "$state"
   assert_success
 }
 
@@ -5421,6 +5435,7 @@ socket_path=$(printf '%s' "$HTS_DEFAULT_SOCKET" | base64 | tr -d '\n')"
   hts_location_pass
   assert_equal "$(jq -r '.panes[0].label' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" btop
   assert_equal "$(jq -r '.panes[0].tokens.worktree' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" old
+  assert_equal "$(jq -r '.panes[0].tokens.agent_line' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" btop
 
   hts_git_location_fixture "$new" "$new" "$common" refs/heads/new-branch
   hts_set_pane_location "$HTS_DEFAULT_SOCKET" pane-1 "$new" "$new"
@@ -5432,6 +5447,7 @@ socket_path=$(printf '%s' "$HTS_DEFAULT_SOCKET" | base64 | tr -d '\n')"
   local state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].label' "$state")" "cargo test"
   assert_equal "$(jq -r '.panes[0].tokens.worktree' "$state")" new-worktree
+  assert_equal "$(jq -r '.panes[0].tokens.agent_line' "$state")" "cargo test"
   assert_file_contains "$HTS_LOG" '^api snapshot$'
   assert_file_contains "$HTS_LOG" '^pane rename pane-1 cargo test$'
 }

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -931,10 +931,9 @@ assert_herdr_sidebar_deployment_contract() {
 
   assert_file_contains "$config" '^sidebar_min_width = 32$'
   assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
-  # Tab labels stay names-only, while the sidebar keeps Git location on its
-  # own row so branch/worktree context never competes with the agent name.
-  # Identity and counts are separate tokens sharing that row.
-  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\], \["\$git_ref", "\$git_pull", "\$git_push", "\$git_conflicts", "\$git_staged", "\$git_unstaged", "\$git_untracked"\]\]$'
+  # Tab labels stay names-only. Each sidebar row uses one aggregate token so
+  # Herdr cannot inject its hardcoded middle-dot separator between values.
+  assert_file_contains "$config" '^rows = \[\["state_icon", "\$agent_line"\], \["\$git_line"\]\]$'
   run grep -E '\$location_label|\$location_status' "$config"
   assert_failure
   width="$(awk '


### PR DESCRIPTION
## Summary

Herdr's agent sidebar now shows workspace, pane, branch, and Git status with ordinary spacing instead of the renderer's hardcoded middle-dot separators. `herdr-task-sync` owns the aggregate display order while continuing to publish the independent Git metadata tokens for other consumers.

The Git row ends with a U+2800 blank cell, which survives Herdr's whitespace normalization and keeps the final count off the sidebar border.

## Validation

- `make lint`
- `make test-templates`
- 12 focused Docker post-apply tests covering managed/deployed configuration, aggregate ordering, no-op convergence, Git transitions, pane renames, and trailing padding
- `make test-ubuntu` was attempted but exceeded the 120-second execution limit. The six Herdr regressions it surfaced were fixed and rerun through the focused Docker checks above.

## Post-Deploy Monitoring & Validation

- Reload with `herdr server reload-config` after applying the managed files.
- Check one clean and one dirty Git checkout through the next task-sync sweep.
- Healthy: no middle dots inside either sidebar row, Git fields retain their configured order, and the final count has one blank cell before the border.
- Failure signal: stale aggregate values, reappearing middle dots, or repeated metadata publication on unchanged sweeps. Roll back this commit and reload the config if any appear.
- Validation window: first Herdr session after deployment. Owner: repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/GPT--5.6--sol-OpenCode-000000)
