### PR TITLE
fix(herdr): preserve reap recovery during event delivery

### DIFF
--- a/docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md
+++ b/docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "herdr"
 tags: ["herdr","race"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "low"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Decide whether deliver_supervision_event should treat invalidated.state with rea
 ## Open decisions
 
 None.
+
+## Resolution
+
+deliver_supervision_event now defers every reason=reap invalidation to watcher_invalidation_action instead of returning status 20 and deleting the run directory. Test 046 deterministically forces invalidation during the delivery window and proves failed-close restoration, watcher survival, one settlement wake, and no child-gone wake; tests 046/047 now keep the unrelated 600000ms supervision deadline out of reach. Verified with five targeted repetitions, make lint, and make test-ubuntu.

--- a/docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md
+++ b/docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-child delivery can wake parent after reap invalidation"
+short_description: "A reap invalidation that lands after deliver_supervision_event's initial check but before parent prompt can still deliver a stale lifecycle event, remove the run directory, and ignore the successful close transition."
+type: "bug"
+category: "herdr"
+tags: ["herdr","race"]
+date: "2026-08-30"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Adversarial review of the 2026-08-30-001 reap-restore fix found a wider pre-existing TOCTOU window. `deliver_supervision_event` checks `invalidated.state` once before child and parent resolution. If reap writes its invalidation after that check, delivery can still prompt the parent and write a receipt after reap successfully closes the pane. The watcher then removes the run directory, while reap's best-effort `reap-closed` signal can fail because the directory is gone. The result is a spurious lifecycle wake for an explicitly reaped child.
+
+## Scope
+
+Serialize reap invalidation against event delivery at the final pre-prompt boundary. Evaluate a per-run transition guard shared by `begin_reap_invalidation` and `deliver_supervision_event`; preserve the current fail-closed reap behavior and avoid holding a filesystem lock across an unbounded external prompt. Add a barrier-driven semantic regression that lands invalidation after delivery's first state check and proves no parent prompt is sent.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md
+++ b/docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md
@@ -1,0 +1,23 @@
+---
+title: "herdr-child reap owner PID reuse can stall supervision"
+short_description: "watcher_invalidation_action identifies a pending reap only with kill -0 on owner_pid, so PID reuse can make an unrelated process hold supervision in the reap-recovery loop indefinitely."
+type: "follow-up"
+category: "herdr"
+tags: ["herdr","race"]
+date: "2026-08-30"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Review of reap recovery found that `reap-pending.state` records only `owner_pid`, and `watcher_invalidation_action` treats `kill -0` as ownership proof. If reap dies and the operating system reuses that PID for an unrelated long-lived process before the watcher observes the death, no `reap-closed` or `reap-restore` transition will arrive. The watcher can remain in the recovery loop indefinitely and stop delivering later child events.
+
+## Scope
+
+Give a reap attempt an identity stronger than PID existence, such as a nonce plus bounded lease or a process-start identity available on both macOS and Linux. Make stale-owner recovery deterministic without converting a slow but live pane close into premature restoration. Add a deterministic test fixture that substitutes an unrelated live process for the recorded owner.
+
+## Open decisions
+
+- Which owner identity is portable across macOS and Linux without adding a heavyweight dependency?
+- What bound distinguishes a stale owner from a legitimately slow pane close under load?

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -578,10 +578,14 @@ deliver_supervision_event() {
   local run_dir="$1" generation="$2" event="$3" outcome="$4" reason="$5"
   local child_name="$6" child_pane="$7" parent_terminal="$8" parent_session="$9"
   local receipt="$run_dir/delivered.$event" list_json parent_record parent_pane parent_status message
-  local pane_json generation_status child_terminal child_session pane_err
+  local pane_json generation_status child_terminal child_session pane_err invalidation_reason
   DELIVERY_REASON=""
   [ ! -f "$receipt" ] || return 0
-  [ ! -f "$run_dir/invalidated.state" ] || return 20
+  if [ -f "$run_dir/invalidated.state" ]; then
+    invalidation_reason="$(supervision_reason "$run_dir/invalidated.state")"
+    [ "$invalidation_reason" != reap ] || return 13
+    return 20
+  fi
 
   if [ "$event" != child-gone ]; then
     child_terminal="$(state_value "$run_dir/launch.state" child_terminal)"
@@ -921,6 +925,7 @@ EOF
           retry_delay="$(next_delivery_retry_delay "$retry_delay")"
           ;;
         12) sleep "$POLL_INTERVAL"; continue ;;
+        13) continue ;;
         20) remove_supervision_run "$run_dir"; exit 0 ;;
         *) watcher_fail "$run_dir" "$pane" "$generation" "$DELIVERY_REASON" "$preserve_waiting" ;;
       esac

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -636,6 +636,16 @@ case "${1:-} ${2:-}" in
     state_file=baseline-state
     [ "$count" -eq 1 ] || state_file=child-state
     read -r child_status child_seq < "$CHILD_STUB/$state_file"
+    if [ "$count" -gt 1 ] && [ -f "$CHILD_STUB/block-agent-get" ]; then
+      : > "$CHILD_STUB/agent-get.ready"
+      attempt=0
+      while [ ! -f "$CHILD_STUB/agent-get.release" ]; do
+        [ -d "$CHILD_STUB" ] || exit 1
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 12000 ] || exit 1
+        sleep 0.01
+      done
+    fi
     child_name="$(read_value started-name child)"
     child_terminal="$(read_value child-terminal term-child)"
     child_session="$(read_value child-session child-session)"
@@ -727,6 +737,12 @@ case "${1:-} ${2:-}" in
     printf '{"result":{"type":"pane_metadata_reported"}}\n'
     ;;
   "pane get")
+    if [ -f "$CHILD_STUB/observe-reap-invalidation" ] && \
+       [ -f "$CHILD_STUB/pane-close.ready" ]; then
+      for run_dir in "$HERDR_CHILD_STATE_DIR"/runs/*; do
+        [ ! -f "$run_dir/invalidated.state" ] || : > "$CHILD_STUB/reap-invalidation-consumed"
+      done
+    fi
     if [ -f "$CHILD_STUB/child-gone" ]; then
       printf '{"error":{"code":"pane_not_found","message":"pane not found"}}\n' >&2
       exit 1
@@ -781,6 +797,16 @@ case "${1:-} ${2:-}" in
       else
         : > "$CHILD_STUB/close-before-invalidation"
       fi
+    fi
+    if [ -f "$CHILD_STUB/block-pane-close" ]; then
+      : > "$CHILD_STUB/pane-close.ready"
+      attempt=0
+      while [ ! -f "$CHILD_STUB/pane-close.release" ]; do
+        [ -d "$CHILD_STUB" ] || exit 1
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 12000 ] || exit 1
+        sleep 0.01
+      done
     fi
     if [ -f "$CHILD_STUB/close-fail" ]; then
       printf '{"error":{"code":"internal_error","message":"close failed"}}\n' >&2
@@ -1514,30 +1540,43 @@ function test_scripts_045_herdr_child_reap_invalidates_before_close_while() {
 function test_scripts_046_herdr_child_failed_reap_restores_supervision_for() {
   _bats_test_init 46 'herdr-child failed reap restores supervision for the kept child'
   child_lifecycle_stub_herdr
-  run child_lifecycle_start --supervision-timeout 5000
+  run child_lifecycle_start --supervision-timeout 600000
   assert_success
-  local generation run_dir watcher_pid attempt=0
+  local generation run_dir watcher_pid reap_pid attempt=0
   generation="$(cat "$CHILD_STUB/generation")"
   run_dir="$CHILD_STUB/state/runs/$generation"
   watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
   printf 'done\n' > "$CHILD_STUB/child-list-status"
+  : > "$CHILD_STUB/block-agent-get"
+  : > "$CHILD_STUB/block-pane-close"
+  : > "$CHILD_STUB/observe-reap-invalidation"
   : > "$CHILD_STUB/close-fail"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/agent-get.ready"
 
-  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+  env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
-    bash "$HERDR_CHILD" reap --pane wT:p9 child-life
-  assert_success
-  assert_output --partial 'supervision recovery requested'
+    bash "$HERDR_CHILD" reap --pane wT:p9 child-life >"$CHILD_STUB/reap.out" 2>&1 &
+  reap_pid=$!
+  child_wait_for_file "$CHILD_STUB/pane-close.ready"
+  assert_file_contains "$run_dir/invalidated.state" '^reason=reap$'
+  : > "$CHILD_STUB/agent-get.release"
+  child_wait_for_file "$CHILD_STUB/reap-invalidation-consumed"
+  : > "$CHILD_STUB/block-parent-prompt"
+  : > "$CHILD_STUB/pane-close.release"
+  wait "$reap_pid"
+  assert_file_contains "$CHILD_STUB/reap.out" 'supervision recovery requested'
   assert_file_not_exists "$CHILD_STUB/pane-closed"
   while [ -f "$run_dir/invalidated.state" ] && [ "$attempt" -lt 500 ]; do
     attempt=$((attempt + 1))
     sleep 0.01
   done
   [ "$attempt" -lt 500 ]
+  child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
   kill -0 "$watcher_pid"
 
-  printf 'idle 11\n' > "$CHILD_STUB/child-state"
-  child_wait_for_log 'event=settled-11'
+  : > "$CHILD_STUB/release-parent-prompt"
+  child_wait_for_file "$CHILD_STUB/successful-prompts.log"
   run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   assert_success
   assert_output 1
@@ -1548,7 +1587,7 @@ function test_scripts_046_herdr_child_failed_reap_restores_supervision_for() {
 function test_scripts_047_herdr_child_detached_ask_follows_parent_identity() {
   _bats_test_init 47 'herdr-child detached ask follows parent identity and suppresses its ordinary blocked wake'
   child_lifecycle_stub_herdr
-  run child_lifecycle_start --supervision-timeout 5000
+  run child_lifecycle_start --supervision-timeout 600000
   assert_success
   local generation watcher_pid attempt=0
   generation="$(cat "$CHILD_STUB/generation")"
@@ -7303,4 +7342,3 @@ function tear_down_after_script() {
 }
 
 function tear_down() { _bats_run_teardown; }
-


### PR DESCRIPTION
## Summary

Failed pane reaps now restore the existing detached watcher even when a lifecycle event reaches delivery in the same iteration. Previously, every invalidation made event delivery erase the supervision run, so a subsequent close failure could no longer signal `reap-restore` and fell back to degraded recovery metadata.

Reap invalidations now defer to the watcher's existing recovery state machine, while non-reap invalidations retain their teardown behavior. Deterministic barriers force the delivery-window interleaving and verify watcher survival, one settlement wake, and no spurious `child-gone` wake; the unrelated supervision deadlines in tests 046/047 are also kept out of reach.

## Validation

- Targeted tests 046/047 passed across five repetitions; test 046 was observed red against the previous delivery behavior.
- `make lint`
- `make test-ubuntu` completed successfully twice, applying the managed file in a disposable Linux home.
- `python3 scripts/issues validate`

## Related

- Related: `docs/issues/2026-08-30-001-herdr-child-watcher-event-delivery-erases-a-pending-reap-run-before-pane-close.md`
- Related: `docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md`
- Related: `docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md`
