### PR TITLE
fix(herdr): remove the superseded watcher's run directory before exit

### DIFF
--- a/docs/issues/2026-08-28-001-assert-file-not-exists-on-a-directory-is-vacuously-green-in-bats-file.md
+++ b/docs/issues/2026-08-28-001-assert-file-not-exists-on-a-directory-is-vacuously-green-in-bats-file.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["test-integrity"]
 date: "2026-08-28"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Audit assert_file_not_exists / assert_file_exists call sites whose path can be a
 ## Open decisions
 
 None.
+
+## Resolution
+
+Both Scope actions are done. (1) The two directory expectations, tests/bashunit/scripts_test.sh tests 040 and 042, now use assert_dir_not_exists; every other assert_file_not_exists path resolves to a regular file, matching the 2026-08-29 audit. The test-dsl.bash comment no longer claims the suite depends on the vacuous -f semantics. (2) The surviving run directory was a real herdr-child bug, not intended: watcher_generation_current re-enables errexit internally, so the callers' set +e brackets were clobbered and the watcher died at the call site with the callee's nonzero status before reaching the status-20 handler that runs remove_supervision_run. The failure-publish and sliced-wait supersede paths now invoke the generation check (and watcher_fail its publish) through conditional context, which is immune to the callee's set flips. Calibration: with assert_dir_not_exists and the unfixed watcher, tests 040 and 042 were observed red; with the fix both are green, and make test-ubuntu passed end to end (254/258 scripts tests passed, 4 pre-existing risky, 0 failed). A cross-model review surfaced one adjacent pre-existing TOCTOU, filed as 2026-08-30-001.

--- a/docs/issues/2026-08-28-001-assert-file-not-exists-on-a-directory-is-vacuously-green-in-bats-file.md
+++ b/docs/issues/2026-08-28-001-assert-file-not-exists-on-a-directory-is-vacuously-green-in-bats-file.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["test-integrity"]
 date: "2026-08-28"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/docs/issues/2026-08-30-001-superseded-watcher-can-restore-stale-failure-metadata-between-generation-check-and-publish.md
+++ b/docs/issues/2026-08-30-001-superseded-watcher-can-restore-stale-failure-metadata-between-generation-check-and-publish.md
@@ -1,0 +1,22 @@
+---
+title: "Superseded watcher can restore stale failure metadata between generation check and publish"
+short_description: "watcher_publish_failed validates the generation with watcher_generation_current and then calls herdr pane report-metadata as a separate step. A continuation that takes over the pane between the check and the publish gets its fresh state labels cleared and the old generation's failure tokens restored. Pre-existing TOCTOU, unchanged by the 2026-08-30 supersede-cleanup fix, which only made the detected-supersede path clean up its run directory."
+type: "bug"
+category: "herdr"
+tags: ["concurrency"]
+date: "2026-08-30"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Found by the cross-model se-code-review of the fix for 2026-08-28-001 (vacuous assert_file_not_exists). The adversarial reviewer validated the interleaving: generation G passes watcher_generation_current, generation H publishes and clears failure metadata, then G's unconditioned report-metadata call runs and restores G's failure labels and tokens over H. The window predates that fix: the old set +e bracket had the same check-then-publish sequence; on this interleaving it also published stale metadata (on the detected mismatch it died instead).
+
+## Scope
+
+Make the failure-metadata publication conditional on the pane still carrying the publishing watcher's generation, e.g. an atomic expected-generation precondition on herdr pane report-metadata (likely needs herdr-side support). Add a deterministic barrier test that supersedes between validation and publication and asserts the new generation keeps cleared failure metadata (extend tests/bashunit/scripts_test.sh test 040's barrier scheme).
+
+## Open decisions
+
+Whether herdr grows an atomic compare-and-publish for pane metadata, or herdr-child re-validates and tolerates a benign race with a bounded self-correction.

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -459,10 +459,14 @@ watcher_publish_failed() {
     : > "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.ready"
     while [ ! -e "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.release" ]; do sleep 0.01; done
   fi
-  set +e
-  watcher_generation_current "$run_dir" "$pane" "$generation"
-  current_status=$?
-  set -e
+  # Conditional invocation: watcher_generation_current re-enables errexit
+  # internally, so a set +e bracket around the call would be clobbered and a
+  # nonzero return would kill this shell before the caller's status handling.
+  if watcher_generation_current "$run_dir" "$pane" "$generation"; then
+    current_status=0
+  else
+    current_status=$?
+  fi
   [ "$current_status" -eq 0 ] || return "$current_status"
   if [ "$preserve_waiting" -eq 1 ]; then
     herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
@@ -487,10 +491,13 @@ watcher_fail() {
   local publish_status
   release_arm_guard "$run_dir"
   rm -f "$run_dir/ready.state" "$run_dir/accepted.state" "$run_dir/abort.state" 2>/dev/null || true
-  set +e
-  watcher_publish_failed "$run_dir" "$pane" "$generation" "$reason" "$preserve_waiting"
-  publish_status=$?
-  set -e
+  # Conditional invocation: see watcher_publish_failed — a set +e bracket here
+  # is clobbered by the callee's internal set -e before its nonzero return.
+  if watcher_publish_failed "$run_dir" "$pane" "$generation" "$reason" "$preserve_waiting"; then
+    publish_status=0
+  else
+    publish_status=$?
+  fi
   if [ "$publish_status" -eq 20 ]; then
     remove_supervision_run "$run_dir"
     exit 0
@@ -900,10 +907,14 @@ EOF
       if [ "$wait_status" -ne 0 ] && ! printf '%s' "$wait_output" | grep -q '"code":"timeout"'; then
         watcher_fail "$run_dir" "$pane" "$generation" wait-error
       fi
-      set +e
-      watcher_generation_current "$run_dir" "$pane" "$generation"
-      generation_status=$?
-      set -e
+      # Conditional invocation: watcher_generation_current's internal set -e
+      # clobbers a set +e bracket, killing the watcher before the supersede
+      # (status 20) cleanup below can run.
+      if watcher_generation_current "$run_dir" "$pane" "$generation"; then
+        generation_status=0
+      else
+        generation_status=$?
+      fi
       case "$generation_status" in
         0) ;;
         20) remove_supervision_run "$run_dir"; exit 0 ;;

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -459,9 +459,8 @@ watcher_publish_failed() {
     : > "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.ready"
     while [ ! -e "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.release" ]; do sleep 0.01; done
   fi
-  # Conditional invocation: watcher_generation_current re-enables errexit
-  # internally, so a set +e bracket around the call would be clobbered and a
-  # nonzero return would kill this shell before the caller's status handling.
+  # watcher_generation_current re-enables errexit internally, clobbering any
+  # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
   if watcher_generation_current "$run_dir" "$pane" "$generation"; then
     current_status=0
   else
@@ -491,8 +490,8 @@ watcher_fail() {
   local publish_status
   release_arm_guard "$run_dir"
   rm -f "$run_dir/ready.state" "$run_dir/accepted.state" "$run_dir/abort.state" 2>/dev/null || true
-  # Conditional invocation: see watcher_publish_failed — a set +e bracket here
-  # is clobbered by the callee's internal set -e before its nonzero return.
+  # watcher_publish_failed re-enables errexit internally, clobbering any
+  # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
   if watcher_publish_failed "$run_dir" "$pane" "$generation" "$reason" "$preserve_waiting"; then
     publish_status=0
   else
@@ -907,9 +906,8 @@ EOF
       if [ "$wait_status" -ne 0 ] && ! printf '%s' "$wait_output" | grep -q '"code":"timeout"'; then
         watcher_fail "$run_dir" "$pane" "$generation" wait-error
       fi
-      # Conditional invocation: watcher_generation_current's internal set -e
-      # clobbers a set +e bracket, killing the watcher before the supersede
-      # (status 20) cleanup below can run.
+      # watcher_generation_current re-enables errexit internally, clobbering any
+      # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
       if watcher_generation_current "$run_dir" "$pane" "$generation"; then
         generation_status=0
       else

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1341,7 +1341,7 @@ function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
     sleep 0.01
   done
   [ "$attempt" -lt 500 ]
-  assert_file_not_exists "$old_run"
+  assert_dir_not_exists "$old_run"
   run cat "$CHILD_STUB/generation"
   assert_success
   assert_output new-generation
@@ -1391,7 +1391,7 @@ function test_scripts_042_herdr_child_sliced_wait_revalidates_generation_b() {
     sleep 0.01
   done
   [ "$attempt" -lt 500 ]
-  assert_file_not_exists "$old_run"
+  assert_dir_not_exists "$old_run"
   run bash -c 'line=$1; file=$2; ! sed -n "$((line + 1)),\$p" "$file" | grep -q "state-label supervised="' _ \
     "$wait_line" "$CHILD_STUB/calls.log"
   assert_success

--- a/tests/bashunit/test-dsl.bash
+++ b/tests/bashunit/test-dsl.bash
@@ -373,10 +373,10 @@ index      : $i
 # bats-file subset used by this suite
 # ---------------------------------------------------------------------------
 
-# bats-file tests -f (regular file), NOT -e. A directory at the path makes
-# assert_file_not_exists vacuously pass — that is oracle behavior and two
-# herdr-child scenarios depend on it (the superseded watcher's run DIRECTORY
-# survives; see docs/issues/ 2026-08-28 vacuous-file-assertion issue).
+# bats-file tests -f (regular file), NOT -e — kept for oracle parity. A
+# directory at the path makes assert_file_not_exists vacuously pass, so
+# directory expectations must use assert_dir_not_exists / assert_dir_exists
+# (see docs/issues/ 2026-08-28 vacuous-file-assertion issue).
 assert_file_exists() {
   if [ ! -f "$1" ]; then
     _bats_assert_fail "-- file does not exist --

--- a/tests/bashunit/test-dsl.bash
+++ b/tests/bashunit/test-dsl.bash
@@ -373,10 +373,9 @@ index      : $i
 # bats-file subset used by this suite
 # ---------------------------------------------------------------------------
 
-# bats-file tests -f (regular file), NOT -e — kept for oracle parity. A
-# directory at the path makes assert_file_not_exists vacuously pass, so
-# directory expectations must use assert_dir_not_exists / assert_dir_exists
-# (see docs/issues/ 2026-08-28 vacuous-file-assertion issue).
+# bats-file semantics kept for oracle parity: -f (regular file), NOT -e.
+# A directory at the path makes assert_file_not_exists vacuously pass —
+# directory expectations must use assert_dir_not_exists / assert_dir_exists.
 assert_file_exists() {
   if [ ! -f "$1" ]; then
     _bats_assert_fail "-- file does not exist --


### PR DESCRIPTION
## Summary

A superseded herdr-child watcher now removes its supervision run directory before it exits; previously the watcher process died before its cleanup handler ran, and the run directory survived every supersede.

The tests that claimed to enforce this cleanup (`scripts_test.sh` tests 040 and 042) used `assert_file_not_exists`, which tests `-f` and is always green when the path is a directory. The assertion never failed, so the leak was invisible.

## The bug the vacuous assertion hid

`watcher_generation_current` brackets an internal pipeline with `set +e` … `set -e`. That inner `set -e` is a global shell option change: it survives the function return and cancels the caller's own protective `set +e` bracket. When the function then returns nonzero (status 20 = superseded), errexit is active at the call site, and the watcher shell exits with that status immediately — before the caller's `20) remove_supervision_run; exit 0` handler can run. The same clobbering chain runs through `watcher_fail` → `watcher_publish_failed`.

The fix invokes the generation check (and `watcher_fail`'s publish) through conditional context (`if fn; then st=0; else st=$?; fi`), which suppresses errexit for the whole call tree regardless of the callee's internal set flips. All other `set +e` brackets in the script were audited: none wraps a callee that toggles errexit, so these three call sites are the complete set.

The two test assertions now use `assert_dir_not_exists`. The DSL keeps the bats-file `-f` semantics for oracle parity; only its comment changed, since no test depends on the vacuous case any more.

## Verification

- Red/green calibration: with `assert_dir_not_exists` and the unfixed watcher, tests 040 and 042 fail (run directory present); with the fix both pass. Both states were observed, not assumed.
- Full `tests/bashunit/scripts_test.sh` locally: 252 passed, 0 failed (2 skipped, 4 risky — pre-existing, unrelated to these tests).
- `make lint` clean.
- `make test-ubuntu`: the first run was invalid — a concurrent Docker build from another branch clobbered the shared image tag, so the container ran that branch's test file (its one failure does not exist on this branch). A rerun built from this checkout exited 0 with all suites green, including 040/042 against the applied checkout.
- Cross-model review (two independent report-only peers): one verdict "Ready to merge"; the other validated a P1 that is a pre-existing TOCTOU, not introduced here — a supersede landing between `watcher_publish_failed`'s generation check and its metadata publish can restore stale failure tokens. This window is unchanged by this PR and needs a herdr-side atomic precondition, so it is filed as `docs/issues/2026-08-30-001-superseded-watcher-can-restore-stale-failure-metadata-between-generation-check-and-publish.md` rather than fixed here.

## Related

- Resolves the repository issue `docs/issues/2026-08-28-001-assert-file-not-exists-on-a-directory-is-vacuously-green-in-bats-file.md` (closed in this PR).
- Related: #105 — it also modifies `home/dot_local/bin/executable_herdr-child` and `tests/bashunit/scripts_test.sh`. A merge conflict between the two is expected; neither PR claims exclusive ownership of the file, and whichever lands second rebases.
