### PR TITLE
fix(herdr): prevent stale metadata after watcher takeover

### DIFF
--- a/docs/issues/2026-08-30-001-superseded-watcher-can-restore-stale-failure-metadata-between-generation-check-and-publish.md
+++ b/docs/issues/2026-08-30-001-superseded-watcher-can-restore-stale-failure-metadata-between-generation-check-and-publish.md
@@ -1,12 +1,13 @@
 ---
 title: "Superseded watcher can restore stale failure metadata between generation check and publish"
-short_description: "watcher_publish_failed validates the generation with watcher_generation_current and then calls herdr pane report-metadata as a separate step. A continuation that takes over the pane between the check and the publish gets its fresh state labels cleared and the old generation's failure tokens restored. Pre-existing TOCTOU, unchanged by the 2026-08-30 supersede-cleanup fix, which only made the detected-supersede path clean up its run directory."
+short_description: "Per-pane serialization now keeps generation validation, monotonic sequence allocation, and metadata publication in one critical section, preventing a superseded watcher from restoring stale failure state after takeover."
 type: "bug"
 category: "herdr"
 tags: ["concurrency"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Make the failure-metadata publication conditional on the pane still carrying the
 ## Open decisions
 
 Whether herdr grows an atomic compare-and-publish for pane metadata, or herdr-child re-validates and tolerates a benign race with a bounded self-correction.
+
+## Resolution
+
+Serialized every herdr-child metadata writer with a per-pane lock, revalidated watcher generation and identity inside the failure publisher's critical section, and allocated process-shared monotonic metadata sequences under the same lock. Added a deterministic takeover barrier regression test and source-sequence-aware Herdr stub. Verified with focused tests, make lint, make test-issues, the full scripts_test.sh suite, and make test-ubuntu.

--- a/docs/issues/2026-08-30-002-superseded-watcher-can-refresh-stale-liveness-metadata.md
+++ b/docs/issues/2026-08-30-002-superseded-watcher-can-refresh-stale-liveness-metadata.md
@@ -1,0 +1,22 @@
+---
+title: "Superseded watcher can refresh stale liveness metadata"
+short_description: "refresh_supervision_liveness publishes supervised=<old-generation> without an under-lock generation precondition, so a watcher already in the refresh path can update stale liveness after a managed takeover."
+type: "bug"
+category: "herdr"
+tags: ["concurrency"]
+date: "2026-08-30"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-08-30-003-herdr-task-sync-fixture-accepts-equal-metadata-sequences.md
+++ b/docs/issues/2026-08-30-003-herdr-task-sync-fixture-accepts-equal-metadata-sequences.md
@@ -1,0 +1,22 @@
+---
+title: "Herdr task-sync fixture accepts equal metadata sequences"
+short_description: "The task-sync metadata stub applies seq equal to the current source high-water, while Herdr accepts only strictly greater sequences; tests can therefore diverge from production ordering semantics."
+type: "bug"
+category: "testing-ci"
+tags: ["semantic-tests","herdr"]
+date: "2026-08-30"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -78,16 +78,72 @@ require_parent() {
   }
 }
 
-now_seq() {
-  if command -v python3 >/dev/null 2>&1; then
-    local value
-    value="$(python3 -c 'import time; print(int(time.time()*1000000))' 2>/dev/null)"
-    if [ -n "$value" ]; then
-      printf '%s' "$value"
-      return
-    fi
-  fi
-  printf '%s000000' "$(date +%s)"
+metadata_report_checked() {
+  local pane="$1" expected_generation="$2" expected_terminal="$3" expected_session="$4"
+  shift 4
+  mkdir -p "$STATE_DIR" 2>/dev/null || return 1
+  chmod 700 "$STATE_DIR" 2>/dev/null || true
+  python3 -c 'import fcntl, hashlib, json, os, subprocess, sys, tempfile, time
+state_dir, pane, expected_generation, expected_terminal, expected_session = sys.argv[1:6]
+report_args = sys.argv[6:]
+clock = os.environ.get("HERDR_CHILD_TEST_NOW_SEQ")
+wall = int(clock) if clock else time.time_ns() // 1000
+pane_lock = os.open(os.path.join(state_dir, "metadata-" + hashlib.sha256(pane.encode()).hexdigest() + ".lock"), os.O_CREAT | os.O_RDWR, 0o600)
+try:
+    fcntl.flock(pane_lock, fcntl.LOCK_EX)
+    if expected_generation != "-":
+        current = subprocess.run(["herdr", "pane", "get", pane], capture_output=True, text=True, pass_fds=(pane_lock,))
+        if current.returncode != 0:
+            raise SystemExit(32 if "pane_not_found" in current.stderr else 34)
+        try:
+            pane_data = json.loads(current.stdout).get("result", {}).get("pane", {})
+            tokens = pane_data.get("tokens") or {}
+            terminal = pane_data.get("terminal_id", "")
+            session = pane_data.get("agent_session", {}).get("value", "")
+        except (AttributeError, json.JSONDecodeError):
+            raise SystemExit(34)
+        if tokens.get("supervision_generation", "") != expected_generation or terminal != expected_terminal or session != expected_session:
+            raise SystemExit(20)
+    seq_lock = os.open(os.path.join(state_dir, "metadata-seq.lock"), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(seq_lock, fcntl.LOCK_EX)
+        counter = os.path.join(state_dir, "metadata-seq")
+        try:
+            with open(counter, encoding="ascii") as handle:
+                previous = int(handle.read())
+        except FileNotFoundError:
+            previous = 0
+        value = max(wall, previous + 1)
+        tmp_fd, tmp = tempfile.mkstemp(prefix=".metadata-seq.", dir=state_dir)
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="ascii") as handle:
+                handle.write(str(value))
+            os.replace(tmp, counter)
+        finally:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+    finally:
+        os.close(seq_lock)
+    result = subprocess.run(["herdr", "pane", "report-metadata", pane, *report_args, "--seq", str(value)], stdout=subprocess.DEVNULL, pass_fds=(pane_lock,))
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+    print(value)
+finally:
+    os.close(pane_lock)' "$STATE_DIR" "$pane" "$expected_generation" "$expected_terminal" "$expected_session" "$@"
+}
+
+metadata_report() {
+  local pane="$1"
+  shift
+  metadata_report_checked "$pane" - - - "$@"
+}
+
+metadata_report_if_generation() {
+  local run_dir="$1" pane="$2" generation="$3" child_terminal child_session
+  shift 3
+  child_terminal="$(state_value "$run_dir/launch.state" child_terminal)"
+  child_session="$(state_value "$run_dir/launch.state" child_session)"
+  metadata_report_checked "$pane" "$generation" "$child_terminal" "$child_session" "$@"
 }
 
 now_ms() {
@@ -462,6 +518,14 @@ watcher_hold_expired() {
 watcher_publish_failed() {
   local run_dir="$1" pane="$2" generation="$3" reason="$4" preserve_waiting="${5:-0}"
   local current_status hold_started
+  # watcher_generation_current re-enables errexit internally, clobbering any
+  # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
+  if watcher_generation_current "$run_dir" "$pane" "$generation"; then
+    current_status=0
+  else
+    current_status=$?
+  fi
+  [ "$current_status" -eq 0 ] || return "$current_status"
   if [ -n "${HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER:-}" ]; then
     : > "$HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER.ready"
     hold_started="$SECONDS"
@@ -473,29 +537,21 @@ watcher_publish_failed() {
       sleep 0.01
     done
   fi
-  # watcher_generation_current re-enables errexit internally, clobbering any
-  # set +e bracket; conditional invocation keeps its nonzero return non-fatal.
-  if watcher_generation_current "$run_dir" "$pane" "$generation"; then
-    current_status=0
-  else
-    current_status=$?
-  fi
-  [ "$current_status" -eq 0 ] || return "$current_status"
   if [ "$preserve_waiting" -eq 1 ]; then
-    herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
+    metadata_report_if_generation "$run_dir" "$pane" "$generation" \
+      --source "$SOURCE_ID" --clear-state-labels \
       --state-label 'blocked=waiting for parent' \
       --state-label "supervision failed=$reason" \
       --token "supervision_failure_reason=$reason" \
       --token "supervision_failure_generation=$generation" \
-      --token "supervision_failure_diagnostic=$generation" \
-      --seq "$(now_seq)" >/dev/null 2>&1
+      --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1
   else
-    herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
+    metadata_report_if_generation "$run_dir" "$pane" "$generation" \
+      --source "$SOURCE_ID" --clear-state-labels \
       --state-label "supervision failed=$reason" \
       --token "supervision_failure_reason=$reason" \
       --token "supervision_failure_generation=$generation" \
-      --token "supervision_failure_diagnostic=$generation" \
-      --seq "$(now_seq)" >/dev/null 2>&1
+      --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1
   fi
 }
 
@@ -527,35 +583,31 @@ watcher_fail_without_publish() {
 
 clear_supervision_metadata() {
   local pane="$1"
-  herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
+  metadata_report "$pane" --source "$SOURCE_ID" --clear-state-labels \
     --clear-token child_mode --clear-token supervision_generation \
     --clear-token supervision_timeout --clear-token supervision_baseline_seq \
     --clear-token parent_terminal --clear-token parent_session \
     --clear-token child_terminal --clear-token child_session \
     --clear-token supervision_failure_reason \
     --clear-token supervision_failure_generation \
-    --clear-token supervision_failure_diagnostic \
-    --seq "$(now_seq)" >/dev/null 2>&1
+    --clear-token supervision_failure_diagnostic >/dev/null 2>&1
 }
 
 clear_supervision_state_labels() {
   local pane="$1"
-  herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
-    --seq "$(now_seq)" >/dev/null 2>&1
+  metadata_report "$pane" --source "$SOURCE_ID" --clear-state-labels >/dev/null 2>&1
 }
 
 preserve_callback_waiting_label() {
   local pane="$1"
-  herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
-    --state-label 'blocked=waiting for parent' --ttl-ms "$WAITING_TTL_MS" \
-    --seq "$(now_seq)" >/dev/null 2>&1
+  metadata_report "$pane" --source "$SOURCE_ID" --clear-state-labels \
+    --state-label 'blocked=waiting for parent' --ttl-ms "$WAITING_TTL_MS" >/dev/null 2>&1
 }
 
 refresh_supervision_liveness() {
   local pane="$1" generation="$2"
-  herdr pane report-metadata "$pane" --source "$SOURCE_ID" \
-    --state-label "supervised=$generation" --ttl-ms "$SUPERVISED_TTL_MS" \
-    --seq "$(now_seq)" >/dev/null 2>&1
+  metadata_report "$pane" --source "$SOURCE_ID" \
+    --state-label "supervised=$generation" --ttl-ms "$SUPERVISED_TTL_MS" >/dev/null 2>&1
 }
 
 delivery_retry_pause() {
@@ -1207,8 +1259,8 @@ EOF
   if [ "$tab_mode" -eq 1 ]; then
     local token_err
     token_err="$(mktemp)"
-    if ! herdr pane report-metadata "$pane" --source "$TAB_SOURCE_ID" \
-      --token "child-tab=$tab" --seq "$(now_seq)" >/dev/null 2>"$token_err"; then
+    if ! metadata_report "$pane" --source "$TAB_SOURCE_ID" \
+      --token "child-tab=$tab" >/dev/null 2>"$token_err"; then
       cat "$token_err" >&2
       rm -f "$token_err"
       printf 'herdr-child: could not record tab ownership; removing tab %s\n' "$tab" >&2
@@ -1354,13 +1406,12 @@ baseline_seq=$baseline_seq" || {
       cleanup_pane
       return 1
     }
-    if ! herdr pane report-metadata "$pane" --source "$SOURCE_ID" \
+    if ! metadata_report "$pane" --source "$SOURCE_ID" \
       --token 'child_mode=detach' --token "supervision_generation=$generation" \
       --token "supervision_timeout=$supervision_timeout" \
       --token "supervision_baseline_seq=$baseline_seq" \
       --token "parent_terminal=$parent_terminal" --token "parent_session=$parent_session" \
-      --token "child_terminal=$child_terminal" --token "child_session=$child_session" \
-      --seq "$(now_seq)" >/dev/null; then
+      --token "child_terminal=$child_terminal" --token "child_session=$child_session" >/dev/null; then
       printf 'herdr-child: detached launch metadata could not be published\n' >&2
       remove_supervision_run "$run_dir"
       cleanup_pane
@@ -1528,12 +1579,11 @@ signal_reap_transition() {
 
 publish_reap_recovery() {
   local pane="$1" generation="$2"
-  herdr pane report-metadata "$pane" --source "$SOURCE_ID" \
+  metadata_report "$pane" --source "$SOURCE_ID" \
     --state-label 'supervision failed=reap-close-failed' \
     --token 'supervision_failure_reason=reap-close-failed' \
     --token "supervision_failure_generation=$generation" \
-    --token "supervision_failure_diagnostic=$generation" \
-    --seq "$(now_seq)" >/dev/null 2>&1
+    --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1
 }
 
 wait_for_fresh_settlement() {
@@ -1662,18 +1712,21 @@ baseline_seq=$baseline_seq" || { remove_supervision_run "$run_dir"; return 1; }
   trap 'continuation_signal_handler INT' INT
   trap 'continuation_signal_handler TERM' TERM
 
-  if ! herdr pane report-metadata "$pane" --source "$SOURCE_ID" --clear-state-labels \
+  if ! metadata_report "$pane" --source "$SOURCE_ID" --clear-state-labels \
     --token 'child_mode=detach' --token "supervision_generation=$generation" \
     --token "supervision_timeout=$supervision_timeout" \
     --token "supervision_baseline_seq=$baseline_seq" \
     --token "parent_terminal=$parent_terminal" --token "parent_session=$parent_session" \
     --token "child_terminal=$child_terminal" --token "child_session=$child_session" \
     --clear-token supervision_failure_reason --clear-token supervision_failure_generation \
-    --clear-token supervision_failure_diagnostic --seq "$(now_seq)" >/dev/null; then
+    --clear-token supervision_failure_diagnostic >/dev/null; then
     stop_owned_watcher "$run_dir" "$watcher_pid" metadata-publish-failed
     printf 'herdr-child: detached continuation metadata could not be published\n' >&2
     trap - HUP INT TERM
     return 1
+  fi
+  if [ -n "${HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED:-}" ]; then
+    : > "$HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED"
   fi
   takeover_complete=1
   if ! invalidate_generation "$old_generation" managed-continuation; then
@@ -1755,9 +1808,8 @@ ask_parent() {
   local pane_json context pane_terminal pane_session mode generation run_dir
   local supervision_timeout stored_parent_terminal stored_parent_session
   local stored_child_terminal stored_child_session route_terminal="" route_session=""
-  seq="$(now_seq)"
-  herdr pane report-metadata "$HERDR_PANE_ID" --source "$SOURCE_ID" \
-    --state-label 'blocked=waiting for parent' --ttl-ms "$WAITING_TTL_MS" --seq "$seq" >/dev/null
+  seq="$(metadata_report "$HERDR_PANE_ID" --source "$SOURCE_ID" \
+    --state-label 'blocked=waiting for parent' --ttl-ms "$WAITING_TTL_MS")"
 
   pane_json="$(herdr pane get "$HERDR_PANE_ID" 2>/dev/null || true)"
   context="$(printf '%s' "$pane_json" | json_child_context 2>/dev/null || true)"
@@ -2040,8 +2092,7 @@ $text"
     printf 'herdr-child: reply delivery failed; waiting label remains published\n' >&2
     exit 1
   fi
-  if ! herdr pane report-metadata "$pane" --source "$SOURCE_ID" \
-    --clear-state-labels --seq "$(now_seq)" >/dev/null; then
+  if ! metadata_report "$pane" --source "$SOURCE_ID" --clear-state-labels >/dev/null; then
     printf 'herdr-child: reply delivered to %s in %s, but the waiting label could not be cleared\n' "$name" "$pane" >&2
     exit 1
   fi

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -17,6 +17,8 @@ setup() {
   unset HERDR_CHILD_TEST_RETRY_LOG
   unset HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER
   unset HERDR_CHILD_TEST_CALLBACK_RECEIPT_BARRIER
+  unset HERDR_CHILD_TEST_NOW_SEQ
+  unset HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED
 }
 
 teardown() {
@@ -24,9 +26,10 @@ teardown() {
   if [[ -n "${CHILD_STUB:-}" ]]; then
     [[ ! -e "$CHILD_STUB/release-watcher" ]] || true
     : > "$CHILD_STUB/release-watcher" 2>/dev/null || true
-    if [[ -s "$CHILD_STUB/watcher.pid" ]]; then
-      local watcher_pid
-      watcher_pid="$(cat "$CHILD_STUB/watcher.pid" 2>/dev/null || true)"
+    local pid_file watcher_pid
+    for pid_file in watcher.pid new-watcher.pid reply.pid; do
+      [[ -s "$CHILD_STUB/$pid_file" ]] || continue
+      watcher_pid="$(cat "$CHILD_STUB/$pid_file" 2>/dev/null || true)"
       if [[ -n "$watcher_pid" ]]; then
         kill -TERM "$watcher_pid" 2>/dev/null || true
         local attempt=0
@@ -40,7 +43,7 @@ teardown() {
           kill -KILL "$watcher_pid" 2>/dev/null || true
         fi
       fi
-    fi
+    done
   fi
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
   [[ -n "${CHILD_STUB:-}" ]] && rm -rf "$CHILD_STUB" || true
@@ -705,24 +708,49 @@ case "${1:-} ${2:-}" in
     clear_labels=0
     waiting_label=0
     clear_next=0
+    seq_next=0
+    seq_value=
+    for arg in "$@"; do
+      if [ "$seq_next" -eq 1 ]; then
+        seq_value="$arg"
+        seq_next=0
+        continue
+      fi
+      [ "$arg" != --seq ] || seq_next=1
+    done
+    if [ -n "$seq_value" ] && [ -f "$CHILD_STUB/metadata-seq" ] && \
+       [ "$seq_value" -le "$(cat "$CHILD_STUB/metadata-seq")" ]; then
+      printf '{"result":{"type":"pane_metadata_reported"}}\n'
+      exit 0
+    fi
+    [ -z "$seq_value" ] || printf '%s\n' "$seq_value" > "$CHILD_STUB/metadata-seq"
     for arg in "$@"; do
       if [ "$clear_next" -eq 1 ]; then
-        if [ "$arg" = supervision_generation ]; then
-          rm -f "$CHILD_STUB/generation"
-          : > "$CHILD_STUB/generation-invalidated"
-        fi
+        case "$arg" in
+          supervision_generation)
+            rm -f "$CHILD_STUB/generation"
+            : > "$CHILD_STUB/generation-invalidated"
+            ;;
+          supervision_failure_reason) rm -f "$CHILD_STUB/failure-reason" ;;
+          supervision_failure_generation) rm -f "$CHILD_STUB/failure-generation" ;;
+          supervision_failure_diagnostic) rm -f "$CHILD_STUB/failure-diagnostic" ;;
+        esac
         clear_next=0
         continue
       fi
       [ "$arg" != --clear-token ] || { clear_next=1; continue; }
       case "$arg" in
         supervision_generation=*) printf '%s\n' "${arg#*=}" > "$CHILD_STUB/generation" ;;
+        supervision_failure_reason=*) printf '%s\n' "${arg#*=}" > "$CHILD_STUB/failure-reason" ;;
+        supervision_failure_generation=*) printf '%s\n' "${arg#*=}" > "$CHILD_STUB/failure-generation" ;;
+        supervision_failure_diagnostic=*) printf '%s\n' "${arg#*=}" > "$CHILD_STUB/failure-diagnostic" ;;
         child-tab=*) printf '%s\n' "${arg#*=}" > "$CHILD_STUB/child-tab" ;;
         --clear-state-labels) clear_labels=1 ;;
         blocked=waiting\ for\ parent) waiting_label=1 ;;
+        supervision\ failed=*) : > "$CHILD_STUB/failure-label" ;;
       esac
     done
-    [ "$clear_labels" -eq 0 ] || rm -f "$CHILD_STUB/waiting-label"
+    [ "$clear_labels" -eq 0 ] || rm -f "$CHILD_STUB/waiting-label" "$CHILD_STUB/failure-label"
     [ "$waiting_label" -eq 0 ] || : > "$CHILD_STUB/waiting-label"
     printf '{"result":{"type":"pane_metadata_reported"}}\n'
     ;;
@@ -1365,28 +1393,66 @@ function test_scripts_039_herdr_child_transient_pane_reads_never_become_ch() {
 function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
   _bats_test_init 40 'herdr-child superseded watcher cannot publish failure metadata over a new generation'
   child_lifecycle_stub_herdr
+  local old_generation old_run new_generation watcher_pid new_watcher_pid reply_pid reply_status attempt=0
   export HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER="$CHILD_STUB/failure-publish"
+  export HERDR_CHILD_TEST_NOW_SEQ=100
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
-  local old_generation old_run watcher_pid attempt=0
   old_generation="$(cat "$CHILD_STUB/generation")"
   old_run="$CHILD_STUB/state/runs/$old_generation"
   watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
-
-  : > "$CHILD_STUB/malformed-state"
-  child_wait_for_file "$CHILD_STUB/failure-publish.ready"
   printf 'new-generation\n' > "$CHILD_STUB/generation"
-  : > "$CHILD_STUB/failure-publish.release"
   while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
     attempt=$((attempt + 1))
     sleep 0.01
   done
-  [ "$attempt" -lt 500 ]
   assert_dir_not_exists "$old_run"
-  run cat "$CHILD_STUB/generation"
+
+  teardown
+  setup
+  child_lifecycle_stub_herdr
+  export HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER="$CHILD_STUB/failure-publish"
+  export HERDR_CHILD_TEST_NOW_SEQ=100
+  run child_lifecycle_start --supervision-timeout 5000
   assert_success
-  assert_output new-generation
-  run grep -q 'supervision_failure_reason=' "$CHILD_STUB/calls.log"
+  old_generation="$(cat "$CHILD_STUB/generation")"
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  attempt=0
+
+  printf '12\n' > "$CHILD_STUB/prompt-fail-count"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/failure-publish.ready"
+  env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    HERDR_CHILD_TEST_WATCHER_PID_FILE="$CHILD_STUB/new-watcher.pid" \
+    HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED="$CHILD_STUB/takeover-metadata-published" \
+    HERDR_CHILD_POLL_INTERVAL=0.01 HERDR_CHILD_RETRY_INTERVAL=0.01 \
+    bash "$HERDR_CHILD" reply --to child-life --pane wT:p9 "Use path A" \
+    >"$CHILD_STUB/reply.out" 2>"$CHILD_STUB/reply.err" &
+  reply_pid=$!
+  printf '%s\n' "$reply_pid" > "$CHILD_STUB/reply.pid"
+  child_wait_for_file "$CHILD_STUB/takeover-metadata-published"
+  : > "$CHILD_STUB/failure-publish.release"
+  if wait "$reply_pid"; then reply_status=0; else reply_status=$?; fi
+  assert_equal 0 "$reply_status"
+  new_generation="$(cat "$CHILD_STUB/generation")"
+  run test "$new_generation" != "$old_generation"
+  assert_success
+  run grep -q 'supervision_failure_reason=prompt-error' "$CHILD_STUB/calls.log"
+  assert_failure
+  assert_file_not_exists "$CHILD_STUB/failure-label"
+  assert_file_not_exists "$CHILD_STUB/failure-reason"
+  assert_file_not_exists "$CHILD_STUB/failure-generation"
+  assert_file_not_exists "$CHILD_STUB/failure-diagnostic"
+  wait "$watcher_pid" 2>/dev/null || true
+  printf 'done 12\n' > "$CHILD_STUB/child-state"
+  child_wait_for_log "generation=$new_generation.*event=settled-12"
+  new_watcher_pid="$(cat "$CHILD_STUB/new-watcher.pid")"
+  while kill -0 "$new_watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$new_watcher_pid"
   assert_failure
 }
 
@@ -2312,16 +2378,20 @@ function test_scripts_079_herdr_child_ask_and_reply_publish_strictly_incre() {
   child_stub_herdr
   local parent_agents='{"result":{"agents":[{"name":"parent","pane_id":"wT:p0"}]}}'
   env PATH="$CHILD_STUB:$PATH" STUB_AGENTS_JSON="$parent_agents" HERDR_ENV=1 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" HERDR_CHILD_TEST_NOW_SEQ=200 \
     HERDR_PANE_ID=wT:p9 HERDR_CHILD_NAME=child-a HERDR_CHILD_PARENT_PANE=wT:p0 \
     bash "$HERDR_CHILD" ask question >/dev/null
   local child_agents='{"result":{"agents":[{"name":"child-a","pane_id":"wT:p9"}]}}'
   env PATH="$CHILD_STUB:$PATH" STUB_AGENTS_JSON="$child_agents" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" HERDR_CHILD_TEST_NOW_SEQ=100 \
     bash "$HERDR_CHILD" reply --to child-a --pane wT:p9 decision >/dev/null
   local first_seq second_seq
   first_seq="$(grep '^pane report-metadata' "$CHILD_STUB/calls.log" | sed -n '1s/.*--seq \([0-9]*\).*/\1/p')"
   second_seq="$(grep '^pane report-metadata' "$CHILD_STUB/calls.log" | sed -n '2s/.*--seq \([0-9]*\).*/\1/p')"
-  [ -n "$first_seq" ]
-  [ "$second_seq" -gt "$first_seq" ]
+  run test -n "$first_seq"
+  assert_success
+  run test "$second_seq" -gt "$first_seq"
+  assert_success
 }
 
 function test_scripts_080_herdr_child_reply_keeps_the_label_when_delivery() {
@@ -7302,5 +7372,9 @@ function tear_down_after_script() {
   _bats_file_cleanup
 }
 
-function tear_down() { _bats_run_teardown; }
-
+function tear_down() {
+  if [ -n "${CHILD_STUB:-}" ] && [ -e "$CHILD_STUB/failure-publish.ready" ]; then
+    : > "$CHILD_STUB/failure-publish.release"
+  fi
+  _bats_run_teardown
+}


### PR DESCRIPTION
## Summary

A superseded `herdr-child` watcher can no longer restore stale failure metadata after a newer managed continuation takes ownership of the pane. Metadata writes for each pane now share one critical section covering identity validation, monotonic source-sequence allocation, and publication, so the generation check cannot become stale before the write. A deterministic takeover barrier exercises the original interleaving, while two repository follow-ups record the remaining liveness-refresh and fixture-fidelity gaps.

## Validation

- `make test-ubuntu` after merging `origin/main`: exit 0; the scripts suite reported 264 passed and 3 pre-existing risky tests, and Docker also passed `chezmoi verify` and idempotence checks.
- Focused takeover regression: 1 passed, 11 assertions.
- `make lint`
- `make test-issues`
