### PR TITLE
perf(tests): cut the production test suite from 159s to 128s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 *
 !docker
 !home/private_dot_config/brewfiles
+# Only the two dependency manifests, to key the baked bun install cache;
+# the package source itself stays out of the context on purpose.
+!home/private_dot_claude/dot_smithers/package.json
+!home/private_dot_claude/dot_smithers/bun.lock

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -100,4 +100,15 @@ RUN chezmoi execute-template --file /tmp/Brewfile.tmpl > /tmp/Brewfile && \
     brew bundle --file=/tmp/Brewfile && \
     rm -rf "$(brew --cache)"
 
+# Warm bun's global install cache from the pinned lockfile so both run-time
+# installs (chezmoi's run_onchange script into ~/.claude/.smithers and the
+# worktree `make test-smithers`) resolve offline from cache. The runtime
+# installs still run with --frozen-lockfile against the tree the worktree
+# actually carries, so the lockfile-vs-tree check this suite relies on
+# (docs/issues/2026-08-19-001) is untouched; only the network cost moves to
+# this layer, keyed on the two manifests. The scratch node_modules is
+# discarded — only ~/.bun's cache is the product.
+COPY --chown=testuser home/private_dot_claude/dot_smithers/package.json home/private_dot_claude/dot_smithers/bun.lock /tmp/smithers-deps/
+RUN cd /tmp/smithers-deps && bun install --frozen-lockfile && rm -rf /tmp/smithers-deps/node_modules
+
 CMD ["/bin/zsh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - CHEZMOI_EMAIL=test@example.com
       - HOMEBREW_NO_AUTO_UPDATE=1
       - HOMEBREW_NO_INSTALL_CLEANUP=1
+      # The container proves every Brewfile dependency is present and the
+      # apply succeeds; it must not also chase upstream version drift, or every
+      # run re-downloads whatever went stale since the image bake. Real
+      # machines never see this env, so host applies still upgrade.
+      - HOMEBREW_BUNDLE_NO_UPGRADE=1
       # The only entry here read from the host rather than written literally.
       # Empty by default, which selects the full Brewfile render, so R5 holds
       # unless the caller opts in.
@@ -43,6 +48,8 @@ services:
       - CHEZMOI_EMAIL=test@example.com
       - HOMEBREW_NO_AUTO_UPDATE=1
       - HOMEBREW_NO_INSTALL_CLEANUP=1
+      # See the ubuntu service: presence, not upstream-drift chasing.
+      - HOMEBREW_BUNDLE_NO_UPGRADE=1
       # Selects the CI-minimal Brewfile render, bound by the `chezmoi init`
       # below. Empty by default so `make test-docker` keeps installing the full
       # cross-platform Brewfile (R5). Set it to compare skip counts between the
@@ -107,6 +114,8 @@ services:
       - CHEZMOI_EMAIL=test@example.com
       - HOMEBREW_NO_AUTO_UPDATE=1
       - HOMEBREW_NO_INSTALL_CLEANUP=1
+      # See the ubuntu service: presence, not upstream-drift chasing.
+      - HOMEBREW_BUNDLE_NO_UPGRADE=1
       # See the ubuntu service above for why this is written literally. Note
       # that MMS_CI_MINIMAL stays absent here on purpose (docs/issues/
       # 2026-08-20-014); only the disposable-$HOME marker is shared.

--- a/docs/benchmarks/test-suite-optimization-measurements.json
+++ b/docs/benchmarks/test-suite-optimization-measurements.json
@@ -1,0 +1,64 @@
+{
+  "run_id": "test-suite-time-20260828",
+  "date": "2026-08-29",
+  "environment": {
+    "host": "macOS 14.7.4 (Darwin 23.6.0), 10 CPU, 32 GB RAM",
+    "docker": "29.4.0",
+    "bats": "1.14.0",
+    "chezmoi": "v2.72.0",
+    "bun": "1.4.0",
+    "ambient_caveat": "live user machine; a runaway process pinned one core throughout; all decisions used adjacent interleaved A/B pairs, never absolutes across windows"
+  },
+  "commands": [
+    "make test-issues",
+    "make build-docker",
+    "docker compose -f docker/docker-compose.yml run --rm -T test-ubuntu",
+    "make test-suite"
+  ],
+  "baseline_ref": "origin/main 9161046",
+  "final_ref": "optimize/test-suite-timing a1e1ca3 (origin/main + 4 commits)",
+  "protocol": "interleaved baseline/final pairs, orphaned-watcher reap before/between/after every rep, docker images pre-warmed untimed on both sides; a pair with any failing rep is discarded whole and replaced with a fresh full pair, never patched one-sided; every kept rep passed with 0 failures (docker 431 tests/11 skips, host 390 tests/2 skips); 12/12 skip-and-fail line-diff parity checks exact on the kept reps",
+  "headline": {
+    "note": "3 clean pairs (finalr2 1, 3, 4) against the final tip a1e1ca3, i.e. including the review-driven restoration of the 5s default-timeout test; pair 2 discarded whole for the pre-existing load-sensitive flake in docs/issues/2026-08-29-004",
+    "full_suite_wall_seconds": {
+      "baseline": {"raw": [163, 158, 159], "median": 159, "mad": 1},
+      "final": {"raw": [131, 127, 128], "median": 128, "mad": 1},
+      "delta_median": -31,
+      "delta_pct": -19.5,
+      "paired_deltas": [-32, -31, -31]
+    },
+    "host_suite_wall_seconds": {
+      "baseline": {"raw": [138, 139, 138], "median": 138, "mad": 0},
+      "final": {"raw": [136, 141, 138], "median": 138, "mad": 2},
+      "delta_median": 0,
+      "delta_pct": 0.0,
+      "paired_deltas": [-2, 2, 0],
+      "verdict": "unchanged"
+    },
+    "docker_leg_seconds": {
+      "baseline": {"raw": [158, 153, 153], "median": 153, "mad": 1},
+      "final": {"raw": [126, 122, 123], "median": 123, "mad": 1},
+      "delta_median": -30,
+      "delta_pct": -19.6,
+      "paired_deltas": [-32, -31, -30]
+    },
+    "discarded_pair": {"tag": "finalr2-2", "cause": "docker test 119 flake (docs/issues/2026-08-29-004), branch-independent", "raw_kept_for_record": {"A_full": 157, "B_full": 130}}
+  },
+  "superseded_pre_review_fix": {
+    "note": "3 clean pairs against 7c08c19, before the coverage review restored one 5s default-timeout test (commit a1e1ca3); kept for the record, not the headline",
+    "full_suite_wall_seconds": {
+      "baseline": {"raw": [159, 160, 160], "median": 160, "mad": 0},
+      "final": {"raw": [124, 123, 126], "median": 124, "mad": 1},
+      "delta_median": -36,
+      "delta_pct": -22.5,
+      "paired_deltas": [-35, -37, -34]
+    },
+    "host_suite_wall_seconds": {
+      "baseline": {"raw": [140, 136, 137], "median": 137, "mad": 1},
+      "final": {"raw": [134, 139, 138], "median": 138, "mad": 1},
+      "delta_median": 1,
+      "delta_pct": 0.7
+    }
+  },
+  "noise_threshold": "5% relative (~8s baseline full suite); observed MAD <= 2s on all kept metrics"
+}

--- a/docs/benchmarks/test-suite-optimization.md
+++ b/docs/benchmarks/test-suite-optimization.md
@@ -1,0 +1,68 @@
+# Test-suite optimization — 2026-08-29
+
+Full production test suite wall-clock time reduced **from 159s to 128s median (−31s, −19.5%)** with zero change to test outcomes: identical test counts, identical skip sets with reasons, zero failures, on both macOS (host) and Ubuntu (docker) legs.
+
+Raw data: [`test-suite-optimization-measurements.json`](test-suite-optimization-measurements.json).
+
+## Scope and commands
+
+The production suite measured is the sum of:
+
+```sh
+make test-issues
+make build-docker
+docker compose -f docker/docker-compose.yml run --rm -T test-ubuntu
+make test-suite
+```
+
+The docker leg applies the checkout inside Ubuntu 24.04 (chezmoi init → templates → apply → `make test-smithers` → post-apply bats). The host leg (`make test-suite`) runs the parallel host-safe bats files against the applied `~/` on macOS.
+
+- Baseline: `origin/main` at 9161046.
+- Final: `optimize/test-suite-timing` at a1e1ca3 (baseline + 4 commits).
+
+## Result
+
+3 clean interleaved baseline/final pairs (docker 431 tests / 11 skips, host 390 tests / 2 skips, 0 failures in every kept rep), 12/12 line-diff skip-and-fail parity checks exact:
+
+| Metric | Baseline (raw → median) | Final (raw → median) | Δ |
+|---|---|---|---|
+| Full suite wall | 163, 158, 159 → **159s** | 131, 127, 128 → **128s** | **−31s (−19.5%)** |
+| — docker leg | 158, 153, 153 → 153s | 126, 122, 123 → 123s | −30s (−19.6%) |
+| Host suite wall | 138, 139, 138 → 138s | 136, 141, 138 → 138s | 0s (unchanged) |
+
+Paired per-rep full-suite deltas: −32, −31, −31. MAD ≤ 2s on every metric — far past the 5% relative noise threshold (~8s) the run used for keep decisions. The host suite is untouched by the kept changes (all affect only the docker leg and one bun test file). One additional pair was discarded whole (never patched one-sided) when a pre-existing load-sensitive race test failed on one side — see docs/issues/2026-08-29-004; its raw numbers agreed with the kept pairs.
+
+## Retained changes (4 commits)
+
+1. **`HOMEBREW_BUNDLE_NO_UPGRADE=1` in the compose test services** (a873ac1). The container's job is to prove every Brewfile dependency is present and the apply succeeds — not to chase upstream version drift. Without it, a stale image spent ~30s per run fetching metadata and upgrading formulae. Container-only; host and production apply semantics untouched.
+2. **Injectable CLI timeout in `publishIssue`** (92dbbda). The two issue-writer timeout tests each burned a full 5s production timeout waiting for a stubbed CLI. `publishIssue` now takes `timeoutMs = ISSUE_CLI_TIMEOUT_MS`; the sole production caller keeps the default.
+3. **Baked bun install cache in `docker/Dockerfile.ubuntu`** (7c08c19). A layer keyed on `package.json` + `bun.lock` warms bun's global cache at image-build time, so both runtime `bun install --frozen-lockfile` runs (the chezmoi run_onchange script and `make test-smithers`) resolve from cache instead of the network. The runtime installs still run frozen against the real tree, so the lockfile-vs-tree invariant (docs/issues/2026-08-19-001) is untouched; only the network cost moves to a cached image layer.
+4. **Review-driven coverage hardening** (a1e1ca3). The final coverage review found that after (2), no test proved the production default timeout still fires against a hung CLI. One of the two timeout tests was restored to the no-arg default (spending ~5s by design; the other keeps a 300ms injection), and `HOMEBREW_BUNDLE_NO_UPGRADE=1` was pinned into `tests/test_docker_contract.py`'s literal per-service contract (control-checked red against origin/main) so a silent revert of (1) cannot pass unnoticed. The headline above was re-measured after this commit.
+
+## Rejected experiments
+
+- **macOS flock-compatible semaphore shim** for local host runs: consistently faster but below the noise threshold; reverted, design preserved in docs/issues/2026-08-28-002.
+- **hts wait-poll latency 0.25s→0.05s + seq-subprocess elimination**: measured dead neutral (full −1s, host +2s) — wait completion is event-dominated, not poll-quantization dominated. Reverted. As a side product, every fixed sleep in scripts.bats was audited and proven to guard a real margin (stub delays, kill-race margins); none is safely shrinkable.
+- **Not attempted** (time budget / below noise / overlap): Makefile target overlap (est. 4–5s, sub-noise), container cache volumes (superseded by the bake layer), scripts.bats file split for cross-file parallelism (structural, the largest remaining lever), spawn amortization (micro).
+
+## Verification evidence
+
+- **Correctness review** (independent subagent): all changed files verified behavior-preserving against origin/main, assertion-by-assertion for the test file; production `publishIssue` caller keeps the 5s default; frozen-lockfile checks proven unmaskable by a warm cache; issue-writer tests re-run green (35/35).
+- **Coverage review** (independent subagent): no test deleted, renamed, merged, or skipped anywhere in the diff; two findings (default-timeout proof, contract pin) — both fixed in a1e1ca3; explicitly recommended no Dockerfile text assertion (would be tautological; the layer self-detects at build time).
+- **Skip parity**: every kept rep's SKIP/FAIL lines (with reasons) line-diffed against the anchored outcome sets — 12/12 exact. Counts moved from the run's original baseline (428/387) only via upstream main adding 3 tests and this worktree's smithers deps making one former host skip execute (and pass).
+- **Process cleanup review**: no orphaned watcher daemons, no leaked containers/volumes from the run, no stray bats processes. One finding: `hts.*` temp-dir accumulation under `$TMPDIR` (pre-existing teardown race), filed as docs/issues/2026-08-29-003.
+- **Methodology review**: interleaving, exclusions, noise floor, baseline validity, warm-cache fairness, and every statistic recomputed and confirmed sound; its two caveats are folded into this document.
+- **Platforms**: Ubuntu leg exercised in every docker rep (431 tests); macOS host leg in every host rep (390 tests). CI runs both jobs on every push.
+
+## Caveats and trade-offs
+
+- **Measurement environment**: a live user machine with a concurrent agent session and a runaway process pinning one core. All keep decisions used adjacent interleaved A/B pairs under a negotiated exclusive-window protocol with orphaned-watcher reaping between reps; absolute times are not comparable across windows, deltas are.
+- **Image staleness trade-off**: with `HOMEBREW_BUNDLE_NO_UPGRADE=1`, containers no longer pick up formula upgrades at run time; upstream drift now surfaces only when the image is rebuilt. That is the intended hermetic behavior for a test container.
+- **Lockfile-change cost**: the bake layer rebuilds whenever `package.json`/`bun.lock` change — one network-heavy image build, then cached again. That recurring cold-build cost was not measured in this run.
+- **Measurement order**: each interleaved pair ran baseline-then-final (no ABBA counterbalancing). The machine's documented ambient drift direction (slowing over a session) biases against the final side, so the result is, if anything, conservative.
+- **Flaky neighbor**: a pre-existing race test (`herdr-child reap invalidates before close…`, from #83) fails under CPU contention (3 of ~16 loaded container runs vs 0 of 10 calm; runner-independent). Filed as docs/issues/2026-08-29-004. Contaminated pairs were discarded whole and replaced.
+- **Runner interaction**: a parallel unpushed branch (`optimize/test-suite-time`) replaces the post-apply bats runner with bashunit. All retained commits here are runner-independent and carry over that migration unchanged, but the two branches' percentage gains were measured against different runners and do not add linearly. Expect a trivial textual merge conflict in `docker/docker-compose.yml` (both branches touch service definitions) and one issue-number collision to renumber (both branches filed a 2026-08-28-001).
+
+## Remaining bottlenecks and recommendation
+
+Post-apply bats inside the container is now the long pole (~100s, of which `tests/scripts.bats` is ~80s and runs with `--no-parallelize-across-files`). Splitting scripts.bats into parallelizable files is the largest remaining lever but structural — and moot if the bashunit runner branch lands first. Recommendation: merge these four commits as-is; re-profile after the runner branches reconcile before investing in the split.

--- a/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
+++ b/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
@@ -1,0 +1,42 @@
+---
+title: "bats runs leak orphaned herdr-child watcher daemons"
+short_description: "Suite runs leave herdr-child __watcher processes (10ms pollers) behind when their --launcher-pid process dies without reaping them; 12 accumulated orphans measurably slowed all subsequent suite timings machine-wide until killed, so repeated local runs progressively degrade both the machine and any benchmark numbers."
+type: "bug"
+category: "testing-ci"
+tags: ["herdr","process-cleanup","test-isolation","performance"]
+date: "2026-08-28"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+During the 2026-08-28 test-suite timing work, two concurrent sessions found the
+machine progressively slowing across repeated suite runs. Diagnosis: 12
+orphaned `herdr-child __watcher` daemons (each polling at 10ms) plus 2 orphaned
+stub prompt processes had accumulated from bats runs — the watchers outlive
+their `--launcher-pid` process when it dies without reaping them, despite the
+teardown reap loop in `tests/scripts.bats`. The accumulation inflated
+full-suite wall time by roughly 7% within an hour (baseline-tree control runs:
+full 155s→165s, host 141s→161s) and destabilized benchmark comparisons.
+
+Detection: `pgrep -f "herdr-child __watcher"`. Cleanup that restored the
+floor: kill each watcher whose `--launcher-pid` process is dead (see
+`ps -o args= -p <pid>` for the launcher pid).
+
+## Scope
+
+- Find the escape path: which test paths let a launcher die without its
+  watcher being reaped (teardown reap loop exists at `tests/scripts.bats:6-36`
+  but does not catch everything, e.g. kills mid-test or nested-bats runs).
+- Make the suite reap its own watchers deterministically (or make watchers
+  self-terminate when their launcher pid dies — they already poll it every
+  10ms, so exiting on a dead launcher is the natural fix at the source).
+- Add a regression guard: a suite-end check that no `herdr-child __watcher`
+  with a dead launcher survives the run.
+
+## Open decisions
+
+- Fix in the watcher itself (exit when launcher pid vanishes) vs. in test
+  teardown (broader reap) vs. both. The watcher-side fix also protects real
+  (non-test) herdr usage from the same leak.

--- a/docs/issues/2026-08-28-002-local-macos-bats-flock-shim-consistent-but-sub-noise-gain.md
+++ b/docs/issues/2026-08-28-002-local-macos-bats-flock-shim-consistent-but-sub-noise-gain.md
@@ -1,0 +1,39 @@
+---
+title: "Local macOS bats flock shim: consistent but sub-noise gain"
+short_description: "A python-fcntl flock shim on run-post-apply.sh's PATH (replacing bats' shlock fallback on Darwin hosts) gave a stable -3..-8s (~3%) host-suite improvement across three interleaved pairs — real but below the 5% keep threshold; the tested diff and full timing data live in the 2026-08-28 test-suite-time optimization log, worth revisiting if host parallelism or suite size grows."
+type: "idea"
+category: "testing-ci"
+tags: ["performance","bats","macos"]
+date: "2026-08-28"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Local Macs ship neither `flock` nor `lockf`, so bats' within-file semaphore
+falls back to `shlock`, which polls a contended lock on a one-second sleep.
+CI macOS already routes around this with `scripts/ci/macos-bats-flock-bin`
+(lockf), and that wrapper measurably helped CI. A local equivalent was
+prototyped during the 2026-08-28 test-suite-time optimization run: a
+python-fcntl `flock` shim placed on PATH by `tests/run-post-apply.sh` only
+on Darwin hosts without a real flock. Across three interleaved A/B pairs on
+a clean process floor it improved the host-safe suite by a consistent
+-3..-8s (~3%) — real, but below the run's 5% keep threshold, and most of
+the historically observed shlock pain turned out to be orphaned-watcher
+accumulation (docs/issues/2026-08-28-001), not lock polling.
+
+The tested implementation (shim + 5-case regression test + runner PATH
+branch) and full timing data are recorded in the optimization run log
+(`.context/compound-engineering/ce-optimize/test-suite-time/` scratch and
+`docs/benchmarks/test-suite-optimization.md` once landed).
+
+## Scope
+
+Revisit if the host suite grows, `--jobs` rises, or lock contention
+reappears after the watcher leak is fixed: re-run the interleaved pairs;
+adopt the shim if the gain clears the noise floor then.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-29-003-measurement-reps-leak-hts-temp-dirs.md
+++ b/docs/issues/2026-08-29-003-measurement-reps-leak-hts-temp-dirs.md
@@ -1,0 +1,26 @@
+---
+title: "Measurement reps leak hts.* temp dirs"
+short_description: "Each bats measurement rep leaves one or more hts.* dirs under $TMPDIR (2663 total, +173 during the 2026-08-29 benchmark reps, 188 modified in 6h); same hts-teardown race family as the peer branch's 2026-08-29-001, so dedupe/renumber against it when branches merge."
+type: "bug"
+category: "testing-ci"
+tags: ["process-cleanup","herdr-task-sync"]
+date: "2026-08-29"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+A process-cleanup review after the 2026-08-29 test-suite optimization benchmark found 2663 `hts.*` directories under `$TMPDIR` (`/var/folders/.../T/`), up roughly 173 from the count a peer session reported before the benchmark window, with 188 modified in the last 6 hours. The growth tracks the day's bats measurement reps: `hts_teardown` in `tests/helpers/herdr_task_sync.bash` can race a surviving engine process, so some per-test `hts.*` state dirs escape deletion. The dirs are inert but accumulate without bound and poison tmp-diff tooling.
+
+A concurrent optimization session on branch `optimize/test-suite-time` filed its own issue for the same root cause (2026-08-29-001 on that branch; this one took -003 to avoid a number collision). When the branches merge, keep one issue.
+
+## Scope
+
+- Reproduce the teardown race (run a herdr-task-sync-heavy bats file repeatedly and diff the `hts.*` count).
+- Make `hts_teardown` reap the engine before removing the state dir, or re-attempt removal after the engine exits.
+- One-time cleanup guidance for the existing pile (dirs are safe to delete when no bats run is active).
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
+++ b/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
@@ -1,0 +1,26 @@
+---
+title: "herdr-child reap/close race test flakes under CPU load"
+short_description: "tests/scripts.bats test 'herdr-child reap invalidates before close while spontaneous loss wakes the parent' (added in #83) failed 3 of ~16 docker runs during loaded 2026-08-29 benchmark reps yet 0 of 10 in calm reruns, so the race window needs a load-tolerant margin rather than a timing assumption."
+type: "bug"
+category: "testing-ci"
+tags: ["flaky-test","herdr"]
+date: "2026-08-29"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+During the 2026-08-29 test-suite benchmark reps, the docker-leg test `herdr-child reap invalidates before close while spontaneous loss wakes the parent` (tests/scripts.bats, introduced by #83 "supervise detached child agents") failed 3 times in ~16 container runs. All runs happened while a runaway host process pinned one core. Independent evidence from a concurrent session: 0/10 failures in a quiet container on both the bats and bashunit runners, plus exactly one failure in a contended run. That is a clean load-sensitivity signature — the scenario's race window (reap must invalidate before close) assumes a scheduling latency that contention breaks. It is runner-independent and distinct from the `hts_teardown` state-dir race.
+
+Each flake poisons a whole measurement or CI run: the suite reports 1 failure and the run must be discarded or retried.
+
+## Scope
+
+- Reproduce under artificial load (e.g., a busy loop pinning cores while looping the single test).
+- Widen the scenario's detection margin so a loaded scheduler cannot reorder reap and close, without weakening what it proves (reap-before-close invalidation and parent wakeup on spontaneous loss).
+- Confirm 0 failures over a loaded 20-run loop after the fix.
+
+## Open decisions
+
+None.

--- a/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.test.ts
@@ -266,21 +266,26 @@ printf 'docs/issues/2026-08-13-001-reviewer-leg-died-mid-stream.md\\n'
     expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
   });
 
-  test("fails closed when the target CLI version probe times out", () => {
-    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));
-    const scripts = path.join(repo, "scripts");
-    fs.mkdirSync(scripts, { recursive: true });
-    fs.writeFileSync(path.join(scripts, "issues"), "#!/bin/sh\nexec sleep 10\n", { mode: 0o755 });
+  test(
+    "fails closed when the target CLI version probe times out",
+    () => {
+      const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));
+      const scripts = path.join(repo, "scripts");
+      fs.mkdirSync(scripts, { recursive: true });
+      fs.writeFileSync(path.join(scripts, "issues"), "#!/bin/sh\nexec sleep 10\n", { mode: 0o755 });
 
-    // A short injected timeout exercises the same ETIMEDOUT fail-closed
-    // path as the production default without spending 5s of wall clock.
-    const result = publishIssue(repo, fields(), 300);
+      // Deliberately no injected timeout: this is the one test proving the
+      // production default (ISSUE_CLI_TIMEOUT_MS) is wired and finite
+      // against a hung CLI. It costs ~5s of wall clock by design.
+      const result = publishIssue(repo, fields());
 
-    expect(result.mode).toBe("cli-failed");
-    expect(result.path).toBeNull();
-    expect(result.error).toContain("ETIMEDOUT");
-    expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
-  });
+      expect(result.mode).toBe("cli-failed");
+      expect(result.path).toBeNull();
+      expect(result.error).toContain("ETIMEDOUT");
+      expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
+    },
+    7_000,
+  );
 
   test("records a compatible CLI publication failure without a legacy direct-write fallback", () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));

--- a/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.test.ts
@@ -266,23 +266,21 @@ printf 'docs/issues/2026-08-13-001-reviewer-leg-died-mid-stream.md\\n'
     expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
   });
 
-  test(
-    "fails closed when the target CLI version probe times out",
-    () => {
-      const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));
-      const scripts = path.join(repo, "scripts");
-      fs.mkdirSync(scripts, { recursive: true });
-      fs.writeFileSync(path.join(scripts, "issues"), "#!/bin/sh\nexec sleep 10\n", { mode: 0o755 });
+  test("fails closed when the target CLI version probe times out", () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));
+    const scripts = path.join(repo, "scripts");
+    fs.mkdirSync(scripts, { recursive: true });
+    fs.writeFileSync(path.join(scripts, "issues"), "#!/bin/sh\nexec sleep 10\n", { mode: 0o755 });
 
-      const result = publishIssue(repo, fields());
+    // A short injected timeout exercises the same ETIMEDOUT fail-closed
+    // path as the production default without spending 5s of wall clock.
+    const result = publishIssue(repo, fields(), 300);
 
-      expect(result.mode).toBe("cli-failed");
-      expect(result.path).toBeNull();
-      expect(result.error).toContain("ETIMEDOUT");
-      expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
-    },
-    7_000,
-  );
+    expect(result.mode).toBe("cli-failed");
+    expect(result.path).toBeNull();
+    expect(result.error).toContain("ETIMEDOUT");
+    expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
+  });
 
   test("records a compatible CLI publication failure without a legacy direct-write fallback", () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), "issue-target-"));
@@ -352,14 +350,14 @@ exec sleep 10
         { mode: 0o755 },
       );
 
-      const result = publishIssue(repo, fields());
+      // Same injected-timeout rationale as the version-probe test above.
+      const result = publishIssue(repo, fields(), 300);
 
       expect(result.mode).toBe("cli-failed");
       expect(result.path).toBeNull();
       expect(result.error).toContain("ETIMEDOUT");
       expect(fs.existsSync(path.join(repo, "docs", "issues"))).toBe(false);
     },
-    7_000,
   );
 
   for (const [name, output, createTarget] of [

--- a/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/issue-writer.ts
@@ -322,7 +322,7 @@ function validatePublishedPath(repoRoot: string, stdout: string | Buffer, extern
 // The target checkout owns issue creation when it advertises the pinned contract.
 // Once that compatible CLI fails, do not bypass its validation and locking with a
 // legacy direct write.
-export function publishIssue(repoRoot: string, fields: IssueFields): PublishedIssue {
+export function publishIssue(repoRoot: string, fields: IssueFields, timeoutMs: number = ISSUE_CLI_TIMEOUT_MS): PublishedIssue {
   const cliPath = path.join(repoRoot, "scripts", "issues");
   try {
     fs.lstatSync(cliPath);
@@ -334,7 +334,7 @@ export function publishIssue(repoRoot: string, fields: IssueFields): PublishedIs
     return cliFailure([], `Could not inspect scripts/issues: ${String(error)}`);
   }
 
-  const probe = spawnSync(cliPath, ["--version"], { cwd: repoRoot, encoding: "utf8", timeout: ISSUE_CLI_TIMEOUT_MS, killSignal: "SIGKILL" });
+  const probe = spawnSync(cliPath, ["--version"], { cwd: repoRoot, encoding: "utf8", timeout: timeoutMs, killSignal: "SIGKILL" });
   if (probe.error || probe.status !== 0) return cliFailure([], spawnFailureMessage("--version", probe));
   if (probe.stdout !== ISSUE_CLI_CONTRACT) return cliFailure([], "scripts/issues --version returned an incompatible contract");
 
@@ -367,7 +367,7 @@ export function publishIssue(repoRoot: string, fields: IssueFields): PublishedIs
   ];
   if (redacted.fields.parentPlan) args.push("--parent-plan", redacted.fields.parentPlan);
 
-  const published = spawnSync(cliPath, args, { cwd: repoRoot, encoding: "utf8", timeout: ISSUE_CLI_TIMEOUT_MS, killSignal: "SIGKILL" });
+  const published = spawnSync(cliPath, args, { cwd: repoRoot, encoding: "utf8", timeout: timeoutMs, killSignal: "SIGKILL" });
   if (published.error || published.status !== 0) {
     return cliFailure(redacted.hits, spawnFailureMessage("create", published));
   }

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -44,6 +44,10 @@ class TestDockerContract(unittest.TestCase):
             "cp -r /home/testuser/issues /home/testuser/worktree/docs/issues",
             "cp /home/testuser/Makefile /home/testuser/worktree/Makefile",
             "make test-smithers",
+            # The container proves dependency presence; upgrading against
+            # upstream drift is not its job and costs ~30s per run. A silent
+            # revert would only surface as wall-clock/network flakiness.
+            "HOMEBREW_BUNDLE_NO_UPGRADE=1",
         ]
 
         for service_name in ("test-full", "test-ubuntu"):


### PR DESCRIPTION
## Summary

The full production test suite (`make test-issues` + `make build-docker` + the docker `test-ubuntu` run + `make test-suite`) now completes in 128s median instead of 159s (−19.5%), with test outcomes proven identical: same test counts, same skip sets with reasons, zero failures on both the macOS host leg and the Ubuntu docker leg.

## Measurements

3 interleaved baseline/final pairs on the same machine, images pre-warmed on both sides, every kept rep passing:

| Metric | Before (median) | After (median) | Δ |
|---|---|---|---|
| Full suite wall | 159s | 128s | **−31s (−19.5%)** |
| — docker leg | 153s | 123s | −30s (−19.6%) |
| Host suite wall | 138s | 138s | unchanged |

Paired per-rep deltas −32/−31/−31, MAD ≤ 2s, against a ~8s noise threshold. Raw data and methodology: `docs/benchmarks/test-suite-optimization.md` and the measurements JSON beside it.

## Where the time went

- **Runtime `brew bundle` upgrades**: the test container's job is to prove every Brewfile dependency is present and the apply succeeds — chasing upstream formula drift on every run cost ~30s on a stale image. `HOMEBREW_BUNDLE_NO_UPGRADE=1` is set for the compose test services only; host and production apply behavior is untouched, and missing formulae still install.
- **Timeout tests burning the production timeout**: the two issue-writer timeout tests each waited out the full 5s CLI timeout against a stubbed hung CLI. `publishIssue` now accepts an injectable `timeoutMs` defaulting to the production constant; one test injects 300ms.
- **Network-bound bun installs**: a new image layer keyed on `package.json` + `bun.lock` warms bun's global cache at build time, so both runtime `bun install --frozen-lockfile` runs resolve from cache. The runtime installs still run frozen against the real tree, so the lockfile-vs-tree check is unchanged; only the network cost moves into a cached layer.

## Design decision: one test still spends 5s on purpose

An independent coverage review found that with both timeout tests injecting short values, no test proved the production default is actually wired and finite — losing the default would make production hang on a wedged CLI while every test stayed green. One timeout test therefore deliberately calls `publishIssue` with no injected timeout and waits out the real 5s. The compose env line is likewise pinned into `tests/test_docker_contract.py` (checked red against the previous compose) so a silent revert of the no-upgrade setting cannot pass unnoticed.

## Verification

- Every kept rep: docker 431 tests / 11 skips, host 390 tests / 2 skips, 0 failures; skip and fail lines (with reasons) line-diffed against anchored outcome sets — 12/12 exact.
- Independent review passes for correctness (assertion-by-assertion diff of the touched test file; issue-writer suite re-run 35/35), test coverage, process cleanup, and measurement methodology.
- Pairs containing any failing rep were discarded whole and replaced, never patched one-sided; the one offender is a pre-existing load-sensitive race test, filed as docs/issues/2026-08-29-004.
- Rejected experiments (a macOS flock shim: consistent but below noise; poll-latency tuning: neutral) are documented in the benchmark report so they are not retried.

## Merge note

An unpushed sibling branch (`optimize/test-suite-time`) migrates the post-apply runner to bashunit. Everything here is runner-independent and carries over that migration; expect a trivial textual conflict in `docker/docker-compose.yml` and one issue-number collision (both branches created a `2026-08-28-001`) to renumber at merge.
