### PR TITLE
fix(herdr): serialize reap with lifecycle delivery

### DIFF
--- a/docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md
+++ b/docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "herdr"
 tags: ["herdr","race"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Serialize reap invalidation against event delivery at the final pre-prompt bound
 ## Open decisions
 
 None.
+
+## Resolution
+
+Serialized reap invalidation with delivery's final prompt decision through a per-run transition guard and delivery claim. Reap now suppresses delivery when invalidation wins, fails closed without holding the guard across an active prompt when delivery wins, and reclaims claims owned by dead watchers. Added barrier-driven tests for all three orderings; calibrated the invalidation-first case red on the old implementation and verified focused tests, make lint, and make test-ubuntu.

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -372,6 +372,70 @@ release_arm_guard() {
   rmdir "$1/arm.guard" 2>/dev/null || true
 }
 
+begin_supervision_transition() {
+  local operation="$1" run_dir="$2" receipt="${3:--}"
+  python3 -c 'import fcntl, os, subprocess, sys, tempfile
+operation, run_dir, receipt, owner_pid = sys.argv[1:5]
+
+def read_state(path):
+    try:
+        with open(path, encoding="ascii") as handle:
+            return dict(line.rstrip("\n").split("=", 1) for line in handle if "=" in line)
+    except (OSError, ValueError):
+        return {}
+
+def process_start(pid):
+    env = dict(os.environ, LC_ALL="C")
+    result = subprocess.run(["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, env=env)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+def atomic_write(name, content):
+    fd, tmp = tempfile.mkstemp(prefix=".write.", dir=run_dir)
+    try:
+        with os.fdopen(fd, "w", encoding="ascii") as handle:
+            handle.write(content + "\n")
+        os.replace(tmp, os.path.join(run_dir, name))
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+try:
+    lock = os.open(os.path.join(run_dir, "transition.lock"), os.O_CREAT | os.O_RDWR, 0o600)
+except FileNotFoundError:
+    raise SystemExit(20 if operation == "delivery" else 2)
+try:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    invalidated = os.path.join(run_dir, "invalidated.state")
+    pending = os.path.join(run_dir, "delivery-pending.state")
+    if operation == "delivery":
+        if os.path.isfile(receipt):
+            try: os.unlink(pending)
+            except FileNotFoundError: pass
+            raise SystemExit(2)
+        if os.path.isfile(invalidated):
+            raise SystemExit(13 if read_state(invalidated).get("reason") == "reap" else 20)
+        start = process_start(owner_pid)
+        if not start:
+            raise SystemExit(1)
+        atomic_write("delivery-pending.state", f"owner_pid={owner_pid}\nowner_start={start}")
+    else:
+        if os.path.isfile(pending):
+            state = read_state(pending)
+            pid = state.get("owner_pid", "")
+            start = state.get("owner_start", "")
+            if pid.isdigit() and start and process_start(pid) == start:
+                raise SystemExit(1)
+            os.unlink(pending)
+        atomic_write("reap-pending.state", f"status=pending\nowner_pid={owner_pid}")
+        atomic_write("invalidated.state", "reason=reap")
+finally:
+    os.close(lock)' "$operation" "$run_dir" "$receipt" "$$"
+}
+
+finish_delivery_transition() {
+  rm -f "$1/delivery-pending.state" 2>/dev/null || true
+}
+
 request_watcher_abort() {
   local run_dir="$1" reason="$2" status=0
   acquire_arm_guard "$run_dir" || return 1
@@ -630,7 +694,7 @@ deliver_supervision_event() {
   local run_dir="$1" generation="$2" event="$3" outcome="$4" reason="$5"
   local child_name="$6" child_pane="$7" parent_terminal="$8" parent_session="$9"
   local receipt="$run_dir/delivered.$event" list_json parent_record parent_pane parent_status message
-  local pane_json generation_status child_terminal child_session pane_err invalidation_reason
+  local pane_json generation_status child_terminal child_session pane_err invalidation_reason transition_status
   DELIVERY_REASON=""
   [ ! -f "$receipt" ] || return 0
   if [ -f "$run_dir/invalidated.state" ]; then
@@ -690,18 +754,30 @@ EOF
     return 10
   fi
 
+  if begin_supervision_transition delivery "$run_dir" "$receipt"; then
+    transition_status=0
+  else
+    transition_status=$?
+  fi
+  case "$transition_status" in
+    0) ;;
+    2) return 0 ;;
+    13|20) return "$transition_status" ;;
+    *) DELIVERY_REASON="prompt-error"; return 11 ;;
+  esac
+
   message="[child-supervision v1 generation=$generation event=$event outcome=$outcome reason=${reason:-none} agent=$child_name pane=$child_pane]
 
 This is an observed child lifecycle state, not a task-success verdict. Verify the live pair, child output, requested commits, worktree state, tests, and artifacts."
-  if ! herdr agent prompt "$parent_pane" "$message" >/dev/null 2>&1; then
-    DELIVERY_REASON="prompt-error"
-    return 11
-  fi
-  if ! atomic_write "$receipt" "generation=$generation
+  if herdr agent prompt "$parent_pane" "$message" >/dev/null 2>&1 && \
+     atomic_write "$receipt" "generation=$generation
 event=$event"; then
-    DELIVERY_REASON="prompt-error"
-    return 11
+    finish_delivery_transition "$run_dir"
+    return 0
   fi
+  finish_delivery_transition "$run_dir"
+  DELIVERY_REASON="prompt-error"
+  return 11
 }
 
 watch_child() {
@@ -1567,12 +1643,7 @@ begin_reap_invalidation() {
   local generation="$1" run_dir
   run_dir="$STATE_DIR/runs/$generation"
   [ -d "$run_dir" ] || return 2
-  atomic_write "$run_dir/reap-pending.state" "status=pending
-owner_pid=$$" || return 1
-  if ! atomic_write "$run_dir/invalidated.state" 'reason=reap'; then
-    rm -f "$run_dir/reap-pending.state" 2>/dev/null || true
-    return 1
-  fi
+  begin_supervision_transition reap "$run_dir"
 }
 
 signal_reap_transition() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -555,6 +555,14 @@ case "${1:-} ${2:-}" in
 esac
 SH
   chmod +x "$CHILD_STUB/herdr"
+  cat > "$CHILD_STUB/ps" <<'SH'
+#!/usr/bin/env bash
+if [ -f "$CHILD_STUB/observe-ps-locale" ]; then
+  printf '%s\n' "${LC_ALL:-unset}" >> "$CHILD_STUB/ps-locales.log"
+fi
+exec /bin/ps "$@"
+SH
+  chmod +x "$CHILD_STUB/ps"
 }
 
 child_start() {
@@ -765,6 +773,18 @@ case "${1:-} ${2:-}" in
     printf '{"result":{"type":"pane_metadata_reported"}}\n'
     ;;
   "pane get")
+    if [ -f "$CHILD_STUB/block-delivery-pane-get" ] && \
+       [ -f "$CHILD_STUB/settlement-observed" ] && \
+       [ ! -f "$CHILD_STUB/delivery-pane-get.ready" ]; then
+      : > "$CHILD_STUB/delivery-pane-get.ready"
+      attempt=0
+      while [ ! -f "$CHILD_STUB/delivery-pane-get.release" ]; do
+        [ -d "$CHILD_STUB" ] || exit 1
+        attempt=$((attempt + 1))
+        [ "$attempt" -lt 12000 ] || exit 1
+        sleep 0.01
+      done
+    fi
     if [ -f "$CHILD_STUB/observe-reap-invalidation" ] && \
        [ -f "$CHILD_STUB/pane-close.ready" ]; then
       for run_dir in "$HERDR_CHILD_STATE_DIR"/runs/*; do
@@ -7479,6 +7499,112 @@ function test_scripts_263_herdr_child_watcher_release_hold_is_bounded() {
   done
   run kill -0 "$watcher_pid"
   assert_failure
+}
+
+function test_scripts_264_herdr_child_reap_invalidation_suppresses_delivery_already_in_progress() {
+  _bats_test_init 264 'herdr-child reap invalidation suppresses delivery already in progress'
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 600000
+  assert_success
+  local watcher_pid attempt=0
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  printf 'done\n' > "$CHILD_STUB/child-list-status"
+  : > "$CHILD_STUB/block-delivery-pane-get"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/delivery-pane-get.ready"
+
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    bash "$HERDR_CHILD" reap --pane wT:p9 child-life
+  assert_success
+  assert_output --partial 'closed pane wT:p9'
+  assert_file_exists "$CHILD_STUB/pane-closed"
+
+  : > "$CHILD_STUB/delivery-pane-get.release"
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  [ "$attempt" -lt 500 ]
+  assert_file_not_exists "$CHILD_STUB/successful-prompts.log"
+}
+
+function test_scripts_265_herdr_child_delivery_claim_keeps_reap_fail_closed_without_holding_guard() {
+  _bats_test_init 265 'herdr-child delivery claim keeps reap fail closed without holding the transition guard'
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 600000
+  assert_success
+  local generation run_dir watcher_pid attempt=0
+  generation="$(cat "$CHILD_STUB/generation")"
+  run_dir="$CHILD_STUB/state/runs/$generation"
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  printf 'done\n' > "$CHILD_STUB/child-list-status"
+  : > "$CHILD_STUB/block-parent-prompt"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
+  assert_file_exists "$run_dir/delivery-pending.state"
+
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    bash "$HERDR_CHILD" reap --pane wT:p9 child-life
+  assert_success
+  assert_output --partial 'supervision generation could not be invalidated'
+  assert_file_not_exists "$CHILD_STUB/pane-closed"
+
+  : > "$CHILD_STUB/release-parent-prompt"
+  child_wait_for_file "$CHILD_STUB/successful-prompts.log"
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  [ "$attempt" -lt 500 ]
+  assert_dir_not_exists "$run_dir"
+}
+
+function test_scripts_266_herdr_child_reap_recovers_a_delivery_claim_owned_by_a_dead_watcher() {
+  _bats_test_init 266 'herdr-child reap recovers a delivery claim owned by a dead watcher'
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 600000
+  assert_success
+  local generation run_dir watcher_pid attempt=0
+  generation="$(cat "$CHILD_STUB/generation")"
+  run_dir="$CHILD_STUB/state/runs/$generation"
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  printf 'done\n' > "$CHILD_STUB/child-list-status"
+  : > "$CHILD_STUB/block-parent-prompt"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
+  assert_file_exists "$run_dir/delivery-pending.state"
+
+  kill -KILL "$watcher_pid"
+  while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  [ "$attempt" -lt 500 ]
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    bash "$HERDR_CHILD" reap --pane wT:p9 child-life
+  assert_success
+  assert_output --partial 'closed pane wT:p9'
+  assert_file_exists "$CHILD_STUB/pane-closed"
+  : > "$CHILD_STUB/release-parent-prompt"
+}
+
+function test_scripts_267_herdr_child_transition_owner_identity_uses_a_stable_locale() {
+  _bats_test_init 267 'herdr-child transition owner identity uses a stable locale'
+  child_lifecycle_stub_herdr
+  : > "$CHILD_STUB/observe-ps-locale"
+  run child_lifecycle_start --supervision-timeout 600000
+  assert_success
+  printf 'done\n' > "$CHILD_STUB/child-list-status"
+  : > "$CHILD_STUB/block-parent-prompt"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
+  assert_file_contains "$CHILD_STUB/ps-locales.log" '^C$'
+  run grep -v '^C$' "$CHILD_STUB/ps-locales.log"
+  assert_failure
+  : > "$CHILD_STUB/release-parent-prompt"
 }
 
 function set_up_before_script() {


### PR DESCRIPTION
## Summary

Explicitly reaping a child can no longer wake its parent through a lifecycle delivery that already passed an earlier invalidation check. Reap invalidation and delivery now share a final serialized transition, while parent prompting remains outside the filesystem lock.

## Design

- Claim delivery under a per-run `fcntl` lock immediately before prompting.
- Make reap fail closed when a live delivery owns the claim, and reclaim claims from dead or PID-reused owners using a locale-stable process-start identity.
- Preserve the existing reap restore path and delivery retry behavior.
- Close `docs/issues/2026-08-30-002-herdr-child-delivery-can-wake-parent-after-reap-invalidation.md` with the verified resolution.

## Tests

- Calibrated the invalidation-first race red on the previous implementation, then green with the fix.
- Added controls for delivery-first fail-closed behavior, dead-watcher recovery, and locale-stable owner identity.
- `make lint`
- `make test-issues`
- `make test-ubuntu` (268 script tests passed; full Docker-applied suite green)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
