### PR TITLE
fix(tests): remove Herdr failure barrier timing race

### DIFF
--- a/docs/issues/2026-08-30-004-herdr-failure-publish-barrier-times-out-under-ubuntu-load.md
+++ b/docs/issues/2026-08-30-004-herdr-failure-publish-barrier-times-out-under-ubuntu-load.md
@@ -1,0 +1,33 @@
+---
+title: "Herdr failure-publish barrier times out under Ubuntu load"
+short_description: "The superseded-watcher regression now reaches its failure-publication barrier after one mocked delivery failure, removing a five-second scheduler race while retry behavior remains covered separately."
+type: "bug"
+category: "testing-ci"
+tags: ["herdr","flaky-test"]
+date: "2026-08-30"
+status: "done"
+priority: "medium"
+closed: "2026-08-30"
+---
+
+## Why this exists
+
+The superseded-watcher regression waited for twelve mocked prompt failures before
+reaching its failure-publication barrier. Its generic 500-poll wait could expire
+under the process contention created by the eight-job Ubuntu suite, even though
+the watcher was progressing normally. Two consecutive Ubuntu CI runs failed at
+the same missing `failure-publish.ready` marker.
+
+## Scope
+
+Pin the regression fixture to one delivery attempt. Retry behavior remains owned
+by the neighboring capped-backoff test, while this test continues to exercise the
+stale-generation publication barrier directly.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Pinned the stale-publication regression fixture to one delivery attempt. Verified with 20 focused repetitions and the full Ubuntu Docker suite.

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1439,6 +1439,7 @@ function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
   child_lifecycle_stub_herdr
   export HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER="$CHILD_STUB/failure-publish"
   export HERDR_CHILD_TEST_NOW_SEQ=100
+  export HERDR_CHILD_MAX_DELIVERY_RETRIES=1
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
   old_generation="$(cat "$CHILD_STUB/generation")"


### PR DESCRIPTION
## Summary

The superseded-watcher regression no longer races its five-second setup guard under parallel Ubuntu load. It now reaches the stale-generation publication barrier after one intentional delivery failure, while retry backoff remains covered by the neighboring dedicated test. Two consecutive Ubuntu CI runs previously failed while waiting for `failure-publish.ready`.

## Validation

- 20 focused regression repetitions passed before merging `main`
- 3 focused repetitions passed after merging `main`
- `make test-issues`
- `make test-ubuntu`
