### PR TITLE
fix(tests): make nine vacuous assertion sites able to fail

### DIFF
--- a/docs/issues/2026-08-29-006-vacuous-assertions-across-five-suites-protect-nothing.md
+++ b/docs/issues/2026-08-29-006-vacuous-assertions-across-five-suites-protect-nothing.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","vacuous-assertions","test-quality"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "high"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -80,3 +81,7 @@ suite; Smithers changes use `make test-smithers`.
 
 Whether `smoke_test.sh:1038-1039` protects a real constraint worth deriving, or should
 simply be deleted. No consumer of the width budget has been identified yet.
+
+## Resolution
+
+All nine sites replaced with assertions that change verdict when the named behavior breaks, each calibrated red by reintroducing its regression: (1) test_docker_contract.py dropped the comment-only idempotent_test.sh assertIn — reachability is owned behaviorally by test_post_apply_suite_contract.py's wrapper-argv check; (2) smoke_test.sh deleted the two constant-arithmetic width lines, keeping the awk [ui]-scoped -eq 32 (section placement is real protection; no width-4 consumer exists in herdr-task-sync, resolving the open decision); (3) scripts_test.sh:161 now asserts status and a .gitconfig positive control before the darwin refutation; (4) scripts_test.sh test 216 proves the sweep ran (api snapshot in the log) before counting zero renames, distinguishing 'no rename' from 'no log' — calibrated red by no-op'ing sweep_tabs; (5) idempotent_test.sh test 010's workstation branch asserts the closed run/skip vocabulary plus the live-env marker flip to run (registered assert_equal) — calibrated red by breaking the truth rule; (6) gates escape composition extracted into appendEscapeAdvisory in lib/gates.ts, called from se-pipeline.tsx, with tests asserting reason content, reasonCount delta and state preservation on green/red/no-escape paths — calibrated red by mutating the helper to flip state; (7) block-registry.test.ts compares two independently built registries in opposite registration order plus a sortedReplacer key-canonicalization discriminator — both calibrated red; (8) blocks/index.test.ts compares two buildRegistry() generations plus a reversed INITIAL_LIBRARY registry; (9) templates_test.sh 002/003 bind CHEZMOI_NAME/EMAIL at init via write_test_config and prove a different value renders differently — calibrated red by breaking the env read. Verified: make test-issues (41 OK), test-templates, test-smithers (545 pass), test-suite, test-ubuntu (full Docker, exit 0), lint. Cross-model se-code-review (sonnet + gpt-5.6-terra) returned Ready-with-fixes; its three findings (registration-order gap, key-canonicalization gap, missing state assertion) applied in 57485e1.

--- a/docs/issues/2026-08-29-006-vacuous-assertions-across-five-suites-protect-nothing.md
+++ b/docs/issues/2026-08-29-006-vacuous-assertions-across-five-suites-protect-nothing.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["tautological-tests","vacuous-assertions","test-quality"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "high"
 ---
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
@@ -74,11 +74,21 @@ describe("BlockRegistry catalog", () => {
     expect((scan?.outputSchema as { type?: string }).type).toBe("object");
   });
 
-  test("catalog JSON is byte-stable across two consecutive generations", () => {
-    const registry = new BlockRegistry();
-    registry.register(agentBlock());
-    registry.register(computeBlock());
-    expect(catalogToJson(registry)).toBe(catalogToJson(registry));
+  test("catalog JSON is byte-stable across independently built registries", () => {
+    // #given two registries holding the same blocks registered in opposite
+    // order. Comparing one registry's JSON to itself could never fail — the
+    // claim the test name makes is that generation order does not leak into
+    // the bytes.
+    const first = new BlockRegistry();
+    first.register(agentBlock());
+    first.register(computeBlock());
+
+    const second = new BlockRegistry();
+    second.register(computeBlock());
+    second.register(agentBlock());
+
+    // #then registration order is erased by list()'s sort
+    expect(catalogToJson(first)).toBe(catalogToJson(second));
   });
 });
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
@@ -75,10 +75,8 @@ describe("BlockRegistry catalog", () => {
   });
 
   test("catalog JSON is byte-stable across independently built registries", () => {
-    // #given two registries holding the same blocks registered in opposite
-    // order. Comparing one registry's JSON to itself could never fail — the
-    // claim the test name makes is that generation order does not leak into
-    // the bytes.
+    // #given the same blocks registered in opposite order — collapsing the
+    // two registries into one would make this test unable to fail
     const first = new BlockRegistry();
     first.register(agentBlock());
     first.register(computeBlock());
@@ -87,16 +85,12 @@ describe("BlockRegistry catalog", () => {
     second.register(computeBlock());
     second.register(agentBlock());
 
-    // #then registration order is erased by list()'s sort; key order inside
-    // each entry is canonicalized separately by sortedReplacer (next test)
+    // #then
     expect(catalogToJson(first)).toBe(catalogToJson(second));
   });
 
   test("catalog JSON canonicalizes object keys regardless of declaration order", () => {
-    // #given a schema whose keys are declared in reverse-alphabetical order.
-    // Registration-order comparisons cannot see key order, because both
-    // registries would carry the same declaration; the discriminator is the
-    // serialized document itself.
+    // #given keys deliberately declared in reverse-alphabetical order
     const registry = new BlockRegistry();
     registry.register(computeBlock({ inputSchema: z.object({ headSha: z.string(), baseSha: z.string() }) }));
 
@@ -105,8 +99,7 @@ describe("BlockRegistry catalog", () => {
     };
     const keys = Object.keys(parsed.blocks[0]!.inputSchema.properties);
 
-    // #then sortedReplacer erased the declaration order from the bytes —
-    // without it JSON.stringify would emit headSha before baseSha
+    // #then sortedReplacer erased the declaration order from the bytes
     expect(keys).toEqual(["baseSha", "headSha"]);
   });
 });

--- a/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/block-registry.test.ts
@@ -87,8 +87,27 @@ describe("BlockRegistry catalog", () => {
     second.register(computeBlock());
     second.register(agentBlock());
 
-    // #then registration order is erased by list()'s sort
+    // #then registration order is erased by list()'s sort; key order inside
+    // each entry is canonicalized separately by sortedReplacer (next test)
     expect(catalogToJson(first)).toBe(catalogToJson(second));
+  });
+
+  test("catalog JSON canonicalizes object keys regardless of declaration order", () => {
+    // #given a schema whose keys are declared in reverse-alphabetical order.
+    // Registration-order comparisons cannot see key order, because both
+    // registries would carry the same declaration; the discriminator is the
+    // serialized document itself.
+    const registry = new BlockRegistry();
+    registry.register(computeBlock({ inputSchema: z.object({ headSha: z.string(), baseSha: z.string() }) }));
+
+    const parsed = JSON.parse(catalogToJson(registry)) as {
+      blocks: { inputSchema: { properties: Record<string, unknown> } }[];
+    };
+    const keys = Object.keys(parsed.blocks[0]!.inputSchema.properties);
+
+    // #then sortedReplacer erased the declaration order from the bytes —
+    // without it JSON.stringify would emit headSha before baseSha
+    expect(keys).toEqual(["baseSha", "headSha"]);
   });
 });
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { catalogToJson } from "../block-registry.ts";
+import { BlockRegistry, catalogToJson } from "../block-registry.ts";
 import { validateFlowSpec } from "../flow-validate.ts";
 import { buildRegistry, INITIAL_LIBRARY } from "./index.ts";
 
@@ -20,6 +20,13 @@ describe("initial block library", () => {
     // per-instance or per-generation content (timestamps, ids, unstable
     // iteration order).
     expect(catalogToJson(buildRegistry())).toBe(catalogToJson(registry));
+
+    // buildRegistry() always inserts in INITIAL_LIBRARY order, so the check
+    // above alone would stay green if list() stopped sorting by name. The
+    // reversed registration proves order-independence on the real library.
+    const reordered = new BlockRegistry();
+    for (const block of [...INITIAL_LIBRARY].reverse()) reordered.register(block);
+    expect(catalogToJson(reordered)).toBe(catalogToJson(registry));
   });
 
   test("catalog exposes external and needsWorkspace flags per block", () => {

--- a/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
@@ -14,8 +14,12 @@ describe("initial block library", () => {
     );
   });
 
-  test("catalog is byte-stable across generations", () => {
-    expect(catalogToJson(registry)).toBe(catalogToJson(registry));
+  test("catalog is byte-stable across independently built registries", () => {
+    // Comparing one registry's JSON to itself could never fail. Two separate
+    // buildRegistry() calls redden this if the catalog ever gains
+    // per-instance or per-generation content (timestamps, ids, unstable
+    // iteration order).
+    expect(catalogToJson(buildRegistry())).toBe(catalogToJson(registry));
   });
 
   test("catalog exposes external and needsWorkspace flags per block", () => {

--- a/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/blocks/index.test.ts
@@ -15,15 +15,12 @@ describe("initial block library", () => {
   });
 
   test("catalog is byte-stable across independently built registries", () => {
-    // Comparing one registry's JSON to itself could never fail. Two separate
-    // buildRegistry() calls redden this if the catalog ever gains
-    // per-instance or per-generation content (timestamps, ids, unstable
-    // iteration order).
+    // Two separate buildRegistry() calls on purpose — a single shared
+    // instance cannot catch per-generation content.
     expect(catalogToJson(buildRegistry())).toBe(catalogToJson(registry));
 
-    // buildRegistry() always inserts in INITIAL_LIBRARY order, so the check
-    // above alone would stay green if list() stopped sorting by name. The
-    // reversed registration proves order-independence on the real library.
+    // buildRegistry() always inserts in INITIAL_LIBRARY order, so only the
+    // reversed registration can see a lost list() sort.
     const reordered = new BlockRegistry();
     for (const block of [...INITIAL_LIBRARY].reverse()) reordered.register(block);
     expect(catalogToJson(reordered)).toBe(catalogToJson(registry));

--- a/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
@@ -473,8 +473,7 @@ describe("mainCheckoutEscapeReason (побег из воркитри, run-178671
     // #when digest не менялся
     const result = appendEscapeAdvisory(verdict, "/abs/repo", "same", "same");
 
-    // #then ни причины, ни состояния — advisory-контракт держится и на
-    // пути без побега
+    // #then
     expect(result.reasons).toHaveLength(reasonCount);
     expect(result.state).toBe("green");
   });

--- a/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  appendEscapeAdvisory,
   codeReviewGate,
   docReviewGate,
   emptyCoverageNotes,
@@ -424,30 +425,54 @@ describe("mainCheckoutEscapeReason (побег из воркитри, run-178671
     expect(mainCheckoutEscapeReason("/abs/repo", null, "digest-now")).toBeUndefined();
   });
 
-  test("причина только ДОБАВЛЯЕТСЯ: зелёный вердикт work остаётся зелёным", () => {
+  test("digest изменился → причина названа и указывает оператору на checkout", () => {
+    // #when
+    const reason = mainCheckoutEscapeReason("/abs/repo", "at-staging", "now");
+
+    // #then сообщение само ведёт к диагнозу: где смотреть и какой командой
+    expect(reason).toContain("/abs/repo");
+    expect(reason).toContain("git -C /abs/repo status");
+    expect(reason).toContain("OUTSIDE its worktree");
+  });
+
+  test("appendEscapeAdvisory: диагноз advisory — зелёный work-гейт остаётся зелёным", () => {
     // #given зелёный work-гейт
     const verdict = workGate({ raw: workEnvelope(), baseTree, headTree, validateExitCode: 0 });
     expect(verdict.state).toBe("green");
 
-    // #when гейт дописывает диагноз побега (как в se-pipeline workGateFn)
-    const reason = mainCheckoutEscapeReason("/abs/repo", "at-staging", "now");
-    expect(reason).toBeDefined();
-    if (reason !== undefined) verdict.reasons.push(reason);
+    // #when продакшен-композиция se-pipeline workGateFn дописывает диагноз
+    const result = appendEscapeAdvisory(verdict, "/abs/repo", "at-staging", "now");
 
-    // #then состояние не меняется — ложный позитив не стоит лишнего work-плеча
-    expect(verdict.state).toBe("green");
+    // #then причина дописана, но состояние не тронуто — ложный позитив не
+    // стоит лишнего work-плеча
+    expect(result.reasons.some((r) => r.includes("/abs/repo"))).toBe(true);
+    expect(result.state).toBe("green");
   });
 
-  test("на красном KTD14-вердикте диагноз стоит рядом с симптомом", () => {
+  test("appendEscapeAdvisory: на красном KTD14-вердикте диагноз стоит рядом с симптомом", () => {
     // #given work-гейт закрылся по «нет изменений контента»
     const verdict = workGate({ raw: workEnvelope(), baseTree, headTree: baseTree, validateExitCode: 0 });
     const reasonCount = verdict.reasons.length;
-    const reason = mainCheckoutEscapeReason("/abs/repo", "at-staging", "now");
-    if (reason !== undefined) verdict.reasons.push(reason);
+
+    // #when
+    const result = appendEscapeAdvisory(verdict, "/abs/repo", "at-staging", "now");
 
     // #then оператор видит и симптом (KTD14), и настоящую причину
-    expect(verdict.state).toBe("failed");
-    expect(verdict.reasons).toHaveLength(reasonCount + 1);
+    expect(result.state).toBe("failed");
+    expect(result.reasons).toHaveLength(reasonCount + 1);
+    expect(result.reasons[reasonCount]).toContain("git -C /abs/repo status");
+  });
+
+  test("appendEscapeAdvisory: без побега вердикт не трогается", () => {
+    // #given
+    const verdict = workGate({ raw: workEnvelope(), baseTree, headTree, validateExitCode: 0 });
+    const reasonCount = verdict.reasons.length;
+
+    // #when digest не менялся
+    const result = appendEscapeAdvisory(verdict, "/abs/repo", "same", "same");
+
+    // #then
+    expect(result.reasons).toHaveLength(reasonCount);
   });
 });
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/gates.test.ts
@@ -439,13 +439,15 @@ describe("mainCheckoutEscapeReason (побег из воркитри, run-178671
     // #given зелёный work-гейт
     const verdict = workGate({ raw: workEnvelope(), baseTree, headTree, validateExitCode: 0 });
     expect(verdict.state).toBe("green");
+    const reasonCount = verdict.reasons.length;
 
     // #when продакшен-композиция se-pipeline workGateFn дописывает диагноз
     const result = appendEscapeAdvisory(verdict, "/abs/repo", "at-staging", "now");
 
     // #then причина дописана, но состояние не тронуто — ложный позитив не
     // стоит лишнего work-плеча
-    expect(result.reasons.some((r) => r.includes("/abs/repo"))).toBe(true);
+    expect(result.reasons).toHaveLength(reasonCount + 1);
+    expect(result.reasons[reasonCount]).toContain("/abs/repo");
     expect(result.state).toBe("green");
   });
 
@@ -471,8 +473,10 @@ describe("mainCheckoutEscapeReason (побег из воркитри, run-178671
     // #when digest не менялся
     const result = appendEscapeAdvisory(verdict, "/abs/repo", "same", "same");
 
-    // #then
+    // #then ни причины, ни состояния — advisory-контракт держится и на
+    // пути без побега
     expect(result.reasons).toHaveLength(reasonCount);
+    expect(result.state).toBe("green");
   });
 });
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/gates.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/gates.ts
@@ -347,12 +347,10 @@ export function mainCheckoutEscapeReason(
   return `the target repository's main checkout at ${repoDir} gained uncommitted changes since staging — the work agent may have written OUTSIDE its worktree (run-1786717826270). Inspect \`git -C ${repoDir} status\` before re-running: the work you are missing from the run branch may be sitting there.`;
 }
 
-// The one composition se-pipeline's workGateFn uses: advisory by contract. It
-// appends the escape diagnosis as a reason and must never touch the verdict's
-// state — an operator committing in their own checkout during a multi-hour run
-// is ordinary, and flipping the gate would buy a second work leg on a false
-// positive. Testable here so the call site cannot silently regress into a red
-// gate.
+// Advisory by contract: the escape diagnosis must never touch the verdict's
+// state — an operator committing in their own checkout during a multi-hour
+// run is ordinary, and flipping the gate would buy a second work leg on a
+// false positive.
 export function appendEscapeAdvisory(
   verdict: GateResult,
   repoDir: string,

--- a/home/private_dot_claude/dot_smithers/workflows/lib/gates.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/gates.ts
@@ -347,6 +347,23 @@ export function mainCheckoutEscapeReason(
   return `the target repository's main checkout at ${repoDir} gained uncommitted changes since staging — the work agent may have written OUTSIDE its worktree (run-1786717826270). Inspect \`git -C ${repoDir} status\` before re-running: the work you are missing from the run branch may be sitting there.`;
 }
 
+// The one composition se-pipeline's workGateFn uses: advisory by contract. It
+// appends the escape diagnosis as a reason and must never touch the verdict's
+// state — an operator committing in their own checkout during a multi-hour run
+// is ordinary, and flipping the gate would buy a second work leg on a false
+// positive. Testable here so the call site cannot silently regress into a red
+// gate.
+export function appendEscapeAdvisory(
+  verdict: GateResult,
+  repoDir: string,
+  stagedDigest: string | null | undefined,
+  currentDigest: string,
+): GateResult {
+  const reason = mainCheckoutEscapeReason(repoDir, stagedDigest, currentDigest);
+  if (reason !== undefined) verdict.reasons.push(reason);
+  return verdict;
+}
+
 export function codeReviewGate(input: CodeReviewGateInput): GateResult {
   if (input.raw === undefined) {
     return { state: "failed", reasons: ["verify-code stage produced no report (crash or timeout)"] };

--- a/home/private_dot_claude/dot_smithers/workflows/se-pipeline.tsx
+++ b/home/private_dot_claude/dot_smithers/workflows/se-pipeline.tsx
@@ -17,7 +17,7 @@ import { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { codeReviewGate, docReviewGate, emptyCoverageNotes, mainCheckoutEscapeReason, planGate, rescanGate, workGate, type GateResult, type RescanReport } from "./lib/gates.ts";
+import { appendEscapeAdvisory, codeReviewGate, docReviewGate, emptyCoverageNotes, planGate, rescanGate, workGate, type GateResult, type RescanReport } from "./lib/gates.ts";
 import { mergeReviewReports } from "./lib/review-merge.ts";
 import { severitySchema } from "./lib/severity-summary.ts";
 import { docReviewSeverityStatusNote, docReviewWaiveNote, readDocReviewAdvisory } from "./lib/doc-review-notes.ts";
@@ -677,13 +677,9 @@ export default smithers((ctx) => {
         if (validate !== null && validate.exitCode !== 0) {
           result.reasons.push(`validate-cmd output tail: ${validate.output.slice(-500)}`);
         }
-        // Escape diagnosis, advisory by construction: it appends a reason and
-        // never touches result.state. An operator committing or editing in
-        // their own checkout during a multi-hour run is ordinary, and turning
-        // that into a red gate would buy a second work leg on a false positive.
-        const escaped = mainCheckoutEscapeReason(repoDir, staged.repoDirtyDigest, repoDirtyDigest(repoDir));
-        if (escaped !== undefined) result.reasons.push(escaped);
-        return result;
+        // Escape diagnosis, advisory by contract (see appendEscapeAdvisory in
+        // lib/gates.ts): it appends a reason and never touches result.state.
+        return appendEscapeAdvisory(result, repoDir, staged.repoDirtyDigest, repoDirtyDigest(repoDir));
       };
 
       // docReviewAdvisory was resolved above: the verify-doc advisory when

--- a/home/private_dot_claude/dot_smithers/workflows/se-pipeline.tsx
+++ b/home/private_dot_claude/dot_smithers/workflows/se-pipeline.tsx
@@ -677,8 +677,7 @@ export default smithers((ctx) => {
         if (validate !== null && validate.exitCode !== 0) {
           result.reasons.push(`validate-cmd output tail: ${validate.output.slice(-500)}`);
         }
-        // Escape diagnosis, advisory by contract (see appendEscapeAdvisory in
-        // lib/gates.ts): it appends a reason and never touches result.state.
+        // Escape diagnosis, advisory by contract — see appendEscapeAdvisory.
         return appendEscapeAdvisory(result, repoDir, staged.repoDirtyDigest, repoDirtyDigest(repoDir));
       };
 

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -144,14 +144,10 @@ function test_idempotent_010_guard_every_disposable_environment_declares_the() {
   # Never skipped. A skip here would be indistinguishable from this file going
   # inert, which is exactly the rot the test exists to catch.
   if [[ -z "${GITHUB_ACTIONS:-}" ]] && [[ ! -f /.dockerenv ]]; then
-    # Nothing reports this $HOME disposable. `!= misconfigured` was vacuous
-    # here: this branch's own condition is exactly what makes the predicate
-    # structurally incapable of returning misconfigured. Assert the live-env
-    # pair instead: the verdict stays inside the closed run/skip vocabulary
-    # (catches vocabulary drift the scrubbed guard tests above cannot see in
-    # this environment), and the marker still flips it to `run` with whatever
-    # else this shell exports — the one claim tests 3-9 deliberately avoid by
-    # scrubbing the environment.
+    # Nothing reports this $HOME disposable. Do not assert `!= misconfigured`
+    # here — this branch's own condition makes that verdict unreachable.
+    # Deliberately unscrubbed: the marker must win over whatever this shell
+    # exports, a claim the env -u guard tests above cannot make.
     local live marked
     live="$(mms_disposable_home_verdict)"
     [[ "$live" == "run" || "$live" == "skip" ]] || \

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -144,11 +144,20 @@ function test_idempotent_010_guard_every_disposable_environment_declares_the() {
   # Never skipped. A skip here would be indistinguishable from this file going
   # inert, which is exactly the rot the test exists to catch.
   if [[ -z "${GITHUB_ACTIONS:-}" ]] && [[ ! -f /.dockerenv ]]; then
-    # Nothing reports this $HOME disposable, so the one claim available is that
-    # the predicate does not accuse this machine of losing a marker it never
-    # needed. It holds under the local opt-in too, where the verdict is `run`.
-    [[ "$(mms_disposable_home_verdict)" != "misconfigured" ]] || \
-      fail "No platform fact reports a disposable \$HOME here, yet the predicate returned misconfigured."
+    # Nothing reports this $HOME disposable. `!= misconfigured` was vacuous
+    # here: this branch's own condition is exactly what makes the predicate
+    # structurally incapable of returning misconfigured. Assert the live-env
+    # pair instead: the verdict stays inside the closed run/skip vocabulary
+    # (catches vocabulary drift the scrubbed guard tests above cannot see in
+    # this environment), and the marker still flips it to `run` with whatever
+    # else this shell exports — the one claim tests 3-9 deliberately avoid by
+    # scrubbing the environment.
+    local live marked
+    live="$(mms_disposable_home_verdict)"
+    [[ "$live" == "run" || "$live" == "skip" ]] || \
+      fail "No platform fact reports a disposable \$HOME here, yet the predicate returned '$live' instead of run or skip."
+    marked="$(MMS_DISPOSABLE_HOME=1 mms_disposable_home_verdict)"
+    assert_equal "$marked" "run"
     return 0
   fi
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -158,6 +158,12 @@ function test_scripts_008_darwin_scripts_excluded_from_managed_list_on_lin() {
   is_linux || skip "Only relevant on Linux"
   skip_if_no_chezmoi
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed
+  # Status first: a failed `chezmoi managed` emits an error string that would
+  # satisfy the refutation below. The .gitconfig line is the positive control
+  # proving the listing is real and non-empty before the darwin exclusion is
+  # refuted against it.
+  assert_success
+  assert_output --partial ".gitconfig"
   refute_output --partial "run_once_after_macos-tunes"
 }
 
@@ -6062,9 +6068,12 @@ function test_scripts_216_herdr_task_sync_sweep_leaves_an_unchanged_tab_la() {
       {"pid":200,"name":"btop","argv0":"btop","argv":["btop"]}]}}}'
   run hts_sweep_run --sweep
   assert_success
-  run cat "$HTS_LOG"
-  refute_output --partial "tab rename"
-  refute_output --partial "pane rename"
+  # Prove the sweep actually talked to herdr before refuting renames: with a
+  # missing or empty log, `cat` noise satisfies any refutation, so a sweep that
+  # made zero calls would pass. The snapshot read is the sweep's first call.
+  assert_file_contains "$HTS_LOG" '^api snapshot$'
+  run grep -c -E '^(pane|tab) rename' "$HTS_LOG"
+  assert_output "0"
 }
 
 # An all-idle tab is numbered instead of skipped, or its last composed label

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -158,10 +158,8 @@ function test_scripts_008_darwin_scripts_excluded_from_managed_list_on_lin() {
   is_linux || skip "Only relevant on Linux"
   skip_if_no_chezmoi
   PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" managed
-  # Status first: a failed `chezmoi managed` emits an error string that would
-  # satisfy the refutation below. The .gitconfig line is the positive control
-  # proving the listing is real and non-empty before the darwin exclusion is
-  # refuted against it.
+  # A failed `chezmoi managed` emits an error string that would satisfy the
+  # refutation, so status and a known-managed line come first.
   assert_success
   assert_output --partial ".gitconfig"
   refute_output --partial "run_once_after_macos-tunes"
@@ -6068,9 +6066,8 @@ function test_scripts_216_herdr_task_sync_sweep_leaves_an_unchanged_tab_la() {
       {"pid":200,"name":"btop","argv0":"btop","argv":["btop"]}]}}}'
   run hts_sweep_run --sweep
   assert_success
-  # Prove the sweep actually talked to herdr before refuting renames: with a
-  # missing or empty log, `cat` noise satisfies any refutation, so a sweep that
-  # made zero calls would pass. The snapshot read is the sweep's first call.
+  # With a missing or empty log any refutation is green, so first prove the
+  # sweep talked to herdr at all — the snapshot read is its first call.
   assert_file_contains "$HTS_LOG" '^api snapshot$'
   run grep -c -E '^(pane|tab) rename' "$HTS_LOG"
   assert_output "0"

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -1030,14 +1030,16 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$config" '^rows = \[\["state_icon", "\$agent_line"\], \["\$git_line"\]\]$'
   run grep -E '\$location_label|\$location_status' "$config"
   assert_failure
+  # The awk scope proves the key sits inside [ui], which the grep above cannot.
+  # The former follow-ups `width - 4 >= 28` and `width - 4 >= 8` were arithmetic
+  # over the constant just asserted and could never fail independently; no
+  # consumer of a "width - 4" budget exists in ~/.local/bin/herdr-task-sync.
   width="$(awk '
     $0 == "[ui]" { in_ui = 1; next }
     /^\[/ { in_ui = 0 }
     in_ui && /^sidebar_min_width = [0-9]+$/ { print $3 }
   ' "$config")"
   [ "$width" -eq 32 ]
-  [ "$((width - 4))" -ge 28 ]
-  [ "$((width - 4))" -ge 8 ]
 }
 
 function test_smoke_068_herdr_managed_source_preserves_the_u6_sidebar_an() {

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -1031,9 +1031,7 @@ assert_herdr_sidebar_deployment_contract() {
   run grep -E '\$location_label|\$location_status' "$config"
   assert_failure
   # The awk scope proves the key sits inside [ui], which the grep above cannot.
-  # The former follow-ups `width - 4 >= 28` and `width - 4 >= 8` were arithmetic
-  # over the constant just asserted and could never fail independently; no
-  # consumer of a "width - 4" budget exists in ~/.local/bin/herdr-task-sync.
+  # No width-derived assertions here: nothing consumes a "width - 4" budget.
   width="$(awk '
     $0 == "[ui]" { in_ui = 1; next }
     /^\[/ { in_ui = 0 }

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -34,13 +34,10 @@ function test_templates_001_python3_is_present_and_at_least_3_9_the_floor_re() {
 # uses promptStringOnce which is unavailable in execute-template)
 # ===========================================
 
-# CHEZMOI_NAME/CHEZMOI_EMAIL bind at `chezmoi init`, not at data/render time,
-# so `chezmoi data` reads whatever config the host already has and the setup()
-# exports above are inert there — asserting on `chezmoi data` output proved
-# nothing about the env vars. Bind each value into its own init-time config via
-# write_test_config and prove a different value renders differently: the second
-# render is the control that the first match came from the env var, not from
-# ambient host state.
+# CHEZMOI_NAME/CHEZMOI_EMAIL bind at `chezmoi init`, not at render time, so
+# the setup() exports above are inert here — each value needs its own
+# init-time config. The second render is the control against ambient host
+# state.
 function test_templates_002_chezmoi_init_binds_name_from_env_var() {
   _bats_test_init 2 'chezmoi init binds name from env var'
   local tmpl="$BATS_TEST_TMPDIR/name.tmpl"

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -34,18 +34,43 @@ function test_templates_001_python3_is_present_and_at_least_3_9_the_floor_re() {
 # uses promptStringOnce which is unavailable in execute-template)
 # ===========================================
 
-function test_templates_002_chezmoi_data_contains_name_from_env_var() {
-  _bats_test_init 2 'chezmoi data contains name from env var'
-  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" data --format json
+# CHEZMOI_NAME/CHEZMOI_EMAIL bind at `chezmoi init`, not at data/render time,
+# so `chezmoi data` reads whatever config the host already has and the setup()
+# exports above are inert there — asserting on `chezmoi data` output proved
+# nothing about the env vars. Bind each value into its own init-time config via
+# write_test_config and prove a different value renders differently: the second
+# render is the control that the first match came from the env var, not from
+# ambient host state.
+function test_templates_002_chezmoi_init_binds_name_from_env_var() {
+  _bats_test_init 2 'chezmoi init binds name from env var'
+  local tmpl="$BATS_TEST_TMPDIR/name.tmpl"
+  printf '{{ .name }}' > "$tmpl"
+
+  CHEZMOI_NAME="Alpha Tester" write_test_config "$BATS_TEST_TMPDIR/name-a.yaml"
+  run render_with_config "$BATS_TEST_TMPDIR/name-a.yaml" "$tmpl"
   assert_success
-  assert_output --partial '"name"'
+  assert_output "Alpha Tester"
+
+  CHEZMOI_NAME="Beta Tester" write_test_config "$BATS_TEST_TMPDIR/name-b.yaml"
+  run render_with_config "$BATS_TEST_TMPDIR/name-b.yaml" "$tmpl"
+  assert_success
+  assert_output "Beta Tester"
 }
 
-function test_templates_003_chezmoi_data_contains_email_from_env_var() {
-  _bats_test_init 3 'chezmoi data contains email from env var'
-  PATH="$PATH_WITHOUT_OP" run "$CHEZMOI_BIN" data --format json
+function test_templates_003_chezmoi_init_binds_email_from_env_var() {
+  _bats_test_init 3 'chezmoi init binds email from env var'
+  local tmpl="$BATS_TEST_TMPDIR/email.tmpl"
+  printf '{{ .email }}' > "$tmpl"
+
+  CHEZMOI_EMAIL="alpha@example.net" write_test_config "$BATS_TEST_TMPDIR/email-a.yaml"
+  run render_with_config "$BATS_TEST_TMPDIR/email-a.yaml" "$tmpl"
   assert_success
-  assert_output --partial '"email"'
+  assert_output "alpha@example.net"
+
+  CHEZMOI_EMAIL="beta@example.net" write_test_config "$BATS_TEST_TMPDIR/email-b.yaml"
+  run render_with_config "$BATS_TEST_TMPDIR/email-b.yaml" "$tmpl"
+  assert_success
+  assert_output "beta@example.net"
 }
 
 # ===========================================

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -32,7 +32,11 @@ class TestDockerContract(unittest.TestCase):
         self.assertRegex(self.compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
         self.assertNotRegex(self.compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
         self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", self.compose)
-        self.assertIn("tests/bashunit/idempotent_test.sh", self.compose)
+        # No compose-text check for idempotent_test.sh here: its only matches in
+        # docker-compose.yml are comments. Reachability is owned behaviorally by
+        # tests/test_post_apply_suite_contract.py, which runs the wrapper and
+        # observes idempotent_test.sh in `full` mode's argv (the mode both
+        # compose services invoke) but not in `host-safe`'s.
 
     def test_full_suite_services_stage_issue_cli_and_use_canonical_smithers_gate(self):
         required = [

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -32,11 +32,9 @@ class TestDockerContract(unittest.TestCase):
         self.assertRegex(self.compose, r"(?m)^  test-ubuntu:\n", "docker-compose.yml must define the service make test-ubuntu runs")
         self.assertNotRegex(self.compose, r"(?m)^  test-quick:\n", "the full apply suite must not be named test-quick")
         self.assertIn("chezmoi apply --source=/home/testuser/.local/share/chezmoi --verbose", self.compose)
-        # No compose-text check for idempotent_test.sh here: its only matches in
-        # docker-compose.yml are comments. Reachability is owned behaviorally by
-        # tests/test_post_apply_suite_contract.py, which runs the wrapper and
-        # observes idempotent_test.sh in `full` mode's argv (the mode both
-        # compose services invoke) but not in `host-safe`'s.
+        # No compose-text check for idempotent_test.sh: it appears only in
+        # comments there; tests/test_post_apply_suite_contract.py owns its
+        # reachability.
 
     def test_full_suite_services_stage_issue_cli_and_use_canonical_smithers_gate(self):
         required = [


### PR DESCRIPTION
## Summary

Nine assertion sites across five suites could not fail no matter what broke — they read as coverage while protecting nothing. Each now carries an assertion that was calibrated red by reintroducing the exact regression it names, or was deleted in favor of the neighboring test that already owns the contract.

Closes the audit issue `docs/issues/2026-08-29-006-vacuous-assertions-across-five-suites-protect-nothing.md` (committed in this PR as done, with the per-site resolution).

## What each site asserts now

| Site | Before | Now |
|---|---|---|
| `test_docker_contract.py` | `assertIn` matched `idempotent_test.sh` only in docker-compose comments | Assertion removed; suite reachability is owned behaviorally by `test_post_apply_suite_contract.py`, which runs the wrapper and observes the file in `full` mode's argv but not `host-safe`'s |
| `smoke_test.sh` sidebar contract | `width-4 >= 28` and `width-4 >= 8` were arithmetic over a constant asserted one line up | Both deleted; the awk `[ui]`-scoped `-eq 32` stays because section placement is real protection the plain grep cannot give. No consumer of a `width-4` budget exists in `herdr-task-sync` |
| `scripts_test.sh` darwin-exclusion (Linux-only) | `refute_output` after `chezmoi managed` with no status check — a failing command's error text satisfied it | `assert_success` plus a `.gitconfig` positive control prove the listing is real and non-empty before the darwin refutation |
| `scripts_test.sh` sweep no-rename | `run cat "$HTS_LOG"` + refutes — green with a missing log and green when the sweep made zero calls | Asserts the sweep talked to herdr (`api snapshot` in the log) first, then `grep -c` renames with `assert_output "0"`, which distinguishes "no rename" from "no log" |
| `idempotent_test.sh` guard test 010 | The workstation branch asserted `verdict != misconfigured` under the exact condition that makes `misconfigured` structurally unreachable | Asserts the closed run/skip vocabulary and that `MMS_DISPOSABLE_HOME=1` flips the live-environment verdict to `run` — the one claim the env-scrubbed guard tests deliberately cannot make. CI/docker branch unchanged |
| `gates.test.ts` escape advisory ×2 | Tests pushed into `verdict.reasons` themselves, then asserted the push — one effectively asserted `Array.prototype.push` | The se-pipeline composition is extracted into `appendEscapeAdvisory` (`lib/gates.ts`), called from `se-pipeline.tsx`; tests assert reason content, reason-count delta, and state preservation on the green, red, and no-escape paths |
| `block-registry.test.ts` byte-stability | Compared one registry's JSON to itself — could never fail | Compares two independently built registries registered in opposite order, plus a key-canonicalization test that reddens if `sortedReplacer` is dropped |
| `blocks/index.test.ts` byte-stability | Same self-comparison | Compares two `buildRegistry()` generations and a reversed-`INITIAL_LIBRARY` registry, so a broken `list()` sort reddens on the real library path |
| `templates_test.sh` 002/003 | `chezmoi data` reads the host's bound config, so the exported `CHEZMOI_NAME`/`CHEZMOI_EMAIL` were inert and any config satisfied the `"name"`/`"email"` substring | Binds each env var at init time via `write_test_config` and proves a different value renders differently — the second render is the control that the match came from the env var, not ambient host state |

Note: the `templates_test.sh` env-binding hole is also being fixed on another branch (PR #103); overlapping edits there are expected to conflict at merge time.

## Red-calibration evidence

Every rewritten assertion was shown to fail against its named regression and pass after restore:

- broke the template's `env "CHEZMOI_NAME"` read → templates test red
- broke the disposable-home truth rule (`== "1"` → `== "2"`) → guard test red
- no-op'd `sweep_tabs` in `herdr-task-sync` → sweep test red (the old refutations stayed green under this mutation)
- mutated `appendEscapeAdvisory` to flip `state` → advisory test red
- removed `list()`'s name sort → both registry byte-stability tests red
- dropped `sortedReplacer` → key-canonicalization test red

## Verification

All canonical gates green: `make test-issues` (41 unittest OK), `make test-templates` (27 passed; +4 assertions vs base, same pre-existing risky test), `make test-smithers` (545 pass, tsc clean), `make lint` (shellcheck + bats-assertion checker), `make test-suite` (host-safe, exit 0), and `make test-ubuntu` (full Docker apply + all five suites, exit 0 — this is where the Linux-only darwin-exclusion test and the real idempotency scenarios run).

One observation, reported for honesty: a single `bun run check` invocation failed one unidentified test once during the session; six subsequent full-suite runs were green (544–545 pass each). Suspected pre-existing git-fixture flake outside the changed files; it did not reproduce.

## Review

Two independent report-only reviews of the same head (Claude Sonnet and GPT-5.6 Terra), both "Ready with fixes", zero contradictions. All three merged findings were applied and calibrated in the second commit: `blocks/index.test.ts` needed registration-order variation on the real library path (P1), neither registry test exercised `sortedReplacer` (P2), and the no-escape advisory test omitted the state assertion its contract names (P2).
