### PR TITLE
fix(tests): replace prose assertions with marker wire-format round-trips

### DIFF
--- a/docs/issues/2026-08-29-007-two-suites-assert-markdown-prose-instead-of-behavior.md
+++ b/docs/issues/2026-08-29-007-two-suites-assert-markdown-prose-instead-of-behavior.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","test-quality","documentation"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -53,3 +54,7 @@ Run `make test-suite`, then `make test-ubuntu`.
 Whether the child-supervision markers documented in `child-agent-contract.md` are a
 consumed wire format or explanatory prose. If they are consumed, a round-trip test between
 emitter and documented shape replaces both tests; if not, the assertions should simply go.
+
+## Resolution
+
+Both prose-assertion suites replaced or removed. scripts_test.sh test 058 no longer greps 16 English sentences: the open decision resolved to 'consumed wire format' — executable_herdr-child emits [child-supervision v1 ...] (line 617) and [child-ask v2 ...] (line 1752) and parents validate them per the contract — so the new test 058 round-trips the markers actually delivered through the lifecycle stub against the shapes documented in child-agent-contract.md (field-key skeleton equality plus value-grammar checks), and verifies every herdr-child subcommand the three docs reference is accepted by the real CLI. Calibrated red: an emitter field rename and a doc-only phantom subcommand both fail it. smoke_test.sh test 60 deleted as tautological; its single non-duplicated fact — deployment of ~/.claude/skills/herdr/SKILL.md — moved into test 21's deployment manifest (contract doc and ask-in-herdr SKILL.md were already owned by tests 21/22). Lifecycle properties the prose named remain behaviorally owned by scripts tests 023/034/053/057/064/092. Verified: make test-suite, make test-ubuntu, make lint all green; cross-model se-code-review applied 3 P2 hardenings.

--- a/docs/issues/2026-08-29-007-two-suites-assert-markdown-prose-instead-of-behavior.md
+++ b/docs/issues/2026-08-29-007-two-suites-assert-markdown-prose-instead-of-behavior.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","test-quality","documentation"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1879,6 +1879,8 @@ function test_scripts_058_herdr_child_markers_round_trip_documented_shape() {
   [ -n "$emitted" ] || fail "no child-supervision marker was delivered to the parent"
   [ -n "$documented" ] || fail "contract no longer documents the child-supervision marker shape"
   assert_equal "$(child_marker_skeleton "$documented")" "$(child_marker_skeleton "$emitted")"
+  grep -Eq '^\[child-supervision v1 generation=[^ ]+ event=(timeout|settled-[0-9]+|blocked-[0-9]+|child-gone) outcome=[^ ]+ reason=[^ ]+ agent=[^ ]+ pane=[^] ]+\]$' \
+    <<<"$emitted" || fail "supervision marker values break the documented grammar: $emitted"
 
   # #given — a detached child calls back through ask
   child_lifecycle_stub_herdr
@@ -1901,12 +1903,19 @@ function test_scripts_058_herdr_child_markers_round_trip_documented_shape() {
   [ -n "$emitted" ] || fail "no child-ask v2 marker was delivered to the parent"
   [ -n "$documented" ] || fail "contract no longer documents the child-ask v2 marker shape"
   assert_equal "$(child_marker_skeleton "$documented")" "$(child_marker_skeleton "$emitted")"
+  grep -Eq '^\[child-ask v2 generation=[^ ]+ event=callback-[0-9]+ agent=[^ ]+ pane=[^] ]+\]$' \
+    <<<"$emitted" || fail "child-ask marker values break the documented grammar: $emitted"
 
   # #then — every subcommand the docs reference is one the CLI accepts
-  local token
-  for token in $(grep -ohE 'herdr-child [a-z][a-z-]*' "$contract" "$skill" "$consult" \
-      | awk '{print $2}' | sort -u); do
+  local tokens token
+  tokens="$(grep -ohE 'herdr-child [a-z][a-z-]*' "$contract" "$skill" "$consult" \
+    | awk '{print $2}' | sort -u)"
+  [ -n "$tokens" ] || fail "docs reference no herdr-child subcommands; the sync sweep would no-op"
+  for token in $tokens; do
+    # Without a herdr environment every real subcommand fails for an env
+    # reason; only a token the CLI dropped fails with "unknown subcommand".
     run env PATH="$CHILD_STUB:$PATH" HERDR_ENV= HERDR_PANE_ID= bash "$HERDR_CHILD" "$token"
+    assert_failure
     refute_output --partial 'unknown subcommand'
   done
 }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1847,28 +1847,68 @@ function test_scripts_057_herdr_child_attached_child_promoted_to_detach_as() {
   assert_file_contains "$CHILD_STUB/successful-prompts.log" 'child-ask v2'
 }
 
-function test_scripts_058_herdr_child_source_contracts_document_attached_a() {
-  _bats_test_init 58 'herdr child source contracts document attached and detached lifecycle boundaries'
+# Reduce a marker to its field-key skeleton: "[child-ask v2 generation=... pane=x]"
+# becomes "[child-ask v2 generation= pane=]", so documented placeholders and
+# emitted values compare as one shape.
+child_marker_skeleton() {
+  sed -E 's/=[^] ]+/=/g' <<<"$1"
+}
+
+# The marker lines in child-agent-contract.md are a consumed wire format: parents
+# validate [child-supervision v1 ...] and [child-ask v2 ...] bodies field by field.
+# Round-trip the markers herdr-child actually emits against the documented shapes,
+# so the test flips when either side renames, reorders, adds, or drops a field —
+# and stays green through prose copy-edits. Replaces the former prose-grep test 058.
+function test_scripts_058_herdr_child_markers_round_trip_documented_shape() {
+  _bats_test_init 58 'herdr-child emitted markers round-trip the documented wire shapes'
   local contract="$SOURCE_ROOT/private_dot_claude/shared/child-agent-contract.md"
   local skill="$SOURCE_ROOT/private_dot_claude/skills/herdr/SKILL.md"
   local consult="$SOURCE_ROOT/private_dot_claude/skills/ask-in-herdr/SKILL.md"
 
-  assert_file_contains "$contract" 'herdr-child start.*--wait'
-  assert_file_contains "$contract" 'herdr-child start.*--detach'
-  assert_file_contains "$contract" 'generation.*event'
-  assert_file_contains "$contract" 'herdr-child prompt.*--wait'
-  assert_file_contains "$contract" 'herdr-child prompt.*--detach'
-  assert_file_contains "$contract" 'not.*task-success verdict'
-  assert_file_contains "$contract" 'start.*prompt.*reply.*nonzero.*recovery JSON'
-  assert_file_contains "$contract" 'Do not retry.*start.*same name'
-  assert_file_contains "$contract" 'herdr agent get.*pane-id'
-  assert_file_contains "$contract" 'managed.*herdr-child prompt.*--detach.*reap'
-  assert_file_contains "$skill" 'cooperative exclusive file scope'
-  assert_file_contains "$skill" 'nonzero recovery JSON.*preserving the child'
-  assert_file_contains "$skill" 'Do not retry.*start.*same name'
-  assert_file_contains "$skill" 'herdr agent get'
-  assert_file_contains "$skill" 'rearm.*managed.*prompt.*--detach.*reap'
-  assert_file_contains "$consult" 'attached.*--wait'
+  # #given — a detached child settles, so the watcher prompts the parent
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 5000
+  assert_success
+  printf 'done 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_log 'event=settled-11'
+
+  # #then — the delivered supervision marker matches the documented shape
+  local emitted documented
+  emitted="$(grep -o '\[child-supervision v1 generation=[^]]*\]' "$CHILD_STUB/successful-prompts.log" | head -n1)"
+  documented="$(grep -o '\[child-supervision v1 generation=[^]]*\]' "$contract" | head -n1)"
+  [ -n "$emitted" ] || fail "no child-supervision marker was delivered to the parent"
+  [ -n "$documented" ] || fail "contract no longer documents the child-supervision marker shape"
+  assert_equal "$(child_marker_skeleton "$documented")" "$(child_marker_skeleton "$emitted")"
+
+  # #given — a detached child calls back through ask
+  child_lifecycle_stub_herdr
+  printf 'child-life' > "$CHILD_STUB/started-name"
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" HERDR_CHILD_POLL_INTERVAL=0.01 \
+    bash "$HERDR_CHILD" prompt --to child-life --pane wT:p9 --detach \
+    --supervision-timeout 5000 "detached task"
+  assert_success
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p9 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" HERDR_CHILD_NAME=child-life \
+    HERDR_CHILD_PARENT_PANE=wT:p0 HERDR_CHILD_LAUNCH_MODE=wait \
+    HERDR_CHILD_PARENT_TERMINAL=term-parent HERDR_CHILD_PARENT_SESSION=parent-session \
+    bash "$HERDR_CHILD" ask "Which path?"
+  assert_success
+
+  # #then — the delivered callback marker matches the documented shape
+  emitted="$(grep -o '\[child-ask v2 generation=[^]]*\]' "$CHILD_STUB/successful-prompts.log" | head -n1)"
+  documented="$(grep -o '\[child-ask v2 generation=[^]]*\]' "$contract" | head -n1)"
+  [ -n "$emitted" ] || fail "no child-ask v2 marker was delivered to the parent"
+  [ -n "$documented" ] || fail "contract no longer documents the child-ask v2 marker shape"
+  assert_equal "$(child_marker_skeleton "$documented")" "$(child_marker_skeleton "$emitted")"
+
+  # #then — every subcommand the docs reference is one the CLI accepts
+  local token
+  for token in $(grep -ohE 'herdr-child [a-z][a-z-]*' "$contract" "$skill" "$consult" \
+      | awk '{print $2}' | sort -u); do
+    run env PATH="$CHILD_STUB:$PATH" HERDR_ENV= HERDR_PANE_ID= bash "$HERDR_CHILD" "$token"
+    refute_output --partial 'unknown subcommand'
+  done
 }
 
 function test_scripts_059_herdr_child_rejects_invalid_and_live_names_befor() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1855,10 +1855,8 @@ child_marker_skeleton() {
 }
 
 # The marker lines in child-agent-contract.md are a consumed wire format: parents
-# validate [child-supervision v1 ...] and [child-ask v2 ...] bodies field by field.
-# Round-trip the markers herdr-child actually emits against the documented shapes,
-# so the test flips when either side renames, reorders, adds, or drops a field —
-# and stays green through prose copy-edits. Replaces the former prose-grep test 058.
+# validate [child-supervision v1 ...] and [child-ask v2 ...] bodies field by field,
+# so the emitted markers must round-trip the documented shapes.
 function test_scripts_058_herdr_child_markers_round_trip_documented_shape() {
   _bats_test_init 58 'herdr-child emitted markers round-trip the documented wire shapes'
   local contract="$SOURCE_ROOT/private_dot_claude/shared/child-agent-contract.md"

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -935,9 +935,8 @@ function test_smoke_059_herdr_task_and_child_engines_are_deployed_and_ex() {
   assert_file_exists "$HOME/.local/lib/herdr-process.sh"
 }
 
-# Test 60 (prose regexes over the deployed contract docs) was removed as
-# tautological; test 21's manifest owns deployment of these files, and
-# scripts_test.sh test 058 round-trips the marker wire format at the source.
+# Test 60 was removed as tautological: deployment of these docs is owned by
+# test 21's manifest, the marker wire format by scripts_test.sh test 058.
 
 function test_smoke_061_herdr_task_sync_claude_code_hook_is_deployed_and() {
   _bats_test_init 61 'herdr-task-sync Claude Code hook is deployed and executable'

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -421,6 +421,7 @@ function test_smoke_021_agent_skills_are_deployed_with_their_scripts_and() {
   local files=(
     skills/ask-in-herdr/SKILL.md
     skills/ask-in-herdr/scripts/ask.sh
+    skills/herdr/SKILL.md
     shared/child-agent-contract.md
     skills/se-flow/SKILL.md
     skills/se-cleanup/SKILL.md
@@ -934,29 +935,9 @@ function test_smoke_059_herdr_task_and_child_engines_are_deployed_and_ex() {
   assert_file_exists "$HOME/.local/lib/herdr-process.sh"
 }
 
-function test_smoke_060_deployed_herdr_child_contracts_expose_managed_su() {
-  _bats_test_init 60 'deployed herdr child contracts expose managed supervision modes'
-  local contract="$HOME/.claude/shared/child-agent-contract.md"
-  local skill="$HOME/.claude/skills/herdr/SKILL.md"
-  local consult="$HOME/.claude/skills/ask-in-herdr/SKILL.md"
-
-  assert_file_contains "$contract" 'herdr-child start.*--wait'
-  assert_file_contains "$contract" 'herdr-child start.*--detach'
-  assert_file_contains "$contract" 'generation.*event'
-  assert_file_contains "$contract" 'herdr-child prompt.*--wait'
-  assert_file_contains "$contract" 'herdr-child prompt.*--detach'
-  assert_file_contains "$contract" 'not.*task-success verdict'
-  assert_file_contains "$contract" 'start.*prompt.*reply.*nonzero.*recovery JSON'
-  assert_file_contains "$contract" 'Do not retry.*start.*same name'
-  assert_file_contains "$contract" 'herdr agent get.*pane-id'
-  assert_file_contains "$contract" 'managed.*herdr-child prompt.*--detach.*reap'
-  assert_file_contains "$skill" 'cooperative exclusive file scope'
-  assert_file_contains "$skill" 'nonzero recovery JSON.*preserving the child'
-  assert_file_contains "$skill" 'Do not retry.*start.*same name'
-  assert_file_contains "$skill" 'herdr agent get'
-  assert_file_contains "$skill" 'rearm.*managed.*prompt.*--detach.*reap'
-  assert_file_contains "$consult" 'attached.*--wait'
-}
+# Test 60 (prose regexes over the deployed contract docs) was removed as
+# tautological; test 21's manifest owns deployment of these files, and
+# scripts_test.sh test 058 round-trips the marker wire format at the source.
 
 function test_smoke_061_herdr_task_sync_claude_code_hook_is_deployed_and() {
   _bats_test_init 61 'herdr-task-sync Claude Code hook is deployed and executable'


### PR DESCRIPTION
## Summary

The herdr child-agent marker wire format is now regression-tested against the real emitter, replacing two suites that could not detect any regression: they matched 32 English sentences in `child-agent-contract.md` and three `SKILL.md` files, so any copy-edit turned them red while the lifecycle failures they named stayed green.

## Why the old tests were tautological

`scripts_test.sh` test 058 and `smoke_test.sh` test 60 ran no script. Their `assert_file_contains` regexes were loose enough that `generation.*event` matched five unrelated lines. Nothing parses that prose at runtime, so a broken lifecycle could not flip either test.

## What replaced them

The contract's marker lines are a consumed wire format: `herdr-child` emits `[child-supervision v1 ...]` and `[child-ask v2 ...]`, and parent agents validate those bodies field by field per the contract. The new test 058:

- drives a detached child to settlement and a detached callback through the lifecycle stub, capturing the markers actually delivered to the parent;
- reduces the emitted marker and the documented shape to the same field-key skeleton (`generation= event= outcome= ...`) and asserts equality, so a renamed, reordered, added, or dropped field on either side fails the test while prose copy-edits do not;
- asserts emitted values satisfy the documented grammar (non-empty fields, `event=callback-<seq>`, the supervision event alternation);
- verifies every `herdr-child` subcommand the three docs reference is accepted by the real CLI, failing on a phantom subcommand or an empty doc-scrape.

Smoke test 60 is deleted. Its one fact not already owned elsewhere — deployment of `~/.claude/skills/herdr/SKILL.md` — moved into smoke test 21's deployment manifest; the contract doc and `ask-in-herdr/SKILL.md` were already covered by tests 21 and 22.

## Red-state calibration

Both failure directions were demonstrated with temporary mutations, then reverted:

- renaming the emitter's `reason=` field to `why=` fails the skeleton comparison;
- appending a phantom `herdr-child vanish` reference to the contract doc fails the subcommand sweep.

Calibration also caught a vacuous assertion in the first draft: the house `run` helper leaves `$stderr` empty without `--separate-stderr`, so a `refute_stderr` check passed unconditionally; it was replaced with `refute_output` and re-calibrated red.

## Verification

- `make test-suite` — exit 0 (smoke 70 passed, scripts 252 passed; the risky-test entries are pre-existing at untouched lines).
- `make test-ubuntu` — exit 0 on the base commit of this branch (full Docker apply + suite).
- `make lint` — clean.
- Cross-model review (two independent report-only peers) returned "Ready with fixes"; the three P2 findings — assert status before output in the subcommand sweep, fail on an empty token scrape, enforce the marker value grammar — are applied in the follow-up commit. That hardening commit was verified on the host (`make test-suite`, `make lint`, isolated test run) but not re-run through Docker; it touches only the test file, which runs identically in both environments.

Related: `docs/issues/2026-08-29-007-two-suites-assert-markdown-prose-instead-of-behavior.md` (closed in this PR).
