### PR TITLE
fix(tests): derive CI/Docker contract tests from consumed behavior

### DIFF
--- a/docs/issues/2026-08-29-008-ci-and-docker-contract-tests-restate-the-config-they-guard.md
+++ b/docs/issues/2026-08-29-008-ci-and-docker-contract-tests-restate-the-config-they-guard.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","test-quality","ci"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -62,3 +63,7 @@ Whether the `timeout-minutes` invariant belongs here or in
 `2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install`. That issue owns the
 ceiling values; this one owns the assertion shape. Adding a presence-only check here does
 not preempt the value decision there.
+
+## Resolution
+
+Rewrote tests/test_ci_workflow.py and tests/test_docker_contract.py to assert derived invariants instead of mirroring config text: cache restore/save trigger sets are computed from the on: block and bound to the MMS_CI_MINIMAL event set (disjoint, covering, role-correct), save uses the save-only action variant with a key findable by a restore-keys prefix at the same per-OS Homebrew cache path; the gitleaks install target is verified against GITHUB_PATH appends preceding the Smithers gate; every job must declare timeout-minutes (values stay owned by 2026-08-21-008); make test-ubuntu is resolved to its compose service which must run chezmoi apply, make test-smithers, and run-post-apply full (line-anchored); apply services must set MMS_DISPOSABLE_HOME=1 and HOMEBREW_BUNDLE_NO_UPGRADE=1 (derived over all services); the staging shell is executed under a temp root built from the declared volume mounts. Calibrated red on 15 targeted mutations and green on a behavior-preserving fromJSON rewrite; hardened after a two-peer (Sonnet + Terra) cross-model review.

--- a/docs/issues/2026-08-29-008-ci-and-docker-contract-tests-restate-the-config-they-guard.md
+++ b/docs/issues/2026-08-29-008-ci-and-docker-contract-tests-restate-the-config-they-guard.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","test-quality","ci"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -44,6 +44,11 @@ class TestDotfilesWorkflow(unittest.TestCase):
         self.assertIsNotNone(match, "step must be gated by an if: condition")
         expr = match.group("expr")
         self.assertIn("github.event_name", expr)
+        # The positive-membership assumption cannot survive negation; reject
+        # such conditions instead of silently misreading them as selections.
+        self.assertNotIn(
+            "!", expr, "negated condition breaks this parser's assumption: %s" % expr
+        )
         selected = {
             event
             for event in declared
@@ -67,6 +72,20 @@ class TestDotfilesWorkflow(unittest.TestCase):
         text = self.workflow_text()
         declared = self.declared_triggers(text)
 
+        # The minimal-install selector defines which events are ordinary runs;
+        # exactly those may restore old downloads, and the remaining
+        # full-verification events must fetch from upstream and save. Deriving
+        # the restore set from MMS_CI_MINIMAL also rejects a swap of the two
+        # conditions, which a bare partition check would accept.
+        minimal_line = re.search(r"^  MMS_CI_MINIMAL: (?P<expr>.+)$", text, re.MULTILINE)
+        self.assertIsNotNone(minimal_line, "workflow must declare MMS_CI_MINIMAL")
+        minimal_events = {
+            event
+            for event in declared
+            if re.search(r"\b%s\b" % re.escape(event), minimal_line.group("expr"))
+        }
+        self.assertTrue(minimal_events, "no declared trigger selects the minimal install")
+
         for job_name in ("test-ubuntu", "test-macos"):
             with self.subTest(job=job_name):
                 job = self.job_block(text, job_name)
@@ -77,14 +96,14 @@ class TestDotfilesWorkflow(unittest.TestCase):
                 save_events = self.events_selected_by_condition(save, declared)
 
                 self.assertEqual(
-                    restore_events & save_events,
-                    set(),
-                    "an event must not both restore old downloads and save them back",
+                    restore_events,
+                    minimal_events,
+                    "only ordinary minimal-install events may restore old downloads",
                 )
                 self.assertEqual(
-                    restore_events | save_events,
-                    declared,
-                    "every declared trigger must be covered by exactly one cache step",
+                    save_events,
+                    declared - minimal_events,
+                    "every full-verification event must save fresh downloads",
                 )
 
                 # The save-only step must use the save-only action variant, or
@@ -98,11 +117,16 @@ class TestDotfilesWorkflow(unittest.TestCase):
                 # Cache identity: the save step must write the path the restore
                 # step reads, and the key it saves under must be findable by at
                 # least one restore-keys prefix — otherwise saved entries are
-                # dead weight.
-                self.assertEqual(
-                    self.step_value(restore, "path"),
-                    self.step_value(save, "path"),
-                )
+                # dead weight. The per-OS fragment is Homebrew's own contract:
+                # it reads its downloads cache from a fixed per-OS location, so
+                # a swapped or invented path warms nothing.
+                restore_path = self.step_value(restore, "path")
+                self.assertEqual(restore_path, self.step_value(save, "path"))
+                expected_fragment = {
+                    "test-ubuntu": ".cache/Homebrew",
+                    "test-macos": "Library/Caches/Homebrew",
+                }[job_name]
+                self.assertIn(expected_fragment, restore_path)
                 save_key = self.step_value(save, "key")
                 restore_keys_block = re.search(
                     r"^          restore-keys: \|\n(?P<keys>(?:^            .+\n?)+)",
@@ -134,14 +158,18 @@ class TestDotfilesWorkflow(unittest.TestCase):
         target = re.search(r"tar\s[^\n]*-C\s+\"?(?P<dir>[^\s\"]+)", script.group("body"))
         self.assertIsNotNone(target, "install script must extract into an explicit directory")
 
+        gate_position = job.index("      - name: Run the Smithers test gate")
         path_appends = {
-            entry.strip()
-            for entry in re.findall(r'echo\s+"?([^"\n]+?)"?\s*>>\s*"?\$GITHUB_PATH', job)
+            append.group(1).strip()
+            for append in re.finditer(r'echo\s+"?([^"\n]+?)"?\s*>>\s*"?\$GITHUB_PATH', job)
+            # $GITHUB_PATH takes effect from the next step on, so an append
+            # after the gate cannot make the scanner resolvable for it.
+            if append.start() < gate_position
         }
         self.assertIn(
             target.group("dir"),
             path_appends,
-            "gitleaks lands in a directory the workflow never puts on $GITHUB_PATH",
+            "gitleaks lands in a directory no step before the Smithers gate puts on $GITHUB_PATH",
         )
 
         self.assertNotIn(

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -11,6 +11,11 @@ class TestDotfilesWorkflow(unittest.TestCase):
     def workflow_text(self):
         return WORKFLOW.read_text(encoding="utf-8")
 
+    def job_names(self, text):
+        jobs = re.search(r"^jobs:\n(?P<body>.*)\Z", text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(jobs, "workflow must declare a jobs block")
+        return re.findall(r"^  ([a-zA-Z0-9_-]+):\n", jobs.group("body"), re.MULTILINE)
+
     def job_block(self, text, job_name):
         pattern = r"^  %s:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)" % re.escape(job_name)
         match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
@@ -23,42 +28,122 @@ class TestDotfilesWorkflow(unittest.TestCase):
         self.assertIsNotNone(match, "%s step is missing" % step_name)
         return match.group("body")
 
-    def test_full_brewfile_verification_does_not_restore_homebrew_downloads(self):
-        text = self.workflow_text()
-        expected = {
-            "test-ubuntu": "~/.cache/Homebrew/downloads",
-            "test-macos": "~/Library/Caches/Homebrew/downloads",
-        }
+    def declared_triggers(self, text):
+        block = re.search(r"^on:\n(?P<body>.*?)(?=^\S)", text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(block, "workflow must declare an on: block")
+        triggers = set(re.findall(r"^  ([a-zA-Z_]+):", block.group("body"), re.MULTILINE))
+        self.assertTrue(triggers, "no triggers parsed from the on: block")
+        return triggers
 
-        for job_name, cache_path in expected.items():
+    def events_selected_by_condition(self, step, declared):
+        """Events a step's `if:` condition selects, as a subset of the declared
+        triggers. Assumes the condition is a positive membership test over
+        `github.event_name` (any spelling: `==` chains, fromJSON lists), which
+        every trigger-gated step in this workflow uses."""
+        match = re.search(r"^        if: (?P<expr>.+)$", step, re.MULTILINE)
+        self.assertIsNotNone(match, "step must be gated by an if: condition")
+        expr = match.group("expr")
+        self.assertIn("github.event_name", expr)
+        selected = {
+            event
+            for event in declared
+            if re.search(r"\b%s\b" % re.escape(event), expr)
+        }
+        self.assertTrue(selected, "condition selects none of the declared triggers: %s" % expr)
+        return selected
+
+    def step_value(self, step, key, indent="          "):
+        match = re.search(r"^%s%s: (.+)$" % (indent, re.escape(key)), step, re.MULTILINE)
+        self.assertIsNotNone(match, "step must set %s" % key)
+        return match.group(1).strip()
+
+    def test_cache_restore_and_save_triggers_partition_the_declared_set(self):
+        # The real invariant behind the cache steps: full-Brewfile verification
+        # events must fetch from upstream (no restore) but still seed the cache
+        # (save), while ordinary events restore. So the restore-trigger set and
+        # the save-trigger set must be disjoint and together cover every
+        # declared trigger — read from the on: block, so a newly added trigger
+        # that neither step accounts for turns this red.
+        text = self.workflow_text()
+        declared = self.declared_triggers(text)
+
+        for job_name in ("test-ubuntu", "test-macos"):
             with self.subTest(job=job_name):
                 job = self.job_block(text, job_name)
                 restore = self.named_step_block(job, "Restore Homebrew downloads cache")
                 save = self.named_step_block(job, "Save Homebrew downloads cache")
 
-                self.assertIn("uses: actions/cache@v4", restore)
-                self.assertIn(
-                    "if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}",
-                    restore,
-                    "schedule and workflow_dispatch full-Brewfile runs must fetch from upstream, not restore old Homebrew downloads",
-                )
-                self.assertIn("path: %s" % cache_path, restore)
-                self.assertIn("uses: actions/cache/save@v4", save)
-                self.assertIn(
-                    "if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}",
-                    save,
-                    "full-Brewfile runs should save fresh upstream downloads only after the verification succeeds",
-                )
-                self.assertIn("path: %s" % cache_path, save)
+                restore_events = self.events_selected_by_condition(restore, declared)
+                save_events = self.events_selected_by_condition(save, declared)
 
-    def test_ubuntu_provisions_gitleaks_outside_skipped_linuxbrew(self):
+                self.assertEqual(
+                    restore_events & save_events,
+                    set(),
+                    "an event must not both restore old downloads and save them back",
+                )
+                self.assertEqual(
+                    restore_events | save_events,
+                    declared,
+                    "every declared trigger must be covered by exactly one cache step",
+                )
+
+                # The save-only step must use the save-only action variant, or
+                # scheduled runs would restore an old archive and mask upstream
+                # fetch decay; the restore step must not be save-only.
+                restore_uses = self.step_value(restore, "uses", indent="        ")
+                save_uses = self.step_value(save, "uses", indent="        ")
+                self.assertIn("/save", save_uses)
+                self.assertNotIn("/save", restore_uses)
+
+                # Cache identity: the save step must write the path the restore
+                # step reads, and the key it saves under must be findable by at
+                # least one restore-keys prefix — otherwise saved entries are
+                # dead weight.
+                self.assertEqual(
+                    self.step_value(restore, "path"),
+                    self.step_value(save, "path"),
+                )
+                save_key = self.step_value(save, "key")
+                restore_keys_block = re.search(
+                    r"^          restore-keys: \|\n(?P<keys>(?:^            .+\n?)+)",
+                    restore,
+                    re.MULTILINE,
+                )
+                self.assertIsNotNone(restore_keys_block, "restore step must declare restore-keys")
+                prefixes = [
+                    line.strip()
+                    for line in restore_keys_block.group("keys").splitlines()
+                    if line.strip()
+                ]
+                self.assertTrue(
+                    any(save_key.startswith(prefix) for prefix in prefixes),
+                    "no restore-keys prefix can find the key the save step writes: %s" % save_key,
+                )
+
+    def test_ubuntu_provisions_gitleaks_on_a_path_later_steps_resolve(self):
+        # The property behind the install step: the directory gitleaks is
+        # extracted into must be one this job also appends to $GITHUB_PATH,
+        # or the Smithers gate cannot resolve the scanner. Derived from the
+        # scripts instead of mirroring the download URL or version pin.
         text = self.workflow_text()
         job = self.job_block(text, "test-ubuntu")
         install = self.named_step_block(job, "Install gitleaks")
 
-        self.assertIn("gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz", install)
-        self.assertIn('$HOME/.local/bin', install)
-        self.assertIn("gitleaks version", install)
+        script = re.search(r"^        run: \|\n(?P<body>(?:^          .*\n?)*)", install, re.MULTILINE)
+        self.assertIsNotNone(script, "Install gitleaks must be a multi-line run script")
+        target = re.search(r"tar\s[^\n]*-C\s+\"?(?P<dir>[^\s\"]+)", script.group("body"))
+        self.assertIsNotNone(target, "install script must extract into an explicit directory")
+
+        path_appends = {
+            entry.strip()
+            for entry in re.findall(r'echo\s+"?([^"\n]+?)"?\s*>>\s*"?\$GITHUB_PATH', job)
+        }
+        self.assertIn(
+            target.group("dir"),
+            path_appends,
+            "gitleaks lands in a directory the workflow never puts on $GITHUB_PATH",
+        )
+
         self.assertNotIn(
             "brew install",
             install,
@@ -68,6 +153,21 @@ class TestDotfilesWorkflow(unittest.TestCase):
             job.index("      - name: Install gitleaks"),
             job.index("      - name: Run the Smithers test gate"),
         )
+
+    def test_every_job_declares_a_timeout(self):
+        # Presence only; the ceiling values are owned by issue
+        # 2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.
+        # Without a declared timeout a hung job burns the 360-minute default.
+        text = self.workflow_text()
+        names = self.job_names(text)
+        self.assertGreaterEqual(len(names), 3, "job parser found fewer jobs than the workflow runs")
+        for name in names:
+            with self.subTest(job=name):
+                self.assertRegex(
+                    self.job_block(text, name),
+                    r"(?m)^    timeout-minutes: \d+",
+                    "%s job must declare timeout-minutes" % name,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -63,20 +63,14 @@ class TestDotfilesWorkflow(unittest.TestCase):
         return match.group(1).strip()
 
     def test_cache_restore_and_save_triggers_partition_the_declared_set(self):
-        # The real invariant behind the cache steps: full-Brewfile verification
-        # events must fetch from upstream (no restore) but still seed the cache
-        # (save), while ordinary events restore. So the restore-trigger set and
-        # the save-trigger set must be disjoint and together cover every
-        # declared trigger — read from the on: block, so a newly added trigger
-        # that neither step accounts for turns this red.
+        # Full-Brewfile verification events must fetch from upstream (no
+        # restore) but still seed the cache; only ordinary events may restore.
         text = self.workflow_text()
         declared = self.declared_triggers(text)
 
-        # The minimal-install selector defines which events are ordinary runs;
-        # exactly those may restore old downloads, and the remaining
-        # full-verification events must fetch from upstream and save. Deriving
-        # the restore set from MMS_CI_MINIMAL also rejects a swap of the two
-        # conditions, which a bare partition check would accept.
+        # MMS_CI_MINIMAL defines which events are ordinary runs. Deriving the
+        # restore set from it rejects a swap of the two conditions, which a
+        # bare partition check would accept.
         minimal_line = re.search(r"^  MMS_CI_MINIMAL: (?P<expr>.+)$", text, re.MULTILINE)
         self.assertIsNotNone(minimal_line, "workflow must declare MMS_CI_MINIMAL")
         minimal_events = {
@@ -106,20 +100,16 @@ class TestDotfilesWorkflow(unittest.TestCase):
                     "every full-verification event must save fresh downloads",
                 )
 
-                # The save-only step must use the save-only action variant, or
-                # scheduled runs would restore an old archive and mask upstream
-                # fetch decay; the restore step must not be save-only.
+                # A save step that can also restore would let scheduled runs
+                # pull an old archive and mask upstream fetch decay.
                 restore_uses = self.step_value(restore, "uses", indent="        ")
                 save_uses = self.step_value(save, "uses", indent="        ")
                 self.assertIn("/save", save_uses)
                 self.assertNotIn("/save", restore_uses)
 
-                # Cache identity: the save step must write the path the restore
-                # step reads, and the key it saves under must be findable by at
-                # least one restore-keys prefix — otherwise saved entries are
-                # dead weight. The per-OS fragment is Homebrew's own contract:
-                # it reads its downloads cache from a fixed per-OS location, so
-                # a swapped or invented path warms nothing.
+                # A saved entry no restore-keys prefix can find is dead weight.
+                # The per-OS path fragment is Homebrew's own contract: a
+                # swapped or invented path warms nothing.
                 restore_path = self.step_value(restore, "path")
                 self.assertEqual(restore_path, self.step_value(save, "path"))
                 expected_fragment = {
@@ -145,10 +135,8 @@ class TestDotfilesWorkflow(unittest.TestCase):
                 )
 
     def test_ubuntu_provisions_gitleaks_on_a_path_later_steps_resolve(self):
-        # The property behind the install step: the directory gitleaks is
-        # extracted into must be one this job also appends to $GITHUB_PATH,
-        # or the Smithers gate cannot resolve the scanner. Derived from the
-        # scripts instead of mirroring the download URL or version pin.
+        # A gitleaks binary in a directory never appended to $GITHUB_PATH is
+        # unresolvable for the Smithers gate.
         text = self.workflow_text()
         job = self.job_block(text, "test-ubuntu")
         install = self.named_step_block(job, "Install gitleaks")
@@ -183,9 +171,8 @@ class TestDotfilesWorkflow(unittest.TestCase):
         )
 
     def test_every_job_declares_a_timeout(self):
-        # Presence only; the ceiling values are owned by issue
-        # 2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.
-        # Without a declared timeout a hung job burns the 360-minute default.
+        # Presence only — ceiling values are owned by issue 2026-08-21-008.
+        # A job without a timeout burns the 360-minute default when it hangs.
         text = self.workflow_text()
         names = self.job_names(text)
         self.assertGreaterEqual(len(names), 3, "job parser found fewer jobs than the workflow runs")

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -39,12 +39,14 @@ class TestDockerContract(unittest.TestCase):
             line[8:] for line in match.group("script").splitlines()
         ) + "\n"
 
-    def service_env_names(self, service):
+    def service_env(self, service):
         block = re.search(
             r"^    environment:\n(?P<body>(?:^      .*\n)+)", service, re.MULTILINE
         )
         self.assertIsNotNone(block, "service must declare an environment block")
-        return set(re.findall(r"^      - ([A-Za-z_]+)=", block.group("body"), re.MULTILINE))
+        return dict(
+            re.findall(r"^      - ([A-Za-z_]+)=(.*)$", block.group("body"), re.MULTILINE)
+        )
 
     def service_volumes(self, service):
         block = re.search(
@@ -83,8 +85,10 @@ class TestDockerContract(unittest.TestCase):
         service_name = run.group("service")
         script = self.service_command_script(self.service_block(service_name))
         self.assertIsNotNone(script, "%s must run a scripted command, not an interactive shell" % service_name)
-        self.assertIn("chezmoi apply", script)
-        self.assertIn("tests/run-post-apply.sh full", script)
+        # Line-anchored so a comment or an echo that merely mentions the
+        # command cannot satisfy the assertion.
+        self.assertRegex(script, r"(?m)^\s*chezmoi apply\b")
+        self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
 
     def test_apply_services_run_the_canonical_gates(self):
         # Gate integrity: every service that runs a real apply must finish with
@@ -94,8 +98,10 @@ class TestDockerContract(unittest.TestCase):
         for name in self.apply_service_names():
             with self.subTest(service=name):
                 script = self.service_command_script(self.service_block(name))
-                self.assertIn("make test-smithers", script)
-                self.assertIn("tests/run-post-apply.sh full", script)
+                # Line-anchored so a comment or echo mentioning the command
+                # does not satisfy the gate check.
+                self.assertRegex(script, r"(?m)^\s*make test-smithers\b")
+                self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
 
     def test_apply_services_declare_disposable_home_and_frozen_brew_bundle(self):
         # Derived over all services rather than two named ones: a real apply
@@ -105,9 +111,9 @@ class TestDockerContract(unittest.TestCase):
         # surfaces as wall-clock/network flakiness).
         for name in self.apply_service_names():
             with self.subTest(service=name):
-                env = self.service_env_names(self.service_block(name))
-                self.assertIn("MMS_DISPOSABLE_HOME", env)
-                self.assertIn("HOMEBREW_BUNDLE_NO_UPGRADE", env)
+                env = self.service_env(self.service_block(name))
+                self.assertEqual(env.get("MMS_DISPOSABLE_HOME"), "1")
+                self.assertEqual(env.get("HOMEBREW_BUNDLE_NO_UPGRADE"), "1")
 
     def test_staging_lands_issue_cli_docs_and_makefile_in_the_worktree(self):
         # Execute the extracted staging commands under a temp root instead of
@@ -125,7 +131,7 @@ class TestDockerContract(unittest.TestCase):
                         break
                     staging_lines.append(line)
                 staging = "\n".join(staging_lines)
-                self.assertIn("mkdir", staging, "no staging commands found before the cd")
+                self.assertTrue(staging.strip(), "no staging commands found before the cd")
 
                 with tempfile.TemporaryDirectory() as tmp:
                     root = Path(tmp)

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import re
+import subprocess
+import tempfile
 import unittest
 
 
@@ -14,49 +16,145 @@ class TestDockerContract(unittest.TestCase):
         cls.makefile = MAKEFILE.read_text(encoding="utf-8")
         cls.compose = COMPOSE.read_text(encoding="utf-8")
 
+    def service_names(self):
+        names = re.findall(r"^  ([a-zA-Z0-9_-]+):\n", self.compose, re.MULTILINE)
+        self.assertTrue(names, "no services parsed from docker-compose.yml")
+        return names
+
     def service_block(self, service_name):
         pattern = r"^  %s:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|^\S|\Z)" % re.escape(service_name)
         match = re.search(pattern, self.compose, re.MULTILINE | re.DOTALL)
         self.assertIsNotNone(match, "docker-compose.yml must define the %s service" % service_name)
         return match.group("body")
 
-    def test_make_test_ubuntu_uses_clearly_named_full_apply_service(self):
-        target = re.search(r"^test-ubuntu:.*\n\t(?P<command>[^\n]+)", self.makefile, re.MULTILINE)
-        self.assertIsNotNone(target, "Makefile must define the test-ubuntu target")
-        self.assertIn(
-            "docker compose -f docker/docker-compose.yml run --rm test-ubuntu",
-            target.group("command"),
-            "make test-ubuntu must not route through a misleading service name",
+    def service_command_script(self, service):
+        match = re.search(
+            r"^    command:\n      - \|\n(?P<script>(?:^        .*\n|^\n)*)",
+            service,
+            re.MULTILINE,
+        )
+        if match is None:
+            return None
+        return "\n".join(
+            line[8:] for line in match.group("script").splitlines()
+        ) + "\n"
+
+    def service_env_names(self, service):
+        block = re.search(
+            r"^    environment:\n(?P<body>(?:^      .*\n)+)", service, re.MULTILINE
+        )
+        self.assertIsNotNone(block, "service must declare an environment block")
+        return set(re.findall(r"^      - ([A-Za-z_]+)=", block.group("body"), re.MULTILINE))
+
+    def service_volumes(self, service):
+        block = re.search(
+            r"^    volumes:\n(?P<body>(?:^      - .+\n)+)", service, re.MULTILINE
+        )
+        self.assertIsNotNone(block, "service must declare volume mounts")
+        return re.findall(
+            r"^      - ([^:\n]+):([^:\n]+?)(?::ro)?$", block.group("body"), re.MULTILINE
         )
 
-        self.assertRegex(self.compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
-        self.assertNotRegex(self.compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
-        self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", self.compose)
-        # No compose-text check for idempotent_test.sh: it appears only in
-        # comments there; tests/test_post_apply_suite_contract.py owns its
-        # reachability.
-
-    def test_full_suite_services_stage_issue_cli_and_use_canonical_smithers_gate(self):
-        required = [
-            "../scripts/issues:/home/testuser/issues-cli:ro",
-            "../docs/issues:/home/testuser/issues:ro",
-            "../Makefile:/home/testuser/Makefile:ro",
-            "mkdir -p /home/testuser/worktree/.git /home/testuser/worktree/docs /home/testuser/worktree/scripts",
-            "cp /home/testuser/issues-cli /home/testuser/worktree/scripts/issues",
-            "cp -r /home/testuser/issues /home/testuser/worktree/docs/issues",
-            "cp /home/testuser/Makefile /home/testuser/worktree/Makefile",
-            "make test-smithers",
-            # The container proves dependency presence; upgrading against
-            # upstream drift is not its job and costs ~30s per run. A silent
-            # revert would only surface as wall-clock/network flakiness.
-            "HOMEBREW_BUNDLE_NO_UPGRADE=1",
+    def apply_service_names(self):
+        names = [
+            name
+            for name in self.service_names()
+            if "chezmoi apply" in (self.service_command_script(self.service_block(name)) or "")
         ]
+        # Control: the derived loop below must actually cover the two full-run
+        # services, not pass vacuously over an empty selection.
+        self.assertGreaterEqual(len(names), 2, "expected at least two full-apply services")
+        return names
 
-        for service_name in ("test-full", "test-ubuntu"):
-            with self.subTest(service=service_name):
-                service = self.service_block(service_name)
-                for contract_line in required:
-                    self.assertIn(contract_line, service)
+    def test_make_test_ubuntu_routes_to_a_full_apply_service(self):
+        # Derived from what the Makefile actually runs: resolve the service the
+        # target names, then require that service to exist and perform the real
+        # contract — apply the checkout and run the full post-apply suite
+        # (the `full` argument is run-post-apply.sh's CLI contract and is what
+        # includes tests/bashunit/idempotent_test.sh).
+        target = re.search(r"^test-ubuntu:.*\n\t(?P<command>.+)$", self.makefile, re.MULTILINE)
+        self.assertIsNotNone(target, "Makefile must define the test-ubuntu target")
+        run = re.search(
+            r"docker compose -f docker/docker-compose\.yml run\s+(?:-\S+\s+)*(?P<service>[a-zA-Z0-9_-]+)\s*$",
+            target.group("command"),
+        )
+        self.assertIsNotNone(run, "make test-ubuntu must run a docker compose service")
+
+        service_name = run.group("service")
+        script = self.service_command_script(self.service_block(service_name))
+        self.assertIsNotNone(script, "%s must run a scripted command, not an interactive shell" % service_name)
+        self.assertIn("chezmoi apply", script)
+        self.assertIn("tests/run-post-apply.sh full", script)
+
+    def test_apply_services_run_the_canonical_gates(self):
+        # Gate integrity: every service that runs a real apply must finish with
+        # the canonical Smithers gate and the full post-apply suite instead of
+        # a partial command list (docs/solutions/design-patterns/
+        # semantic-regression-tests-over-source-shape.md).
+        for name in self.apply_service_names():
+            with self.subTest(service=name):
+                script = self.service_command_script(self.service_block(name))
+                self.assertIn("make test-smithers", script)
+                self.assertIn("tests/run-post-apply.sh full", script)
+
+    def test_apply_services_declare_disposable_home_and_frozen_brew_bundle(self):
+        # Derived over all services rather than two named ones: a real apply
+        # needs MMS_DISPOSABLE_HOME (idempotent_test.sh hard-fails in a
+        # container without it) and HOMEBREW_BUNDLE_NO_UPGRADE (the container
+        # proves dependency presence, not upstream drift; a silent revert only
+        # surfaces as wall-clock/network flakiness).
+        for name in self.apply_service_names():
+            with self.subTest(service=name):
+                env = self.service_env_names(self.service_block(name))
+                self.assertIn("MMS_DISPOSABLE_HOME", env)
+                self.assertIn("HOMEBREW_BUNDLE_NO_UPGRADE", env)
+
+    def test_staging_lands_issue_cli_docs_and_makefile_in_the_worktree(self):
+        # Execute the extracted staging commands under a temp root instead of
+        # mirroring their text: sources are created exactly where the declared
+        # volume mounts put them, so a cp that references a path no mount
+        # provides — or a dropped mount — fails here, and the assertions check
+        # the staged worktree, not the script's wording.
+        for name in self.apply_service_names():
+            with self.subTest(service=name):
+                service = self.service_block(name)
+                script = self.service_command_script(service)
+                staging_lines = []
+                for line in script.splitlines():
+                    if line.strip().startswith("cd "):
+                        break
+                    staging_lines.append(line)
+                staging = "\n".join(staging_lines)
+                self.assertIn("mkdir", staging, "no staging commands found before the cd")
+
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    for source, destination in self.service_volumes(service):
+                        host = (COMPOSE.parent / source).resolve()
+                        self.assertTrue(
+                            host.exists(),
+                            "volume mount source %s does not exist in the repository" % source,
+                        )
+                        target = root / destination.lstrip("/")
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        if host.is_dir():
+                            target.mkdir()
+                            (target / "mount-marker").write_text(source)
+                        else:
+                            target.write_text(source)
+
+                    result = subprocess.run(
+                        ["bash", "-c", staging.replace("/home/testuser", str(root / "home/testuser"))],
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+                    worktree = root / "home/testuser/worktree"
+                    self.assertTrue((worktree / "scripts/issues").is_file())
+                    self.assertTrue((worktree / "docs/issues/mount-marker").is_file())
+                    self.assertTrue((worktree / "Makefile").is_file())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -63,17 +63,14 @@ class TestDockerContract(unittest.TestCase):
             for name in self.service_names()
             if "chezmoi apply" in (self.service_command_script(self.service_block(name)) or "")
         ]
-        # Control: the derived loop below must actually cover the two full-run
-        # services, not pass vacuously over an empty selection.
+        # An empty selection would let every caller pass vacuously.
         self.assertGreaterEqual(len(names), 2, "expected at least two full-apply services")
         return names
 
     def test_make_test_ubuntu_routes_to_a_full_apply_service(self):
-        # Derived from what the Makefile actually runs: resolve the service the
-        # target names, then require that service to exist and perform the real
-        # contract — apply the checkout and run the full post-apply suite
-        # (the `full` argument is run-post-apply.sh's CLI contract and is what
-        # includes tests/bashunit/idempotent_test.sh).
+        # No compose-text check for idempotent_test.sh: its only matches in
+        # docker-compose.yml are comments. Reachability is owned by
+        # tests/test_post_apply_suite_contract.py.
         target = re.search(r"^test-ubuntu:.*\n\t(?P<command>.+)$", self.makefile, re.MULTILINE)
         self.assertIsNotNone(target, "Makefile must define the test-ubuntu target")
         run = re.search(
@@ -91,10 +88,8 @@ class TestDockerContract(unittest.TestCase):
         self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
 
     def test_apply_services_run_the_canonical_gates(self):
-        # Gate integrity: every service that runs a real apply must finish with
-        # the canonical Smithers gate and the full post-apply suite instead of
-        # a partial command list (docs/solutions/design-patterns/
-        # semantic-regression-tests-over-source-shape.md).
+        # Partial per-service command lists once let a green run skip parts of
+        # the canonical gates.
         for name in self.apply_service_names():
             with self.subTest(service=name):
                 script = self.service_command_script(self.service_block(name))
@@ -104,11 +99,9 @@ class TestDockerContract(unittest.TestCase):
                 self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
 
     def test_apply_services_declare_disposable_home_and_frozen_brew_bundle(self):
-        # Derived over all services rather than two named ones: a real apply
-        # needs MMS_DISPOSABLE_HOME (idempotent_test.sh hard-fails in a
-        # container without it) and HOMEBREW_BUNDLE_NO_UPGRADE (the container
-        # proves dependency presence, not upstream drift; a silent revert only
-        # surfaces as wall-clock/network flakiness).
+        # idempotent_test.sh hard-fails in a container without
+        # MMS_DISPOSABLE_HOME; without HOMEBREW_BUNDLE_NO_UPGRADE a revert to
+        # drift-chasing surfaces only as wall-clock/network flakiness.
         for name in self.apply_service_names():
             with self.subTest(service=name):
                 env = self.service_env(self.service_block(name))
@@ -116,11 +109,9 @@ class TestDockerContract(unittest.TestCase):
                 self.assertEqual(env.get("HOMEBREW_BUNDLE_NO_UPGRADE"), "1")
 
     def test_staging_lands_issue_cli_docs_and_makefile_in_the_worktree(self):
-        # Execute the extracted staging commands under a temp root instead of
-        # mirroring their text: sources are created exactly where the declared
-        # volume mounts put them, so a cp that references a path no mount
-        # provides — or a dropped mount — fails here, and the assertions check
-        # the staged worktree, not the script's wording.
+        # Sources are created where the declared volume mounts put them, so a
+        # cp referencing a path no mount provides — or a dropped mount — fails
+        # here.
         for name in self.apply_service_names():
             with self.subTest(service=name):
                 service = self.service_block(name)


### PR DESCRIPTION
## Summary

The contract tests for the CI workflow and the Docker suite (`tests/test_ci_workflow.py`, `tests/test_docker_contract.py`) now assert the invariants CI and Docker actually consume, so they go red on real regressions and stay green through behavior-preserving rewrites. Before, four of their six tests asserted verbatim copies of `test-dotfiles.yml`, `docker-compose.yml`, and `Makefile` lines. That shape had both failure modes of a tautological test: rewriting a trigger condition to the equivalent `contains(fromJSON('["push","pull_request"]'), github.event_name)` broke them, while an uncovered new trigger, a flipped env value, or a gate command demoted to an `echo` passed. One assertion was satisfied only by comments: `idempotent_test.sh` appears in `docker-compose.yml` solely inside comment lines, so the check could never fail.

## Derived invariants

- Cache trigger sets are parsed from the steps' `if:` conditions and the declared `on:` block: the restore set must equal the `MMS_CI_MINIMAL` (ordinary-run) event set, and the save set must cover every remaining declared trigger — so a newly added trigger nobody accounted for, or a restore/save role swap, fails. Conditions using negation are rejected instead of misread.
- Cache identity: restore and save use the same path (with the per-OS Homebrew cache fragment, which is Homebrew's own contract), the save step uses the save-only action variant, and the saved key is findable by a restore-keys prefix.
- The gitleaks install's tar target directory must be appended to `$GITHUB_PATH` by a step that precedes the Smithers gate.
- Every job declares `timeout-minutes` (presence only; the ceiling values stay owned by `docs/issues/2026-08-21-008-revisit-ci-timeout-minutes-after-minimal-install.md`).
- `make test-ubuntu` is resolved to the compose service it actually runs; that service and every apply service must run `chezmoi apply`, `make test-smithers`, and `tests/run-post-apply.sh full` as executable lines (line-anchored, so comments and echoes do not satisfy them), and must set `MMS_DISPOSABLE_HOME=1` and `HOMEBREW_BUNDLE_NO_UPGRADE=1` — checked over all services, not two named ones.
- The compose staging shell is executed for real under a temp root built from each service's declared volume mounts, and the staged worktree is inspected afterwards — a dropped mount or a wrong `cp` path fails the run instead of passing a text search.

## Verification

- `make test-issues`: 44 tests OK.
- Red calibration: 15 targeted production mutations (dropped or added triggers, swapped restore/save roles, swapped per-OS cache paths, negated condition, PATH append moved after the gate, removed timeout, dropped staging copy, dropped volume mount, env value flipped to 0, gate command wrapped in `echo`, target rerouted to the interactive service) each turned the suite red.
- Green control: the behavior-preserving `fromJSON` rewrite of the trigger condition — which reddened the old tests — stays green.
- Two independent cross-model reviews (Claude Sonnet and GPT Terra) of the first commit produced six accepted findings; the second commit applies them, each hardened assertion calibrated red on its own mutation.

## Known limitations

- The tests parse the YAML with regexes, not a YAML parser: a semantically neutral reformat (changed indentation, reordered keys) can redden them.
- The apply-service selector matches the literal line `chezmoi apply`; a future service invoking chezmoi through a wrapper script would silently drop out of the derived checks.

Closes repository issue `docs/issues/2026-08-29-008-ci-and-docker-contract-tests-restate-the-config-they-guard.md` (closure recorded in the same range).
