### PR TITLE
test(bashunit): guard the vendored payload-marker parsing patch

### DIFF
--- a/docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-marker-result-parsing.md
+++ b/docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-marker-result-parsing.md
@@ -5,8 +5,9 @@ type: "chore"
 category: "testing-ci"
 tags: ["bashunit","vendored-patch"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-29"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Keep the patch when re-pinning bashunit, or upstream it (github.com/TypedDevs/ba
 ## Open decisions
 
 None.
+
+## Resolution
+
+The patch stays vendored and is now regression-guarded instead of upstreamed: upstreaming to TypedDevs/bashunit remains possible later, but the repo needs protection against a silent re-pin today. Added tests/bashunit/bashunit_late_output_probe_test.sh, a deterministic late-child repro (the child waits for the test subshell to die via a bash-3.2-safe pid probe, then appends output after the payload line on the inherited capture), and tests/bashunit/scripts_test.sh test scripts_259, which runs the probe through the real pinned runner in parallel and sequential modes. Calibrated both states: green on the patched runner; against a de-patched copy (both 'Local patch vs upstream 0.50.1' sites reverted to the blind last-line read) the parallel leg reports a phantom failed test (exit 1) and the sequential leg zeroes the assertion count - both flip scripts_259 red. make test-suite passes with verdict parity to the clean baseline; python3 scripts/check_bats_assertions.py tests is clean.

--- a/docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-marker-result-parsing.md
+++ b/docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-marker-result-parsing.md
@@ -5,7 +5,7 @@ type: "chore"
 category: "testing-ci"
 tags: ["bashunit","vendored-patch"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/tests/bashunit/bashunit_late_output_probe_test.sh
+++ b/tests/bashunit/bashunit_late_output_probe_test.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 # Dedicated one-test fixture for the local bashunit patch "payload-marker
 # result parsing" (docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-
-# patch-payload-marker-result-parsing). A test's background child that
+# patch-payload-marker-result-parsing): a test's background child that
 # inherits the captured stdout can append output after the ##...## payload
-# line; stock upstream 0.50.1 then parses that garbage as the result line and
-# reports a phantom failed test with zero failed assertions and no name.
-# scripts_test.sh runs this file under a nested `tests/lib/bashunit -j`
-# invocation and requires a clean 1-passed verdict, so a re-pin of bashunit
-# that drops the patch (sites marked 'Local patch vs upstream 0.50.1') turns
-# that guard red instead of resurfacing as anonymous CI failures.
+# line, which stock upstream 0.50.1 parses as the result line. The guard is
+# owned by test_scripts_259 in tests/bashunit/scripts_test.sh.
 # Vocabulary (run, assert_*, BATS_* contract) comes from
 # tests/bashunit/test-dsl.bash.
 source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
@@ -23,12 +19,10 @@ function test_late_child_output_lands_after_the_result_payload() {
   # $PPID names that already-dead fork, not this test's subshell.
   local body_pid
   body_pid=$(exec sh -c 'echo $PPID')
-  # The child inherits this test's captured stdout. It waits for the test
-  # subshell to die -- by then bashunit's EXIT trap has written the payload
-  # line to the capture -- then appends noise and closes the descriptor.
-  # Ordering is deterministic: the runner's command substitution (and the
-  # parallel .result writer fed from it) reads the capture to EOF, which it
-  # cannot reach before the noise lands after the payload.
+  # Wait for subshell death, not a sleep: the payload line is written by the
+  # subshell's EXIT trap, so death is the only signal that it already exists.
+  # The runner reads the capture to EOF, which the child's open descriptor
+  # holds back until the noise has landed after the payload.
   (
     while kill -0 "$body_pid" 2>/dev/null; do sleep 0.01; done
     echo "late child noise after the payload line"

--- a/tests/bashunit/bashunit_late_output_probe_test.sh
+++ b/tests/bashunit/bashunit_late_output_probe_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Dedicated one-test fixture for the local bashunit patch "payload-marker
+# result parsing" (docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-
+# patch-payload-marker-result-parsing). A test's background child that
+# inherits the captured stdout can append output after the ##...## payload
+# line; stock upstream 0.50.1 then parses that garbage as the result line and
+# reports a phantom failed test with zero failed assertions and no name.
+# scripts_test.sh runs this file under a nested `tests/lib/bashunit -j`
+# invocation and requires a clean 1-passed verdict, so a re-pin of bashunit
+# that drops the patch (sites marked 'Local patch vs upstream 0.50.1') turns
+# that guard red instead of resurfacing as anonymous CI failures.
+# Vocabulary (run, assert_*, BATS_* contract) comes from
+# tests/bashunit/test-dsl.bash.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+function test_late_child_output_lands_after_the_result_payload() {
+  _bats_test_init 1 'late child output lands after the result payload'
+  # Not $BASHPID: the suite must stay bash-3.2-clean (test-dsl.bash header),
+  # and on macOS bash 3.2 $BASHPID is unset, which would end the child's wait
+  # loop instantly and land the noise harmlessly before the payload. The
+  # `exec` is load-bearing: without it the substitution forks once more and
+  # $PPID names that already-dead fork, not this test's subshell.
+  local body_pid
+  body_pid=$(exec sh -c 'echo $PPID')
+  # The child inherits this test's captured stdout. It waits for the test
+  # subshell to die -- by then bashunit's EXIT trap has written the payload
+  # line to the capture -- then appends noise and closes the descriptor.
+  # Ordering is deterministic: the runner's command substitution (and the
+  # parallel .result writer fed from it) reads the capture to EOF, which it
+  # cannot reach before the noise lands after the payload.
+  (
+    while kill -0 "$body_pid" 2>/dev/null; do sleep 0.01; done
+    echo "late child noise after the payload line"
+  ) &
+  run true
+  assert_success
+}
+
+function set_up_before_script() {
+  :
+}
+
+function tear_down_after_script() {
+  _bats_file_cleanup
+}
+
+function tear_down() { _bats_run_teardown; }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6972,6 +6972,35 @@ function test_scripts_259_hts_teardown_reaps_a_surviving_engine_worker() {
   [[ ! -e "$work" ]] || fail "an engine process resurrected $work after teardown"
 }
 
+# Guards the local patch in the pinned runner itself ('Local patch vs upstream
+# 0.50.1' in tests/lib/bashunit): result parsing takes the last
+# ##TEST_EXIT_CODE=-marked line, not the blind last line, so a test's
+# background child appending output after the payload cannot corrupt the
+# verdict. The probe file makes that late write deterministic; on a stock
+# 0.50.1 runner (a re-pin that dropped the patch) the parallel leg reports a
+# phantom failed test (exit 1) and the sequential leg zeroes the assertion
+# count -- both flip this test red. Calibrated against a de-patched copy in
+# docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-
+# marker-result-parsing.
+function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
+  _bats_test_init 260 'pinned bashunit survives late child output after the result payload'
+  local probe_file="$BATS_TEST_DIRNAME/bashunit/bashunit_late_output_probe_test.sh"
+  assert_file_exists "$probe_file"
+
+  # Parallel leg: aggregate_parallel_results parses the .result file.
+  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
+  assert_success
+  assert_output --partial "Passed: late child output lands after the result payload"
+  assert_output --partial "Assertions: 1 passed, 1 total"
+
+  # Sequential leg: extract_result_counts parses the captured execution
+  # result. Unpatched it stays exit 0 but reports 0 assertions, so the
+  # assertion-count line is the discriminator here, not the status.
+  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
+  assert_success
+  assert_output --partial "Assertions: 1 passed, 1 total"
+}
+
 function set_up_before_script() {
   :
 }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6974,14 +6974,10 @@ function test_scripts_259_hts_teardown_reaps_a_surviving_engine_worker() {
 
 # Guards the local patch in the pinned runner itself ('Local patch vs upstream
 # 0.50.1' in tests/lib/bashunit): result parsing takes the last
-# ##TEST_EXIT_CODE=-marked line, not the blind last line, so a test's
-# background child appending output after the payload cannot corrupt the
-# verdict. The probe file makes that late write deterministic; on a stock
-# 0.50.1 runner (a re-pin that dropped the patch) the parallel leg reports a
-# phantom failed test (exit 1) and the sequential leg zeroes the assertion
-# count -- both flip this test red. Calibrated against a de-patched copy in
-# docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-
-# marker-result-parsing.
+# ##TEST_EXIT_CODE=-marked line, not the blind last line. A re-pin of bashunit
+# that drops the patch turns this test red
+# (docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-
+# marker-result-parsing).
 function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
   _bats_test_init 260 'pinned bashunit survives late child output after the result payload'
   local probe_file="$BATS_TEST_DIRNAME/bashunit/bashunit_late_output_probe_test.sh"


### PR DESCRIPTION
The pinned test runner `tests/lib/bashunit` carries a local patch vs upstream 0.50.1: result parsing takes the last `##TEST_EXIT_CODE=`-marked line instead of the blind last line, so a test's background child that writes to the captured stdout after the payload cannot corrupt the verdict. Until now nothing guarded that patch — a routine re-pin to stock upstream would have dropped it silently and brought back the anonymous phantom CI failures it fixes. This PR makes such a re-pin fail loudly: a new probe fixture (`tests/bashunit/bashunit_late_output_probe_test.sh`) reproduces the late-child write deterministically, and `scripts_259` runs it through the real pinned runner in both parallel and sequential modes.

The probe is deterministic, not sleep-based: the child waits for the test subshell to die (by then the payload line is already written), then appends its noise and closes the capture; the runner's read-to-EOF cannot complete before the noise lands. This closes `docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-patch-payload-marker-result-parsing.md`; the issue's resolution records the calibration below.

## Verification

- Red state proven against a de-patched runner copy (both `Local patch vs upstream 0.50.1` sites reverted to the blind last-line read): the parallel leg reports a phantom failed test with zero failed assertions (exit 1), the sequential leg zeroes the assertion count. With the de-patched copy swapped into `tests/lib/bashunit`, `scripts_259` itself goes red.
- Green state: the patched runner passes the probe in both modes; `scripts_259` passes (6 assertions).
- An independent reviewer agent reproduced the red/green calibration from scratch — 10/10 deterministic in both directions on macOS bash 3.2 — replacing the usual external cross-model peer review, which could not run due to a peer-pane prompt-delivery fault in the review infrastructure.
- `make test-suite` passes with verdict parity to a clean-baseline run (same pre-existing risky-test set, zero failures); `scripts/check_bats_assertions.py` is clean.

## New concepts

**Bash 3.2 `$BASHPID` substitute: `$(exec sh -c 'echo $PPID')`.** macOS ships bash 3.2, which has no `$BASHPID`, and `$$` in a subshell still names the original shell. The probe needs the pid of the test's own subshell so the child can detect its death. `$(exec sh -c 'echo $PPID')` provides it: the command substitution forks once, `exec` replaces that fork with `sh` instead of forking again, so `sh`'s parent is the enclosing subshell. Without `exec`, `$PPID` names the substitution's own short-lived fork — already dead by the time it is checked, which made the first version of the probe silently vacuous. Use it only where bash 3.2 must be supported; on bash 4+, `$BASHPID` is the answer.
