### PR TITLE
fix(skills): quiet successful CLI runs

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -32,6 +32,8 @@ Use `skills add <source> [skill...]`, `skills remove <source> <skill...>`,
 entry and reports unmanaged or obsolete lock entries with explicit `skills
 remove` commands. It never removes drift automatically. Restart Claude Code,
 OpenCode, and Pi after installation or discovery configuration changes.
+Successful upstream CLI output is hidden by default; use `skills --verbose
+<command>` to restore it. Failed commands always replay the captured diagnostics.
 
 ## Plugin-Owned Functionality
 

--- a/home/dot_local/bin/executable_skills
+++ b/home/dot_local/bin/executable_skills
@@ -12,9 +12,10 @@ CANONICAL_ROOT="${SKILLS_CANONICAL_ROOT:-$HOME/.agents/skills}"
 REPOSITORY_OWNED_MANIFEST="${SKILLS_REPOSITORY_OWNED_MANIFEST:-$CONFIG_HOME/agent-skills/repository-owned}"
 MAX_FILE_BYTES="${SKILLS_MAX_FILE_BYTES:-2097152}"
 TMPDIR="${TMPDIR:-/tmp}"
+SKILLS_VERBOSE="${SKILLS_VERBOSE:-0}"
 
 usage() {
-  printf '%s\n' 'Usage: skills {add SOURCE [SKILL...]|remove SOURCE SKILL...|update [SKILL...]|sync}' >&2
+  printf '%s\n' 'Usage: skills [--verbose] {add SOURCE [SKILL...]|remove SOURCE SKILL...|update [SKILL...]|sync}' >&2
 }
 
 fail() {
@@ -76,10 +77,9 @@ os.replace(temporary, lock)
 PY
 }
 
-run_npx() {
+invoke_npx() {
   local command="$1"
   shift
-  mkdir -p "$TMPDIR" "$CONFIG_HOME" "$STATE_HOME" "$DATA_HOME" "$CACHE_HOME" || return 1
   (
     cd "$TMPDIR" || exit 1
     env -i HOME="$HOME" PATH="$PATH" TMPDIR="$TMPDIR" \
@@ -88,6 +88,23 @@ run_npx() {
       LC_ALL=C CI=1 NO_COLOR=1 \
       npx --yes skills@latest "$command" "$@"
   )
+}
+
+run_npx() {
+  local output status
+  mkdir -p "$TMPDIR" "$CONFIG_HOME" "$STATE_HOME" "$DATA_HOME" "$CACHE_HOME" || return 1
+  if [ "$SKILLS_VERBOSE" = 1 ]; then
+    invoke_npx "$@"
+    return
+  fi
+  output="$(mktemp "$TMPDIR/skills-output.XXXXXX")" || return 1
+  trap 'status=$?; rm -f "$output"; trap - EXIT HUP INT TERM; exit "$status"' EXIT HUP INT TERM
+  invoke_npx "$@" > "$output" 2>&1
+  status=$?
+  [ "$status" -eq 0 ] || cat "$output" >&2
+  rm -f "$output"
+  trap - EXIT HUP INT TERM
+  return "$status"
 }
 
 run_add() {
@@ -285,7 +302,7 @@ add() {
   local skill
   for skill in "$@"; do [ "$skill" = '*' ] || valid_skill "$skill" || { fail "invalid skill: $skill"; return 1; }; done
   validate_live_lock || return 1
-  run_add "$source" "$@" || return 1
+  run_add "$source" "$@" || return "$?"
   grep -Fqx "$source $*" "$MANIFEST" 2>/dev/null || printf 'warning: add diverges from managed manifest\n' >&2
 }
 
@@ -300,7 +317,7 @@ remove() {
     owner="$(lock_source_for_skill "$skill")"
     [ "$owner" = "$source" ] || { fail "lock does not own $skill as $source"; return 1; }
   done
-  run_remove "$@" || return 1
+  run_remove "$@" || return "$?"
   printf 'warning: remove diverges from managed manifest\n' >&2
 }
 
@@ -311,6 +328,10 @@ update() {
   run_update "$@"
 }
 
+if [ "${1:-}" = '--verbose' ]; then
+  SKILLS_VERBOSE=1
+  shift
+fi
 command="${1:-}"
 shift || true
 case "$command" in

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -7818,6 +7818,101 @@ function test_scripts_272_skills_add_is_global_isolated_and_preserves_cwd() {
   assert_equal "$PWD" "$original"
 }
 
+function test_scripts_2721_skills_hides_success_output_but_preserves_verbose_and_failure_diagnostics() {
+  _bats_test_init 2721 'skills hides successful upstream output but preserves verbose and failure diagnostics'
+  local stub="$BATS_TEST_TMPDIR/skills-output-stub"
+  mkdir -p "$stub"
+  cat > "$stub/npx" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'upstream stdout'
+printf '%s\n' 'upstream stderr' >&2
+for arg in "$@"; do [ "$arg" != fail ] || exit 7; done
+SH
+  chmod +x "$stub/npx"
+  mkdir -p "$BATS_TEST_TMPDIR/home/.local/state/skills"
+  printf '%s\n' '{"version":3,"skills":{"fail":{"source":"owner/repo"}}}' \
+    > "$BATS_TEST_TMPDIR/home/.local/state/skills/.skill-lock.json"
+
+  run --separate-stderr env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" update
+  assert_success
+  assert_output ''
+  assert_stderr ''
+
+  run --separate-stderr env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" --verbose update
+  assert_success
+  assert_output --partial 'upstream stdout'
+  refute_output --partial 'upstream stderr'
+  assert_stderr --partial 'upstream stderr'
+  refute_stderr --partial 'upstream stdout'
+
+  run --separate-stderr env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" --verbose update fail
+  assert_failure 7
+  assert_output --partial 'upstream stdout'
+  assert_stderr --partial 'upstream stderr'
+
+  run --separate-stderr env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" update fail
+  assert_failure 7
+  assert_output ''
+  assert_stderr --partial 'upstream stdout'
+  assert_stderr --partial 'upstream stderr'
+
+  run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" add owner/repo fail
+  assert_failure 7
+
+  run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" remove owner/repo fail
+  assert_failure 7
+
+  run bash -c 'for item in "$1"/skills-output.*; do [ ! -e "$item" ] || exit 1; done' _ \
+    "$BATS_TEST_TMPDIR/tmp"
+  assert_success
+}
+
+function test_scripts_2722_skills_removes_captured_output_after_a_signal() {
+  _bats_test_init 2722 'skills removes captured upstream output after a signal'
+  local stub="$BATS_TEST_TMPDIR/skills-signal-stub"
+  mkdir -p "$stub" "$BATS_TEST_TMPDIR/tmp"
+  cat > "$stub/npx" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' 'captured before interruption'
+: > "$TMPDIR/npx-ready"
+while :; do sleep 1; done
+SH
+  chmod +x "$stub/npx"
+
+  run python3 - "$SKILLS_WRAPPER" "$stub" "$BATS_TEST_TMPDIR" <<'PY'
+import glob
+import os
+import signal
+import subprocess
+import sys
+import time
+
+wrapper, stub, root = sys.argv[1:]
+tmpdir = os.path.join(root, "tmp")
+env = {"PATH": f"{stub}:/usr/bin:/bin", "HOME": os.path.join(root, "home"), "TMPDIR": tmpdir}
+process = subprocess.Popen(["bash", wrapper, "update"], env=env, start_new_session=True)
+deadline = time.monotonic() + 5
+while not os.path.exists(os.path.join(tmpdir, "npx-ready")):
+    if process.poll() is not None or time.monotonic() >= deadline:
+        process.kill()
+        raise SystemExit("upstream stub did not start")
+    time.sleep(0.01)
+os.killpg(process.pid, signal.SIGTERM)
+status = process.wait(timeout=5)
+if status == 0:
+    raise SystemExit("interrupted wrapper succeeded")
+if glob.glob(os.path.join(tmpdir, "skills-output.*")):
+    raise SystemExit("captured output survived interruption")
+PY
+  assert_success
+}
+
 function test_scripts_273_skills_dispatch_validates_inert_argv_and_uses_global_remove_update() {
   _bats_test_init 273 'skills validates argv before npx and maps remove and update to global upstream calls'
   local stub="$BATS_TEST_TMPDIR/skills-stub" lock


### PR DESCRIPTION
## Summary

Skills installs and syncs now stay silent when the upstream command succeeds, removing the repeated banner and installation summary. Failures still replay captured diagnostics with the original exit status, while `skills --verbose` restores native stdout and stderr.

The wrapper captures quiet-mode output in a temporary file and cleans it up on normal completion or interruption. Behavioral coverage exercises quiet success, verbose success and failure, failure status propagation for add/update/remove, stream routing, and signal cleanup.

## Testing

- `make lint`
- `make test-ubuntu`
- `tests/lib/bashunit tests/bashunit/scripts_test.sh --filter "test_scripts_272"`

## Post-Deploy Monitoring & Validation

- Validate the next `skills sync` or managed chezmoi run stays silent on success.
- Confirm `skills --verbose sync` restores upstream output and a forced upstream failure preserves diagnostics and status.
- Treat missing failure output or retained `skills-output.*` files as rollback signals; revert this commit if either occurs.
- Validation window: the first sync after deployment. Owner: workstation operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000?logo=openai&logoColor=white)
