### PR TITLE
fix(herdr): separate Git and folder identities

### DIFF
--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -550,27 +550,29 @@ location_state_file() {
 
 write_location_state() {
   local file="$1" pane_id="$2" root="$3" anchor="$4" repo="$5" branch="$6"
-  local is_linked="$7" sha="$8" content
+  local is_linked="$7" sha="$8" folder="$9" content
   content="pane=$(encode_value "$pane_id")
 checkout_root=$(encode_value "$root")
 repository_anchor=$(encode_value "$anchor")
 repo=$(encode_value "$repo")
 branch=$(encode_value "$branch")
 is_linked=$(encode_value "$is_linked")
-sha=$(encode_value "$sha")"
+sha=$(encode_value "$sha")
+folder=$(encode_value "$folder")"
   atomic_write "$file" "$content"
 }
 
 location_state_matches() {
   local file="$1" pane_id="$2" root="$3" anchor="$4" repo="$5" branch="$6"
-  local is_linked="$7" sha="$8"
+  local is_linked="$7" sha="$8" folder="$9"
   [ "$(read_state_field "$file" pane)" = "$pane_id" ] &&
     [ "$(read_state_field "$file" checkout_root)" = "$root" ] &&
     [ "$(read_state_field "$file" repository_anchor)" = "$anchor" ] &&
     [ "$(read_state_field "$file" repo)" = "$repo" ] &&
     [ "$(read_state_field "$file" branch)" = "$branch" ] &&
     [ "$(read_state_field "$file" is_linked)" = "$is_linked" ] &&
-    [ "$(read_state_field "$file" sha)" = "$sha" ]
+    [ "$(read_state_field "$file" sha)" = "$sha" ] &&
+    [ "$(read_state_field "$file" folder)" = "$folder" ]
 }
 
 cleanup_old_task_context() {
@@ -706,7 +708,7 @@ repository_name() {
 }
 
 transient_location_result() {
-  printf 'transient\037%s\037%s\037%s\037%s\037%s\037%s' "$1" "$2" "$3" "$4" "$5" "$6"
+  printf 'transient\037%s\037%s\037%s\037%s\037%s\037%s\037%s' "$1" "$2" "$3" "$4" "$5" "$6" "$7"
 }
 
 authoritative_worktree_deleted() {
@@ -730,19 +732,20 @@ authoritative_worktree_deleted() {
 }
 
 # Prints outcome, canonical checkout root, common Git directory, repository,
-# symbolic branch, linked-worktree flag, and detached short SHA separated by
-# unit separators. A transient result carries retained evidence when one
-# exists; confirmed non-Git carries empty evidence.
+# symbolic branch, linked-worktree flag, detached short SHA, and non-Git folder
+# separated by unit separators. A transient result carries whichever identity
+# was last confirmed.
 resolve_pane_location() {
   local pane_json="$1" state_file="$2" has_agent has_foreground cwd reported prior_root prior_anchor
-  local prior_repo prior_branch prior_is_linked prior_sha candidate outfile errfile status
-  local root anchor branch repo lines is_linked sha sha_outfile sha_errfile
+  local prior_repo prior_branch prior_is_linked prior_sha prior_folder candidate outfile errfile status
+  local root anchor branch repo lines is_linked sha folder sha_outfile sha_errfile
   prior_root="$(read_state_field "$state_file" checkout_root)"
   prior_anchor="$(read_state_field "$state_file" repository_anchor)"
   prior_repo="$(read_state_field "$state_file" repo)"
   prior_branch="$(read_state_field "$state_file" branch)"
   prior_is_linked="$(read_state_field "$state_file" is_linked)"
   prior_sha="$(read_state_field "$state_file" sha)"
+  prior_folder="$(read_state_field "$state_file" folder)"
   has_agent="$(printf '%s' "$pane_json" | jq -r '(.agent // "") != ""' 2>/dev/null)"
   has_foreground="$(printf '%s' "$pane_json" | jq -r 'has("foreground_cwd")' 2>/dev/null)"
   reported=""
@@ -760,9 +763,9 @@ resolve_pane_location() {
 
   if [ -z "$cwd" ] || ! (cd "$cwd" 2>/dev/null); then
     if authoritative_worktree_deleted "$prior_root" "$prior_anchor"; then
-      printf 'non_git\037\037\037\037\037\037'
+      printf 'non_git\037\037\037\037\037\037\037'
     else
-      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     fi
     return 0
   fi
@@ -771,17 +774,17 @@ resolve_pane_location() {
   case "$cwd" in
     */.git | */.git/*)
       candidate="$(admin_checkout_for_path "$cwd" 2>/dev/null)" || {
-        transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+        transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
         return 0
       }
       ;;
   esac
   command -v git >/dev/null 2>&1 || {
-    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     return 0
   }
   outfile="$(mktemp "$(namespace_dir)/.git-location.XXXXXX" 2>/dev/null)" || {
-    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     return 0
   }
   errfile="$outfile.err"
@@ -795,10 +798,13 @@ resolve_pane_location() {
     if { [ "$status" -eq 1 ] || [ "$status" -eq 128 ]; } && \
       grep -Eqi 'not a git repository|not inside a work tree' "$errfile" 2>/dev/null; then
       rm -f "$outfile" "$errfile"
-      printf 'non_git\037\037\037\037\037\037'
+      folder="${cwd%/}"
+      folder="${folder##*/}"
+      [ -n "$folder" ] || folder=/
+      printf 'non_git\037\037\037\037\037\037\037%s' "$folder"
     else
       rm -f "$outfile" "$errfile"
-      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     fi
     return 0
   fi
@@ -825,7 +831,7 @@ resolve_pane_location() {
   sha="$(sed -n '4p' "$outfile")"
   rm -f "$outfile" "$errfile"
   if [ -z "$root" ] || [ -z "$anchor" ] || [ -z "$branch" ]; then
-    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     return 0
   fi
   case "$branch" in
@@ -840,19 +846,19 @@ resolve_pane_location() {
       branch=""
       case "$sha" in
         *[!0-9a-f]* | '')
-          transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+          transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
           return 0
           ;;
       esac
       ;;
     *)
-      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+      transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
       return 0
       ;;
   esac
   repo="$(repository_name "$anchor")"
   [ -n "$repo" ] || {
-    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha"
+    transient_location_result "$prior_root" "$prior_anchor" "$prior_repo" "$prior_branch" "$prior_is_linked" "$prior_sha" "$prior_folder"
     return 0
   }
   # A linked worktree carries a .git FILE at the checkout root; the main
@@ -861,7 +867,7 @@ resolve_pane_location() {
   # not in the main checkout.
   is_linked=""
   [ ! -f "$root/.git" ] || is_linked=1
-  printf 'git\037%s\037%s\037%s\037%s\037%s\037%s' "$root" "$anchor" "$repo" "$branch" "$is_linked" "$sha"
+  printf 'git\037%s\037%s\037%s\037%s\037%s\037%s\037' "$root" "$anchor" "$repo" "$branch" "$is_linked" "$sha"
 }
 
 # Counts are volatile where identity is stable, so they get their own probe,
@@ -1095,12 +1101,11 @@ filter_records_of_width() {
   '
 }
 
-# One formatter for every surface:
-#   $git_ref = <place-icon> <ref> [<folder-icon> <folder>] [<stale-icon>]
+# One formatter for every location surface:
+#   Git:     $git_ref = <place-icon> <ref> [<stale-icon>]
+#   non-Git: $git_ref = <folder-icon> <folder> [<stale-icon>]
 # place is "branch" (main checkout), "worktree" (linked worktree), or
 # "commit" (detached HEAD); ref is the branch name or the detached short SHA.
-# The caller decides folder-qualifier suppression — it knows the pane's
-# workspace name. Ref-less retained evidence renders as folder icon + token.
 git_ref_for() {
   local place="$1" ref="$2" folder="$3" status="$4" label=""
   if [ -n "$ref" ]; then
@@ -1109,7 +1114,6 @@ git_ref_for() {
       commit) label="$ICON_COMMIT $ref" ;;
       *) label="$ICON_BRANCH $ref" ;;
     esac
-    [ -z "$folder" ] || label="$label $ICON_FOLDER $folder"
   elif [ -n "$folder" ]; then
     label="$ICON_FOLDER $folder"
   else
@@ -1286,7 +1290,7 @@ compose_tab_intents() {
   local tab_rows tab_id workspace current index parts named
   local _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
-  local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
+  local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha _location_folder
   local _git_ref _worktree_token _git_status
   tab_rows="$(printf '%s' "$snapshot" | jq -r '
     reduce .result.snapshot.tabs[]? as $t ({counts: {}, out: []};
@@ -1298,7 +1302,7 @@ compose_tab_intents() {
     [ -n "$tab_id" ] || continue
     parts=""
     named=0
-    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status _git_ref _worktree_token _git_status; do
+    while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_folder _location_status _git_ref _worktree_token _git_status; do
       [ "$pane_tab" = "$tab_id" ] || continue
       [ -n "$pane_intended" ] || continue
       [ "$pane_intended" = "$IDLE_PANE_LABEL" ] || named=1
@@ -1322,11 +1326,11 @@ reconcile_presentation_pass() {
   local current_repo current_worktree current_branch current_location_status current_git_ref current_git_status pane_json_encoded pane_json
   local intended slug metadata_seq control active_agent active_session generation committed task_file
   local saved_pane="$pane" saved_agent="$agent" saved_session="$session"
-  local location_file location_result location_outcome checkout_root repository_anchor repo branch location_status is_linked sha
+  local location_file location_result location_outcome checkout_root repository_anchor repo branch location_status is_linked sha folder
   local roots root_tokens root_statuses worktree_token git_ref git_status location_seq location_changed
   local _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session
   local _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome
-  local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha
+  local _checkout_root _repository_anchor _repo _branch _location_status _is_linked _sha _location_folder
   local _current_worktree _worktree_token _git_ref _git_status status_row _status_outcome _status_counts
   local _ref _place _folder _workspace_name
   local final_payload final_label final_task final_tokens
@@ -1389,8 +1393,7 @@ reconcile_presentation_pass() {
     | select(((.tokens.location_label // "") != "") or ((.tokens.git_status // "") != ""))
     | (.pane_id // "")' 2>/dev/null)"
 
-  # Workspace names suppress the $git_ref folder qualifier when the worktree
-  # token merely repeats the pane's workspace name. Live herdr 0.8 snapshots
+  # Workspace names feed the aggregate agent line. Live herdr 0.8 snapshots
   # carry the display name as `label`; `name` stays as a fallback for older
   # snapshot shapes.
   workspace_rows="$(printf '%s' "$snapshot" | jq -r '
@@ -1482,29 +1485,35 @@ EOF
       location_probe_results="${location_probe_results#*$'\n'}"
     fi
     location_file="$(location_state_file "$id")"
-    IFS="$FIELD_SEPARATOR" read -r location_outcome checkout_root repository_anchor repo branch is_linked sha <<EOF
+    IFS="$FIELD_SEPARATOR" read -r location_outcome checkout_root repository_anchor repo branch is_linked sha folder <<EOF
 $location_result
 EOF
     location_status=""
     case "$location_outcome" in
       git)
         if ! location_state_matches "$location_file" "$id" "$checkout_root" \
-          "$repository_anchor" "$repo" "$branch" "$is_linked" "$sha"; then
+          "$repository_anchor" "$repo" "$branch" "$is_linked" "$sha" ""; then
           write_location_state "$location_file" "$id" "$checkout_root" \
-            "$repository_anchor" "$repo" "$branch" "$is_linked" "$sha" || return 1
+            "$repository_anchor" "$repo" "$branch" "$is_linked" "$sha" "" || return 1
         fi
         ;;
       non_git)
-        rm -f "$location_file" 2>/dev/null || return 1
         checkout_root=""
         repository_anchor=""
         repo=""
         branch=""
         is_linked=""
         sha=""
+        if [ -n "$folder" ]; then
+          if ! location_state_matches "$location_file" "$id" "" "" "" "" "" "" "$folder"; then
+            write_location_state "$location_file" "$id" "" "" "" "" "" "" "$folder" || return 1
+          fi
+        else
+          rm -f "$location_file" 2>/dev/null || return 1
+        fi
         ;;
       transient)
-        if [ -n "$checkout_root" ]; then
+        if [ -n "$checkout_root" ] || [ -n "$folder" ]; then
           location_status="stale"
         elif [ -n "$current_repo" ] && [ -n "$current_worktree" ]; then
           # Fresh snapshot tokens are weaker than canonical evidence, but they
@@ -1552,16 +1561,16 @@ EOF
       [ -n "$intended" ] || intended="$IDLE_PANE_LABEL"
     fi
     pane_intents="${pane_intents}${pane_intents:+
-}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${location_status}"
+}${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${agent_of}${FIELD_SEPARATOR}${native_session}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${current_task}${FIELD_SEPARATOR}${slug}${FIELD_SEPARATOR}${metadata_seq}${FIELD_SEPARATOR}${location_outcome}${FIELD_SEPARATOR}${checkout_root}${FIELD_SEPARATOR}${repository_anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${is_linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${folder}${FIELD_SEPARATOR}${location_status}"
   done <<EOF
 $pane_rows
 EOF
   pane="$saved_pane"
   agent="$saved_agent"
   session="$saved_session"
-  pane_intents="$(printf '%s\n' "$pane_intents" | filter_records_of_width 19)"
+  pane_intents="$(printf '%s\n' "$pane_intents" | filter_records_of_width 20)"
 
-  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status; do
+  roots="$(while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_folder _location_status; do
     [ -z "$_checkout_root" ] || printf '%s\n' "$_checkout_root"
   done <<EOF
 $pane_intents
@@ -1570,7 +1579,7 @@ EOF
   roots="$(printf '%s\n' "$roots" | sed '/^$/d' | LC_ALL=C sort -u)"
   root_tokens="$(build_worktree_tokens "$roots")"
   root_statuses="$(build_root_statuses "$roots")"
-  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_status; do
+  while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_folder _location_status; do
     [ -n "$_pane_id" ] || continue
     _worktree_token=""
     if [ -n "$_checkout_root" ]; then
@@ -1594,15 +1603,10 @@ EOF
     elif [ "$_is_linked" = "1" ]; then
       _place="worktree"
     fi
-    _folder="$_worktree_token"
-    if [ -n "$_ref" ]; then
-      # The folder qualifier earns its place only when it disagrees with both
-      # the ref and the pane's herdr workspace name.
-      _workspace_name="$(table_value_for "$_pane_workspace" "$workspace_rows")"
-      if [ "$_worktree_token" = "$_ref" ] || [ "$_worktree_token" = "$_workspace_name" ]; then
-        _folder=""
-      fi
-    fi
+    _folder="$_location_folder"
+    # Legacy transient token-only evidence can lack a ref and durable state.
+    # In that one fallback, its prior worktree token remains a folder identity.
+    if [ -z "$_ref" ] && [ -z "$_folder" ]; then _folder="$_worktree_token"; fi
     _git_ref="$(git_ref_for "$_place" "$_ref" "$_folder" "$_location_status")"
     # The one place an outcome becomes a token decision: `fresh` publishes
     # its count tokens, and both `stale` and `absent` publish nothing, because a
@@ -1622,11 +1626,11 @@ EOF
       [ "$_status_outcome" != "fresh" ] || _git_status="$_status_counts"
     fi
     pane_presentations="${pane_presentations}${pane_presentations:+
-}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_git_status}"
+}${_pane_id}${FIELD_SEPARATOR}${_pane_terminal}${FIELD_SEPARATOR}${pane_tab}${FIELD_SEPARATOR}${_pane_workspace}${FIELD_SEPARATOR}${_pane_agent}${FIELD_SEPARATOR}${_pane_native_session}${FIELD_SEPARATOR}${_pane_current}${FIELD_SEPARATOR}${pane_intended}${FIELD_SEPARATOR}${_pane_task}${FIELD_SEPARATOR}${_pane_slug}${FIELD_SEPARATOR}${_pane_metadata}${FIELD_SEPARATOR}${_location_outcome}${FIELD_SEPARATOR}${_checkout_root}${FIELD_SEPARATOR}${_repository_anchor}${FIELD_SEPARATOR}${_repo}${FIELD_SEPARATOR}${_branch}${FIELD_SEPARATOR}${_is_linked}${FIELD_SEPARATOR}${_sha}${FIELD_SEPARATOR}${_location_folder}${FIELD_SEPARATOR}${_location_status}${FIELD_SEPARATOR}${_git_ref}${FIELD_SEPARATOR}${_worktree_token}${FIELD_SEPARATOR}${_git_status}"
   done <<EOF
 $pane_intents
 EOF
-  pane_presentations="$(printf '%s\n' "$pane_presentations" | filter_records_of_width 22)"
+  pane_presentations="$(printf '%s\n' "$pane_presentations" | filter_records_of_width 23)"
 
   # A complete snapshot authoritatively deletes evidence for panes that no
   # longer exist. No label policy or applied-label copy is retained.
@@ -1643,7 +1647,7 @@ EOF
   # Herdr 0.8 has no rename compare-and-swap. A target can change after the
   # final get and briefly receive stale intent; the next pass repairs it.
   presentation_generation_valid "$pass" || return 2
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha location_status git_ref worktree_token git_status; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace agent_of native_session current intended current_task slug metadata_seq location_outcome checkout_root repository_anchor repo branch is_linked sha folder location_status git_ref worktree_token git_status; do
     [ -n "$id" ] || continue
     # The published-token baseline this pane is diffed against lives in the
     # keyed table, not in the record.
@@ -1678,10 +1682,10 @@ EOF
     # A transient pass with no evidence publishes nothing: location tokens
     # retain as-is. Same gate as the publish arms below, so such a pass also
     # keeps the legacy token for now.
-    if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
+    if [ -n "$git_ref" ] || [ "$location_outcome" = "non_git" ]; then
       ! list_contains_line "$id" "$legacy_token_panes" || location_changed=1
     fi
-    if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
+    if [ -n "$git_ref" ]; then
       [ "$current_repo" = "$repo" ] || location_changed=1
       [ "$current_worktree" = "$worktree_token" ] || location_changed=1
       [ "$current_branch" = "$branch" ] || location_changed=1
@@ -1718,11 +1722,11 @@ EOF
 $final_tokens
 EOF
       location_changed=0
-      if { [ -n "$repo" ] && [ -n "$worktree_token" ]; } || [ "$location_outcome" = "non_git" ]; then
+      if [ -n "$git_ref" ] || [ "$location_outcome" = "non_git" ]; then
         [ -z "$final_location_label" ] || location_changed=1
         [ -z "$final_legacy_tokens" ] || location_changed=1
       fi
-      if [ -n "$repo" ] && [ -n "$worktree_token" ]; then
+      if [ -n "$git_ref" ]; then
         [ "$final_repo" = "$repo" ] || location_changed=1
         [ "$final_worktree" = "$worktree_token" ] || location_changed=1
         [ "$final_branch" = "$branch" ] || location_changed=1
@@ -1756,6 +1760,9 @@ EOF
           if [ -n "$git_staged" ]; then set -- "$@" --token "git_staged=$git_staged"; else set -- "$@" --clear-token git_staged; fi
           if [ -n "$git_unstaged" ]; then set -- "$@" --token "git_unstaged=$git_unstaged"; else set -- "$@" --clear-token git_unstaged; fi
           if [ -n "$git_untracked" ]; then set -- "$@" --token "git_untracked=$git_untracked"; else set -- "$@" --clear-token git_untracked; fi
+        elif [ -n "$git_ref" ]; then
+          set -- "$@" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token git_status --clear-token git_pull --clear-token git_push --clear-token git_conflicts --clear-token git_staged --clear-token git_unstaged --clear-token git_untracked --clear-token location_label
+          if [ -n "$location_status" ]; then set -- "$@" --token "location_status=$location_status"; else set -- "$@" --clear-token location_status; fi
         else
           set -- "$@" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token git_status --clear-token git_pull --clear-token git_push --clear-token git_conflicts --clear-token git_staged --clear-token git_unstaged --clear-token git_untracked --clear-token location_label
         fi

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -531,9 +531,8 @@ hts_set_tab() {
   hts_upsert "$1" tabs tab_id "$2"
 }
 
-# Workspace names come from the snapshot's workspaces array; the formatter
-# suppresses the $git_ref folder qualifier when the worktree token equals
-# the pane's workspace name.
+# Workspace names come from the snapshot's workspaces array and feed the
+# aggregate agent line independently of location identity.
 hts_set_workspace() {
   hts_upsert "$1" workspaces workspace_id "$2"
 }

--- a/tests/scripts.bats
+++ b/tests/scripts.bats
@@ -4050,17 +4050,18 @@ EOF
 
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.repo' "$state" | sort -u)" repository
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.worktree' "$state" | sort -u)" repository
-  # Main checkout: branch icon; folder qualifier suppressed because the
-  # worktree token equals the workspace name.
+  # Main checkout: Git identity is only the branch.
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_BRANCH main"
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.branch' "$state" | sort -u)" feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.worktree' "$state" | sort -u)" feature
-  # Linked worktree (.git file at root): worktree icon; folder qualifier
-  # suppressed because the worktree token equals the branch.
+  # Linked worktree (.git file at root): Git identity is only the branch.
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_WORKTREE feature"
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "agent-ignores-foreground") | .tokens.branch' "$state")" feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "agent-ignores-foreground") | .tokens.worktree' "$state")" feature
-  run jq -e '.panes[] | select(.pane_id == "foreground-wins") | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.git_ref == null)' "$state"
+  run jq -e --arg ref "$HTS_ICON_FOLDER outside" '
+    .panes[] | select(.pane_id == "foreground-wins")
+    | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.git_ref == $ref)
+  ' "$state"
   assert_success
   assert_equal "$(cat "$(hts_git_fixture_dir "$nongit")/locale")" C
 }
@@ -4091,7 +4092,7 @@ EOF
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE feature $HTS_ICON_STALE"
 }
 
-@test "herdr-task-sync location detached publishes a commit ref and non-Git clears are source-local with monotonic restart high-water" {
+@test "herdr-task-sync location detached and non-Git identities persist across transient probes" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git"
@@ -4125,10 +4126,19 @@ EOF
   hts_set_pane_location "$HTS_DEFAULT_SOCKET" pane-1 "$nongit" "$nongit"
   HERDR_TASK_SYNC_TEST_NOW_SEQ=0 hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  # pane_inline is deferred by the plan and never published; the non-Git arm
-  # clears every Git token while the task and aggregate agent label survive.
-  assert_equal "$(jq -cS '.panes[0].tokens' "$state")" '{"agent_line":"repo worker","task":"kept-task"}'
+  # Confirmed non-Git clears Git-specific metadata but publishes the cwd
+  # basename as the durable location identity.
+  assert_equal "$(jq -cS '.panes[0].tokens' "$state")" \
+    "{\"agent_line\":\"repo worker\",\"git_line\":\"$HTS_ICON_FOLDER non-git$HTS_SIDEBAR_PADDING\",\"git_ref\":\"$HTS_ICON_FOLDER non-git\",\"task\":\"kept-task\"}"
   [[ "$(hts_location_source_seq "$HTS_DEFAULT_SOCKET" pane-1)" -gt "$second_seq" ]] || fail "non-Git location sequence did not advance"
+
+  # A later probe failure retains the prior folder identity instead of
+  # reverting to the older Git identity or clearing the location.
+  printf '%s' 127 > "$(hts_git_fixture_dir "$nongit")/status"
+  hts_location_pass
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_FOLDER non-git $HTS_ICON_STALE"
+  assert_equal "$(jq -r '.panes[0].tokens.location_status' "$state")" stale
 }
 
 @test "herdr-task-sync location real probe shape pays the second sha call only when detached" {
@@ -4259,8 +4269,10 @@ EOF
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
   run jq -e '.panes[] | select(.pane_id == "pane-1") | .tokens.location_label == null' "$state"
   assert_success
-  # then: the non-Git clear path sheds it alongside the other location tokens
-  run jq -e '.panes[] | select(.pane_id == "pane-2") | (.tokens.location_label == null and .tokens.git_ref == null)' "$state"
+  # then: the non-Git path sheds it while publishing its folder identity
+  run jq -e --arg ref "$HTS_ICON_FOLDER non-git" '
+    .panes[] | select(.pane_id == "pane-2") | (.tokens.location_label == null and .tokens.git_ref == $ref)
+  ' "$state"
   assert_success
 }
 
@@ -4393,8 +4405,8 @@ EOF
   run jq -e '.panes[] | select(.pane_id == "pane-1") | .tokens.branch == "initial-1" and .tokens.location_status == "stale"' "$state"
   assert_success
   for i in $(seq 2 8); do
-    run jq -e --arg pane "pane-$i" \
-      '.panes[] | select(.pane_id == $pane) | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.location_status == null and .tokens.git_ref == null)' "$state"
+    run jq -e --arg pane "pane-$i" --arg ref "$HTS_ICON_FOLDER work" \
+      '.panes[] | select(.pane_id == $pane) | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.location_status == null and .tokens.git_ref == $ref)' "$state"
     assert_success
     fixture="$(hts_git_fixture_dir "$HTS_WORK/repos/repo-$i/work")"
     assert_file_exists "$fixture/started"
@@ -4455,10 +4467,9 @@ EOF
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   # Token-only evidence carries no is_linked proof, so the place icon falls
-  # back to the branch icon; without any ref evidence the folder icon plus
-  # worktree token is the whole $git_ref.
+  # back to the branch icon. A ref-less prior identity remains a folder.
   run jq -e \
-    --arg ref_one "$HTS_ICON_BRANCH topic-one $HTS_ICON_FOLDER live-token $HTS_ICON_STALE" \
+    --arg ref_one "$HTS_ICON_BRANCH topic-one $HTS_ICON_STALE" \
     --arg ref_two "$HTS_ICON_FOLDER live-token $HTS_ICON_STALE" \
     --arg pad "$HTS_SIDEBAR_PADDING" '
     (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one,agent_line:"one",git_line:($ref_one + $pad)})
@@ -4572,7 +4583,7 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "~ 1"
   assert_equal "$(jq -r '.panes[] | .label' "$state" | sort -u)" "~"
-  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_BRANCH main $HTS_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_BRANCH main"
 }
 
 @test "herdr-task-sync Git-only location changes do not rename a names-only tab" {
@@ -4598,13 +4609,11 @@ EOF
   assert_failure
 }
 
-@test "herdr-task-sync formatter keeps the folder qualifier on a main checkout in a differently-named folder" {
+@test "herdr-task-sync formatter never qualifies a Git branch with its folder" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
-  # Plan decision 5 describes the typical main checkout, whose folder repeats
-  # the branch or the workspace name. When the folder differs from BOTH it is
-  # real location information, so the sidebar qualifier stays — the same
-  # suppression rule as every other checkout, no main-checkout special case.
+  # Git identity is the branch regardless of the checkout folder or workspace
+  # name. Folder identity belongs exclusively to confirmed non-Git locations.
   local root="$HTS_WORK/setup-copy" state
   mkdir -p "$root/.git"
   hts_git_location_fixture "$root" "$root" "$root/.git" refs/heads/main
@@ -4614,16 +4623,15 @@ EOF
   hts_set_process_label pane-1 task
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH main $HTS_ICON_FOLDER setup-copy"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH main"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
 }
 
-@test "herdr-task-sync formatter reads the workspace display name from the legacy name field when label is absent" {
+@test "herdr-task-sync formatter reads the workspace display name from the legacy name field" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
-  # Older snapshot shapes carry the workspace display name as `name`; the
-  # (.label // .name // "") read must still suppress the folder qualifier when
-  # the worktree token merely repeats that name.
+  # Older snapshot shapes carry the workspace display name as `name`; it still
+  # feeds the aggregate agent line independently of the Git identity.
   local root="$HTS_WORK/legacy-ws" state
   mkdir -p "$root/.git"
   hts_git_location_fixture "$root" "$root" "$root/.git" refs/heads/topic
@@ -4633,6 +4641,7 @@ EOF
   hts_set_process_label pane-1 task
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.agent_line' "$state")" "legacy-ws task"
   assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
 }
 
@@ -4640,8 +4649,7 @@ EOF
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
   # The commit place deliberately wins over the worktree place: the detached
-  # short SHA locates the pane more precisely than worktree-ness does, and the
-  # folder qualifier still names the linked worktree in the sidebar.
+  # short SHA is the complete Git identity.
   local root="$HTS_WORK/wt-detached" common="$HTS_WORK/repository/.git" state
   mkdir -p "$root" "$common"
   hts_mark_linked_worktree "$root" "$common/worktrees/wt-detached"
@@ -4652,15 +4660,15 @@ EOF
   hts_set_process_label pane-1 task
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_COMMIT a1b2c3d $HTS_ICON_FOLDER wt-detached"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_COMMIT a1b2c3d"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
 }
 
-@test "herdr-task-sync formatter qualifies a divergent worktree folder in metadata only" {
+@test "herdr-task-sync formatter never qualifies a linked worktree branch with its folder" {
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
-  # A divergent folder remains useful in the sidebar while the tab stays
-  # limited to the two pane labels.
+  # The worktree icon and branch are the complete Git identity even when the
+  # checkout folder has a different name.
   local root="$HTS_WORK/wt-hotfix" common="$HTS_WORK/repository/.git" state
   mkdir -p "$root" "$common"
   hts_mark_linked_worktree "$root" "$common/worktrees/wt-hotfix"
@@ -4673,7 +4681,7 @@ EOF
   hts_set_process_label pane-2 beta
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_WORKTREE fix-login $HTS_ICON_FOLDER wt-hotfix"
+  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HTS_ICON_WORKTREE fix-login"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "alpha · beta"
 }
 
@@ -4746,9 +4754,9 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.worktree' "$state")" team/feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.worktree' "$state")" release/feature
-  # The slash-suffix folder token appears only in the sidebar qualifier.
-  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE one $HTS_ICON_FOLDER team/feature"
-  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE two $HTS_ICON_FOLDER release/feature"
+  # Worktree tokens remain independently available but never qualify Git refs.
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE one"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE two"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "alpha · beta"
 }
 
@@ -4824,7 +4832,7 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" "$long_ref"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE $long_ref $HTS_ICON_FOLDER worktree"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE $long_ref"
 }
 
 @test "herdr-task-sync long repository names do not alter a multi-repo tab label" {
@@ -4860,7 +4868,7 @@ EOF
   # given: one pass has already published every current token
   hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic $HTS_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
   assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
   # given: a stale daemon of the retired version puts both aggregate tokens
@@ -4880,7 +4888,7 @@ EOF
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
   assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic $HTS_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_BRANCH topic"
   assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" topic
 }
@@ -4920,7 +4928,7 @@ EOF
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" plain-task
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE plain $HTS_ICON_FOLDER plain-worktree"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE plain"
   assert_equal "$(jq -r '[.panes[0].tokens | .git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | map(select(. != null)) | join(" ")' "$state")" \
     "${HTS_GIT_BEHIND}4 ${HTS_GIT_AHEAD}3 ${HTS_GIT_CONFLICT}1 ${HTS_GIT_STAGED}1 ${HTS_GIT_UNSTAGED}1 ${HTS_GIT_UNTRACKED}1"
   assert_equal "$(jq -r '.panes[0].tokens.git_status // ""' "$state")" ""
@@ -5092,8 +5100,12 @@ EOF
   HERDR_TASK_SYNC_TEST_NOW_SEQ=3001 hts_location_pass
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
 
-  # then: the counts go with the rest of the location tokens
-  run jq -e '.panes[0].tokens | ([.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null)) and (.git_ref == null and .git_line == null and .repo == null)' "$state"
+  # then: Git counts and metadata clear while the non-Git folder takes over
+  run jq -e --arg ref "$HTS_ICON_FOLDER plain" --arg line "$HTS_ICON_FOLDER plain$HTS_SIDEBAR_PADDING" '
+    .panes[0].tokens
+    | ([.git_pull, .git_push, .git_conflicts, .git_staged, .git_unstaged, .git_untracked] | all(. == null))
+      and (.git_ref == $ref and .git_line == $line and .repo == null)
+  ' "$state"
   assert_success
 }
 
@@ -5163,7 +5175,7 @@ EOF
 
   # then: the row names the worktree the agent actually works in
   assert_equal "$(jq -r '.panes[0].cwd' "$state")" "$launch"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE feature $HTS_ICON_FOLDER wt-feature"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HTS_ICON_WORKTREE feature"
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" feature
 }
 
@@ -5311,7 +5323,7 @@ EOF
   hts_location_pass
 
   # then: the sweep publishes the last reported directory, not the first
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "$HTS_ICON_WORKTREE two $HTS_ICON_FOLDER wt-two"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "$HTS_ICON_WORKTREE two"
 }
 
 @test "herdr-task-sync plugin exposes only the approved pane, tab, and worktree invalidations" {


### PR DESCRIPTION
## Summary

Herdr sidebar locations no longer append checkout folders to Git branches or detached commits. Confirmed non-Git directories now display their basename as a folder, while transient probes preserve the last confirmed Git or folder identity with a stale marker.

The durable location record now stores non-Git folder identity alongside the existing Git evidence. Git status counters and independently published repository, worktree, and branch metadata keep their existing behavior.

Related: #93

## Validation

- `make lint`
- 34 focused location and formatter Bats scenarios
- Red/green calibration across four Git, non-Git, and transient regressions
- Scoped Ubuntu chezmoi deployment, source/deployed comparison, and four focused Bats scenarios

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
