### PR TITLE
fix(tests): enforce Herdr metadata sequence ordering

### DIFF
--- a/docs/issues/2026-08-30-003-herdr-task-sync-fixture-accepts-equal-metadata-sequences.md
+++ b/docs/issues/2026-08-30-003-herdr-task-sync-fixture-accepts-equal-metadata-sequences.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "testing-ci"
 tags: ["semantic-tests","herdr"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Define the work that resolves this issue.
 ## Open decisions
 
 None.
+
+## Resolution
+
+Changed the Herdr task-sync stub to ignore metadata sequences less than or equal to the current source high-water, added an equal-sequence regression assertion, and updated the retired-token fixture to publish with a strictly newer sequence. Verified with focused bashunit tests and make test-suite.

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -3165,8 +3165,10 @@ function test_scripts_107_herdr_task_sync_harness_applies_source_metadata() {
 
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata --source location pane-1 --seq 2 --token repo=alpha
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata --source task pane-1 --seq 1 --token task=review
-  hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata --source location pane-1 --seq 1 --clear-token repo
+  hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata --source location pane-1 --seq 2 --token repo=beta
   local state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
+  assert_equal "$(jq -r '.metadata["pane-1"].location.tokens.repo' "$state")" alpha
+  hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata --source location pane-1 --seq 1 --clear-token repo
   assert_equal "$(jq -r '.metadata["pane-1"].location.tokens.repo' "$state")" alpha
   assert_equal "$(jq -r '.panes[0].tokens.task' "$state")" review
 
@@ -5255,9 +5257,9 @@ function test_scripts_174_herdr_task_sync_clears_retired_aggregate_tokens() {
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
   # given: a stale daemon of the retired version puts both aggregate tokens
   # back while leaving every current token untouched. It reports under the same
-  # source at the sequence the last pass used, as a sharing old daemon would.
+  # source with a newer sequence, as a sharing old daemon would need to.
   local legacy_seq
-  legacy_seq="$(jq -r '.metadata["pane-1"]["location-sync"].seq' "$state")"
+  legacy_seq=$(( $(jq -r '.metadata["pane-1"]["location-sync"].seq' "$state") + 1 ))
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane report-metadata pane-1 \
     --source location-sync --seq "$legacy_seq" --token 'location_label=repository/topic' \
     --token 'git_status=old-dirty-1'

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -445,7 +445,7 @@ elif [ "$1" = "pane" ] && [ "$2" = "report-metadata" ]; then
   jq --arg pane "$pane_id" --arg source "$source_id" --argjson seq "$report_seq" \
     --argjson tokens "$tokens" --argjson clears "$clear_tokens" '
       (.metadata[$pane][$source].seq // -1) as $current
-      | if $seq < $current then . else
+      | if $seq <= $current then . else
           .metadata[$pane][$source].seq = $seq
           | .metadata[$pane][$source].tokens = ((.metadata[$pane][$source].tokens // {}) + $tokens | with_entries(select(.key as $key | $clears | index($key) | not)))
           | (.metadata[$pane] // {} | [.[] | .tokens // {}] | add // {}) as $merged


### PR DESCRIPTION
The task-sync harness now rejects stale and equal sequence reports exactly as Herdr does, preventing tests from accepting metadata writes production ignores. Regression coverage demonstrates that an equal report leaves prior metadata intact, while the stale-daemon scenario now publishes with a genuinely newer sequence.

Validation completed with the focused metadata tests, `make test-suite`, `make test-issues`, and `make lint`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
