### PR TITLE
perf(herdr): probe checkout statuses concurrently

### DIFF
--- a/docs/issues/2026-08-27-007-herdr-task-sync-probes-git-status-one-checkout-root-at-a-time.md
+++ b/docs/issues/2026-08-27-007-herdr-task-sync-probes-git-status-one-checkout-root-at-a-time.md
@@ -1,12 +1,13 @@
 ---
 title: "herdr-task-sync probes git status one checkout root at a time"
-short_description: "Each distinct checkout root spends its own status budget in sequence, so a developer with several open worktrees adds most of a second to every five-second sweep."
+short_description: "Distinct checkout roots consume separate 0.3-second status budgets in sequence, making several timed-out worktrees approach a second per sweep even though warm probes take about 36-60 ms each."
 type: "follow-up"
 category: "herdr"
 tags: ["performance"]
 date: "2026-08-27"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Measure first, with several seeded roots and a raised status budget, so there is
 ## Open decisions
 
 None.
+
+## Resolution
+
+Ran distinct checkout status probes concurrently through ordered per-root result files; added a barrier-based regression test that proves both probes start before either can finish; verified with shellcheck, focused bashunit coverage, and make test-ubuntu.

--- a/home/dot_local/bin/executable_herdr-task-sync
+++ b/home/dot_local/bin/executable_herdr-task-sync
@@ -951,17 +951,65 @@ EOF
 
 # Panes routinely share a checkout, so the probe runs once per distinct root
 # rather than once per pane — the dedup build_worktree_tokens already does for
-# worktree tokens.
+# worktree tokens. Distinct roots run concurrently so several slow worktrees
+# cost one status budget rather than one budget each.
 build_root_statuses() {
-  local roots="$1" table="" root row
+  local roots="$1" table="" root row result_file status_pid
+  local status_pids="" status_results="" status_child_failed=0
   while IFS= read -r root; do
     [ -n "$root" ] || continue
-    row="$(resolve_pane_git_status "$root")"
-    table="${table}${table:+
-}${root}${FIELD_SEPARATOR}${row}"
+    result_file="$(umask 077; mktemp "$(namespace_dir)/.status-result.XXXXXX" 2>/dev/null)" || {
+      while IFS= read -r status_pid; do
+        [ -n "$status_pid" ] && wait "$status_pid" 2>/dev/null || true
+      done <<EOF
+$status_pids
+EOF
+      while IFS= read -r result_file; do
+        [ -z "$result_file" ] || rm -f "$result_file"
+      done <<EOF
+$status_results
+EOF
+      return 1
+    }
+    (
+      printf '%s%s' "$root" "$FIELD_SEPARATOR"
+      resolve_pane_git_status "$root"
+    ) > "$result_file" &
+    status_pids="${status_pids}${status_pids:+
+}$!"
+    status_results="${status_results}${status_results:+
+}$result_file"
   done <<EOF
 $roots
 EOF
+  while IFS= read -r status_pid; do
+    [ -n "$status_pid" ] || continue
+    wait "$status_pid" || status_child_failed=1
+  done <<EOF
+$status_pids
+EOF
+  if [ "$status_child_failed" -ne 0 ]; then
+    while IFS= read -r result_file; do
+      [ -z "$result_file" ] || rm -f "$result_file"
+    done <<EOF
+$status_results
+EOF
+    return 1
+  fi
+  while IFS= read -r result_file; do
+    [ -n "$result_file" ] || continue
+    row="$(cat "$result_file" 2>/dev/null)"
+    rm -f "$result_file"
+    if [ -z "$row" ]; then
+      status_child_failed=1
+      continue
+    fi
+    table="${table}${table:+
+}$row"
+  done <<EOF
+$status_results
+EOF
+  [ "$status_child_failed" -eq 0 ] || return 1
   printf '%s' "$table"
 }
 
@@ -1607,7 +1655,7 @@ EOF
 )"
   roots="$(printf '%s\n' "$roots" | sed '/^$/d' | LC_ALL=C sort -u)"
   root_tokens="$(build_worktree_tokens "$roots")"
-  root_statuses="$(build_root_statuses "$roots")"
+  root_statuses="$(build_root_statuses "$roots")" || return 1
   while IFS="$FIELD_SEPARATOR" read -r _pane_id _pane_terminal pane_tab _pane_workspace _pane_agent _pane_native_session _pane_current pane_intended _pane_task _pane_slug _pane_metadata _location_outcome _checkout_root _repository_anchor _repo _branch _is_linked _sha _location_folder _location_status; do
     [ -n "$_pane_id" ] || continue
     _worktree_token=""

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -5426,6 +5426,82 @@ function test_scripts_181_herdr_task_sync_status_probe_over_budget_drops_t() {
   assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
 }
 
+function test_scripts_266_herdr_task_sync_status_probes_start_concurrently() {
+  _bats_test_init 266 'herdr-task-sync starts distinct checkout status probes concurrently'
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  local root_one="$HTS_WORK/repo-one" root_two="$HTS_WORK/repo-two"
+  local common_one="$HTS_WORK/repo-one.git" common_two="$HTS_WORK/repo-two.git" state leaked
+  mkdir -p "$root_one/.git" "$root_two/.git" "$common_one" "$common_two"
+  hts_git_location_fixture "$root_one" "$root_one" "$common_one" refs/heads/one
+  hts_git_location_fixture "$root_two" "$root_two" "$common_two" refs/heads/two
+  hts_git_status_fixture "$root_one" '1 M. N... 100644 100644 100644 1111111 1111111 one.txt'
+  hts_git_status_fixture "$root_two" '1 .M N... 100644 100644 100644 2222222 2222222 two.txt'
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root_one")"
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-2 tab-1 "$root_two")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repos"}'
+  hts_set_process_label pane-1 worker-one
+  hts_set_process_label pane-2 worker-two
+
+  # Each status call waits until both markers exist. A serial loop times out
+  # the first probe before it can start the second; concurrent probes release
+  # each other and preserve both independent outcomes.
+  export HERDR_TASK_SYNC_TEST_STATUS_BARRIER="$HTS_WORK/status-probes-started"
+  export HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT=2
+  run hts_location_pass
+  unset HERDR_TASK_SYNC_TEST_STATUS_BARRIER HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT
+  assert_success
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_staged' "$state")" "${HTS_GIT_STAGED}1"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
+  for leaked in "$(hts_namespace "$HTS_DEFAULT_SOCKET")"/.status-result.*; do
+    [[ ! -e "$leaked" ]] || fail "status result file leaked: $leaked"
+  done
+
+  # One timed-out root remains isolated from a healthy peer after the probes
+  # are parallelized; stale/fresh outcomes keep their existing semantics.
+  hts_block_git_status "$root_one"
+  run hts_location_pass
+  assert_success
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_staged' "$state")" null
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
+}
+
+function test_scripts_267_herdr_task_sync_status_infrastructure_failure_p() {
+  _bats_test_init 267 'herdr-task-sync status infrastructure failure preserves published counts'
+  command -v jq >/dev/null || skip "jq not available"
+  hts_setup
+  local root="$HTS_WORK/repo" common="$HTS_WORK/repo.git" state
+  mkdir -p "$root/.git" "$common"
+  hts_git_location_fixture "$root" "$root" "$common" refs/heads/topic
+  hts_git_status_fixture "$root" '1 .M N... 100644 100644 100644 1111111 1111111 one.txt'
+  hts_set_pane "$HTS_DEFAULT_SOCKET" "$(hts_process_pane_json pane-1 tab-1 "$root")"
+  hts_set_tab "$HTS_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hts_set_workspace "$HTS_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"repo"}'
+  hts_set_process_label pane-1 worker
+  hts_location_pass
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$(hts_socket_state "$HTS_DEFAULT_SOCKET")")" "${HTS_GIT_UNSTAGED}1"
+
+  # Queue a fresh generation, then fail only the aggregate result allocation.
+  # The presentation command is fail-open, so preservation is the observable
+  # contract: publishing an empty table would clear the existing count.
+  HERDR_TASK_SYNC_TEST_NO_PRESENTATION=1 hts_event_run
+  cat > "$HTS_STUB/mktemp" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"/.status-result."*) exit 1 ;;
+esac
+exec /usr/bin/mktemp "$@"
+SH
+  chmod +x "$HTS_STUB/mktemp"
+  run hts_presentation_run
+  assert_success
+  state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.panes[0].tokens.git_unstaged' "$state")" "${HTS_GIT_UNSTAGED}1"
+}
+
 function test_scripts_182_herdr_task_sync_agent_pane_follows_the_directory() {
   _bats_test_init 182 'herdr-task-sync agent pane follows the directory its own statusline reports, not its launch directory'
   command -v jq >/dev/null || skip "jq not available"
@@ -7303,4 +7379,3 @@ function tear_down_after_script() {
 }
 
 function tear_down() { _bats_run_teardown; }
-

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -533,6 +533,17 @@ if [ -d "$fixture" ]; then
       fi
       ;;
     *"--porcelain=v2"*)
+      if [ -n "${HERDR_TASK_SYNC_TEST_STATUS_BARRIER:-}" ] && \
+        [ -n "${HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT:-}" ]; then
+        mkdir "$HERDR_TASK_SYNC_TEST_STATUS_BARRIER" 2>/dev/null || \
+          [ -d "$HERDR_TASK_SYNC_TEST_STATUS_BARRIER" ] || exit 1
+        : > "$HERDR_TASK_SYNC_TEST_STATUS_BARRIER/${fixture##*/}"
+        while :; do
+          set -- "$HERDR_TASK_SYNC_TEST_STATUS_BARRIER"/*
+          [ "$#" -ge "$HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT" ] && break
+          sleep 0.001
+        done
+      fi
       if [ -f "$fixture/block.status" ]; then
         while [ ! -f "$fixture/release" ]; do sleep 0.01; done
       fi
@@ -1239,6 +1250,8 @@ hts_presentation_run() {
     HERDR_TASK_SYNC_TEST_LOCATION_BARRIER="${HERDR_TASK_SYNC_TEST_LOCATION_BARRIER:-}" \
     HERDR_TASK_SYNC_TEST_LOCATION_BARRIER_COUNT="${HERDR_TASK_SYNC_TEST_LOCATION_BARRIER_COUNT:-}" \
     HERDR_TASK_SYNC_TEST_LOCATION_BARRIER_RELEASE="${HERDR_TASK_SYNC_TEST_LOCATION_BARRIER_RELEASE:-}" \
+    HERDR_TASK_SYNC_TEST_STATUS_BARRIER="${HERDR_TASK_SYNC_TEST_STATUS_BARRIER:-}" \
+    HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT="${HERDR_TASK_SYNC_TEST_STATUS_BARRIER_COUNT:-}" \
     bash "$HTS_ENGINE" --presentation-worker
 }
 


### PR DESCRIPTION
## Summary

Status reconciliation across multiple worktrees now spends one shared wall-clock timeout envelope instead of accumulating a separate budget for every checkout root. Results stay associated with their original roots, mixed fresh/stale outcomes remain isolated, and aggregate infrastructure failures preserve previously published counts instead of clearing them.

| Scenario | Before | After |
| --- | --- | --- |
| Warm probes across N roots | N x 36-60 ms | Approximately the slowest 36-60 ms probe, plus scheduling overhead |
| Three probes reaching the 0.3 s budget | Approximately 0.9 s | Approximately 0.3 s |

## Validation

- The barrier regression failed on the serial implementation because the first probe timed out before the second started, then passed with both probes launched concurrently.
- Mixed timeout/success coverage confirms one stale root does not suppress a healthy peer.
- Allocation-failure coverage confirms the fail-open presentation path retains existing Git counts.
- `make test-ubuntu` exited 0; the scripts suite reported 263 passed, 4 pre-existing risky, 267 total.
- ShellCheck passed for the changed production script and test helper.
