### PR TITLE
feat(tests): bound fail-open stdin regressions instead of hanging CI

### DIFF
--- a/docs/issues/2026-08-29-011-add-bounded-open-pipe-regression-for-fail-open-tests.md
+++ b/docs/issues/2026-08-29-011-add-bounded-open-pipe-regression-for-fail-open-tests.md
@@ -5,7 +5,7 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["bashunit","inherited-descriptors","regression-test","herdr-task-sync"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/docs/issues/2026-08-29-011-add-bounded-open-pipe-regression-for-fail-open-tests.md
+++ b/docs/issues/2026-08-29-011-add-bounded-open-pipe-regression-for-fail-open-tests.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["bashunit","inherited-descriptors","regression-test","herdr-task-sync"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -24,3 +25,7 @@ PR #98 fixes the observed Docker-suite hang by redirecting three no-payload fail
 ## Open decisions
 
 Whether one nested invocation can cover both affected tests without materially extending scripts_test.sh wall time, or two narrower invocations provide clearer failure attribution.
+
+## Resolution
+
+Added tests 259/260 in tests/bashunit/scripts_test.sh: each reruns an affected fail-open test (119, 121) under a nested bashunit whose stdin is a non-TTY pipe held open with no payload, and asserts process exit plus output-pipe EOF within an env-overridable budget, with a ps-based descendant scan that names the blocked cat when the inherited-pipe regression is present (status 125). Open decision resolved as two narrower invocations for clear failure attribution; the only extra cost over one invocation is a second runner startup. Calibrated red/green: removing the /dev/null redirect from test 119 or 121 failed the matching scenario with status 125 inside its budget; with redirects intact both pass. Verified: focused runs of 259/260, tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh (254 passed, 2 pre-existing skips, 4 pre-existing risky), make test-ubuntu exit 0, make lint. Cross-model review applied one fix (removed the EOF-join grace floor that could accept EOF past the deadline).

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6997,6 +6997,196 @@ function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
   assert_output --partial "Assertions: 1 passed, 1 total"
 }
 
+# Bounded open-pipe regression for the fail-open guard's stdin contract
+# (docs/issues/2026-08-29-011). Every no-payload hts_run_fail_open_guard call
+# site must redirect stdin from /dev/null: the guard's payload capture
+# (`cat > "$input"` in tests/helpers/herdr_task_sync.bash) otherwise reads the
+# runner's inherited stdin, and when that stdin is a pipe whose write end stays
+# open, cat blocks until an outer CI timeout kills the whole suite -- the
+# Docker hang PR #98 fixed. This scenario owns the test-fixture stdin contract;
+# the detached-child descriptor probes (tests 102/258) own production
+# descendant descriptors and stay separate.
+#
+# The nested runner's stdin is a non-TTY pipe whose write end the fixture holds
+# open, with no payload, for the entire run -- the exact regressed condition.
+# Correct call sites get EOF from their own /dev/null redirects and finish;
+# a call site that lost its redirect inherits the pipe and hangs, and the
+# deadline turns that hang into a bounded failure that names the blocked cat
+# descendant instead of stalling the suite.
+#
+# Two narrower invocations, not one: each affected test (119 and 121) gets its
+# own scenario so a deadline failure attributes to one call-site family, and
+# the only extra cost over a single invocation is a second runner startup.
+hts_run_nested_fail_open_open_pipe_scenario() {
+  local test_filter="$1" budget="$2"
+  run python3 - "$BATS_TEST_DIRNAME/lib/bashunit" \
+    "$BATS_TEST_DIRNAME/bashunit/scripts_test.sh" "$test_filter" "$budget" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+bashunit, suite, test_filter, budget_arg = sys.argv[1:5]
+budget = float(budget_arg)
+
+# Distinct status per failure mode, so the outer test names which property
+# broke without parsing the message. Avoid 126 and 127: the shell reserves
+# them for "not executable" and "not found".
+EXIT_INHERITED_PIPE = 125  # a descendant cat is reading the held-open stdin pipe
+EXIT_HANG = 124            # deadline passed without exit, cause undetermined
+EXIT_EOF_WITHHELD = 5      # runner exited but its output pipes never hit EOF
+
+read_fd, write_fd = os.pipe()
+# close_fds (the Popen default) keeps write_fd out of the child: only this
+# process holds the write end open, exactly like the outer runner in the
+# Docker hang, so EOF on the nested stdin can only come from a /dev/null
+# redirect inside the tests under scrutiny. No payload is ever written.
+proc = subprocess.Popen(
+    [bashunit, "--filter", test_filter, suite],
+    stdin=read_fd,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    start_new_session=True,
+    env={**os.environ, "NO_COLOR": "1"},
+)
+os.close(read_fd)
+
+# Drain both pipes from launch in their own threads. Nothing may leave a pipe
+# unread: the nested run blocks on a full pipe buffer otherwise, and on the
+# nested-test-failure path the runner echoes the failed test's captured
+# output, which is exactly when that output is largest.
+captured = {}
+
+
+def drain(name, stream):
+    captured[name] = stream.read()
+    stream.close()
+
+
+readers = [
+    threading.Thread(target=drain, args=("stdout", proc.stdout), daemon=True),
+    threading.Thread(target=drain, args=("stderr", proc.stderr), daemon=True),
+]
+for reader in readers:
+    reader.start()
+
+
+def descendant_comms(root):
+    """Transitive children of the nested runner, by command name, via
+    portable ps -- this must work on both macOS and the Ubuntu container."""
+    try:
+        out = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,comm="],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+    except Exception:
+        return []
+    children = {}
+    comms = {}
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid, ppid = int(parts[0]), int(parts[1])
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(pid)
+        comms[pid] = parts[2]
+    found, stack = [], [root]
+    while stack:
+        for child in children.get(stack.pop(), []):
+            stack.append(child)
+            found.append(comms.get(child, "?"))
+    return found
+
+
+def report(message, code):
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+    for reader in readers:
+        reader.join(timeout=5)
+    sys.stdout.write(captured.get("stdout") or "")
+    sys.stderr.write(captured.get("stderr") or "")
+    print(message, file=sys.stderr)
+    raise SystemExit(code)
+
+
+deadline = time.monotonic() + budget
+try:
+    proc.wait(timeout=budget)
+except subprocess.TimeoutExpired:
+    # State-aware verdict: before naming a cause, look for the regressed
+    # state itself -- a cat descendant still reading our held-open pipe.
+    comms = descendant_comms(proc.pid)
+    if any(comm == "cat" or comm.endswith("/cat") for comm in comms):
+        report(
+            "a no-payload hts_run_fail_open_guard call inherited the runner's "
+            "open stdin pipe: a cat descendant is still reading it after "
+            f"{budget_arg} seconds (descendants: {', '.join(comms)})",
+            EXIT_INHERITED_PIPE,
+        )
+    report(
+        f"nested fail-open run did not exit within {budget_arg} seconds "
+        f"(descendants: {', '.join(comms) or 'none'})",
+        EXIT_HANG,
+    )
+
+# Exit alone is not the property: a descendant that inherited the output
+# pipes keeps them open past the runner's exit, so EOF is asserted
+# separately, on the same deadline.
+for reader in readers:
+    reader.join(timeout=max(deadline - time.monotonic(), 1.0))
+if any(reader.is_alive() for reader in readers):
+    report(
+        "nested fail-open run exited but its output pipes did not reach EOF "
+        "before the deadline",
+        EXIT_EOF_WITHHELD,
+    )
+
+os.close(write_fd)
+sys.stdout.write(captured.get("stdout") or "")
+sys.stderr.write(captured.get("stderr") or "")
+raise SystemExit(proc.returncode)
+PY
+}
+
+# Budgets are wall-clock ceilings for a hang that is otherwise infinite, not
+# performance expectations: green baselines measured 2026-08-30 on an idle
+# workstation were ~6s (test 119) and ~24s (test 121), and the defaults leave
+# an order of magnitude for Docker and loaded CI. Override via
+# HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS when recalibrating.
+function test_scripts_264_herdr_task_sync_fail_open_deadline_test_complet() {
+  _bats_test_init 264 'herdr-task-sync fail-open deadline test completes with the runner stdin pipe held open'
+  hts_run_nested_fail_open_open_pipe_scenario \
+    fail_open_deadline_rejects_late "${HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS:-90}"
+  assert_success
+  # Title prefixes only: the nested runner truncates long titles to the
+  # terminal width (observed under make test-ubuntu), so a full-title match
+  # is environment-dependent. "1 passed, 1 total" pins the filter to exactly
+  # one nested test.
+  assert_output --partial "Passed: herdr-task-sync fail-open deadline rejects late"
+  assert_output --partial "1 passed, 1 total"
+  assert_output --partial "All tests passed"
+}
+
+function test_scripts_265_herdr_task_sync_fails_open_test_completes_with() {
+  _bats_test_init 265 'herdr-task-sync fails-open test completes with the runner stdin pipe held open'
+  hts_run_nested_fail_open_open_pipe_scenario \
+    fails_open_for_missing_tools "${HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS:-240}"
+  assert_success
+  # Truncation-safe title prefix; see test 264 for why.
+  assert_output --partial "Passed: herdr-task-sync fails open for missing tools"
+  assert_output --partial "1 passed, 1 total"
+  assert_output --partial "All tests passed"
+}
+
 function set_up_before_script() {
   :
 }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -7140,9 +7140,12 @@ except subprocess.TimeoutExpired:
 
 # Exit alone is not the property: a descendant that inherited the output
 # pipes keeps them open past the runner's exit, so EOF is asserted
-# separately, on the same deadline.
+# separately, on the same deadline -- no grace floor, or EOF arriving after
+# the declared deadline would still pass.
 for reader in readers:
-    reader.join(timeout=max(deadline - time.monotonic(), 1.0))
+    remaining = deadline - time.monotonic()
+    if remaining > 0:
+        reader.join(timeout=remaining)
 if any(reader.is_alive() for reader in readers):
     report(
         "nested fail-open run exited but its output pipes did not reach EOF "

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6998,25 +6998,15 @@ function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
 }
 
 # Bounded open-pipe regression for the fail-open guard's stdin contract
-# (docs/issues/2026-08-29-011). Every no-payload hts_run_fail_open_guard call
-# site must redirect stdin from /dev/null: the guard's payload capture
-# (`cat > "$input"` in tests/helpers/herdr_task_sync.bash) otherwise reads the
-# runner's inherited stdin, and when that stdin is a pipe whose write end stays
-# open, cat blocks until an outer CI timeout kills the whole suite -- the
-# Docker hang PR #98 fixed. This scenario owns the test-fixture stdin contract;
-# the detached-child descriptor probes (tests 102/258) own production
-# descendant descriptors and stay separate.
-#
-# The nested runner's stdin is a non-TTY pipe whose write end the fixture holds
-# open, with no payload, for the entire run -- the exact regressed condition.
-# Correct call sites get EOF from their own /dev/null redirects and finish;
-# a call site that lost its redirect inherits the pipe and hangs, and the
-# deadline turns that hang into a bounded failure that names the blocked cat
-# descendant instead of stalling the suite.
-#
-# Two narrower invocations, not one: each affected test (119 and 121) gets its
-# own scenario so a deadline failure attributes to one call-site family, and
-# the only extra cost over a single invocation is a second runner startup.
+# (docs/issues/2026-08-29-011, follow-up to PR #98). A no-payload
+# hts_run_fail_open_guard call without a /dev/null redirect makes the guard's
+# payload capture (`cat > "$input"` in tests/helpers/herdr_task_sync.bash)
+# read the runner's inherited stdin; when that stdin is a pipe whose write end
+# stays open, cat blocks until an outer CI timeout kills the whole suite. The
+# nested runner below gets exactly that stdin, so a lost redirect fails here
+# in seconds instead. Two scenarios, not one, so a failure attributes to one
+# call-site family (119 or 121). The detached-child descriptor probes
+# (tests 102/258) own production descendant descriptors.
 hts_run_nested_fail_open_open_pipe_scenario() {
   local test_filter="$1" budget="$2"
   run python3 - "$BATS_TEST_DIRNAME/lib/bashunit" \
@@ -7040,9 +7030,9 @@ EXIT_EOF_WITHHELD = 5      # runner exited but its output pipes never hit EOF
 
 read_fd, write_fd = os.pipe()
 # close_fds (the Popen default) keeps write_fd out of the child: only this
-# process holds the write end open, exactly like the outer runner in the
-# Docker hang, so EOF on the nested stdin can only come from a /dev/null
-# redirect inside the tests under scrutiny. No payload is ever written.
+# process holds the write end open, so EOF on the nested stdin can only come
+# from a /dev/null redirect inside the tests under scrutiny. No payload is
+# ever written.
 proc = subprocess.Popen(
     [bashunit, "--filter", test_filter, suite],
     stdin=read_fd,
@@ -7122,8 +7112,8 @@ deadline = time.monotonic() + budget
 try:
     proc.wait(timeout=budget)
 except subprocess.TimeoutExpired:
-    # State-aware verdict: before naming a cause, look for the regressed
-    # state itself -- a cat descendant still reading our held-open pipe.
+    # A cat descendant still reading our held-open pipe is the regressed
+    # state itself, so it outranks a generic hang verdict.
     comms = descendant_comms(proc.pid)
     if any(comm == "cat" or comm.endswith("/cat") for comm in comms):
         report(
@@ -7160,20 +7150,17 @@ raise SystemExit(proc.returncode)
 PY
 }
 
-# Budgets are wall-clock ceilings for a hang that is otherwise infinite, not
-# performance expectations: green baselines measured 2026-08-30 on an idle
-# workstation were ~6s (test 119) and ~24s (test 121), and the defaults leave
-# an order of magnitude for Docker and loaded CI. Override via
-# HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS when recalibrating.
+# Budgets are wall-clock ceilings for an otherwise-infinite hang, not
+# performance expectations: the defaults leave an order of magnitude over
+# idle-workstation green baselines (~6s / ~24s) for Docker and loaded CI.
+# Override via HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS when recalibrating.
 function test_scripts_264_herdr_task_sync_fail_open_deadline_test_complet() {
   _bats_test_init 264 'herdr-task-sync fail-open deadline test completes with the runner stdin pipe held open'
   hts_run_nested_fail_open_open_pipe_scenario \
     fail_open_deadline_rejects_late "${HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS:-90}"
   assert_success
-  # Title prefixes only: the nested runner truncates long titles to the
-  # terminal width (observed under make test-ubuntu), so a full-title match
-  # is environment-dependent. "1 passed, 1 total" pins the filter to exactly
-  # one nested test.
+  # The nested runner truncates long titles to the terminal width, so match
+  # title prefixes only; "1 passed, 1 total" pins the filter to one test.
   assert_output --partial "Passed: herdr-task-sync fail-open deadline rejects late"
   assert_output --partial "1 passed, 1 total"
   assert_output --partial "All tests passed"


### PR DESCRIPTION
## Summary

A no-payload `hts_run_fail_open_guard` call that loses its `< /dev/null` redirect no longer hangs the whole suite until an outer CI timeout — it now fails one attributed test within a fixed budget, with a message naming the blocked `cat` descendant. This is the bounded regression owner that PR #98's fix was missing: after #98, a removed redirect was detectable only by the Docker suite hanging.

The in-repo issue `docs/issues/2026-08-29-011` is resolved and marked done in this branch.

## How the guard works

The guard's payload capture (`cat > "$input"` in `tests/helpers/herdr_task_sync.bash`) reads the runner's inherited stdin when a call site has no redirect. If that stdin is a pipe whose write end stays open, `cat` blocks forever — the condition that hung `make test-ubuntu` before #98.

New tests 264 and 265 each rerun one affected test (119, 121) under a nested bashunit whose stdin is exactly that: a non-TTY pipe whose write end the fixture holds open, with no payload, for the entire run. Correct call sites get EOF from their own `/dev/null` redirects and finish. A call site that lost its redirect inherits the pipe, and the deadline converts the hang into a bounded failure:

| Status | Meaning |
|---|---|
| 125 | a `cat` descendant is still reading the held-open stdin pipe — the guarded regression, named explicitly |
| 124 | no exit within budget, cause undetermined (descendant list included) |
| 5 | runner exited but its output pipes never reached EOF before the deadline |

Process exit and output-pipe EOF are asserted separately on the same deadline because a descendant that inherited the output pipes keeps them open past the runner's exit. Budgets are env-overridable (`HTS_FAIL_OPEN_PIPE_BUDGET_SECONDS`, defaults 90s/240s against ~6s/~24s green baselines). Two narrower invocations rather than one combined filter so a failure attributes to one call-site family; the only extra cost is a second runner startup.

## Calibration and verification

- Red: removing the `< /dev/null` redirect from test 119 made the first scenario fail in 29s with status 125 ("a cat descendant is still reading it"); removing one from test 121 made the second scenario fail in 42s the same way. Redirects restored, both green (6.5s / 24s).
- Full `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh`: 254 passed, 2 skipped, 4 risky — skips and risky all pre-existing.
- `make test-ubuntu`: exit 0 at 12bf1c5. The subsequent review fix 70cb717 (3 lines: EOF join uses only the time remaining on the budget, no one-second grace floor that could accept EOF past the declared deadline) was verified by focused runs of both scenarios and `make lint`, not by a fresh Docker pass.
- Dual cross-model review (Sonnet + GPT-5.6 Terra) ran on 12bf1c5; the one validated P2 (the grace floor above) is applied as 70cb717. Two structural suggestions (extract the harness to a dedicated file; replace reader threads with `communicate(timeout=)`) were declined — the second would collapse the separate exit-vs-EOF attribution the other reviewer's finding strengthens.

## Notes for review

- Status-125 attribution relies on `ps -axo comm=` reporting a descendant literally named `cat`; a busybox/renamed `cat` would degrade the verdict to the generic 124 hang path without weakening the failure itself.
- Rebased onto main after PRs #102/#104/#108/#109 merged; the scenarios are numbered 264/265 (259 landed with #109, 260 is reserved for the PR #99 branch, 261-263 for the PR #105 branch). Renumbered tests re-verified green post-rebase.

Related: #98, #105

