### PR TITLE
fix(tests): close stdin for fail-open guard checks

### DIFF
--- a/docs/issues/2026-08-29-005-scripts-test-sh-hangs-the-docker-suite-on-cat-holding-inherited-stdin.md
+++ b/docs/issues/2026-08-29-005-scripts-test-sh-hangs-the-docker-suite-on-cat-holding-inherited-stdin.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["bashunit","inherited-descriptors","herdr-task-sync","docker-suite"]
 date: "2026-08-29"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-08-29"
 ---
 
 ## Why this exists
@@ -50,3 +51,7 @@ Impact: `make test-ubuntu` is the only target that applies the checkout before a
 ## Open decisions
 
 - Whether a suite-level guard belongs here as well: a runner that refuses to wait on an inherited stdin pipe would turn this class of hang into a fast failure for every future test, not just these two.
+
+## Resolution
+
+Redirected stdin from /dev/null for the three fail-open guard invocations that expect no payload. Verified both affected tests under an intentionally open stdin pipe, the 258-test scripts suite with no surviving cat in anon_pipe, and make test-ubuntu to completion with exit status 0.

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -3399,7 +3399,7 @@ function test_scripts_119_herdr_task_sync_fail_open_deadline_rejects_late() {
   local HTS_FAIL_OPEN_BASELINE_MULTIPLIER=1
   local HTS_FAIL_OPEN_MAX_SECONDS=5
 
-  run hts_run_fail_open_guard sleep 2
+  run hts_run_fail_open_guard sleep 2 < /dev/null
 
   assert_failure 124
   assert_output --partial "exceeded fail-open behavioral deadline"
@@ -3448,7 +3448,7 @@ function test_scripts_121_herdr_task_sync_fails_open_for_missing_tools_con() {
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
   rmdir "$namespace/tasks"
   printf 'not-a-directory\n' > "$namespace/tasks"
-  run hts_run_fail_open_guard hts_worker_run
+  run hts_run_fail_open_guard hts_worker_run < /dev/null
   assert_success
   [[ "$(hts_record_number "$control" generation)" -gt \
     "$(hts_record_number "$control" committed_generation)" ]] || fail "worker write failure committed its pending generation"
@@ -3469,7 +3469,7 @@ function test_scripts_121_herdr_task_sync_fails_open_for_missing_tools_con() {
   control="$(hts_control_file "$HTS_DEFAULT_SOCKET" pane-1)"
   task_file="$(hts_task_file "$HTS_DEFAULT_SOCKET" pi pane-1 commit-write-failure)"
   mkdir "$task_file"
-  run hts_run_fail_open_guard hts_worker_run
+  run hts_run_fail_open_guard hts_worker_run < /dev/null
   assert_success
   [[ "$(hts_record_number "$control" generation)" -gt \
     "$(hts_record_number "$control" committed_generation)" ]] || fail "task write failure committed its pending generation"
@@ -6893,4 +6893,3 @@ function tear_down_after_script() {
 }
 
 function tear_down() { _bats_run_teardown; }
-

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6893,3 +6893,4 @@ function tear_down_after_script() {
 }
 
 function tear_down() { _bats_run_teardown; }
+


### PR DESCRIPTION
## Summary

The Docker suite no longer stalls after the herdr-task-sync fail-open tests complete. Guard invocations that expect no payload now read from `/dev/null`, so an open bashunit stdin pipe cannot leave `cat` blocked indefinitely.

## Verification

- Reproduced the red state with test 119 blocked on an intentionally open stdin pipe, then verified tests 119 and 121 exit under the same condition.
- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh` completed all 258 tests with no surviving `cat` in `anon_pipe`.
- `make test-ubuntu` completed in Docker with exit status 0.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
