### PR TITLE
fix(tests): stop hts teardown leaking tmp dirs from surviving engines

### DIFF
--- a/docs/issues/2026-08-29-001-hts-test-teardown-races-a-surviving-engine-process-that-recreates-state-sockets-shedding-hts-tmp-dirs.md
+++ b/docs/issues/2026-08-29-001-hts-test-teardown-races-a-surviving-engine-process-that-recreates-state-sockets-shedding-hts-tmp-dirs.md
@@ -5,7 +5,7 @@ type: "bug"
 category: "testing-ci"
 tags: ["bashunit-experiment"]
 date: "2026-08-29"
-status: "open"
+status: "in-progress"
 priority: "medium"
 ---
 

--- a/docs/issues/2026-08-29-001-hts-test-teardown-races-a-surviving-engine-process-that-recreates-state-sockets-shedding-hts-tmp-dirs.md
+++ b/docs/issues/2026-08-29-001-hts-test-teardown-races-a-surviving-engine-process-that-recreates-state-sockets-shedding-hts-tmp-dirs.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["bashunit-experiment"]
 date: "2026-08-29"
-status: "in-progress"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -26,3 +27,7 @@ Merged in from the duplicate 2026-08-29-003 (closed 2026-08-29):
 ## Open decisions
 
 None.
+
+## Resolution
+
+hts_teardown now terminates and awaits every sandbox process before removing HTS_WORK, using three ledgers: a fork-time spawn registry the engine writes under HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY (test-only, with process-start tokens so recycled pids are never signalled), claim/lock owner records, and a ps scan for commands under the sandbox path (catches blocked stubs that give up tens of seconds later). Removal is then confirmed settled with a bounded recreation watch. Complementarily, the engine and harness stubs now create at most one directory level and never ancestors (atomic_write, initialize_namespace, pane dirs, sweep daemon, stub fixtures), so any straggler fails closed instead of resurrecting the deleted tree; foreground modes still bootstrap STATE_DIR recursively so fresh machines keep naming. The descriptor probe opts out of reaping because its contract requires the detached coordinator to outlive teardown. Regression test 'hts_teardown reaps a surviving engine worker before removing state' proven red on the pre-fix teardown and green after. Full -j 8 scripts_test.sh: 253 passed, 0 failed, 0 leaked hts.* dirs (previously 4-15 per run). One-time cleanup done: 3067 stale dirs moved from TMPDIR and /tmp to ~/.scratchpad/hts-pile-1788054805.

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -293,7 +293,10 @@ process_start_token() {
 # the variable and skip this entirely.
 register_test_spawn() {
   [ -n "${HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY:-}" ] || return 0
-  printf '%s\n' "$1" >> "$HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY" 2>/dev/null || true
+  # The start token lets the harness refuse a recycled pid: a later process
+  # that happens to reuse this pid carries a different start time.
+  printf '%s %s\n' "$1" "$(process_start_token "$1")" \
+    >> "$HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY" 2>/dev/null || true
 }
 
 claim_owner_id=""
@@ -2319,13 +2322,31 @@ case "$mode" in
       printf '%s\n' 'herdr-task-sync: presentation skipped without HERDR_SOCKET_PATH' >&2
       exit 0
     fi
+    # Foreground hook invocation: bootstrap STATE_DIR recursively here, the
+    # way the naming entry point does. initialize_namespace itself creates at
+    # most one level so DETACHED survivors cannot resurrect a deleted tree,
+    # which would strand a fresh machine (no ~/.cache yet) with no namespace
+    # if no foreground path ever ran `mkdir -p`.
+    mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
     SWEEP_LOCK_DIR="$(namespace_dir)/sweep.lock"
     ;;
-  presentation-worker | sweep | sweep-daemon | ensure-daemon | restart-daemon)
+  sweep | ensure-daemon | restart-daemon)
     if [ -z "$SOCKET_PATH" ]; then
       printf '%s\n' 'herdr-task-sync: presentation skipped without HERDR_SOCKET_PATH' >&2
       exit 0
     fi
+    # Foreground CLI invocations bootstrap like the event hook above.
+    mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+    initialize_namespace || exit 0
+    SWEEP_LOCK_DIR="$(namespace_dir)/sweep.lock"
+    ;;
+  presentation-worker | sweep-daemon)
+    if [ -z "$SOCKET_PATH" ]; then
+      printf '%s\n' 'herdr-task-sync: presentation skipped without HERDR_SOCKET_PATH' >&2
+      exit 0
+    fi
+    # Detached: stays fail-closed — a missing STATE_DIR means the state tree
+    # was deleted underneath this process (docs/issues/2026-08-29-001).
     initialize_namespace || exit 0
     SWEEP_LOCK_DIR="$(namespace_dir)/sweep.lock"
     ;;
@@ -2404,7 +2425,10 @@ umask 077
 initialize_namespace || exit 0
 
 pane_dir="$(pane_state_dir)"
-mkdir -p "$pane_dir" 2>/dev/null || exit 0
+# Single-level like the worker's sibling: panes/ exists after
+# initialize_namespace two lines up, so `-p` would only ever be resurrecting
+# a concurrently deleted tree (docs/issues/2026-08-29-001).
+mkdir "$pane_dir" 2>/dev/null || [ -d "$pane_dir" ] || exit 0
 control="$pane_dir/control.state"
 high_water="$pane_dir/high-water.state"
 control_lock="$pane_dir/control.lock"

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -243,7 +243,14 @@ atomic_write() {
   local file="$1" content="$2" dir tmp
   [ ! -d "$file" ] || return 1
   dir="$(dirname "$file")"
-  mkdir -p "$dir" 2>/dev/null || return 1
+  # Create at most the leaf directory, never ancestors. `mkdir -p` here
+  # recreated every missing level, so a detached process racing a test
+  # teardown resurrected the deleted state tree from the tmp root up
+  # (docs/issues/2026-08-29-001). One caller legitimately needs the leaf:
+  # the presentation pass writes location.state for panes that never
+  # enqueued, whose pane dir nothing else creates. A missing PARENT means
+  # the tree was deleted out from under us; fail closed.
+  mkdir "$dir" 2>/dev/null || [ -d "$dir" ] || return 1
   tmp="$(umask 077; mktemp "$dir/.record.XXXXXX" 2>/dev/null)" || return 1
   if ! printf '%s\n' "$content" > "$tmp" 2>/dev/null; then
     rm -f "$tmp"
@@ -277,6 +284,16 @@ max_number() {
 
 process_start_token() {
   ps -p "$1" -o lstart= 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# Test-only spawn ledger. A detached worker publishes its pid in a claim only
+# after its startup mkdirs, so a test teardown that runs inside that window
+# cannot find it and races its state recreation (docs/issues/2026-08-29-001).
+# Recording the pid at fork time closes the window; production runs never set
+# the variable and skip this entirely.
+register_test_spawn() {
+  [ -n "${HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY:-}" ] || return 0
+  printf '%s\n' "$1" >> "$HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY" 2>/dev/null || true
 }
 
 claim_owner_id=""
@@ -341,9 +358,17 @@ release_claim() {
 }
 
 initialize_namespace() {
-  local namespace socket_record reconcile_record
+  local namespace socket_record reconcile_record level
   namespace="$(namespace_dir)" || return 1
-  mkdir -p "$namespace/panes" "$namespace/tasks" "$namespace/migration" 2>/dev/null || return 1
+  # Single-level mkdirs on purpose, never `mkdir -p`: `-p` recreates every
+  # missing ancestor, so a detached worker racing a test teardown resurrected
+  # the deleted sandbox from the tmp root up (docs/issues/2026-08-29-001).
+  # STATE_DIR itself is created one level deep at most — its parent
+  # (~/.cache, or a test's work dir) must already exist.
+  for level in "$STATE_DIR" "$STATE_DIR/sockets" "$namespace" \
+    "$namespace/panes" "$namespace/tasks" "$namespace/migration"; do
+    mkdir "$level" 2>/dev/null || [ -d "$level" ] || return 1
+  done
   socket_record="socket_path=$(encode_value "$SOCKET_PATH")"
   [ -f "$namespace/socket.state" ] || atomic_write "$namespace/socket.state" "$socket_record" || return 1
   reconcile_record="pending_generation=0
@@ -1227,6 +1252,7 @@ start_presentation_coordinator() {
   # gives the coordinator its own group so event-triggered work can finish.
   set -m
   nohup bash "$self" --presentation-worker </dev/null >/dev/null 2>&1 &
+  register_test_spawn "$!"
   set +m
 }
 
@@ -1424,7 +1450,10 @@ EOF
     (
       if [ -n "${HERDR_TASK_SYNC_TEST_LOCATION_BARRIER:-}" ] && \
         [ -n "${HERDR_TASK_SYNC_TEST_LOCATION_BARRIER_COUNT:-}" ]; then
-        mkdir -p "$HERDR_TASK_SYNC_TEST_LOCATION_BARRIER" || exit 1
+        # Single-level: the barrier lives inside the test sandbox, and `-p`
+        # would resurrect it after teardown (docs/issues/2026-08-29-001).
+        mkdir "$HERDR_TASK_SYNC_TEST_LOCATION_BARRIER" 2>/dev/null || \
+          [ -d "$HERDR_TASK_SYNC_TEST_LOCATION_BARRIER" ] || exit 1
         : > "$HERDR_TASK_SYNC_TEST_LOCATION_BARRIER/$(encode_key "$id")"
         while :; do
           set -- "$HERDR_TASK_SYNC_TEST_LOCATION_BARRIER"/*
@@ -1868,7 +1897,10 @@ sweep_tabs() {
 # pane that already exists. The lock directory is created atomically, so a
 # second daemon exits instead of doubling the rename traffic.
 run_sweep_daemon() {
-  mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+  # Single-level, not `-p`: the daemon is detached, and recreating missing
+  # ancestors resurrects a deleted test sandbox (docs/issues/2026-08-29-001).
+  # A fresh machine's STATE_DIR is created by the foreground entry point.
+  mkdir "$STATE_DIR" 2>/dev/null || [ -d "$STATE_DIR" ] || exit 0
   # A daemon started right after its predecessor was killed finds the lock still
   # there for a moment. Waiting a few seconds beats exiting, which would leave
   # the machine with no daemon at all until the next herdr event.
@@ -1925,6 +1957,7 @@ ensure_sweep_daemon() {
   # Job control puts the daemon in a process group of its own, out of reach.
   set -m
   nohup bash "$self" --sweep-daemon </dev/null >/dev/null 2>&1 &
+  register_test_spawn "$!"
   set +m
   return 0
 }
@@ -2167,7 +2200,9 @@ run_worker() {
   local task_file task_generation presentation_required commit_status abort_worker
   initialize_namespace || exit 0
   pane_dir="$(pane_state_dir)"
-  mkdir -p "$pane_dir" 2>/dev/null || exit 0
+  # Single-level: panes/ exists after initialize_namespace, and `-p` would
+  # resurrect a deleted state tree (docs/issues/2026-08-29-001).
+  mkdir "$pane_dir" 2>/dev/null || [ -d "$pane_dir" ] || exit 0
   control="$pane_dir/control.state"
   high_water="$pane_dir/high-water.state"
   worker_lock="$pane_dir/worker.claim"
@@ -2433,5 +2468,6 @@ self="$(script_path)" || exit 0
 # claimed worker reads the inbox rather than request argv, so every completion
 # is fenced against the latest active native session and committed generation.
 nohup bash "$self" --worker --pane "$pane" </dev/null >/dev/null 2>&1 &
+register_test_spawn "$!"
 
 exit 0

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -243,13 +243,11 @@ atomic_write() {
   local file="$1" content="$2" dir tmp
   [ ! -d "$file" ] || return 1
   dir="$(dirname "$file")"
-  # Create at most the leaf directory, never ancestors. `mkdir -p` here
-  # recreated every missing level, so a detached process racing a test
-  # teardown resurrected the deleted state tree from the tmp root up
-  # (docs/issues/2026-08-29-001). One caller legitimately needs the leaf:
-  # the presentation pass writes location.state for panes that never
-  # enqueued, whose pane dir nothing else creates. A missing PARENT means
-  # the tree was deleted out from under us; fail closed.
+  # Create at most the leaf, never ancestors: `mkdir -p` lets a detached
+  # process resurrect a deleted state tree (docs/issues/2026-08-29-001). The
+  # leaf itself is needed — the presentation pass writes location.state for
+  # panes that never enqueued, whose pane dir nothing else creates. A missing
+  # PARENT means the tree was deleted out from under us; fail closed.
   mkdir "$dir" 2>/dev/null || [ -d "$dir" ] || return 1
   tmp="$(umask 077; mktemp "$dir/.record.XXXXXX" 2>/dev/null)" || return 1
   if ! printf '%s\n' "$content" > "$tmp" 2>/dev/null; then
@@ -363,11 +361,10 @@ release_claim() {
 initialize_namespace() {
   local namespace socket_record reconcile_record level
   namespace="$(namespace_dir)" || return 1
-  # Single-level mkdirs on purpose, never `mkdir -p`: `-p` recreates every
-  # missing ancestor, so a detached worker racing a test teardown resurrected
-  # the deleted sandbox from the tmp root up (docs/issues/2026-08-29-001).
-  # STATE_DIR itself is created one level deep at most — its parent
-  # (~/.cache, or a test's work dir) must already exist.
+  # Single-level mkdirs, never `mkdir -p`: `-p` lets a detached worker
+  # resurrect a deleted state tree (docs/issues/2026-08-29-001). STATE_DIR is
+  # created one level deep at most — its parent (~/.cache, or a test's work
+  # dir) must already exist.
   for level in "$STATE_DIR" "$STATE_DIR/sockets" "$namespace" \
     "$namespace/panes" "$namespace/tasks" "$namespace/migration"; do
     mkdir "$level" 2>/dev/null || [ -d "$level" ] || return 1
@@ -2322,11 +2319,9 @@ case "$mode" in
       printf '%s\n' 'herdr-task-sync: presentation skipped without HERDR_SOCKET_PATH' >&2
       exit 0
     fi
-    # Foreground hook invocation: bootstrap STATE_DIR recursively here, the
-    # way the naming entry point does. initialize_namespace itself creates at
-    # most one level so DETACHED survivors cannot resurrect a deleted tree,
-    # which would strand a fresh machine (no ~/.cache yet) with no namespace
-    # if no foreground path ever ran `mkdir -p`.
+    # Foreground invocations may bootstrap STATE_DIR recursively; only
+    # detached paths must fail closed (docs/issues/2026-08-29-001). Without
+    # this a fresh machine with no ~/.cache never gets a namespace.
     mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
     SWEEP_LOCK_DIR="$(namespace_dir)/sweep.lock"
     ;;
@@ -2425,9 +2420,8 @@ umask 077
 initialize_namespace || exit 0
 
 pane_dir="$(pane_state_dir)"
-# Single-level like the worker's sibling: panes/ exists after
-# initialize_namespace two lines up, so `-p` would only ever be resurrecting
-# a concurrently deleted tree (docs/issues/2026-08-29-001).
+# Single-level: panes/ exists after initialize_namespace, and `-p` would
+# resurrect a deleted state tree (docs/issues/2026-08-29-001).
 mkdir "$pane_dir" 2>/dev/null || [ -d "$pane_dir" ] || exit 0
 control="$pane_dir/control.state"
 high_water="$pane_dir/high-water.state"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6884,10 +6884,8 @@ function test_scripts_258_herdr_child_descriptor_probe_passes_under_a_nes() {
   assert_output --partial "Passed: herdr-child detached watcher closes launcher descriptors"
 }
 
-# Guards the teardown half of the docs/issues/2026-08-29-001 leak: a worker
-# still running when hts_teardown fires used to outlive the rm -rf and re-run
-# `mkdir -p` on its state paths, resurrecting HTS_WORK as an orphan tmp dir.
-# The contract is causal — teardown terminates and awaits the engine — so the
+# Guards docs/issues/2026-08-29-001: hts_teardown must terminate and await a
+# still-running engine before removing state. The contract is causal, so the
 # assertion is process death, with the directory's settled absence as the
 # observable effect.
 function test_scripts_259_hts_teardown_reaps_a_surviving_engine_worker() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6884,6 +6884,41 @@ function test_scripts_258_herdr_child_descriptor_probe_passes_under_a_nes() {
   assert_output --partial "Passed: herdr-child detached watcher closes launcher descriptors"
 }
 
+# Guards the teardown half of the docs/issues/2026-08-29-001 leak: a worker
+# still running when hts_teardown fires used to outlive the rm -rf and re-run
+# `mkdir -p` on its state paths, resurrecting HTS_WORK as an orphan tmp dir.
+# The contract is causal — teardown terminates and awaits the engine — so the
+# assertion is process death, with the directory's settled absence as the
+# observable effect.
+function test_scripts_259_hts_teardown_reaps_a_surviving_engine_worker() {
+  _bats_test_init 259 'hts_teardown reaps a surviving engine worker before removing state'
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  # The model stub blocks until a release that never comes, pinning the worker
+  # mid-task through teardown. The stub creates its own fixture dir, so no
+  # canned stdout/status is needed for a call that is never released.
+  hts_stub_controlled_engine pi
+
+  hts_run --agent claude --session reap-s <<< 'reap request'
+  hts_wait_for_file "$HTS_WORK/models/pi/1/started" || fail "worker never reached its model call"
+  local engine_pid work="$HTS_WORK"
+  engine_pid="$(hts_record_number \
+    "$(hts_pane_state_dir "$HTS_DEFAULT_SOCKET" pane-1)/worker.claim/owner" pid)"
+  # Control: prove a live engine was observed, not startup or cleanup noise.
+  [[ -n "$engine_pid" ]] || fail "worker claim published no pid"
+  kill -0 "$engine_pid" 2>/dev/null || fail "worker was not alive at teardown time"
+
+  hts_teardown
+
+  run kill -0 "$engine_pid"
+  assert_failure
+  [[ ! -e "$work" ]] || fail "teardown left $work behind"
+  # A survivor recreates state within its first claim window; a settled check
+  # distinguishes real removal from a removal about to be raced.
+  sleep 0.3
+  [[ ! -e "$work" ]] || fail "an engine process resurrected $work after teardown"
+}
+
 function set_up_before_script() {
   :
 }

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -63,30 +63,50 @@ HTS_SIDEBAR_PADDING="$(printf '\342\240\200')"
 #      path under $HTS_WORK, and a blocked stub orphaned by its engine's death
 #      gives up tens of seconds later and recreates socket dirs on its way out.
 # Registry and claim pids are emitted only while `ps` still shows them running
-# herdr-task-sync, so a recycled pid can never be signalled; scan pids carry
-# the sandbox path in their argv, which no unrelated process can.
+# herdr-task-sync AND carrying the start token recorded at fork/claim time, so
+# a recycled pid can never be signalled; scan pids carry the sandbox path in
+# their argv, which no unrelated process can.
+
+# $1 = pid, $2 = recorded start token ('' = unverifiable, command check only).
+_hts_engine_pid_live() {
+  local pid="$1" start="$2" current
+  case "$(ps -p "$pid" -o command= 2>/dev/null)" in
+    *herdr-task-sync*) ;;
+    *) return 1 ;;
+  esac
+  [[ -n "$start" ]] || return 0
+  current="$(ps -p "$pid" -o lstart= 2>/dev/null |
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [[ -z "$current" || "$current" == "$start" ]]
+}
+
 _hts_sandbox_pids() {
-  local file pid command
+  local file pid command start
   {
     if [[ -s "${HTS_SPAWN_REGISTRY:-}" ]]; then
-      while IFS= read -r pid; do
+      # Registry lines are "pid start-token". A recycled pid fails the
+      # start-token comparison and is left alone; an empty recorded token
+      # (ps raced the fork) degrades to the command check alone.
+      while IFS=' ' read -r pid start; do
         case "$pid" in '' | *[!0-9]*) continue ;; esac
-        case "$(ps -p "$pid" -o command= 2>/dev/null)" in
-          *herdr-task-sync*) printf '%s\n' "$pid" ;;
-        esac
+        _hts_engine_pid_live "$pid" "$start" || continue
+        printf '%s\n' "$pid"
       done < "$HTS_SPAWN_REGISTRY"
     fi
     if [[ -n "${HTS_STATE:-}" && -d "$HTS_STATE" ]]; then
       find "$HTS_STATE" -type f \( -name owner -o -path '*/sweep.lock/pid' \) 2>/dev/null |
         while IFS= read -r file; do
+          start=""
           case "$file" in
             */sweep.lock/pid) pid="$(cat "$file" 2>/dev/null)" ;;
-            *) pid="$(sed -n 's/^pid=//p' "$file" 2>/dev/null | head -1)" ;;
+            *)
+              pid="$(sed -n 's/^pid=//p' "$file" 2>/dev/null | head -1)"
+              start="$(hts_state_field "$file" process_start 2>/dev/null || true)"
+              ;;
           esac
           case "$pid" in '' | *[!0-9]*) continue ;; esac
-          case "$(ps -p "$pid" -o command= 2>/dev/null)" in
-            *herdr-task-sync*) printf '%s\n' "$pid" ;;
-          esac
+          _hts_engine_pid_live "$pid" "$start" || continue
+          printf '%s\n' "$pid"
         done
     fi
     # Plain read-loop on purpose: an awk/grep here would carry $HTS_WORK in its

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -52,16 +52,15 @@ HTS_GIT_UNTRACKED='?'
 HTS_SIDEBAR_PADDING="$(printf '\342\240\200')"
 
 # Pids of every process the sandbox detached, from three complementary
-# ledgers:
-#   1. The engine's fork-time spawn registry (HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY),
-#      which sees a worker in the window before its first claim -- the window in
-#      which it re-runs `mkdir -p` on its state paths and no claim names it yet.
-#   2. Claim/lock owner records under HTS_STATE, for engines started by paths
-#      that predate the registry (and as overlap-tolerant redundancy).
+# ledgers — each covers a blind spot of the others:
+#   1. The engine's fork-time spawn registry (HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY):
+#      the only ledger that sees a worker before its first claim.
+#   2. Claim/lock owner records under HTS_STATE: cover engines tests start
+#      directly (hts_worker_run &), which the registry never sees.
 #   3. A ps scan for commands referencing this sandbox's private HTS_WORK path:
-#      stub processes (herdr, git, model stubs) are exec'd by their absolute
-#      path under $HTS_WORK, and a blocked stub orphaned by its engine's death
-#      gives up tens of seconds later and recreates socket dirs on its way out.
+#      stubs are exec'd by absolute path under $HTS_WORK and hold no claim; a
+#      blocked stub orphaned by its engine's death gives up tens of seconds
+#      later and recreates socket dirs on its way out.
 # Registry and claim pids are emitted only while `ps` still shows them running
 # herdr-task-sync AND carrying the start token recorded at fork/claim time, so
 # a recycled pid can never be signalled; scan pids carry the sandbox path in
@@ -141,13 +140,11 @@ _hts_engine_process_tree() {
   done | sort -u
 }
 
-# Terminate every surviving sandbox process and WAIT for it to die. `rm -rf`
-# alone races them: a survivor re-runs `mkdir -p` on its state paths and
-# resurrects HTS_WORK as a skeleton holding only state/sockets debris
+# Terminate every surviving sandbox process and WAIT for it to die — `rm -rf`
+# alone races a survivor's writes, which resurrect HTS_WORK
 # (docs/issues/2026-08-29-001). Multiple rounds, because a root killed in one
-# round may have forked a child (a worker starting its presentation
-# coordinator) between the snapshot and the signal; the child surfaces in the
-# next round's ledgers.
+# round may have forked a child between the snapshot and the signal; the
+# child surfaces in the next round's ledgers.
 _hts_reap_engines() {
   local _round roots tree pid _ alive
   for _round in 1 2 3 4 5; do
@@ -186,12 +183,10 @@ hts_teardown() {
     unset HTS_READER_PID
   fi
   if [[ -n "${HTS_WORK:-}" ]]; then
-    # The descriptor probe's whole contract is that its detached coordinator
-    # and blocked herdr stub OUTLIVE this teardown: the bounded-invocation
-    # driver in scripts_test.sh proves the nested runner exits while a detached
-    # descendant still holds its inherited pipes, then releases and reaps that
-    # descendant itself. Reaping here would kill the held descriptor and turn
-    # that run vacuous, so the probe keeps the legacy removal.
+    # The descriptor probe's contract requires its detached coordinator and
+    # blocked herdr stub to OUTLIVE this teardown; reaping here would turn
+    # that run vacuous. Its driver (the bounded-invocation test in
+    # scripts_test.sh) releases and reaps them itself.
     if [[ -n "${HTS_DESCRIPTOR_PID_FILE:-}" ]]; then
       rm -rf "$HTS_WORK" 2>/dev/null || true
     # Every detached engine spawn is preceded by a synchronous
@@ -283,9 +278,8 @@ hts_fixture_socket_dir() {
   done
   id="$(cat "$HTS_SOCKET_ROOT/next-id" 2>/dev/null)"
   # An unreadable next-id means the sandbox is being torn down around this
-  # call; registering "socket-" into a resurrected root was one of the leak
-  # shapes of docs/issues/2026-08-29-001. Single-level mkdir for the same
-  # reason: fail closed rather than recreate deleted ancestors.
+  # call: fail closed rather than register a bogus "socket-" dir. Single-level
+  # mkdir for the same reason (docs/issues/2026-08-29-001).
   case "$id" in
     '' | *[!0-9]*) rmdir "$lock" 2>/dev/null; return 1 ;;
   esac
@@ -474,9 +468,9 @@ set -e
 name="$(basename "$0")"
 root="$HTS_WORK/models/$name"
 lock="$root/allocate.lock"
-# hts_stub_controlled_engine created this root at setup. A missing root means
-# the sandbox is torn down; `mkdir -p` here resurrected it from the tmp root
-# up (docs/issues/2026-08-29-001), so fail closed instead.
+# hts_stub_controlled_engine created this root at setup; a missing root means
+# the sandbox is torn down, so fail closed instead of `mkdir -p`-resurrecting
+# it (docs/issues/2026-08-29-001).
 [ -d "$root" ] || exit 1
 while ! mkdir "$lock" 2>/dev/null; do
   [ -d "$root" ] || exit 1

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -51,6 +51,110 @@ HTS_GIT_UNTRACKED='?'
 # shellcheck disable=SC2034
 HTS_SIDEBAR_PADDING="$(printf '\342\240\200')"
 
+# Pids of every process the sandbox detached, from three complementary
+# ledgers:
+#   1. The engine's fork-time spawn registry (HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY),
+#      which sees a worker in the window before its first claim -- the window in
+#      which it re-runs `mkdir -p` on its state paths and no claim names it yet.
+#   2. Claim/lock owner records under HTS_STATE, for engines started by paths
+#      that predate the registry (and as overlap-tolerant redundancy).
+#   3. A ps scan for commands referencing this sandbox's private HTS_WORK path:
+#      stub processes (herdr, git, model stubs) are exec'd by their absolute
+#      path under $HTS_WORK, and a blocked stub orphaned by its engine's death
+#      gives up tens of seconds later and recreates socket dirs on its way out.
+# Registry and claim pids are emitted only while `ps` still shows them running
+# herdr-task-sync, so a recycled pid can never be signalled; scan pids carry
+# the sandbox path in their argv, which no unrelated process can.
+_hts_sandbox_pids() {
+  local file pid command
+  {
+    if [[ -s "${HTS_SPAWN_REGISTRY:-}" ]]; then
+      while IFS= read -r pid; do
+        case "$pid" in '' | *[!0-9]*) continue ;; esac
+        case "$(ps -p "$pid" -o command= 2>/dev/null)" in
+          *herdr-task-sync*) printf '%s\n' "$pid" ;;
+        esac
+      done < "$HTS_SPAWN_REGISTRY"
+    fi
+    if [[ -n "${HTS_STATE:-}" && -d "$HTS_STATE" ]]; then
+      find "$HTS_STATE" -type f \( -name owner -o -path '*/sweep.lock/pid' \) 2>/dev/null |
+        while IFS= read -r file; do
+          case "$file" in
+            */sweep.lock/pid) pid="$(cat "$file" 2>/dev/null)" ;;
+            *) pid="$(sed -n 's/^pid=//p' "$file" 2>/dev/null | head -1)" ;;
+          esac
+          case "$pid" in '' | *[!0-9]*) continue ;; esac
+          case "$(ps -p "$pid" -o command= 2>/dev/null)" in
+            *herdr-task-sync*) printf '%s\n' "$pid" ;;
+          esac
+        done
+    fi
+    # Plain read-loop on purpose: an awk/grep here would carry $HTS_WORK in its
+    # own argv and match itself in the snapshot.
+    ps -ax -o pid= -o command= 2>/dev/null |
+      while IFS=' ' read -r pid command; do
+        case "$pid" in '' | *[!0-9]*) continue ;; esac
+        case "$command" in
+          *"$HTS_WORK"*) printf '%s\n' "$pid" ;;
+        esac
+      done
+  } | sort -u
+}
+
+# The pids above plus every live descendant (location-probe subshells, blocked
+# stub calls, watchdogs). Descendants inherit no claim of their own, and the
+# presentation coordinator's probe children keep writing state after their
+# parent dies, so killing only the roots still loses the race.
+_hts_engine_process_tree() {
+  local roots="$1" table frontier pid next children
+  [[ -n "$roots" ]] || return 0
+  table="$(ps -ax -o pid= -o ppid= 2>/dev/null)"
+  frontier="$roots"
+  while [[ -n "$frontier" ]]; do
+    printf '%s\n' "$frontier"
+    next=""
+    for pid in $frontier; do
+      children="$(awk -v parent="$pid" '$2 == parent { print $1 }' <<< "$table")"
+      [[ -z "$children" ]] || next="$next $children"
+    done
+    frontier="${next# }"
+  done | sort -u
+}
+
+# Terminate every surviving sandbox process and WAIT for it to die. `rm -rf`
+# alone races them: a survivor re-runs `mkdir -p` on its state paths and
+# resurrects HTS_WORK as a skeleton holding only state/sockets debris
+# (docs/issues/2026-08-29-001). Multiple rounds, because a root killed in one
+# round may have forked a child (a worker starting its presentation
+# coordinator) between the snapshot and the signal; the child surfaces in the
+# next round's ledgers.
+_hts_reap_engines() {
+  local _round roots tree pid _ alive
+  for _round in 1 2 3 4 5; do
+    roots="$(_hts_sandbox_pids)"
+    [[ -n "$roots" ]] || return 0
+    tree="$(_hts_engine_process_tree "$roots")"
+    while IFS= read -r pid; do
+      kill "$pid" 2>/dev/null || true
+    done <<< "$tree"
+    for _ in $(seq 1 100); do
+      alive=""
+      while IFS= read -r pid; do
+        kill -0 "$pid" 2>/dev/null && alive=1
+      done <<< "$tree"
+      [[ -n "$alive" ]] || break
+      sleep 0.02
+    done
+    if [[ -n "$alive" ]]; then
+      while IFS= read -r pid; do
+        kill -9 "$pid" 2>/dev/null || true
+      done <<< "$tree"
+      sleep 0.02
+    fi
+  done
+  return 0
+}
+
 hts_teardown() {
   # Reap a background reader a failed test left running BEFORE deleting its
   # HTS_WORK: the loop only stops via a file inside HTS_WORK, so once that
@@ -61,8 +165,42 @@ hts_teardown() {
     wait "$HTS_READER_PID" 2>/dev/null || true
     unset HTS_READER_PID
   fi
-  [[ -n "${HTS_WORK:-}" ]] && rm -rf "$HTS_WORK" || true
+  if [[ -n "${HTS_WORK:-}" ]]; then
+    # The descriptor probe's whole contract is that its detached coordinator
+    # and blocked herdr stub OUTLIVE this teardown: the bounded-invocation
+    # driver in scripts_test.sh proves the nested runner exits while a detached
+    # descendant still holds its inherited pipes, then releases and reaps that
+    # descendant itself. Reaping here would kill the held descriptor and turn
+    # that run vacuous, so the probe keeps the legacy removal.
+    if [[ -n "${HTS_DESCRIPTOR_PID_FILE:-}" ]]; then
+      rm -rf "$HTS_WORK" 2>/dev/null || true
+    # Every detached engine spawn is preceded by a synchronous
+    # initialize_namespace, so a missing state/sockets dir proves no engine was
+    # ever forked and the plain removal below cannot be raced. With it present,
+    # reap survivors first, then CONFIRM the removal held: recreation by a
+    # process this round's ledgers missed is only observable after the fact,
+    # and each retry pass reaps again before removing.
+    elif [[ -d "${HTS_STATE:-$HTS_WORK/state}/sockets" ]]; then
+      local _hts_settle=0 _hts_attempt=0
+      _hts_reap_engines
+      rm -rf "$HTS_WORK" 2>/dev/null || true
+      while [[ "$_hts_settle" -lt 2 && "$_hts_attempt" -lt 40 ]]; do
+        _hts_attempt=$((_hts_attempt + 1))
+        sleep 0.05
+        if [[ -e "$HTS_WORK" ]]; then
+          _hts_settle=0
+          _hts_reap_engines
+          rm -rf "$HTS_WORK" 2>/dev/null || true
+        else
+          _hts_settle=$((_hts_settle + 1))
+        fi
+      done
+    else
+      rm -rf "$HTS_WORK" 2>/dev/null || true
+    fi
+  fi
   unset HTS_WORK HTS_STUB HTS_STATE HTS_LOG HTS_DEFAULT_SOCKET HTS_SOCKET_ROOT
+  unset HTS_SPAWN_REGISTRY HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY
 }
 
 hts_setup() {
@@ -75,6 +213,12 @@ hts_setup() {
   HTS_SOCKET_ROOT="$HTS_WORK/sockets"
   export HTS_WORK HTS_DEFAULT_SOCKET HTS_SOCKET_ROOT
   export HERDR_SOCKET_PATH="$HTS_DEFAULT_SOCKET"
+  # Fork-time spawn ledger for hts_teardown (docs/issues/2026-08-29-001). The
+  # engine appends every detached pid here the instant it forks, which is the
+  # only signal that exists in the window before the child's first claim.
+  # Exported so nohup'd engines hand it down to the engines they spawn.
+  HTS_SPAWN_REGISTRY="$HTS_WORK/spawn-registry"
+  export HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY="$HTS_SPAWN_REGISTRY"
   mkdir -p "$HTS_STUB" "$HTS_STATE" "$HTS_SOCKET_ROOT/socket-1"
   : > "$HTS_LOG"
   printf '%s' "$HTS_DEFAULT_SOCKET" > "$HTS_SOCKET_ROOT/socket-1/socket-path"
@@ -86,7 +230,13 @@ hts_setup() {
   # directories avoid the collision caused by replacing punctuation in names.
   cat > "$HTS_WORK/fixture-lib.sh" <<'SH'
 hts_fixture_init_dir() {
-  mkdir -p "$1/calls" "$1/completions" "$1/locks" "$1/after"
+  # Single-level mkdirs, never -p: a stub call surviving hts_teardown must
+  # fail closed instead of resurrecting the deleted sandbox from the tmp
+  # root up (docs/issues/2026-08-29-001).
+  [ -d "$1" ] || return 1
+  for _hts_sub in calls completions locks after; do
+    mkdir "$1/$_hts_sub" 2>/dev/null || [ -d "$1/$_hts_sub" ] || return 1
+  done
   [ -f "$1/state.json" ] || printf '%s\n' \
     '{"complete":true,"protocol":19,"panes":[],"tabs":[],"agents":[],"layouts":[],"workspaces":[],"metadata":{}}' \
     > "$1/state.json"
@@ -111,10 +261,17 @@ hts_fixture_socket_dir() {
       return 0
     fi
   done
-  id="$(cat "$HTS_SOCKET_ROOT/next-id")"
+  id="$(cat "$HTS_SOCKET_ROOT/next-id" 2>/dev/null)"
+  # An unreadable next-id means the sandbox is being torn down around this
+  # call; registering "socket-" into a resurrected root was one of the leak
+  # shapes of docs/issues/2026-08-29-001. Single-level mkdir for the same
+  # reason: fail closed rather than recreate deleted ancestors.
+  case "$id" in
+    '' | *[!0-9]*) rmdir "$lock" 2>/dev/null; return 1 ;;
+  esac
   printf '%s' $((id + 1)) > "$HTS_SOCKET_ROOT/next-id"
   dir="$HTS_SOCKET_ROOT/socket-$id"
-  mkdir -p "$dir"
+  mkdir "$dir" 2>/dev/null || { rmdir "$lock" 2>/dev/null; return 1; }
   printf '%s' "$socket_path" > "$dir/socket-path"
   hts_fixture_init_dir "$dir"
   rmdir "$lock"
@@ -297,13 +454,21 @@ set -e
 name="$(basename "$0")"
 root="$HTS_WORK/models/$name"
 lock="$root/allocate.lock"
-mkdir -p "$root"
-while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done
+# hts_stub_controlled_engine created this root at setup. A missing root means
+# the sandbox is torn down; `mkdir -p` here resurrected it from the tmp root
+# up (docs/issues/2026-08-29-001), so fail closed instead.
+[ -d "$root" ] || exit 1
+while ! mkdir "$lock" 2>/dev/null; do
+  [ -d "$root" ] || exit 1
+  sleep 0.01
+done
 call=$(( $(cat "$root/next" 2>/dev/null || printf '%s' 0) + 1 ))
 printf '%s' "$call" > "$root/next"
 rmdir "$lock"
 fixture="$root/$call"
-mkdir -p "$fixture"
+# Single-level, not -p: hts_model_fixture may have pre-created it, and a
+# missing parent means the sandbox is torn down (docs/issues/2026-08-29-001).
+mkdir "$fixture" 2>/dev/null || [ -d "$fixture" ] || exit 1
 cat > "$fixture/stdin"
 : > "$fixture/started"
 for _ in $(seq 1 "${HTS_WAIT_POLLS:-6000}"); do
@@ -338,7 +503,9 @@ if [ -d "$fixture" ]; then
   printf '%s\n' "$command_args" >> "$fixture/calls"
   printf '%s' "${LC_ALL:-}" > "$fixture/locale"
   : > "$fixture/started"
-  mkdir -p "$HTS_WORK/git-started"
+  # Single-level, not -p: fail closed when the sandbox is torn down instead
+  # of resurrecting it (docs/issues/2026-08-29-001).
+  mkdir "$HTS_WORK/git-started" 2>/dev/null || [ -d "$HTS_WORK/git-started" ] || exit 1
   : > "$HTS_WORK/git-started/${fixture##*/}"
   if [ -f "$fixture/block" ]; then
     while [ ! -f "$fixture/release" ]; do sleep 0.01; done


### PR DESCRIPTION
## Summary

`scripts_test.sh` runs no longer shed `hts.*` directories into `TMPDIR` — every full `-j 8` run used to leak 4–15 of them, and thousands had accumulated on developer machines. `hts_teardown` now terminates and awaits every process its sandbox spawned before deleting state, and a straggler that survives anyway fails closed instead of recreating the deleted tree.

Related: `docs/issues/2026-08-29-001-hts-test-teardown-races-a-surviving-engine-process-that-recreates-state-sockets-shedding-hts-tmp-dirs.md` (repo-tracked issue, closed by this branch).

## The race the diff cannot show

`hts_teardown` ran `rm -rf "$HTS_WORK"` while detached `herdr-task-sync` processes — nohup'd workers, presentation coordinators, blocked stub calls — were still alive. Any late write went through `mkdir -p`, which recreates **every missing ancestor**, so a single post-teardown write resurrected the whole sandbox from the tmp root down as a skeleton holding only `state/sockets` debris. The worst offender was a blocked `herdr` stub that gives up ~30 s after its test ended and recreated the tree on its way out.

The fix is two-sided because neither side alone closes it:

- **Lifecycle (teardown):** reap before removal, from three ledgers — a fork-time spawn registry the engine appends under a test-only env hook (`HERDR_TASK_SYNC_TEST_SPAWN_REGISTRY`), claim/lock owner records under the state dir, and a `ps` scan for commands under the sandbox's private path (which is what catches orphaned blocked stubs). Removal is then confirmed settled with a bounded recreation watch.
- **Resurrection-proofing (engine + stubs):** every directory create on a detached code path is now single-level — `atomic_write`, `initialize_namespace`, pane dirs, the sweep daemon, and the harness stubs create at most the leaf and never ancestors. A deleted state tree makes the write fail and the process exit quietly.

## Design decisions

- **Three ledgers, not one.** The registry sees a worker in the window before its first claim (when no claim names it); claims cover engines started directly by tests (`hts_worker_run &`) that the registry never sees; the argv scan covers stub processes that hold no claim at all. Each has a blind spot the others cover.
- **Recycled-pid guard.** The registry records each fork's process-start token and teardown signals a pid only when its current start token matches; claim pids verify their recorded `process_start` the same way. A pid reused by an unrelated process is left alone.
- **Descriptor probe opts out of reaping.** The bounded-invocation driver (test 102) exists to prove the nested runner exits while a detached descendant still holds its inherited pipes — reaping there would kill the held descriptor and make the run vacuous. The probe keeps the legacy plain removal; the driver releases and reaps its own worker.
- **Fail-closed is scoped to detached paths only.** Foreground invocations (`--event`, `--sweep`, `--ensure-daemon`, `--restart-daemon`, and the naming entry point) still `mkdir -p` the state dir, so a fresh machine without `~/.cache` keeps working. Only detached survivors — the ones that can outlive a teardown — refuse to recreate missing ancestors.

## New concepts

**`mkdir -p` as a resurrection hazard.** `mkdir -p` does not just create a directory — it recreates every missing ancestor. In any system where one actor deletes a tree while detached writers may still be running, every `mkdir -p` (including the one hidden inside "ensure parent dir exists before write" helpers) is a path by which a dead tree comes back. The discipline applied here: detached code creates at most one level (`mkdir "$leaf" || [ -d "$leaf" ] || fail`), so a missing parent is evidence of intentional deletion and the writer exits; only foreground bootstrap paths get recursive creation. Use it when teardown/cleanup can race background writers; skip it where nothing ever deletes the tree mid-run.

## Verification

- New regression test (`hts_teardown reaps a surviving engine worker before removing state`) pins the causal contract — engine terminated before state removal — and was calibrated **red** against the pre-fix teardown, green after.
- Leak measurement around full `-j 8` runs of `tests/bashunit/scripts_test.sh`: 15 new `hts.*` dirs pre-fix; **0** across two consecutive post-fix runs (253 passed, 0 failed, ~2 min each), confirmed by an independent third run (1041 assertions, 0 leaked dirs). A serial run of all 128 hts tests also leaked 0.
- Cross-model review (two independent peer sessions) returned "Ready with fixes"; the consensus findings were applied — including the one real regression it caught, the fresh-machine `STATE_DIR` bootstrap — and the suite re-verified green afterwards.
- `make lint` and the template suite pass. Not run locally: `make test-ubuntu` (Docker apply path); CI's ubuntu and macos jobs cover it.
- Housekeeping: the pre-existing pile (3,067 stale dirs from `TMPDIR` and `/tmp`) was moved to `~/.scratchpad/hts-pile-*` on the machine where this was developed; delete at leisure.
