### PR TITLE
perf(ci): lower job timeouts to observed post-minimal-install durations

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -58,9 +58,10 @@ env:
 jobs:
   test-ubuntu:
     runs-on: ubuntu-latest
-    # A normal run takes ~5 min; a hung apt mirror otherwise holds the job
-    # for the 360-min default and burns Actions minutes.
-    timeout-minutes: 15
+    # A normal push/PR run (minimal install) takes ~5 min; the nightly full
+    # install takes ~8 min. A hung apt mirror otherwise holds the job for the
+    # 360-min default and burns Actions minutes.
+    timeout-minutes: 12
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -225,8 +226,9 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
-    # A normal run takes ~10 min; brew install times vary, so keep headroom.
-    timeout-minutes: 25
+    # A normal push/PR run (minimal install) takes ~8-10 min; the nightly full
+    # install takes ~15 min and brew install times vary, so keep headroom.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
+++ b/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
@@ -5,7 +5,7 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]
 date: "2026-08-21"
-status: "open"
+status: "in-progress"
 priority: "low"
 parent-plan: "docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md"
 ---

--- a/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
+++ b/docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md
@@ -1,13 +1,14 @@
 ---
 title: "Revisit the CI timeout-minutes downward once two weeks of minimal-install runs exist"
-short_description: "After two weeks of minimal-install data, the 15-minute Ubuntu and 25-minute macOS ceilings should use observed slow-tail durations while remaining high enough for scheduled full-Brewfile runs."
+short_description: "Recalibrated: test-ubuntu timeout-minutes 15 -> 12 and test-macos 25 -> 20, sized from 9 days of post-minimal-install run data (push/PR minimal and nightly full-Brewfile distributions measured separately)."
 type: "follow-up"
 category: "testing-ci"
 tags: ["testing-ci","follow-up"]
 date: "2026-08-21"
-status: "in-progress"
+status: "done"
 priority: "low"
 parent-plan: "docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md"
+closed: "2026-08-29"
 ---
 
 ## Why this exists
@@ -52,3 +53,7 @@ least watched.
 - Should this wait on `docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md`?
   If the ubuntu job stops running `brew bundle` altogether, or starts putting Linuxbrew on
   `PATH`, its duration changes again and this measurement has to be redone.
+
+## Resolution
+
+Lowered .github/workflows/test-dotfiles.yml timeout-minutes: test-ubuntu 15 -> 12, test-macos 25 -> 20 (commit 8fb43d6). Sized from observed runs 2026-08-21..2026-08-29 via gh run list/view, separating distributions: push/PR minimal installs (test-ubuntu n=31, max 5.3 min; test-macos max 10.7 min) and scheduled nightly full-Brewfile runs (test-ubuntu successes 6.6-7.9 min; test-macos successes 10.8-14.8 min, worst self-completing failure 18.4 min). Chose one event-independent ceiling per job, per this issue's own simplicity bias: 12 is ~1.5x the nightly ubuntu max 7.9; 20 clears the worst observed macos failure 18.4 and is ~1.35x the slow successful tail 14.8. The blocker 2026-08-21-007 (linuxbrew prefix) is done and the sample post-dates it. Caveats recorded honestly: the issue asked for two weeks of data but 9 days were available, judged sufficient because the minimal-run sample is n=31 and stable and the nightly full-run distribution never depended on the CI-minimal change; and the macos margin over the worst self-completing failure is thin (1.6 min), so if a legitimate nightly run is ever timeout-killed near 20 min, raise or split the ceiling by event. Comments in the workflow and the stale cross-reference in tests/helpers/herdr_task_sync.bash were updated to match; cross-model review flagged only record-keeping drift, fixed alongside.

--- a/docs/solutions/design-patterns/skip-set-parity-proves-reduced-dependencies.md
+++ b/docs/solutions/design-patterns/skip-set-parity-proves-reduced-dependencies.md
@@ -126,7 +126,7 @@ Skip sets identical line for line; the one failure identical and pre-existing in
 - `docs/issues/2026-08-21-009-python3-is-both-required-and-optional-in-the-test-suite.md` — open: one `setup()` skip guard silences all 56 tests in `tests/palette.bats`; found by the parity gate, invisible to ordinary CI.
 - `docs/issues/2026-08-21-010-grc-is-vestigial-and-rgrc-was-never-moved-cross-platform.md` — open: `grc` survives only as the accidental python3 carrier — a second face of "the declared dependency set is not the one holding the suite up".
 - `docs/issues/2026-08-21-007-linuxbrew-prefix-unreachable-in-ubuntu-ci-job.md` — open: the inverse miss — 37 installed brew packages no test can reach because the prefix never lands on PATH.
-- `docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md` — open: timeout ceilings still sized for the full install, deliberately left for a separate change so a timeout failure stays attributable.
+- `docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md` — done: ceilings recalibrated to 12 min (ubuntu) / 20 min (macos) from 9 days of post-minimal-install run data; the deliberate separate-change delay kept the timeout failure attributable.
 - `completion-is-not-a-verdict.md` — same family, one layer up: there the runner's completion mark hid a red verdict from the human; here the suite's green hides which tests ran from everyone.
 - `external-review-legs-as-unreliable-subprocesses.md` — same family, machine-side: a step that dies quietly must not read as a clean pass; a test that skips quietly must not read as a passing test.
 - Known pre-existing failure the parity run had to reason around: `docs/issues/2026-08-19-001-make-test-ubuntu-fails-two-tests-on-main.md`.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -768,7 +768,7 @@ export HTS_WAIT_POLLS
 # its pid file. It never fires in a healthy run or in the guarded regression --
 # only a genuine hang reaches it. Sixty seconds is intentionally still a guard,
 # not a performance budget: it is far above the measured dedicated-file run, and
-# far enough below the macOS job's timeout-minutes: 25 that it prints its own
+# far enough below the macOS job's timeout-minutes: 20 that it prints its own
 # message instead of the job being killed with none.
 HTS_INNER_BATS_PROGRESS_SECONDS="${HTS_INNER_BATS_PROGRESS_SECONDS:-60}"
 # EXIT is the assertion, and the only bound here that can fire on a healthy run.


### PR DESCRIPTION
## Summary

The CI job timeout ceilings now match what the jobs actually take since the minimal-install change: `test-ubuntu` 15 → 12 minutes, `test-macos` 25 → 20 minutes. These timeouts are the only bound on a hung apt mirror or a stalled brew download, and both were still sized for the old full-Brewfile install.

## Observed durations (2026-08-21 to 2026-08-29)

Push/PR runs install a minimal Brewfile; scheduled nightly runs still install the full one, so the nightly distribution is the constraint.

| Run class | test-ubuntu | test-macos |
|---|---|---|
| push/PR, minimal install (n=31) | max 5.3 min | max 10.7 min |
| nightly, full Brewfile — successes | 6.6–7.9 min | 10.8–14.8 min |
| nightly — worst self-completing failure | — | 18.4 min |

## Why 12 and 20

One event-independent ceiling per job, sized against the slower nightly class: 12 is roughly 1.5× the nightly ubuntu maximum (7.9 min); 20 clears the worst observed macos failure that completed on its own (18.4 min) and is about 1.35× the slow successful tail (14.8 min).

Two caveats, recorded in the closed issue as well:

- The tracking issue asked for two weeks of data; 9 days existed. Judged sufficient because the minimal-run sample is n=31 and stable, and the nightly full-install distribution never depended on the CI-minimal change.
- The macos margin over the 18.4-min worst self-completing failure is thin (1.6 min). If a legitimate nightly run is ever timeout-killed near 20 minutes, raise the ceiling or split it by event rather than treating the kill as a hang.

## Also in this PR

Closes the tracking record `docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md` with the data above, and updates two references that still described the 15/25 ceilings as current: a guard-margin comment in `tests/helpers/herdr_task_sync.bash` and a cross-reference in `docs/solutions/design-patterns/skip-set-parity-proves-reduced-dependencies.md`.

## Verification

Workflow YAML parses; `make lint` clean; nightly per-job durations re-derived independently from `gh run view` and matched the table above. No behavioral tests apply — a hosted-runner wall-clock budget cannot be asserted locally, so no exact-value test was added.
