### PR TITLE
fix(skills): keep synchronization non-interactive

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -8,8 +8,7 @@ Codex, Gemini CLI, and GitHub Copilot are intentionally out of scope.
 `home/private_dot_config/agent-skills/manifest` is the source of truth for
 selected upstream skills. `~/.local/bin/skills` installs them globally under
 `~/.agents/skills`; its global lock owns those upstream children at
-`${XDG_STATE_HOME}/skills/.skill-lock.json` when `XDG_STATE_HOME` is non-empty,
-or `~/.agents/.skill-lock.json` otherwise.
+`${XDG_STATE_HOME:-$HOME/.local/state}/skills/.skill-lock.json`.
 
 `home/private_dot_agents/skills/` owns repository model-invocable skills.
 Claude Code receives symlink adapters under `~/.claude/skills`; OpenCode and Pi
@@ -20,7 +19,7 @@ owners.
 | --- | --- |
 | Repository-owned | `ask-in-herdr`, `herdr`, `markdown-new`, `pf-build`, `pf-research`, `pf-spec`, `plan-explainer`, `se-cleanup`, `se-code-review`, `se-doc-review`, `se-flow`, `se-plan`, `se-review-and-work`, `se-simplify`, `se-work`, `vector-prime`, `work-summary`, `writing-for-agents` |
 | Explicit-only | `eli5`, `open-questions`: Claude/Pi manual adapters and OpenCode command adapters only |
-| Upstream-managed | Compound Engineering `*`; `linear-cli`; `improve-claude-md`; `architecture-designer`; `orca-cli`, `orchestration`; `find-skills`; `smithers`; `frontend-design`, `skill-creator`; `playground` |
+| Upstream-managed | Compound Engineering `*`; `linear-cli`; `improve-claude-md`; `orca-cli`, `orchestration`; `find-skills`; `smithers`; `frontend-design`, `skill-creator` |
 
 `handoff` is absent and is not managed. `linear-cli`, not `linear`, is the
 selected upstream skill name. `writing-for-agents` is a repository-owned local
@@ -42,8 +41,8 @@ then portable bare `ce-*` skills replace their client-specific providers.
 
 Claude retains `claude-md-management`, `playwright`, `plugin-dev`,
 `security-guidance`, and `typescript-lsp` for non-skill functionality. Its
-Compound Engineering, `frontend-design`, and `playground` plugins are retired
-after exact cutover. OpenCode retires its Compound Engineering plugin, including
+Compound Engineering and `frontend-design` plugins are retired after exact
+cutover. OpenCode retires its Compound Engineering plugin, including
 its generated convenience commands, after exact cutover. Pi retires its
 Compound Engineering package after exact cutover; its managed extension list
 remains the source of truth for non-skill packages.

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -32,6 +32,9 @@
 .config/opencode/skills/work-summary
 .config/opencode/skills/writing-for-agents
 
+# architecture-designer is no longer selected; remove the legacy external tree.
+.claude/skills/architecture-designer
+
 # Marta now reads configuration from Application Support/org.yanex.marta.
 # Remove the legacy config directory that earlier applies left behind.
 Library/marta

--- a/home/dot_local/bin/executable_skills
+++ b/home/dot_local/bin/executable_skills
@@ -7,8 +7,7 @@ CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
 STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-LOCK_PATH="${XDG_STATE_HOME:+$XDG_STATE_HOME/skills/.skill-lock.json}"
-LOCK_PATH="${LOCK_PATH:-$HOME/.agents/.skill-lock.json}"
+LOCK_PATH="$STATE_HOME/skills/.skill-lock.json"
 CANONICAL_ROOT="${SKILLS_CANONICAL_ROOT:-$HOME/.agents/skills}"
 REPOSITORY_OWNED_MANIFEST="${SKILLS_REPOSITORY_OWNED_MANIFEST:-$CONFIG_HOME/agent-skills/repository-owned}"
 CUTOVER_READY="$CONFIG_HOME/agent-skills/cutover-ready"
@@ -98,10 +97,10 @@ run_add() {
   shift
   local args=("$source") skill
   for skill in "$@"; do args+=(--skill "$skill"); done
-  run_npx add "${args[@]}" --global --agent claude-code --agent opencode --agent pi
+  run_npx add "${args[@]}" --global --agent claude-code --agent opencode --agent pi --yes
 }
 
-run_remove() { run_npx remove --global "$@"; }
+run_remove() { run_npx remove --global "$@" --yes; }
 run_update() { run_npx update --global "$@"; }
 
 parse_manifest() {

--- a/home/private_dot_claude/dot_smithers/workflows/lib/compound-skill.test.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/compound-skill.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { resolveCompoundSkill, stageCompoundSkill, type CompoundSkillPaths } from "./compound-skill.ts";
+import { defaultCompoundSkillPaths, resolveCompoundSkill, stageCompoundSkill, type CompoundSkillPaths } from "./compound-skill.ts";
 
 const tempDirs: string[] = [];
 const SOURCE = "EveryInc/compound-engineering-plugin";
@@ -55,6 +55,12 @@ afterAll(() => {
 });
 
 describe("Compound Engineering skill resolution", () => {
+  test("uses the default XDG state path when XDG_STATE_HOME is unset", () => {
+    const home = "/test/home";
+
+    expect(defaultCompoundSkillPaths(home, {}).lockPath).toBe(path.join(home, ".local/state/skills/.skill-lock.json"));
+  });
+
   test("accepts only bare skill names", () => {
     const paths = fixture();
 

--- a/home/private_dot_claude/dot_smithers/workflows/lib/compound-skill.ts
+++ b/home/private_dot_claude/dot_smithers/workflows/lib/compound-skill.ts
@@ -28,9 +28,8 @@ type SkillLock = Map<string, LockEntry> | undefined;
 
 export function defaultCompoundSkillPaths(home = os.homedir(), env = process.env): CompoundSkillPaths {
   const configHome = env.XDG_CONFIG_HOME || path.join(home, ".config");
-  const lockPath = env.XDG_STATE_HOME
-    ? path.join(env.XDG_STATE_HOME, "skills/.skill-lock.json")
-    : path.join(home, ".agents/.skill-lock.json");
+  const stateHome = env.XDG_STATE_HOME || path.join(home, ".local/state");
+  const lockPath = path.join(stateHome, "skills/.skill-lock.json");
   return {
     canonicalRoot: path.join(home, ".agents/skills"),
     legacyRoot: path.join(home, ".claude/plugins/cache/compound-engineering-plugin/compound-engineering"),

--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -111,7 +111,6 @@
 {{- if not $cutoverActive }}
     "compound-engineering@compound-engineering-plugin": true,
     "frontend-design@claude-plugins-official": true,
-    "playground@claude-plugins-official": true,
 {{- end }}
     "playwright@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -8104,7 +8104,7 @@ function test_scripts_272_skills_add_is_global_isolated_and_preserves_cwd() {
     bash "$SKILLS_WRAPPER" add owner/repo named-skill
   assert_success
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^PWD=.*/tmp$'
-  assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^ARGS=<--yes><skills@latest><add><owner/repo><--skill><named-skill><--global><--agent><claude-code><--agent><opencode><--agent><pi>$'
+  assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^ARGS=<--yes><skills@latest><add><owner/repo><--skill><named-skill><--global><--agent><claude-code><--agent><opencode><--agent><pi><--yes>$'
   assert_equal "$PWD" "$original"
 }
 
@@ -8124,7 +8124,7 @@ function test_scripts_273_skills_dispatch_validates_inert_argv_and_uses_global_r
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
     XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" bash "$SKILLS_WRAPPER" remove owner/repo owned
   assert_success
-  assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '<remove><--global><owned>$'
+  assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '<remove><--global><owned><--yes>$'
 
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
     XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" bash "$SKILLS_WRAPPER" update owned
@@ -8185,12 +8185,12 @@ SH
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^add$'
 }
 
-function test_scripts_276_skills_remove_uses_xdg_and_fallback_locks_identically() {
-  _bats_test_init 276 'skills remove validates source ownership through XDG and fallback global locks'
+function test_scripts_276_skills_remove_uses_explicit_and_default_xdg_locks_identically() {
+  _bats_test_init 276 'skills remove validates source ownership through explicit and default XDG state locks'
   local stub state_lock fallback_lock
   stub="$(skills_stub_npx)"
   state_lock="$BATS_TEST_TMPDIR/state/skills/.skill-lock.json"
-  fallback_lock="$BATS_TEST_TMPDIR/home/.agents/.skill-lock.json"
+  fallback_lock="$BATS_TEST_TMPDIR/home/.local/state/skills/.skill-lock.json"
   mkdir -p "$(dirname "$state_lock")" "$(dirname "$fallback_lock")"
   printf '%s\n' '{"version":3,"skills":{"owned":{"source":"owner/repo"}}}' > "$state_lock"
   printf '%s\n' '{"version":3,"skills":{"owned":{"source":"owner/repo"}}}' > "$fallback_lock"
@@ -8201,7 +8201,7 @@ function test_scripts_276_skills_remove_uses_xdg_and_fallback_locks_identically(
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
     XDG_STATE_HOME= bash "$SKILLS_WRAPPER" remove owner/repo owned
   assert_success
-  run grep -c '<remove><--global><owned>' "$BATS_TEST_TMPDIR/tmp/npx.log"
+  run grep -c '<remove><--global><owned><--yes>' "$BATS_TEST_TMPDIR/tmp/npx.log"
   assert_output '2'
 }
 

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -701,20 +701,23 @@ function test_templates_031_agent_skills_provider_removal_requires_an_exact_cuto
     assert_success
 
     if [ "$state" = matched ]; then
-      run jq -e '.enabledPlugins | has("compound-engineering@compound-engineering-plugin") or has("frontend-design@claude-plugins-official") or has("playground@claude-plugins-official")' <<< "$claude"
+      run jq -e '.enabledPlugins | has("compound-engineering@compound-engineering-plugin") or has("frontend-design@claude-plugins-official")' <<< "$claude"
       assert_failure
       run jq -e '.extraKnownMarketplaces | has("compound-engineering-plugin")' <<< "$claude"
       assert_failure
       run jq -e '.plugin | index("compound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git")' <<< "$opencode"
       assert_failure
     else
-      run jq -e '.enabledPlugins["compound-engineering@compound-engineering-plugin"] and .enabledPlugins["frontend-design@claude-plugins-official"] and .enabledPlugins["playground@claude-plugins-official"]' <<< "$claude"
+      run jq -e '.enabledPlugins["compound-engineering@compound-engineering-plugin"] and .enabledPlugins["frontend-design@claude-plugins-official"]' <<< "$claude"
       assert_success
       run jq -e '.extraKnownMarketplaces | has("compound-engineering-plugin")' <<< "$claude"
       assert_success
       run jq -e '.plugin | index("compound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git")' <<< "$opencode"
       assert_success
     fi
+
+    run jq -e '.enabledPlugins | has("playground@claude-plugins-official")' <<< "$claude"
+    assert_failure
 
     # These plugins have non-skill behavior and must survive both branches.
     run jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"] and .enabledPlugins["playwright@claude-plugins-official"] and .enabledPlugins["plugin-dev@claude-plugins-official"] and .enabledPlugins["security-guidance@claude-plugins-official"] and .enabledPlugins["typescript-lsp@claude-plugins-official"]' <<< "$claude"


### PR DESCRIPTION
## Summary

Managed skill synchronization no longer stops for an installation-method prompt during `chezmoi apply`. Both add and remove operations now pass non-interactive confirmation to the Skills CLI itself, rather than only to the `npx` launcher.

Canonical validation and Smithers now read the same effective XDG state lock that the installer writes. This prevents a successful install under `~/.local/state/skills` from being reported as a missing canonical skill. The retired `architecture-designer` tree and `playground` plugin are also removed consistently with the updated manifest.

## Validation

- Regression tests demonstrated red -> green for CLI-level confirmation, default XDG lock resolution, and Smithers lock resolution.
- `make lint`
- `make test-templates` (30 passed, 1 pre-existing risky test)
- `make test-smithers` (557 passed)
- Focused skills wrapper tests (13 passed)
- `make test-ubuntu` was incomplete: the harness terminated it at the 120-second limit after the Smithers and focused skill suites passed; it was not rerun with a longer limit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000?logoColor=white)
