### PR TITLE
fix(tests): replace vacuous template assertions with real coverage

### DIFF
--- a/docs/issues/2026-08-29-010-templates-test-sh-runs-in-no-post-apply-mode-and-covers-a-dead-env-path.md
+++ b/docs/issues/2026-08-29-010-templates-test-sh-runs-in-no-post-apply-mode-and-covers-a-dead-env-path.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["test-coverage","templates","chezmoi"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -56,3 +57,7 @@ Verify with `make test-templates`, then `make test-ubuntu`.
 Whether `templates_test.sh` belongs in the post-apply suite at all. It asserts rendering
 rather than deployed state, which is a different stage from what `run-post-apply.sh` covers,
 so adding it may be the wrong fix and an explicit note in the runner may be the right one.
+
+## Resolution
+
+run-post-apply.sh now states explicitly that templates_test.sh is a pre-apply rendering gate wired through CI, docker-compose, and make test-templates — it stays out of both post-apply modes by design (the open decision resolved toward the explicit note). The dead CHEZMOI_NAME/CHEZMOI_EMAIL path got real coverage: tests 002/003 now bind the env vars at init time via write_test_config with two differing probe values each (control: a different env value produces a different config value). Tests 005/006 render dot_gitconfig.tmpl against a probe-value config and assert the substituted user.name/user.email lines plus refute any unrendered directive, instead of the unconditional 'name = ' boilerplate. Test 012's provider/plugin/model literal restatement was deleted as tautological; a narrowed 012 pins the two externally consumed security invariants (external_directory grant, stdio executor transport). Test 014 became a cross-artifact contract: every opencode instructions entry must resolve via chezmoi source-path to a managed source file. Every rewritten test was calibrated red with a production mutation and green after restore. Verified: make test-templates (Docker, green), make test-ubuntu (full Docker suite, exit 0), post-apply contract test, check_bats_assertions. This also implements the templates_test.sh item of issue 2026-08-29-006.

--- a/docs/issues/2026-08-29-010-templates-test-sh-runs-in-no-post-apply-mode-and-covers-a-dead-env-path.md
+++ b/docs/issues/2026-08-29-010-templates-test-sh-runs-in-no-post-apply-mode-and-covers-a-dead-env-path.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["test-coverage","templates","chezmoi"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -10,10 +10,8 @@ load 'helpers/common'
 
 setup() {
   skip_if_no_chezmoi
-  # Feeds write_test_config()'s `execute-template --init` render, where an
-  # unset var would fall through to promptStringOnce and fail — execute-template
-  # has no prompt. Tests that assert the env→config binding itself override
-  # these per call with probe values.
+  # Unset, write_test_config()'s `execute-template --init` render would fall
+  # through to promptStringOnce, which execute-template cannot prompt for.
   export CHEZMOI_NAME="Test User"
   export CHEZMOI_EMAIL="test@example.com"
 }
@@ -83,11 +81,8 @@ function test_templates_004_gitconfig_template_renders_successfully() {
   assert_success
 }
 
-# "name = " / "email = " are unconditional boilerplate in the template, so
-# asserting them proves nothing about substitution. Render against a config
-# carrying a probe value and require that value on the rendered line — an
-# unrendered `{{ .name }}` or a template that stopped reading the config
-# both go red here.
+# "name = " / "email = " are unconditional boilerplate in the template;
+# asserting them proves nothing about substitution — hence the probe values.
 function test_templates_005_gitconfig_renders_the_config_name_into_user_name() {
   _bats_test_init 5 'gitconfig renders the config name into user.name'
   local cfg="$BATS_TEST_TMPDIR/gitconfig-name.yaml"
@@ -264,14 +259,10 @@ function test_templates_011_opencode_json_tmpl_renders_valid_json() {
   assert_success
 }
 
-# Test 012 once restated most of opencode.json.tmpl's literals (provider
-# models, plugin URL, mcp command names) — the file has zero template
-# directives, so those assertions mirrored the source and protected nothing.
-# What survives is the two security invariants OpenCode consumes verbatim:
-# the external-directory grant and the executor transport. Widening the
-# grant or moving executor off stdio (which is what keeps OpenCode from
-# holding the daemon's rotating token) is exactly the accidental edit worth
-# a red verdict — an externally consumed literal contract, not source shape.
+# opencode.json.tmpl has zero template directives, so asserting its other
+# literals would only mirror the source. These two are consumed verbatim as
+# a security contract: `executor mcp` speaks stdio, so OpenCode never holds
+# the daemon's rotating token.
 function test_templates_012_opencode_keeps_the_external_dir_grant_and_stdio() {
   _bats_test_init 12 'opencode keeps the external-directory grant and the stdio executor transport'
   command_exists jq || skip "jq is required"
@@ -301,9 +292,7 @@ function test_templates_013_opencode_skill_symlinks_target_canonical_claude() {
 function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
   _bats_test_init 14 'every opencode instructions entry is a managed source file'
   command_exists jq || skip "jq is required"
-  # OpenCode fails silently on a dangling instructions path, so the contract
-  # worth pinning is cross-artifact: each entry must resolve to a file chezmoi
-  # actually manages in this source tree, not merely appear in the JSON.
+  # OpenCode fails silently on a dangling instructions path.
   BATS_TEST_TMPFILE="$(mktemp)"
   render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
 

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -10,6 +10,10 @@ load 'helpers/common'
 
 setup() {
   skip_if_no_chezmoi
+  # Feeds write_test_config()'s `execute-template --init` render, where an
+  # unset var would fall through to promptStringOnce and fail — execute-template
+  # has no prompt. Tests that assert the env→config binding itself override
+  # these per call with probe values.
   export CHEZMOI_NAME="Test User"
   export CHEZMOI_EMAIL="test@example.com"
 }
@@ -30,8 +34,7 @@ function test_templates_001_python3_is_present_and_at_least_3_9_the_floor_re() {
 }
 
 # ===========================================
-# .chezmoi.yaml.tmpl (validated via chezmoi data — init-only template
-# uses promptStringOnce which is unavailable in execute-template)
+# .chezmoi.yaml.tmpl
 # ===========================================
 
 # CHEZMOI_NAME/CHEZMOI_EMAIL bind at `chezmoi init`, not at render time, so
@@ -80,16 +83,31 @@ function test_templates_004_gitconfig_template_renders_successfully() {
   assert_success
 }
 
-function test_templates_005_gitconfig_template_contains_user_name() {
-  _bats_test_init 5 'gitconfig template contains user name'
-  run render_template "$SOURCE_ROOT/dot_gitconfig.tmpl"
-  assert_output --partial "name = "
+# "name = " / "email = " are unconditional boilerplate in the template, so
+# asserting them proves nothing about substitution. Render against a config
+# carrying a probe value and require that value on the rendered line — an
+# unrendered `{{ .name }}` or a template that stopped reading the config
+# both go red here.
+function test_templates_005_gitconfig_renders_the_config_name_into_user_name() {
+  _bats_test_init 5 'gitconfig renders the config name into user.name'
+  local cfg="$BATS_TEST_TMPDIR/gitconfig-name.yaml"
+  CHEZMOI_NAME="Gitconfig Name Probe" write_test_config "$cfg"
+
+  run render_with_config "$cfg" "$SOURCE_ROOT/dot_gitconfig.tmpl"
+  assert_success
+  assert_output --partial "name = Gitconfig Name Probe"
+  refute_output --partial '{{'
 }
 
-function test_templates_006_gitconfig_template_contains_user_email() {
-  _bats_test_init 6 'gitconfig template contains user email'
-  run render_template "$SOURCE_ROOT/dot_gitconfig.tmpl"
-  assert_output --partial "email = "
+function test_templates_006_gitconfig_renders_the_config_email_into_user_ema() {
+  _bats_test_init 6 'gitconfig renders the config email into user.email'
+  local cfg="$BATS_TEST_TMPDIR/gitconfig-email.yaml"
+  CHEZMOI_EMAIL="gitconfig-probe@env.example" write_test_config "$cfg"
+
+  run render_with_config "$cfg" "$SOURCE_ROOT/dot_gitconfig.tmpl"
+  assert_success
+  assert_output --partial "email = gitconfig-probe@env.example"
+  refute_output --partial '{{'
 }
 
 # ===========================================
@@ -246,21 +264,11 @@ function test_templates_011_opencode_json_tmpl_renders_valid_json() {
   assert_success
 }
 
-function test_templates_012_opencode_json_tmpl_grants_unbounded_external_dir() {
-  _bats_test_init 12 'opencode.json.tmpl grants unbounded external-directory reads without changing integrations'
-  command_exists jq || skip "jq is required"
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
-
-  run jq -r '.permission.external_directory["*"]' "$BATS_TEST_TMPFILE"
-  assert_success
-  assert_output "allow"
-
-  run jq -r '[.mcp.fff.command[0], (.mcp.executor.command | join(" ")), .mcp.executor.enabled, (.provider.openrouter.models | has("qwen/qwen3-coder:free")), .plugin[0]] | @tsv' "$BATS_TEST_TMPFILE"
-  assert_success
-  # `executor mcp` speaks stdio, so OpenCode never holds the daemon's rotating token.
-  assert_output $'fff-mcp\texecutor mcp\ttrue\ttrue\tcompound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git'
-}
+# Test 012 (opencode permission/mcp/provider literals) was deleted:
+# opencode.json.tmpl contains zero template directives, so the assertions
+# restated the source file verbatim and any deliberate config edit updated
+# test and file together — no regression was protected. Render validity is
+# owned by test 011; the instructions cross-artifact contract by test 014.
 
 function test_templates_013_opencode_skill_symlinks_target_canonical_claude() {
   _bats_test_init 13 'opencode skill symlinks target canonical claude skills'
@@ -273,12 +281,26 @@ function test_templates_013_opencode_skill_symlinks_target_canonical_claude() {
   done
 }
 
-function test_templates_014_opencode_instructions_point_at_the_shared_writin() {
-  _bats_test_init 14 'opencode instructions point at the shared writing-style file'
+function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
+  _bats_test_init 14 'every opencode instructions entry is a managed source file'
+  command_exists jq || skip "jq is required"
+  # OpenCode fails silently on a dangling instructions path, so the contract
+  # worth pinning is cross-artifact: each entry must resolve to a file chezmoi
+  # actually manages in this source tree, not merely appear in the JSON.
   BATS_TEST_TMPFILE="$(mktemp)"
   render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
-  run jq -e '.instructions | index("~/.config/agents/writing-style.md") != null' "$BATS_TEST_TMPFILE"
-  assert_success
+
+  local entries entry
+  entries="$(jq -r '.instructions[]' "$BATS_TEST_TMPFILE")"
+  [[ -n "$entries" ]] || fail "no instructions entries in opencode.json.tmpl"
+
+  while IFS= read -r entry; do
+    [[ "$entry" == "~/"* ]] || fail "instructions entry '$entry' is not home-relative, so it cannot be checked against the source tree"
+    run env PATH="$PATH_WITHOUT_OP" "$CHEZMOI_BIN" source-path \
+      --source "$SOURCE_ROOT" "$HOME/${entry#\~/}"
+    assert_success
+    assert_file_exists "$output"
+  done <<< "$entries"
 }
 
 # ===========================================

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -264,11 +264,28 @@ function test_templates_011_opencode_json_tmpl_renders_valid_json() {
   assert_success
 }
 
-# Test 012 (opencode permission/mcp/provider literals) was deleted:
-# opencode.json.tmpl contains zero template directives, so the assertions
-# restated the source file verbatim and any deliberate config edit updated
-# test and file together — no regression was protected. Render validity is
-# owned by test 011; the instructions cross-artifact contract by test 014.
+# Test 012 once restated most of opencode.json.tmpl's literals (provider
+# models, plugin URL, mcp command names) — the file has zero template
+# directives, so those assertions mirrored the source and protected nothing.
+# What survives is the two security invariants OpenCode consumes verbatim:
+# the external-directory grant and the executor transport. Widening the
+# grant or moving executor off stdio (which is what keeps OpenCode from
+# holding the daemon's rotating token) is exactly the accidental edit worth
+# a red verdict — an externally consumed literal contract, not source shape.
+function test_templates_012_opencode_keeps_the_external_dir_grant_and_stdio() {
+  _bats_test_init 12 'opencode keeps the external-directory grant and the stdio executor transport'
+  command_exists jq || skip "jq is required"
+  BATS_TEST_TMPFILE="$(mktemp)"
+  render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
+
+  run jq -r '.permission.external_directory["*"]' "$BATS_TEST_TMPFILE"
+  assert_success
+  assert_output "allow"
+
+  run jq -r '[(.mcp.executor.command | join(" ")), (.mcp.executor.enabled | tostring)] | join("|")' "$BATS_TEST_TMPFILE"
+  assert_success
+  assert_output "executor mcp|true"
+}
 
 function test_templates_013_opencode_skill_symlinks_target_canonical_claude() {
   _bats_test_init 13 'opencode skill symlinks target canonical claude skills'
@@ -291,7 +308,9 @@ function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
   render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
 
   local entries entry
-  entries="$(jq -r '.instructions[]' "$BATS_TEST_TMPFILE")"
+  run jq -r '.instructions[]' "$BATS_TEST_TMPFILE"
+  assert_success
+  entries="$output"
   [[ -n "$entries" ]] || fail "no instructions entries in opencode.json.tmpl"
 
   while IFS= read -r entry; do

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -9,11 +9,9 @@
 # $MMS_BASHUNIT_JOBS workers (idempotent serializes itself via its
 # '# bashunit: no-parallel-tests' marker).
 #
-# tests/bashunit/templates_test.sh is deliberately NOT in either mode: it
-# asserts source-tree rendering, a pre-apply stage, while every file here
-# asserts post-apply state. Its wiring is the pre-apply gate that CI
-# (.github/workflows/test-dotfiles.yml), docker/docker-compose.yml, and
-# `make test-templates` each run before their apply step.
+# templates_test.sh is deliberately absent: it asserts pre-apply source-tree
+# rendering, not post-apply state. It runs as the pre-apply gate in CI,
+# docker-compose, and `make test-templates`.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -8,6 +8,12 @@
 # Execution shape: files run sequentially, tests within a file run with up to
 # $MMS_BASHUNIT_JOBS workers (idempotent serializes itself via its
 # '# bashunit: no-parallel-tests' marker).
+#
+# tests/bashunit/templates_test.sh is deliberately NOT in either mode: it
+# asserts source-tree rendering, a pre-apply stage, while every file here
+# asserts post-apply state. Its wiring is the pre-apply gate that CI
+# (.github/workflows/test-dotfiles.yml), docker/docker-compose.yml, and
+# `make test-templates` each run before their apply step.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## Summary

The template suite now proves the behaviors it claimed to protect. Its `CHEZMOI_NAME`/`CHEZMOI_EMAIL` coverage was a dead path: `setup()` exported the variables, but the tests read `chezmoi data`, which returns a config bound at a much earlier `chezmoi init` — the exports were inert, and no environment anywhere exercised the env-var binding with a value that could distinguish it from the `--promptString` fallback.

## What changed

- **Env binding at init (tests 002/003)** — each test now generates a config through `write_test_config` (chezmoi's `execute-template --init`) with two different probe values and asserts the config carries each one. The second value is the control: it proves the env var drives the result rather than a constant matching by accident.
- **Gitconfig substitution (tests 005/006)** — previously asserted `name = ` / `email = `, which is unconditional boilerplate in the template and stays green with substitution broken. They now render against a probe-value config, assert the substituted values on the rendered lines, and refute any unrendered `{{` directive.
- **OpenCode config (tests 012/014)** — `opencode.json.tmpl` contains zero template directives, so test 012's broad literal restatement (providers, plugins, model lists) protected nothing and was cut. What remains pins the two invariants OpenCode consumes as a literal contract: the unbounded external-directory grant and the executor MCP running over stdio (which keeps OpenCode from holding the daemon's rotating token). Test 014 became a cross-artifact contract: every `instructions` entry must resolve via `chezmoi source-path` to a managed source file, because OpenCode fails silently on a dangling path.
- **Runner note** — `tests/run-post-apply.sh` now states that `templates_test.sh` stays out of both post-apply modes by design: it asserts source-tree rendering, a pre-apply stage, and is wired as the pre-apply gate in CI, docker-compose, and `make test-templates`.

## Verification

- Red calibration: four temporary production mutations (env binding hardcoded in `.chezmoi.yaml.tmpl`, `{{ .name }}` removed from the gitconfig template, a dangling `instructions` entry, the external-directory grant narrowed to `ask`) each turned the corresponding test red; all green after restore.
- `make test-templates` (Docker) green on both commits; `make test-ubuntu` (full Docker suite including apply) exit 0.
- Reviewed by two independent cross-model sessions; both actionable findings (restore the narrowed security-invariant test, route the new `jq` extraction through `run`/`assert_success`) are applied here.

Resolves the repository issue tracked in `docs/issues/2026-08-29-010-templates-test-sh-runs-in-no-post-apply-mode-and-covers-a-dead-env-path.md` (closed in this PR).
