### PR TITLE
fix(herdr): make reap ownership PID-reuse safe

### DIFF
--- a/docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md
+++ b/docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md
@@ -1,12 +1,13 @@
 ---
 title: "herdr-child reap owner PID reuse can stall supervision"
-short_description: "watcher_invalidation_action identifies a pending reap only with kill -0 on owner_pid, so PID reuse can make an unrelated process hold supervision in the reap-recovery loop indefinitely."
+short_description: "Reap recovery now uses an owner-held kernel lock, so process death releases ownership independently of PID reuse while a legitimate slow pane close keeps supervision invalidated."
 type: "follow-up"
 category: "herdr"
 tags: ["herdr","race"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "low"
+closed: "2026-08-30"
 ---
 
 ## Why this exists
@@ -21,3 +22,7 @@ Give a reap attempt an identity stronger than PID existence, such as a nonce plu
 
 - Which owner identity is portable across macOS and Linux without adding a heavyweight dependency?
 - What bound distinguishes a stale owner from a legitimately slow pane close under load?
+
+## Resolution
+
+Held a per-run kernel lock for each reap attempt and made the watcher restore supervision when that lock is released, independently of PID reuse. Extended lifecycle test 046 with both a post-lock-check blocked-owner control and a deterministic unrelated-live-process fixture. Verified the calibrated red state, five targeted green repetitions, `make lint`, and `make test-ubuntu`.

--- a/home/dot_local/bin/executable_herdr-child
+++ b/home/dot_local/bin/executable_herdr-child
@@ -19,6 +19,8 @@ MAX_DELIVERY_RETRIES="${HERDR_CHILD_MAX_DELIVERY_RETRIES:-12}"
 DELIVERY_RETRY_INITIAL="${HERDR_CHILD_DELIVERY_RETRY_INITIAL:-1}"
 DELIVERY_RETRY_MAX="${HERDR_CHILD_DELIVERY_RETRY_MAX:-15}"
 WAIT_SLICE_MS="${HERDR_CHILD_WAIT_SLICE_MS:-30000}"
+REAP_OWNER_GUARD_PID=""
+REAP_OWNER_TOKEN=""
 
 usage() {
   cat >&2 <<'EOF'
@@ -446,20 +448,18 @@ publish_supervision_recovery() {
 
 watcher_invalidation_action() {
   local run_dir="$1" pane="$2" generation="$3" reason attempt=0 pane_err owner_pid
+  local owner_token lock_status
   [ -f "$run_dir/invalidated.state" ] || return 1
   reason="$(supervision_reason "$run_dir/invalidated.state")"
   [ "$reason" = reap ] || return 20
   owner_pid="$(state_value "$run_dir/reap-pending.state" owner_pid)"
+  owner_token="$(state_value "$run_dir/reap-pending.state" owner_token)"
   case "$owner_pid" in '' | *[!0-9]*) return 21 ;; esac
+  case "$owner_token" in *[!0-9a-f]* | '') return 21 ;; esac
+  [ "${#owner_token}" -eq 32 ] || return 21
   while :; do
     [ -d "$run_dir" ] || return 20
     [ ! -f "$run_dir/reap-closed.state" ] || return 20
-    if [ -f "$run_dir/reap-restore.state" ]; then
-      rm -f "$run_dir/invalidated.state" "$run_dir/reap-pending.state" \
-        "$run_dir/reap-restore.state" 2>/dev/null || return 21
-      refresh_supervision_liveness "$pane" "$generation" || return 21
-      return 0
-    fi
     pane_err="$run_dir/reap-pane-get.err"
     if herdr pane get "$pane" >/dev/null 2>"$pane_err"; then
       rm -f "$pane_err"
@@ -469,10 +469,21 @@ watcher_invalidation_action() {
     else
       rm -f "$pane_err"
     fi
-    if ! kill -0 "$owner_pid" 2>/dev/null; then
-      rm -f "$run_dir/invalidated.state" "$run_dir/reap-pending.state" 2>/dev/null || return 21
-      refresh_supervision_liveness "$pane" "$generation" || return 21
-      return 0
+    if [ $((attempt % 100)) -eq 0 ]; then
+      if reap_owner_recovery_status "$run_dir" "$owner_token"; then lock_status=0; else lock_status=$?; fi
+      case "$lock_status" in
+        0)
+          [ -z "${HERDR_CHILD_TEST_REAP_OWNER_VERIFIED:-}" ] ||
+            : > "$HERDR_CHILD_TEST_REAP_OWNER_VERIFIED"
+          ;;
+        1|10)
+          refresh_supervision_liveness "$pane" "$generation" || return 21
+          return 0
+          ;;
+        3) return 0 ;;
+        20) return 20 ;;
+        *) return 21 ;;
+      esac
     fi
     attempt=$((attempt + 1))
     if [ $((attempt % 3000)) -eq 0 ]; then
@@ -1567,12 +1578,107 @@ begin_reap_invalidation() {
   local generation="$1" run_dir
   run_dir="$STATE_DIR/runs/$generation"
   [ -d "$run_dir" ] || return 2
+  start_reap_owner_guard "$run_dir" || return 1
   atomic_write "$run_dir/reap-pending.state" "status=pending
-owner_pid=$$" || return 1
+owner_pid=$$
+owner_token=$REAP_OWNER_TOKEN" || { stop_reap_owner_guard "$run_dir"; return 1; }
   if ! atomic_write "$run_dir/invalidated.state" 'reason=reap'; then
     rm -f "$run_dir/reap-pending.state" 2>/dev/null || true
+    stop_reap_owner_guard "$run_dir"
     return 1
   fi
+}
+
+start_reap_owner_guard() {
+  local run_dir="$1" ready release gone
+  local attempt=0
+  REAP_OWNER_TOKEN="$(generation_nonce)" || return 1
+  ready="$run_dir/reap-owner-$REAP_OWNER_TOKEN.ready"
+  release="$run_dir/reap-owner-$REAP_OWNER_TOKEN.release"
+  gone="$run_dir/reap-owner-$REAP_OWNER_TOKEN.gone"
+  rm -f "$ready" "$release" "$gone" 2>/dev/null || return 1
+  python3 -c 'import fcntl, os, sys, time
+lock_path, ready_path, release_path, gone_path, parent_pid = sys.argv[1:]
+lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+try:
+    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    raise SystemExit(3)
+os.close(os.open(ready_path, os.O_CREAT | os.O_WRONLY, 0o600))
+while os.getppid() == int(parent_pid) and not os.path.exists(release_path):
+    time.sleep(0.01)
+if not os.path.exists(release_path):
+    os.close(os.open(gone_path, os.O_CREAT | os.O_WRONLY, 0o600))
+os.close(lock_fd)' "$run_dir/reap-owner.lock" "$ready" "$release" "$gone" "$$" &
+  REAP_OWNER_GUARD_PID=$!
+  while [ ! -f "$ready" ] && kill -0 "$REAP_OWNER_GUARD_PID" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  if [ -f "$ready" ] && kill -0 "$REAP_OWNER_GUARD_PID" 2>/dev/null; then
+    return 0
+  fi
+  kill "$REAP_OWNER_GUARD_PID" 2>/dev/null || true
+  wait "$REAP_OWNER_GUARD_PID" 2>/dev/null || true
+  REAP_OWNER_GUARD_PID=""
+  rm -f "$ready" "$release" "$gone" 2>/dev/null || true
+  REAP_OWNER_TOKEN=""
+  return 1
+}
+
+stop_reap_owner_guard() {
+  local run_dir="$1" token="$REAP_OWNER_TOKEN"
+  [ -n "$token" ] || return 0
+  : > "$run_dir/reap-owner-$token.release" 2>/dev/null ||
+    kill "$REAP_OWNER_GUARD_PID" 2>/dev/null || true
+  [ -z "$REAP_OWNER_GUARD_PID" ] || wait "$REAP_OWNER_GUARD_PID" 2>/dev/null || true
+  REAP_OWNER_GUARD_PID=""
+  REAP_OWNER_TOKEN=""
+  rm -f "$run_dir/reap-owner-$token.ready" "$run_dir/reap-owner-$token.release" \
+    "$run_dir/reap-owner-$token.gone" 2>/dev/null || true
+}
+
+reap_owner_recovery_status() {
+  local run_dir="$1" owner_token="$2"
+  python3 -c 'import fcntl, os, sys
+run_dir, expected_token = sys.argv[1:]
+
+def state_value(path, key):
+    try:
+        with open(path, encoding="ascii") as handle:
+            for line in handle:
+                if line.startswith(key + "="):
+                    return line.rstrip("\n").split("=", 1)[1]
+    except OSError:
+        return ""
+    return ""
+
+def remove(*names):
+    try:
+        for name in names:
+            os.unlink(os.path.join(run_dir, name))
+    except OSError:
+        raise SystemExit(2)
+
+try:
+    lock_fd = os.open(os.path.join(run_dir, "reap-owner.lock"), os.O_CREAT | os.O_RDWR, 0o600)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    raise SystemExit(0)
+except OSError:
+    raise SystemExit(2)
+if state_value(os.path.join(run_dir, "reap-pending.state"), "owner_token") != expected_token:
+    raise SystemExit(3)
+if os.path.exists(os.path.join(run_dir, "reap-closed.state")):
+    raise SystemExit(20)
+if os.path.exists(os.path.join(run_dir, "reap-restore.state")):
+    remove("invalidated.state", "reap-pending.state", "reap-restore.state")
+    raise SystemExit(10)
+gone = "reap-owner-" + expected_token + ".gone"
+if not os.path.exists(os.path.join(run_dir, gone)):
+    raise SystemExit(2)
+remove("invalidated.state", "reap-pending.state", gone)
+raise SystemExit(1)' "$run_dir" "$owner_token"
 }
 
 signal_reap_transition() {
@@ -2267,6 +2373,7 @@ except Exception:
         printf '%s: kept; pane %s could not be closed; supervision recovery could not be published\n' "$name" "$pane"
       fi
     fi
+    [ "$reap_transition" != pending ] || stop_reap_owner_guard "$STATE_DIR/runs/$generation"
     rm -f "$close_err"
   done
 }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -17,6 +17,7 @@ setup() {
   unset HERDR_CHILD_TEST_RETRY_LOG
   unset HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER
   unset HERDR_CHILD_TEST_CALLBACK_RECEIPT_BARRIER
+  unset HERDR_CHILD_TEST_REAP_OWNER_VERIFIED
   unset HERDR_CHILD_TEST_NOW_SEQ
   unset HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED
 }
@@ -770,6 +771,16 @@ case "${1:-} ${2:-}" in
       for run_dir in "$HERDR_CHILD_STATE_DIR"/runs/*; do
         [ ! -f "$run_dir/invalidated.state" ] || : > "$CHILD_STUB/reap-invalidation-consumed"
       done
+      if [ -f "$CHILD_STUB/block-reap-pane-get" ]; then
+        : > "$CHILD_STUB/reap-pane-get.ready"
+        attempt=0
+        while [ ! -f "$CHILD_STUB/reap-pane-get.release" ]; do
+          [ -d "$CHILD_STUB" ] || exit 1
+          attempt=$((attempt + 1))
+          [ "$attempt" -lt 12000 ] || exit 1
+          sleep 0.01
+        done
+      fi
     fi
     if [ -f "$CHILD_STUB/child-gone" ]; then
       printf '{"error":{"code":"pane_not_found","message":"pane not found"}}\n' >&2
@@ -858,6 +869,7 @@ SH
 child_lifecycle_start() {
   env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    HERDR_CHILD_TEST_REAP_OWNER_VERIFIED="${HERDR_CHILD_TEST_REAP_OWNER_VERIFIED:-}" \
     HERDR_CHILD_TEST_WATCHER_PID_FILE="$CHILD_STUB/watcher.pid" \
     HERDR_CHILD_POLL_INTERVAL=0.01 HERDR_CHILD_TEST_SKIP_RETRY_SLEEP=1 \
     bash "$HERDR_CHILD" start --kind claude --name child-life --detach \
@@ -1604,8 +1616,9 @@ function test_scripts_045_herdr_child_reap_invalidates_before_close_while() {
 }
 
 function test_scripts_046_herdr_child_failed_reap_restores_supervision_for() {
-  _bats_test_init 46 'herdr-child failed reap restores supervision for the kept child'
+  _bats_test_init 46 'herdr-child failed or stale reap restores supervision for the kept child'
   child_lifecycle_stub_herdr
+  HERDR_CHILD_TEST_REAP_OWNER_VERIFIED="$CHILD_STUB/reap-owner-verified"
   run child_lifecycle_start --supervision-timeout 600000
   assert_success
   local generation run_dir watcher_pid reap_pid attempt=0
@@ -1628,11 +1641,26 @@ function test_scripts_046_herdr_child_failed_reap_restores_supervision_for() {
   assert_file_contains "$run_dir/invalidated.state" '^reason=reap$'
   : > "$CHILD_STUB/agent-get.release"
   child_wait_for_file "$CHILD_STUB/reap-invalidation-consumed"
+  child_wait_for_file "$CHILD_STUB/reap-owner-verified"
+  assert_file_exists "$run_dir/invalidated.state"
+  assert_file_not_exists "$CHILD_STUB/parent-prompt-accepted"
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
+    bash "$HERDR_CHILD" reap --pane wT:p9 child-life
+  assert_success
+  assert_output --partial 'supervision generation could not be invalidated'
+  assert_file_exists "$run_dir/invalidated.state"
+  : > "$CHILD_STUB/block-reap-pane-get"
+  child_wait_for_file "$CHILD_STUB/reap-pane-get.ready"
   : > "$CHILD_STUB/block-parent-prompt"
   : > "$CHILD_STUB/pane-close.release"
-  wait "$reap_pid"
+  if ! wait "$reap_pid"; then
+    cat "$CHILD_STUB/reap.out" >&2
+    return 1
+  fi
   assert_file_contains "$CHILD_STUB/reap.out" 'supervision recovery requested'
   assert_file_not_exists "$CHILD_STUB/pane-closed"
+  : > "$CHILD_STUB/reap-pane-get.release"
   while [ -f "$run_dir/invalidated.state" ] && [ "$attempt" -lt 500 ]; do
     attempt=$((attempt + 1))
     sleep 0.01
@@ -1648,6 +1676,39 @@ function test_scripts_046_herdr_child_failed_reap_restores_supervision_for() {
   assert_output 1
   run grep -q 'event=child-gone' "$CHILD_STUB/calls.log"
   assert_failure
+
+  teardown
+  setup
+  child_lifecycle_stub_herdr
+  run child_lifecycle_start --supervision-timeout 600000
+  assert_success
+  generation="$(cat "$CHILD_STUB/generation")"
+  run_dir="$CHILD_STUB/state/runs/$generation"
+  watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
+  : > "$CHILD_STUB/block-agent-get"
+  : > "$CHILD_STUB/block-parent-prompt"
+  printf 'idle 11\n' > "$CHILD_STUB/child-state"
+  child_wait_for_file "$CHILD_STUB/agent-get.ready"
+
+  local stale_token=00000000000000000000000000000001
+  printf 'status=pending\nowner_pid=%s\nowner_token=%s\n' "$$" "$stale_token" > "$run_dir/reap-pending.state"
+  printf 'reason=reap\n' > "$run_dir/invalidated.state"
+  : > "$run_dir/reap-owner-$stale_token.gone"
+  : > "$CHILD_STUB/agent-get.release"
+  attempt=0
+  while [ -f "$run_dir/invalidated.state" ] && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  [ "$attempt" -lt 500 ]
+  child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
+  kill -0 "$watcher_pid"
+
+  : > "$CHILD_STUB/release-parent-prompt"
+  child_wait_for_file "$CHILD_STUB/successful-prompts.log"
+  run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
+  assert_success
+  assert_output 1
 }
 
 function test_scripts_047_herdr_child_detached_ask_follows_parent_identity() {


### PR DESCRIPTION
## Summary

Detached child supervision now recovers when a reap owner dies and its PID is reused, instead of waiting forever on an unrelated process. A kernel lock carries owner lifetime across slow pane closes, while nonce-scoped state and lock-protected cleanup serialize concurrent reaps and transition publication.

Regression coverage forces the live-owner, concurrent-contender, restore-publication, and stale-owner interleavings. The stale fixture records an unrelated live PID and proves later child settlement still reaches the parent.

## Validation

- `make lint`
- Test 046 passed across five repetitions with 15 assertions per run
- `make test-ubuntu` completed the full disposable Ubuntu apply and post-apply suite
- Final correctness review found no residual P0-P2 issues

## Related

- `docs/issues/2026-08-30-003-herdr-child-reap-owner-pid-reuse-can-stall-supervision.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
