### PR TITLE
fix(herdr): stop reap guard when run state disappears

### DIFF
--- a/docs/issues/2026-08-30-011-tab-reap-can-strand-reap-owner-guard-in-parallel-suite.md
+++ b/docs/issues/2026-08-30-011-tab-reap-can-strand-reap-owner-guard-in-parallel-suite.md
@@ -1,12 +1,13 @@
 ---
 title: "tab reap can strand reap-owner guard in parallel suite"
-short_description: "make test-ubuntu can hang in herdr-child test 092 because its 5-second deadline exposes a general reap-owner race: the run directory can disappear after release publication but before the guard observes it, while reap waits without a bound."
+short_description: "The reap-owner guard now exits when its run directory disappears, closing the release-file deletion race with a bounded regression and a passing full Ubuntu suite."
 type: "bug"
 category: "testing-ci"
 tags: ["herdr-child","flaky-test","process-cleanup","parallel-tests"]
 date: "2026-08-30"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-09-01"
 ---
 
 ## Why this exists
@@ -33,3 +34,7 @@ Verify the focused scenario, complete scripts_test.sh, and make test-ubuntu.
 How the guard should distinguish an intentionally released run directory from
 unexpected state loss; a test-only timeout must not mask the production
 orphan-guard path.
+
+## Resolution
+
+Made run-directory disappearance terminal for the reap-owner guard, added deterministic normal-release and deletion-race coverage, and verified make lint plus make test-ubuntu.

--- a/docs/issues/2026-09-01-001-docker-suite-stalls-in-herdr-child-reap-test.md
+++ b/docs/issues/2026-09-01-001-docker-suite-stalls-in-herdr-child-reap-test.md
@@ -1,12 +1,13 @@
 ---
 title: "Docker suite stalls in herdr-child reap test"
-short_description: "After merging origin/main at 193198d, make test-ubuntu blocks in scripts_test.sh for over four minutes while herdr-child reap waits on an unreleased reap-owner lock; interrupting the process leaves make with exit 1."
+short_description: "The reap-owner guard now exits when its run directory disappears, closing the Docker stall with a bounded regression and a passing full Ubuntu suite."
 type: "bug"
 category: "testing-ci"
 tags: ["bashunit","herdr-child","docker"]
 date: "2026-09-01"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-01"
 ---
 
 ## Why this exists
@@ -35,3 +36,7 @@ though the Worktrunk-specific tests passed before the merge.
 ## Open decisions
 
 None.
+
+## Resolution
+
+Confirmed this as the same release-file deletion race tracked by 2026-08-30-011, fixed the guard lifecycle, added deterministic coverage, and verified make lint plus make test-ubuntu.

--- a/home/dot_local/lib/herdr-child-supervision.sh
+++ b/home/dot_local/lib/herdr-child-supervision.sh
@@ -403,15 +403,16 @@ start_reap_owner_guard() {
   rm -f "$ready" "$release" "$gone" 2>/dev/null || return 1
   python3 -c 'import fcntl, os, sys, time
 lock_path, ready_path, release_path, gone_path, parent_pid = sys.argv[1:]
+run_dir = os.path.dirname(release_path)
 lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
 try:
     fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 except BlockingIOError:
     raise SystemExit(3)
 os.close(os.open(ready_path, os.O_CREAT | os.O_WRONLY, 0o600))
-while os.getppid() == int(parent_pid) and not os.path.exists(release_path):
+while os.getppid() == int(parent_pid) and os.path.isdir(run_dir) and not os.path.exists(release_path):
     time.sleep(0.01)
-if not os.path.exists(release_path):
+if os.path.isdir(run_dir) and not os.path.exists(release_path):
     os.close(os.open(gone_path, os.O_CREAT | os.O_WRONLY, 0o600))
 os.close(lock_fd)' "$run_dir/reap-owner.lock" "$ready" "$release" "$gone" "$$" &
   REAP_OWNER_GUARD_PID=$!

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -7708,6 +7708,66 @@ function test_scripts_270_herdr_child_reap_invalidation_barrier_is_bounded() {
   assert_dir_not_exists "$run_dir"
 }
 
+function test_scripts_2701_herdr_child_reap_owner_guard_stops_when_run_dir() {
+  _bats_test_init 2701 'herdr-child reap owner guard stops when its run directory disappears'
+  local work_dir runtime supervision guard_test_pid guard_test_status guard_pid attempt=0
+  work_dir="$BATS_TEST_TMPDIR/reap-owner-guard"
+  mkdir -p "$work_dir"
+  runtime="$SOURCE_ROOT/dot_local/lib/herdr-child-runtime.sh"
+  supervision="$SOURCE_ROOT/dot_local/lib/herdr-child-supervision.sh"
+
+  env WORK_DIR="$work_dir" RUNTIME="$runtime" SUPERVISION="$supervision" bash -c '
+    set -euo pipefail
+    source "$RUNTIME"
+    source "$SUPERVISION"
+
+    normal_dir="$WORK_DIR/normal"
+    mkdir -p "$normal_dir"
+    start_reap_owner_guard "$normal_dir"
+    stop_reap_owner_guard "$normal_dir"
+    [ -d "$normal_dir" ]
+    remove_supervision_run "$normal_dir"
+
+    race_dir="$WORK_DIR/race"
+    mkdir -p "$race_dir"
+    start_reap_owner_guard "$race_dir"
+    printf "%s\n" "$REAP_OWNER_GUARD_PID" > "$WORK_DIR/guard.pid"
+    kill -STOP "$REAP_OWNER_GUARD_PID"
+    (
+      attempt=0
+      while [ ! -e "$race_dir/reap-owner-$REAP_OWNER_TOKEN.release" ] && [ "$attempt" -lt 500 ]; do
+        attempt=$((attempt + 1))
+        sleep 0.01
+      done
+      [ "$attempt" -lt 500 ]
+      remove_supervision_run "$race_dir"
+      kill -CONT "$REAP_OWNER_GUARD_PID"
+    ) &
+    cleanup_pid=$!
+    stop_reap_owner_guard "$race_dir"
+    wait "$cleanup_pid"
+    : > "$WORK_DIR/stopped"
+  ' > "$work_dir/guard.out" 2>&1 &
+  guard_test_pid=$!
+
+  while kill -0 "$guard_test_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  if kill -0 "$guard_test_pid" 2>/dev/null; then
+    guard_pid="$(cat "$work_dir/guard.pid" 2>/dev/null || true)"
+    [ -z "$guard_pid" ] || kill -CONT "$guard_pid" 2>/dev/null || true
+    [ -z "$guard_pid" ] || kill -TERM "$guard_pid" 2>/dev/null || true
+    kill -TERM "$guard_test_pid" 2>/dev/null || true
+    wait "$guard_test_pid" 2>/dev/null || true
+    fail 'reap owner guard did not stop after its run directory disappeared'
+  fi
+  if wait "$guard_test_pid"; then guard_test_status=0; else guard_test_status=$?; fi
+  assert_equal "$guard_test_status" 0
+  assert_file_exists "$work_dir/stopped"
+  assert_dir_not_exists "$work_dir/race"
+}
+
 function test_scripts_271_herdr_child_shared_lifecycle_primitives_keep_con() {
   _bats_test_init 271 'herdr-child shared lifecycle primitives keep polling and launch-state contracts'
   local work_dir runtime supervision


### PR DESCRIPTION
## Summary

`herdr-child reap` no longer hangs when terminal watcher cleanup removes its run state after release publication but before the owner guard observes the release file. The guard now treats a missing run directory as terminal while preserving normal release and stale-owner recovery.

The regression test forces the exact deletion ordering with a suspended guard and a bounded cleanup handshake, so the old implementation fails instead of stalling the suite.

## Validation

- Red/green calibration of the deterministic reap-owner regression
- `herdr-child` marker test, including 20 focused repetitions
- `make lint`
- `make test-issues`
- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh`
- `make test-ubuntu`

## Related

- `docs/issues/2026-08-30-011-tab-reap-can-strand-reap-owner-guard-in-parallel-suite.md`
- `docs/issues/2026-09-01-001-docker-suite-stalls-in-herdr-child-reap-test.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
