### PR TITLE
fix(herdr): stop test runs leaking orphaned herdr-child watcher daemons

### DIFF
--- a/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
+++ b/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["herdr","process-cleanup","test-isolation","performance"]
 date: "2026-08-28"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 
@@ -45,3 +45,32 @@ floor: kill each watcher whose `--launcher-pid` process is dead (see
 - Fix in the watcher itself (exit when launcher pid vanishes) vs. in test
   teardown (broader reap) vs. both. The watcher-side fix also protects real
   (non-test) herdr usage from the same leak.
+
+## Findings (2026-08-29)
+
+Three escape paths confirmed by deterministic reproduction (red on the
+pre-fix revision, green after):
+
+1. `HERDR_CHILD_TEST_ARM_BARRIER` wait: spun at 10ms with no
+   `kill -0 "$launcher_pid"` check, so a SIGKILLed harness (which writes no
+   `abort.state`) orphaned the watcher forever.
+2. `HERDR_CHILD_TEST_WATCHER_RELEASE` wait: the launcher legitimately exits
+   before this hold is released, so launcher liveness cannot free it; an
+   abandoned hold (harness killed before touching the release file) spun
+   forever.
+3. Main supervision loop — the shape every live orphan on the machine
+   actually had (`ps` showed dead launcher, deleted run dir, growing
+   /dev/null write offset): once teardown removes the run dir, the
+   `herdr pane get` error path fails to write `$run_dir/pane-get.err`, the
+   `pane_not_found` grep finds nothing, and the loop treats every iteration
+   as transient — polling forever at `POLL_INTERVAL` (10ms in lifecycle
+   tests). This branch also affects real herdr usage when run state is
+   removed while herdr is unreachable.
+
+Fix: watchers now exit when their run dir disappears (main loop, release
+hold, invalidation loop); the pre-arm barrier fails on a dead launcher; all
+test-only barrier holds (arm, release, failure-publish) are bounded by
+`HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS` (default 120s). Test teardown
+escalates TERM→KILL, the blocking herdr stubs are bounded, and
+`tests/run-post-apply.sh` fails the run if any watcher from this checkout
+survives with a dead launcher (then reaps it).

--- a/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
+++ b/docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["herdr","process-cleanup","test-isolation","performance"]
 date: "2026-08-28"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -74,3 +75,7 @@ test-only barrier holds (arm, release, failure-publish) are bounded by
 escalates TERM→KILL, the blocking herdr stubs are bounded, and
 `tests/run-post-apply.sh` fails the run if any watcher from this checkout
 survives with a dead launcher (then reaps it).
+
+## Resolution
+
+Fixed at the source in home/dot_local/bin/executable_herdr-child: watchers now exit when their supervision run dir is externally removed (main loop, release hold, invalidation loop) — this was the escape every observed orphan actually took, since a deleted run dir made the herdr error path look transient forever; the pre-arm test barrier fails on a dead launcher (launcher-lost-before-arm); all test-only barrier holds are bounded by HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS (default 120s). Suite-side: teardown escalates TERM to KILL, all blocking herdr-stub loops are bounded, and tests/run-post-apply.sh fails the run and reaps any watcher from this checkout with a dead launcher AND missing run dir (both criteria required so a concurrent run's legitimately held watcher is not a false positive; pid identity is re-verified before TERM and KILL). Regression coverage: scripts_test 259/260/261 (launcher death, torn-down state, bounded hold — each proven red on the pre-fix revision) and smoke_test 076 (guard reaps only abandoned fakes, controls survive). Verified: full scripts+smoke suites green on host, make lint, make test-ubuntu green in Docker; a pre-fix baseline suite run leaked a watcher while the fixed run left zero.

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -453,10 +453,8 @@ watcher_generation_current() {
   esac
 }
 
-# Test-only barrier holds must not orphan the watcher daemon when the test
-# harness dies without releasing them (docs/issues/2026-08-28-001): every hold
-# is bounded, and an expired hold means the harness is gone, so the holder
-# cleans up its run state and exits instead of polling forever.
+# Test-only barrier holds are bounded (docs/issues/2026-08-28-001): an
+# expired hold means the harness died without releasing the barrier.
 watcher_hold_expired() {
   [ $((SECONDS - $1)) -ge "${HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS:-120}" ]
 }

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -396,6 +396,7 @@ watcher_invalidation_action() {
   owner_pid="$(state_value "$run_dir/reap-pending.state" owner_pid)"
   case "$owner_pid" in '' | *[!0-9]*) return 21 ;; esac
   while :; do
+    [ -d "$run_dir" ] || return 20
     [ ! -f "$run_dir/reap-closed.state" ] || return 20
     if [ -f "$run_dir/reap-restore.state" ]; then
       rm -f "$run_dir/invalidated.state" "$run_dir/reap-pending.state" \
@@ -452,12 +453,27 @@ watcher_generation_current() {
   esac
 }
 
+# Test-only barrier holds must not orphan the watcher daemon when the test
+# harness dies without releasing them (docs/issues/2026-08-28-001): every hold
+# is bounded, and an expired hold means the harness is gone, so the holder
+# cleans up its run state and exits instead of polling forever.
+watcher_hold_expired() {
+  [ $((SECONDS - $1)) -ge "${HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS:-120}" ]
+}
+
 watcher_publish_failed() {
   local run_dir="$1" pane="$2" generation="$3" reason="$4" preserve_waiting="${5:-0}"
-  local current_status
+  local current_status hold_started
   if [ -n "${HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER:-}" ]; then
     : > "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.ready"
-    while [ ! -e "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.release" ]; do sleep 0.01; done
+    hold_started="$SECONDS"
+    while [ ! -e "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.release" ]; do
+      if watcher_hold_expired "$hold_started"; then
+        remove_supervision_run "$run_dir"
+        exit 1
+      fi
+      sleep 0.01
+    done
   fi
   # watcher_generation_current re-enables errexit internally, clobbering any
   # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
@@ -696,7 +712,16 @@ watch_child() {
   done
   if [ -n "${HERDR_CHILD_TEST_ARM_BARRIER:-}" ]; then
     : > "$HERDR_CHILD_TEST_ARM_BARRIER.ready"
+    local arm_hold_started="$SECONDS"
     while [ ! -e "$HERDR_CHILD_TEST_ARM_BARRIER.release" ] && [ ! -f "$run_dir/abort.state" ]; do
+      # A live holder of this pre-arm barrier always has a live launcher
+      # blocked on armed.state; a dead launcher means the harness is gone.
+      kill -0 "$launcher_pid" 2>/dev/null || \
+        watcher_fail "$run_dir" "$pane" "$generation" launcher-lost-before-arm
+      if watcher_hold_expired "$arm_hold_started"; then
+        remove_supervision_run "$run_dir"
+        exit 1
+      fi
       sleep 0.01
     done
   fi
@@ -724,7 +749,15 @@ watch_child() {
 
   # Existing descriptor tests hold the watcher at this explicit boundary.
   if [ -n "${HERDR_CHILD_TEST_WATCHER_RELEASE:-}" ]; then
+    local release_hold_started="$SECONDS"
     while [ ! -e "$HERDR_CHILD_TEST_WATCHER_RELEASE" ]; do
+      # The launcher legitimately exits before this hold is released, so the
+      # only abandonment signals are torn-down run state and the hold bound.
+      [ -d "$run_dir" ] || exit 1
+      if watcher_hold_expired "$release_hold_started"; then
+        remove_supervision_run "$run_dir"
+        exit 1
+      fi
       if [ -f "$run_dir/invalidated.state" ]; then
         set +e
         watcher_invalidation_action "$run_dir" "$pane" "$generation"
@@ -754,6 +787,12 @@ watch_child() {
   local delivery_status pane_get_status get_status wait_status wait_output slice remaining
   local wait_phase=0 retry_delay="$DELIVERY_RETRY_INITIAL" callback_status preserve_waiting
   while :; do
+    # Externally removed run state means supervision was torn down (test
+    # teardown or reap); without this check a dead run dir turns the herdr
+    # error path below into a permanent poll loop, because the pane_err
+    # redirection fails and every iteration looks transient
+    # (docs/issues/2026-08-28-001).
+    [ -d "$run_dir" ] || exit 1
     if [ -f "$run_dir/invalidated.state" ]; then
       set +e
       watcher_invalidation_action "$run_dir" "$pane" "$generation"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -34,6 +34,11 @@ teardown() {
           attempt=$((attempt + 1))
           sleep 0.01
         done
+        # A watcher that survives TERM (e.g., stuck publishing through a
+        # deleted stub) must not outlive the test (docs/issues/2026-08-28-001).
+        if kill -0 "$watcher_pid" 2>/dev/null; then
+          kill -KILL "$watcher_pid" 2>/dev/null || true
+        fi
       fi
     fi
   fi
@@ -482,7 +487,15 @@ case "${1:-} ${2:-}" in
     : > "$CHILD_STUB/prompt-seen"
     if [ "${STUB_PROMPT_BLOCK:-0}" = 1 ]; then
       trap 'exit 143' HUP INT TERM
-      while [ ! -e "$CHILD_STUB/release-prompt" ]; do sleep 0.01; done
+      # Bounded so an orphaned stub prompt cannot poll forever after a killed
+      # harness (docs/issues/2026-08-28-001).
+      attempt=0
+      while [ ! -e "$CHILD_STUB/release-prompt" ]; do
+        [ -d "$CHILD_STUB" ] || exit 1
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 12000 ] || exit 1
+        sleep 0.01
+      done
     fi
     [ "${STUB_PROMPT_FAIL:-0}" = 1 ] && { printf '{"error":{"code":"agent_prompt_stalled"}}\n' >&2; exit 1; }
     [ "${STUB_PROMPT_TIMEOUT:-0}" = 1 ] && { printf '{"error":{"code":"timeout"}}\n' >&2; exit 1; }
@@ -493,7 +506,15 @@ case "${1:-} ${2:-}" in
       if [ "${STUB_SUPERVISION_REPORT_BLOCK:-0}" = 1 ]; then
         : > "$CHILD_STUB/liveness-started"
         trap 'exit 143' HUP INT TERM
-        while [ ! -e "$CHILD_STUB/release-liveness" ]; do sleep 0.01; done
+        # Bounded so an orphaned stub cannot poll forever after a killed
+        # harness (docs/issues/2026-08-28-001).
+        attempt=0
+        while [ ! -e "$CHILD_STUB/release-liveness" ]; do
+          [ -d "$CHILD_STUB" ] || exit 1
+          attempt=$((attempt + 1))
+          [ "$attempt" -lt 12000 ] || exit 1
+          sleep 0.01
+        done
       fi
       [ "${STUB_SUPERVISION_REPORT_FAIL:-0}" != 1 ] || exit 1
     fi
@@ -7175,6 +7196,87 @@ function test_scripts_265_herdr_task_sync_fails_open_test_completes_with() {
   assert_output --partial "Passed: herdr-task-sync fails open for missing tools"
   assert_output --partial "1 passed, 1 total"
   assert_output --partial "All tests passed"
+}
+
+# ===========================================
+# watcher orphan self-termination (docs/issues/2026-08-28-001)
+# ===========================================
+
+function test_scripts_261_herdr_child_watcher_at_arm_barrier_exits_when_la() {
+  _bats_test_init 261 'herdr-child watcher held at the arm barrier exits when its launcher is SIGKILLed'
+  child_stub_herdr
+  env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 STUB_START_CONTEXT=1 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    HERDR_CHILD_TEST_WATCHER_PID_FILE="$CHILD_STUB/watcher.pid" \
+    HERDR_CHILD_TEST_ARM_BARRIER="$CHILD_STUB/arm" \
+    bash "$HERDR_CHILD" start --kind claude --name child-orphan-arm --detach \
+    --prompt "test task" > /dev/null 2>&1 &
+  local launcher_pid=$!
+  local attempt=0
+  while [ ! -e "$CHILD_STUB/arm.ready" ] && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$CHILD_STUB/arm.ready"
+  local watcher_pid
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  # SIGKILL writes no abort.state, so only the watcher's own launcher
+  # liveness check can free it from the held barrier.
+  kill -KILL "$launcher_pid" 2>/dev/null || true
+  wait "$launcher_pid" 2>/dev/null || true
+  attempt=0
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$watcher_pid"
+  assert_failure
+}
+
+function test_scripts_262_herdr_child_armed_watcher_exits_when_run_state_i() {
+  _bats_test_init 262 'herdr-child armed watcher exits when its supervision run state is torn down'
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 5000
+  assert_success
+  local watcher_pid
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  kill -0 "$watcher_pid"
+  # Teardown-style destruction while the watcher polls its main loop: with
+  # the run dir gone every herdr error looks transient, which used to spin
+  # the watcher forever at the poll interval.
+  rm -rf "$CHILD_STUB/state"
+  local attempt=0
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$watcher_pid"
+  assert_failure
+}
+
+function test_scripts_263_herdr_child_watcher_release_hold_is_bounded() {
+  _bats_test_init 263 'herdr-child watcher held for release self-terminates once the hold bound expires'
+  child_stub_herdr
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    STUB_START_CONTEXT=1 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    HERDR_CHILD_TEST_WATCHER_PID_FILE="$CHILD_STUB/watcher.pid" \
+    HERDR_CHILD_TEST_WATCHER_RELEASE="$CHILD_STUB/release-watcher" \
+    HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS=1 \
+    bash "$HERDR_CHILD" start --kind claude --name child-orphan-hold --detach \
+    --prompt "test task"
+  assert_success
+  local watcher_pid
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  # No release file is ever written: an abandoned hold must expire on its own
+  # instead of orphaning a polling daemon.
+  local attempt=0
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 400 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$watcher_pid"
+  assert_failure
 }
 
 function set_up_before_script() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -652,7 +652,15 @@ case "${1:-} ${2:-}" in
   "agent wait")
     : > "$CHILD_STUB/wait-observed"
     if [ -f "$CHILD_STUB/wait-block" ]; then
-      while [ ! -f "$CHILD_STUB/wait-release" ]; do sleep 0.01; done
+      # Bounded so an orphaned stub cannot poll forever after a killed
+      # harness (docs/issues/2026-08-28-001).
+      attempt=0
+      while [ ! -f "$CHILD_STUB/wait-release" ]; do
+        [ -d "$CHILD_STUB" ] || exit 1
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 12000 ] || exit 1
+        sleep 0.01
+      done
     fi
     if [ -f "$CHILD_STUB/wait-error" ]; then
       printf '{"error":{"code":"internal_error","message":"transient wait failure"}}\n' >&2
@@ -677,7 +685,15 @@ case "${1:-} ${2:-}" in
       fi
       if [ -f "$CHILD_STUB/block-parent-prompt" ]; then
         : > "$CHILD_STUB/parent-prompt-accepted"
-        while [ ! -f "$CHILD_STUB/release-parent-prompt" ]; do sleep 0.01; done
+        # Bounded so an orphaned stub cannot poll forever after a killed
+        # harness (docs/issues/2026-08-28-001).
+        attempt=0
+        while [ ! -f "$CHILD_STUB/release-parent-prompt" ]; do
+          [ -d "$CHILD_STUB" ] || exit 1
+          attempt=$((attempt + 1))
+          [ "$attempt" -lt 12000 ] || exit 1
+          sleep 0.01
+        done
       fi
       printf '%s\n' "${4:-}" >> "$CHILD_STUB/successful-prompts.log"
     elif [ -f "$CHILD_STUB/advance-on-prompt" ]; then

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -7257,9 +7257,8 @@ function test_scripts_262_herdr_child_armed_watcher_exits_when_run_state_i() {
   local watcher_pid
   watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
   kill -0 "$watcher_pid"
-  # Teardown-style destruction while the watcher polls its main loop: with
-  # the run dir gone every herdr error looks transient, which used to spin
-  # the watcher forever at the poll interval.
+  # Teardown-style destruction mid-poll: with the run dir gone every herdr
+  # error looks transient, so an unguarded watcher spins forever.
   rm -rf "$CHILD_STUB/state"
   local attempt=0
   while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -69,14 +69,17 @@ function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
   local stop_fakes="$BATS_TEST_TMPDIR/stop-fakes"
   mkdir -p "$live_run_dir"
   # Fakes poll a stop file instead of holding a fixed-lifetime sleep: their
-  # lifetime is not a wall-clock bound (no flake under load), and a killed
-  # fake leaves at most a 0.2s sleep grandchild behind. stdio is detached so
-  # no child can hold the test runner's output pipe open.
-  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+  # lifetime is not a tight wall-clock bound (no flake under load), and a
+  # killed fake leaves at most a 0.2s sleep grandchild behind. The 300 x 0.2s
+  # cap makes a failed assertion (which skips the stop-file write below) end
+  # in a bounded red test instead of an indefinite hang while bashunit waits
+  # on the background jobs. stdio is detached so no child can hold the test
+  # runner's output pipe open.
+  bash -c 'n=0; until [ -e "$1" ] || [ "$n" -ge 300 ]; do n=$((n + 1)); sleep 0.2; done' \
     "guard-fake-live-launcher $watcher_argv --run-dir $BATS_TEST_TMPDIR/gone --launcher-pid $$" \
     "$stop_fakes" </dev/null >/dev/null 2>&1 &
   local live_launcher_fake=$!
-  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+  bash -c 'n=0; until [ -e "$1" ] || [ "$n" -ge 300 ]; do n=$((n + 1)); sleep 0.2; done' \
     "guard-fake-live-rundir $watcher_argv --run-dir $live_run_dir --launcher-pid $dead_pid" \
     "$stop_fakes" </dev/null >/dev/null 2>&1 &
   local live_rundir_fake=$!
@@ -86,7 +89,7 @@ function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
   kill -0 "$live_launcher_fake"
   kill -0 "$live_rundir_fake"
 
-  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+  bash -c 'n=0; until [ -e "$1" ] || [ "$n" -ge 300 ]; do n=$((n + 1)); sleep 0.2; done' \
     "guard-fake-orphan $watcher_argv --run-dir $BATS_TEST_TMPDIR/gone --launcher-pid $dead_pid" \
     "$stop_fakes" </dev/null >/dev/null 2>&1 &
   local orphan_fake=$!

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -47,13 +47,11 @@ function test_smoke_003_post_apply_suite_wrapper_rejects_an_unknown_mode() {
   assert_output --partial "usage: tests/run-post-apply.sh full|host-safe"
 }
 
-# The suite-end orphan guard (docs/issues/2026-08-28-001) must kill and fail
-# on a watcher whose launcher is dead AND whose run dir is gone, while leaving
-# both near-miss controls alone: a live launcher, and a dead launcher whose
-# run dir still exists (a concurrent run's legitimately held watcher).
+# Covers the suite-end orphan guard (docs/issues/2026-08-28-001). The
+# near-miss controls are load-bearing: a dead launcher with a surviving run
+# dir is a concurrent run's legitimately held watcher, not an orphan.
 # MMS_BASHUNIT_BIN=/usr/bin/true stubs the per-file runs so only the guard
-# executes. The fake watchers are `sleep` holders whose argv carries the
-# process-table shape the guard scans for.
+# executes.
 function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
   _bats_test_init 76 'post-apply orphan guard reaps only abandoned watchers'
   local repository_root
@@ -68,13 +66,10 @@ function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
   local live_run_dir="$BATS_TEST_TMPDIR/guard-live-run"
   local stop_fakes="$BATS_TEST_TMPDIR/stop-fakes"
   mkdir -p "$live_run_dir"
-  # Fakes poll a stop file instead of holding a fixed-lifetime sleep: their
-  # lifetime is not a tight wall-clock bound (no flake under load), and a
-  # killed fake leaves at most a 0.2s sleep grandchild behind. The 300 x 0.2s
-  # cap makes a failed assertion (which skips the stop-file write below) end
-  # in a bounded red test instead of an indefinite hang while bashunit waits
-  # on the background jobs. stdio is detached so no child can hold the test
-  # runner's output pipe open.
+  # Fakes poll a stop file rather than sleep for a fixed lifetime, which
+  # would flake under load. The 300 x 0.2s cap keeps a failed assertion
+  # (which skips the stop-file write) a bounded red test instead of a hang;
+  # stdio is detached so no child holds the runner's output pipe open.
   bash -c 'n=0; until [ -e "$1" ] || [ "$n" -ge 300 ]; do n=$((n + 1)); sleep 0.2; done' \
     "guard-fake-live-launcher $watcher_argv --run-dir $BATS_TEST_TMPDIR/gone --launcher-pid $$" \
     "$stop_fakes" </dev/null >/dev/null 2>&1 &

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -47,6 +47,64 @@ function test_smoke_003_post_apply_suite_wrapper_rejects_an_unknown_mode() {
   assert_output --partial "usage: tests/run-post-apply.sh full|host-safe"
 }
 
+# The suite-end orphan guard (docs/issues/2026-08-28-001) must kill and fail
+# on a watcher whose launcher is dead AND whose run dir is gone, while leaving
+# both near-miss controls alone: a live launcher, and a dead launcher whose
+# run dir still exists (a concurrent run's legitimately held watcher).
+# MMS_BASHUNIT_BIN=/usr/bin/true stubs the per-file runs so only the guard
+# executes. The fake watchers are `sleep` holders whose argv carries the
+# process-table shape the guard scans for.
+function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
+  _bats_test_init 76 'post-apply orphan guard reaps only abandoned watchers'
+  local repository_root
+  repository_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  [[ -x "$repository_root/tests/run-post-apply.sh" ]] || skip "repository checkout is not mounted"
+  local watcher_argv="$repository_root/home/dot_local/bin/executable_herdr-child __watcher"
+
+  local dead_pid
+  true & dead_pid=$!
+  wait "$dead_pid" || true
+
+  local live_run_dir="$BATS_TEST_TMPDIR/guard-live-run"
+  local stop_fakes="$BATS_TEST_TMPDIR/stop-fakes"
+  mkdir -p "$live_run_dir"
+  # Fakes poll a stop file instead of holding a fixed-lifetime sleep: their
+  # lifetime is not a wall-clock bound (no flake under load), and a killed
+  # fake leaves at most a 0.2s sleep grandchild behind. stdio is detached so
+  # no child can hold the test runner's output pipe open.
+  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+    "guard-fake-live-launcher $watcher_argv --run-dir $BATS_TEST_TMPDIR/gone --launcher-pid $$" \
+    "$stop_fakes" </dev/null >/dev/null 2>&1 &
+  local live_launcher_fake=$!
+  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+    "guard-fake-live-rundir $watcher_argv --run-dir $live_run_dir --launcher-pid $dead_pid" \
+    "$stop_fakes" </dev/null >/dev/null 2>&1 &
+  local live_rundir_fake=$!
+
+  run env MMS_BASHUNIT_BIN=/usr/bin/true "$repository_root/tests/run-post-apply.sh" host-safe
+  assert_success
+  kill -0 "$live_launcher_fake"
+  kill -0 "$live_rundir_fake"
+
+  bash -c 'until [ -e "$1" ]; do sleep 0.2; done' \
+    "guard-fake-orphan $watcher_argv --run-dir $BATS_TEST_TMPDIR/gone --launcher-pid $dead_pid" \
+    "$stop_fakes" </dev/null >/dev/null 2>&1 &
+  local orphan_fake=$!
+  run env MMS_BASHUNIT_BIN=/usr/bin/true "$repository_root/tests/run-post-apply.sh" host-safe
+  [ "$status" -eq 1 ]
+  assert_output --partial "ORPHANED herdr-child watcher survived the suite"
+  local attempt=0
+  while kill -0 "$orphan_fake" 2>/dev/null && [ "$attempt" -lt 300 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$orphan_fake"
+  assert_failure
+
+  : > "$stop_fakes"
+  wait "$live_launcher_fake" "$live_rundir_fake" 2>/dev/null || true
+}
+
 # ===========================================
 # Chezmoi-managed files exist
 # ===========================================

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -67,7 +67,10 @@ done
 # exists) must not be killed; every observed leak shape had its run dir
 # already deleted. Scoped to $ROOT so runs from other checkouts cannot
 # cross-fire; the awk program's own command line never matches because its
-# literal "--launcher-pid [0-9]+" text carries no digits.
+# literal "--launcher-pid [0-9]+" text carries no digits. Known parse limit:
+# the /--run-dir [^ ]+/ extraction truncates a run-dir path containing
+# spaces; no environment that spawns these watchers (mktemp dirs, $HOME
+# state dirs) produces such a path today.
 watcher_args_match() {
   # Re-verify pid identity right before signaling (the ps snapshot is stale
   # and pids can be recycled).

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -60,19 +60,35 @@ PYEOF
 done
 
 # Suite-end orphan guard (docs/issues/2026-08-28-001): no herdr-child
-# __watcher spawned from this checkout may survive the run once its
-# --launcher-pid process is dead. Scoped to $ROOT so concurrent runs from
-# other checkouts cannot cross-fire; the awk program's own command line never
-# matches because its literal "--launcher-pid [0-9]+" text carries no digits.
+# __watcher spawned from this checkout may survive the run abandoned — dead
+# --launcher-pid AND missing --run-dir. Both criteria are required: a dead
+# launcher alone is the normal terminal state of an armed detached watcher,
+# so a concurrent run's legitimately held watcher (whose run dir still
+# exists) must not be killed; every observed leak shape had its run dir
+# already deleted. Scoped to $ROOT so runs from other checkouts cannot
+# cross-fire; the awk program's own command line never matches because its
+# literal "--launcher-pid [0-9]+" text carries no digits.
+watcher_args_match() {
+  # Re-verify pid identity right before signaling (the ps snapshot is stale
+  # and pids can be recycled).
+  ps -o args= -p "$1" 2>/dev/null \
+    | grep -F "herdr-child __watcher" | grep -Fq "$ROOT/"
+}
 orphan_rows="$(ps -axo pid=,args= | awk -v root="$ROOT/" '
-  index($0, "herdr-child __watcher") && index($0, root) && match($0, /--launcher-pid [0-9]+/) {
-    print $1 " " substr($0, RSTART + 15, RLENGTH - 15)
+  index($0, "herdr-child __watcher") && index($0, root) \
+    && match($0, /--launcher-pid [0-9]+/) {
+    launcher = substr($0, RSTART + 15, RLENGTH - 15)
+    rundir = ""
+    if (match($0, /--run-dir [^ ]+/)) rundir = substr($0, RSTART + 10, RLENGTH - 10)
+    print $1 " " launcher " " rundir
   }' || true)"
 orphan_pids=""
-while read -r pid launcher; do
+while read -r pid launcher rundir; do
   [ -n "$pid" ] || continue
   kill -0 "$launcher" 2>/dev/null && continue
-  echo "ORPHANED herdr-child watcher survived the suite: pid=$pid (dead launcher $launcher)" >&2
+  [ -n "$rundir" ] && [ -d "$rundir" ] && continue
+  watcher_args_match "$pid" || continue
+  echo "ORPHANED herdr-child watcher survived the suite: pid=$pid (dead launcher $launcher, missing run dir $rundir)" >&2
   kill -TERM "$pid" 2>/dev/null || true
   orphan_pids="$orphan_pids $pid"
 done <<EOF
@@ -81,6 +97,8 @@ EOF
 if [ -n "${orphan_pids# }" ]; then
   sleep 0.5
   for pid in $orphan_pids; do
+    kill -0 "$pid" 2>/dev/null || continue
+    watcher_args_match "$pid" || continue
     kill -KILL "$pid" 2>/dev/null || true
   done
   echo "suite-end watcher orphan guard failed (docs/issues/2026-08-28-001)" >&2

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -58,4 +58,32 @@ PYEOF
   fi
   command rm -f "$report"
 done
+
+# Suite-end orphan guard (docs/issues/2026-08-28-001): no herdr-child
+# __watcher spawned from this checkout may survive the run once its
+# --launcher-pid process is dead. Scoped to $ROOT so concurrent runs from
+# other checkouts cannot cross-fire; the awk program's own command line never
+# matches because its literal "--launcher-pid [0-9]+" text carries no digits.
+orphan_rows="$(ps -axo pid=,args= | awk -v root="$ROOT/" '
+  index($0, "herdr-child __watcher") && index($0, root) && match($0, /--launcher-pid [0-9]+/) {
+    print $1 " " substr($0, RSTART + 15, RLENGTH - 15)
+  }' || true)"
+orphan_pids=""
+while read -r pid launcher; do
+  [ -n "$pid" ] || continue
+  kill -0 "$launcher" 2>/dev/null && continue
+  echo "ORPHANED herdr-child watcher survived the suite: pid=$pid (dead launcher $launcher)" >&2
+  kill -TERM "$pid" 2>/dev/null || true
+  orphan_pids="$orphan_pids $pid"
+done <<EOF
+$orphan_rows
+EOF
+if [ -n "${orphan_pids# }" ]; then
+  sleep 0.5
+  for pid in $orphan_pids; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  echo "suite-end watcher orphan guard failed (docs/issues/2026-08-28-001)" >&2
+  [ "$rc" -ne 0 ] || rc=1
+fi
 exit "$rc"

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -64,13 +64,12 @@ done
 # --launcher-pid AND missing --run-dir. Both criteria are required: a dead
 # launcher alone is the normal terminal state of an armed detached watcher,
 # so a concurrent run's legitimately held watcher (whose run dir still
-# exists) must not be killed; every observed leak shape had its run dir
-# already deleted. Scoped to $ROOT so runs from other checkouts cannot
-# cross-fire; the awk program's own command line never matches because its
-# literal "--launcher-pid [0-9]+" text carries no digits. Known parse limit:
-# the /--run-dir [^ ]+/ extraction truncates a run-dir path containing
-# spaces; no environment that spawns these watchers (mktemp dirs, $HOME
-# state dirs) produces such a path today.
+# exists) must not be killed. Scoped to $ROOT so runs from other checkouts
+# cannot cross-fire; the awk program's own command line never matches
+# because its literal "--launcher-pid [0-9]+" text carries no digits.
+# Known parse limit: the /--run-dir [^ ]+/ extraction truncates a run-dir
+# path containing spaces; no environment that spawns these watchers
+# produces such a path today.
 watcher_args_match() {
   # Re-verify pid identity right before signaling (the ps snapshot is stale
   # and pids can be recycled).


### PR DESCRIPTION
## Summary

Test runs no longer leave `herdr-child __watcher` daemons polling forever after their harness dies, and any watcher that still survives a suite run now fails the run loudly instead of silently degrading the machine. Twelve accumulated orphans (10ms pollers) had inflated full-suite wall time by ~7% within an hour and destabilized benchmark numbers (`docs/issues/2026-08-28-001-bats-runs-leak-orphaned-herdr-child-watcher-daemons.md`, closed by this PR).

## The three escape paths

Each was reproduced deterministically: red on the pre-fix revision, green after.

1. **Main supervision loop misread a torn-down run dir as a transient herdr error.** When teardown deletes the run dir, the `2>"$run_dir/pane-get.err"` redirection fails, the `pane_not_found` grep finds nothing, and every iteration takes the `sleep "$POLL_INTERVAL"; continue` branch — forever. Every live orphan found on the machine had exactly this shape (dead launcher, deleted run dir, growing `/dev/null` write offset). The watcher now exits when its run dir is externally removed.
2. **The pre-arm test barrier never checked launcher liveness.** A SIGKILLed harness writes no `abort.state`, so the watcher spun at the barrier indefinitely. It now fails with `launcher-lost-before-arm`, mirroring the existing takeover/acceptance checks.
3. **Test-only holds were unbounded.** The release and failure-publish barriers now expire after `HERDR_CHILD_TEST_HOLD_TIMEOUT_SECONDS` (default 120s) and clean up their run state.

## Why the production exit paths are safe

The run-dir existence check is terminal by construction: the only writers that remove a run dir are the watcher itself (right before exiting) and the teardown/reap owner — an externally removed run dir always means supervision was ended. The dead-launcher exit fires only at the pre-arm barrier, a stage every legitimate flow passes with a live launcher; after arming, a dead launcher is the normal state of a detached watcher and is deliberately not used as an exit signal. The hold bounds live inside test-env-guarded blocks, so production behavior outside those environment variables is unchanged.

## Suite-side defense

- Per-test teardown escalates TERM to KILL; all four blocking herdr-stub loops are bounded, so a killed harness cannot strand a stub either.
- `tests/run-post-apply.sh` gains a suite-end guard: a watcher from this checkout with a dead `--launcher-pid` **and** a missing `--run-dir` fails the run and is reaped. Both criteria are required because a dead launcher alone is the normal terminal state of an armed detached watcher — a concurrent run's legitimately held watcher must not be a false-positive kill. Pid identity is re-verified from the live process table before TERM and again before the KILL escalation.

## Validation

- New regression tests each proven red on the pre-fix revision and green after: `scripts_test` 259 (launcher SIGKILL at the arm barrier), 260 (run-state teardown mid-supervision), 261 (bounded release hold), and `smoke_test` 076 (the guard reaps only an abandoned fake; live-launcher and surviving-run-dir controls are untouched). Smoke 076's own failure mode was probed against a guard-less runner: bounded red in ~63s, not a hang.
- Live proof: a pre-fix baseline suite run leaked one watcher; the fixed full run left zero.
- `make test-ubuntu` (full Docker suite, applies the checkout) exit 0; full `scripts_test.sh` and `smoke_test.sh` green on macOS with unchanged skip/risky identities; `make lint` and `make test-issues` green.

## Review

Cross-model review: a Claude peer review returned four findings — guard false-positive scope, pid-reuse window, two remaining unbounded stub loops, missing guard test coverage — all applied and covered above. The second (OpenCode) review leg failed to produce a report; an independent substitute reviewer re-executed the red/green calibration and traced the production paths, and its one MEDIUM finding (a regressed guard turned smoke 076 into an indefinite hang rather than a red test) is fixed by bounding the fake watchers' lifetime.

Known parse limit, recorded in the guard: `--run-dir` paths containing spaces would be truncated; no environment that spawns these watchers produces such a path.
