### PR TITLE
fix(tests): keep the supervision deadline out of the herdr-child reap race

### DIFF
--- a/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
+++ b/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["flaky-test","herdr"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -24,3 +25,7 @@ Each flake poisons a whole measurement or CI run: the suite reports 1 failure an
 ## Open decisions
 
 None.
+
+## Resolution
+
+Reproduced the loaded-run mechanism deterministically (6/6 forced failures): with --supervision-timeout 5000 the watcher's deadline could expire mid-reap, and the timeout-delivery iteration re-checks invalidated.state inside deliver_supervision_event (executable_herdr-child:564), removes the whole run dir, and exits before reap's pane close - erasing the invalidated.state evidence the reap-before-close stub probe scans for. Fixed by keeping the supervision deadline out of reach (600000 ms) in both halves of test 045; the deadline is not what the scenario proves, and all assertions remain event/marker-based. Verified 25/25 green iterations under 10 busy-loop CPU load plus 20/20 calm, and make test-suite green. The production-side wrinkle (delivery path erasing a pending reap run, degrading the reap-restore path) and deterministic coverage for that interleaving are tracked in 2026-08-30-001.

--- a/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
+++ b/docs/issues/2026-08-29-004-herdr-child-reap-close-race-test-flakes-under-cpu-load.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["flaky-test","herdr"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md
+++ b/docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-child watcher event delivery erases a pending reap run before pane close"
+short_description: "When a supervision event (e.g. timeout) is being delivered in the same watcher iteration that a reap invalidation lands, deliver_supervision_event returns 20 on invalidated.state regardless of reason=reap, so the watcher removes the run dir and exits instead of deferring to watcher_invalidation_action; a reap that then fails pane close cannot signal reap-restore (the run dir is gone) and falls to the degraded publish_reap_recovery path, and the invalidation evidence disappears before close."
+type: "bug"
+category: "herdr"
+tags: ["herdr","race"]
+date: "2026-08-30"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Found while fixing the 2026-08-29-004 test flake: the loaded-scheduler interleaving (deadline expiring mid-reap) was reproduced deterministically 6/6 and traced to deliver_supervision_event's unconditional invalidated.state -> return 20 -> remove_supervision_run shortcut in home/dot_local/bin/executable_herdr-child. The parent-wake contract still holds (no spurious child-gone), but the reap-restore recovery path silently degrades in this window, and tests 046/047 still start supervision with a 5000ms deadline that could expire mid-scenario under extreme load. A parallel branch is reworking watcher lifecycle in the same file; coordinate before changing teardown logic.
+
+## Scope
+
+Decide whether deliver_supervision_event should treat invalidated.state with reason=reap plus a live reap-pending owner as a defer (let watcher_invalidation_action wait for reap-closed/reap-restore) instead of returning 20. Cover with a semantic regression test that forces the delivery-window interleaving. Consider widening the 5000ms supervision timeouts in tests 046/047 the same way 045 was widened.
+
+## Open decisions
+
+None.

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1441,8 +1441,13 @@ function test_scripts_044_herdr_child_detached_watcher_rejects_malformed_s() {
 
 function test_scripts_045_herdr_child_reap_invalidates_before_close_while() {
   _bats_test_init 45 'herdr-child reap invalidates before close while spontaneous loss wakes the parent'
+  # The supervision deadline must never expire while reap runs: a timeout
+  # event that races the reap invalidation lets the watcher remove the run
+  # dir before `pane close`, which erases the invalidated.state evidence the
+  # reap-before-close probe needs (3/16 loaded docker runs, 2026-08-29).
+  # The deadline is not what this scenario proves, so keep it out of reach.
   child_lifecycle_stub_herdr
-  run child_lifecycle_start --supervision-timeout 5000
+  run child_lifecycle_start --supervision-timeout 600000
   assert_success
   printf 'done\n' > "$CHILD_STUB/child-list-status"
   : > "$CHILD_STUB/require-reap-invalidation"
@@ -1459,7 +1464,7 @@ function test_scripts_045_herdr_child_reap_invalidates_before_close_while() {
   teardown
   setup
   child_lifecycle_stub_herdr
-  run child_lifecycle_start --supervision-timeout 5000
+  run child_lifecycle_start --supervision-timeout 600000
   assert_success
   : > "$CHILD_STUB/child-gone"
   child_wait_for_log 'event=child-gone'

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1441,11 +1441,8 @@ function test_scripts_044_herdr_child_detached_watcher_rejects_malformed_s() {
 
 function test_scripts_045_herdr_child_reap_invalidates_before_close_while() {
   _bats_test_init 45 'herdr-child reap invalidates before close while spontaneous loss wakes the parent'
-  # The supervision deadline must never expire while reap runs: a timeout
-  # event that races the reap invalidation lets the watcher remove the run
-  # dir before `pane close`, which erases the invalidated.state evidence the
-  # reap-before-close probe needs (3/16 loaded docker runs, 2026-08-29).
-  # The deadline is not what this scenario proves, so keep it out of reach.
+  # The deadline is not what this scenario proves; keep it out of reach so a
+  # loaded run cannot race reap (issues 2026-08-29-004, 2026-08-30-001).
   child_lifecycle_stub_herdr
   run child_lifecycle_start --supervision-timeout 600000
   assert_success


### PR DESCRIPTION
## Summary

The herdr-child test `reap invalidates before close while spontaneous loss wakes the parent` failed 3 of ~16 docker runs under CPU load (0/10 calm). The flake is a real race between the test's 5-second supervision deadline and the reap sequence; the fix moves the deadline out of reach (600 s) so a loaded scheduler can no longer trigger it, and closes `docs/issues/2026-08-29-004`.

## The race the diff cannot show

The test starts a watcher with `--supervision-timeout 5000` and then runs `reap`. When load stretches the start-to-reap span toward 5 s, the watcher iteration that crosses the deadline opens a window between its loop-top `invalidated.state` check and the re-check inside `deliver_supervision_event` (`executable_herdr-child:564`). If reap's invalidation lands inside that window, the delivery path returns 20, and the watcher removes the whole run directory and exits before reap's `pane close`. The stub's reap-before-close probe then finds no `invalidated.state` anywhere and the test fails on `reap-invalidation-observed`.

Forcing this interleaving (stub holds `agent get` until the invalidation lands, with a compressed deadline) reproduced the exact observed failure 6/6 times.

## Why widening does not weaken coverage

The supervision deadline is not what this scenario proves. Every assertion is event- or marker-based: `reap-invalidation-observed`, absence of `close-before-invalidation`, `pane-closed`, and the `event=child-gone` delivery in the second half. Those verdicts still flip when the reap-before-close ordering or the spontaneous-loss wakeup breaks. The timeout path has its own owners elsewhere in the suite.

The interleaving itself (delivery-window erasure of a pending reap run, which also degrades the reap-restore recovery path in production) is now statistically unreachable by any test, so it is tracked as its own issue with a deterministic-coverage scope: `docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md`.

## Verification

- Pre-fix red state: forced interleaving fails 6/6 with the exact flake signature.
- Post-fix: 25/25 green iterations under full CPU load (10 busy loops on 10 cores) and 20/20 calm iterations of the single test.
- `make test-suite` green (exit 0). `make test-ubuntu` was not run locally; CI's ubuntu job covers the docker leg.
- Dual cross-model review (Sonnet + GPT-5.6 Terra, independent report-only legs): no actionable code findings; the one advisory finding (add deterministic coverage for the delivery-window race) is the follow-up issue above.

## Related

- Related: #105 — expect a small merge overlap in `tests/bashunit/scripts_test.sh`; both intents compose (the widened timeout in test 045 should survive the merge).
