### PR TITLE
feat(agents): block absence tests without a named oracle

### DIFF
--- a/docs/issues/2026-09-02-001-herdr-child-descriptor-probe-test-is-terminal-width-dependent.md
+++ b/docs/issues/2026-09-02-001-herdr-child-descriptor-probe-test-is-terminal-width-dependent.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-child descriptor probe test is terminal-width dependent"
+short_description: "The nested-bashunit assertion in scripts_test.sh matches the full test name in the child run's output, but bashunit truncates test names to the terminal width, so make test-ubuntu fails in a narrow pane and passes full-width."
+type: "bug"
+category: "testing-ci"
+tags: ["flaky-test"]
+date: "2026-09-02"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Observed once: 'herdr-child descriptor probe passes under a nested bashunit run' failed with assert_output --partial 'closes launcher descriptors' because the nested run rendered '...closes launcher desc... 258ms' in a ~half-width herdr pane; the same suite passed twice in a full-width pane. The assertion should match width-stable output (e.g. the nested run's exit status or report JSON) instead of the rendered test-name line.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.

--- a/home/dot_local/bin/executable_test-oracle-guard
+++ b/home/dot_local/bin/executable_test-oracle-guard
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test-oracle-guard — negative-assertion gate shared by the Claude Code hook,
+# the opencode plugin, and the pi extension of the same name.
+#
+# A test that asserts the ABSENCE of a string usually restates the patch that
+# removed it instead of protecting behavior (the standard this enforces lives
+# in docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md).
+# The gate fires only on proposed edits to test files and only on
+# negative-assertion patterns, so a clean edit costs the calling agent zero
+# context.
+#
+# Usage: test-oracle-guard <file-path>    (proposed content on stdin)
+#   exit 0  not a test file, or no unjustified negative assertion; no output
+#   exit 1  flagged; human-readable reason on stdout
+#
+# Escape hatch: a comment containing "oracle:" on the flagged line or within
+# the 3 lines above it names the independent oracle and lets the line pass.
+# Fails open: missing input or tooling exits 0 so a broken guard never blocks
+# an agent.
+
+set -uo pipefail
+
+path="${1:-}"
+[ -n "$path" ] || exit 0
+
+case "$path" in
+  */tests/* | tests/* | */test/* | test/* | */__tests__/* | __tests__/*) : ;;
+  *)
+    case "${path##*/}" in
+      *_test.* | test_* | *.test.* | *.spec.* | *_spec.*) : ;;
+      *) exit 0 ;;
+    esac
+    ;;
+esac
+
+flagged=$(awk '
+  {
+    low = tolower($0)
+    if (index(low, "oracle:") > 0) last_oracle = NR
+    if (low ~ /assert_not_contains|assert_file_not_contains|assert_not_matches|refute_match|refute_includes|not\.tocontain|not\.tomatch|not_to include|not_to match|! grep /) {
+      if (last_oracle == 0 || NR - last_oracle > 3) {
+        printf "  line %d: %s\n", NR, $0
+      }
+    }
+  }
+' 2>/dev/null) || exit 0
+
+[ -n "$flagged" ] || exit 0
+
+cat <<EOF
+test-oracle-guard: negative assertion(s) without a named oracle in ${path}:
+${flagged}
+An absence assertion usually restates the patch that removed the string instead of protecting behavior. Before keeping it, name three things: the consumer, the observable failure, and an oracle independent of the files this patch changes. Prefer testing the capability that remains, or the real deployment/runtime transition that clears stale state. If this negative assertion is genuinely load-bearing, add a comment naming the oracle (the comment must contain "oracle:") on the line above it and retry.
+EOF
+exit 1

--- a/home/dot_pi/agent/extensions/test-oracle-guard.ts
+++ b/home/dot_pi/agent/extensions/test-oracle-guard.ts
@@ -1,0 +1,64 @@
+// pi adapter for test-oracle-guard.
+//
+// Thin wrapper over ~/.local/bin/test-oracle-guard: on edit/write tool calls
+// it feeds the proposed new content and target path to the shared engine and
+// blocks the call ({ block: true, reason }) when the engine flags an
+// unjustified negative assertion in a test file. The engine owns the patterns,
+// the test-file filter, and the "oracle:" escape hatch, so all agent clients
+// enforce one contract.
+//
+// Fails open: a missing or broken engine must never block a pi edit.
+// @ts-nocheck
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const ENGINE_NAME = "test-oracle-guard";
+
+function enginePath(): string | undefined {
+  const home = process.env.HOME;
+  if (!home) return undefined;
+  const local = path.join(home, ".local", "bin", ENGINE_NAME);
+  return existsSync(local) ? local : undefined;
+}
+
+export default function (pi) {
+  pi.on("tool_call", (event) => {
+    const toolName = event?.toolName;
+    let filePath: string | undefined;
+    let content = "";
+
+    if (toolName === "write") {
+      filePath = event?.input?.path;
+      content = typeof event?.input?.content === "string" ? event.input.content : "";
+    } else if (toolName === "edit") {
+      filePath = event?.input?.path;
+      const edits = Array.isArray(event?.input?.edits) ? event.input.edits : [];
+      content = edits
+        .map((edit: any) => edit?.newText)
+        .filter((text: any) => typeof text === "string" && text !== "")
+        .join("\n");
+    } else {
+      return;
+    }
+
+    if (typeof filePath !== "string" || filePath === "" || content === "") return;
+
+    const engine = enginePath();
+    if (!engine) return;
+
+    try {
+      const result = spawnSync(engine, [filePath], {
+        input: content,
+        encoding: "utf8",
+        timeout: 3000,
+      });
+      if (result.status === 1 && result.stdout && result.stdout.trim() !== "") {
+        return { block: true, reason: result.stdout.trim() };
+      }
+    } catch {
+      // Engine failures (spawn error, timeout) fail open.
+    }
+  });
+}

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -61,6 +61,8 @@ Every skill's own description already carries its triggers. These four lines res
 
 - **Tautological tests considered harmful: require an independent oracle.** Name the consumer and observable failure. A useful test fails when the protected behavior breaks and stays green through harmless source refactors.
 - Reject expected values copied from source, prompt, config, fixture, or inventory changed by the same patch. Prefer one behavioral, deployment, or validation owner; keep exact text only for externally consumed literal contracts and inventories only when they compare independent sides of a relationship.
+- **Proof-first is subordinate to this gate.** A test failing before implementation proves nothing when its expected value is copied from the same patch or it inspects source shape. When the consumer, the observable failure, and an independent oracle cannot be named, the correct output of a "write tests first" step is zero new tests.
+- Removing a dependency, command, config entry, or file does not by itself justify an absence assertion. Test the capability that remains, or exercise the real deployment/runtime transition that clears stale state — never a source grep.
 
 </important>
 

--- a/home/private_dot_claude/hooks/executable_test-oracle-guard.sh
+++ b/home/private_dot_claude/hooks/executable_test-oracle-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse guard for Edit|Write|MultiEdit on test files.
+#
+# Thin Claude Code adapter over ~/.local/bin/test-oracle-guard: extracts the
+# target path and the proposed new content from the tool input and denies the
+# call when the shared engine flags an unjustified negative assertion. The
+# engine owns the patterns, the test-file filter, and the "oracle:" escape
+# hatch, so all agent clients enforce one contract.
+#
+# Fails open: any missing dependency, unreadable input, or parse error exits 0
+# and the call proceeds.
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+guard="$HOME/.local/bin/test-oracle-guard"
+[ -x "$guard" ] || exit 0
+
+input=$(cat) || exit 0
+
+path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -n "$path" ] || exit 0
+
+content=$(printf '%s' "$input" | jq -r '
+  [.tool_input.content // empty,
+   .tool_input.new_string // empty,
+   ((.tool_input.edits // []) | map(.new_string // empty) | join("\n"))]
+  | map(select(. != "")) | join("\n")' 2>/dev/null) || exit 0
+[ -n "$content" ] || exit 0
+
+if reason=$(printf '%s' "$content" | "$guard" "$path" 2>/dev/null); then
+  exit 0
+fi
+[ -n "$reason" ] || exit 0
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -51,6 +51,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '{{ .chezmoi.homeDir }}/.claude/hooks/test-oracle-guard.sh'",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/home/private_dot_config/opencode/plugins/test-oracle-guard.ts
+++ b/home/private_dot_config/opencode/plugins/test-oracle-guard.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+// Type checking is off here for the same reason herdr's own managed extensions
+// turn it off: this file is checked out in a plain dotfiles repo with no
+// node_modules, and only resolves its imports once deployed under
+// ~/.config/opencode/, where opencode's own dependencies live.
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+// opencode adapter for test-oracle-guard.
+//
+// Thin wrapper over ~/.local/bin/test-oracle-guard: on edit/write it feeds the
+// proposed new content and target path to the shared engine and blocks the
+// call (throw) when the engine flags an unjustified negative assertion in a
+// test file. The engine owns the patterns, the test-file filter, and the
+// "oracle:" escape hatch, so all agent clients enforce one contract.
+//
+// Fails open: a missing or broken engine must never block an opencode edit.
+
+const ENGINE_NAME = "test-oracle-guard"
+
+function enginePath(): string | undefined {
+  const home = process.env.HOME
+  if (!home) return undefined
+  const local = path.join(home, ".local", "bin", ENGINE_NAME)
+  return existsSync(local) ? local : undefined
+}
+
+export const TestOracleGuardPlugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      const tool = input?.tool
+      if (tool !== "edit" && tool !== "write") return
+
+      const args = output?.args ?? {}
+      const filePath = args.filePath ?? args.file_path
+      if (typeof filePath !== "string" || filePath === "") return
+
+      const content = [args.content, args.newString]
+        .filter((part: any) => typeof part === "string" && part !== "")
+        .join("\n")
+      if (content === "") return
+
+      const engine = enginePath()
+      if (!engine) return
+
+      try {
+        const result = spawnSync(engine, [filePath], {
+          input: content,
+          encoding: "utf8",
+          timeout: 3000,
+        })
+        if (result.status === 1 && result.stdout && result.stdout.trim() !== "") {
+          throw new Error(result.stdout.trim())
+        }
+      } catch (error: any) {
+        if (error instanceof Error && error.message.startsWith("test-oracle-guard:")) {
+          throw error
+        }
+        // Engine failures (spawn error, timeout) fail open.
+      }
+    },
+  }
+}

--- a/tests/bashunit/oracle_guard_test.sh
+++ b/tests/bashunit/oracle_guard_test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# test-oracle-guard suite — bashunit source. Vocabulary (run, assert_*,
+# skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
+#
+# Consumer: the Claude Code hook, opencode plugin, and pi extension all shell
+# out to this engine and trust its exit contract. Observable failure: the
+# engine stops flagging unjustified negative assertions (weak absence tests
+# slip back into repos) or starts flagging clean edits (every agent edit to a
+# test file gets blocked). Oracle: the usage contract in the engine's header,
+# exercised behaviorally with fixture content independent of the engine source.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+load 'helpers/common'
+
+GUARD="$SOURCE_ROOT/dot_local/bin/executable_test-oracle-guard"
+
+run_guard() {
+  local path="$1" fixture="$2"
+  run bash -c 'printf "%s\n" "$2" | bash "$0" "$1"' "$GUARD" "$path" "$fixture"
+}
+
+function test_oracle_guard_001_non_test_file_passes_even_with_negative_assertion() {
+  _bats_test_init 1 'non-test file passes even with negative assertion'
+  # oracle: engine header — the gate applies to test files only.
+  run_guard "src/deploy.sh" 'assert_not_contains "$output" "worktrunk"'
+  assert_success
+  assert_output ""
+}
+
+function test_oracle_guard_002_flags_negative_assertion_in_test_file() {
+  _bats_test_init 2 'flags negative assertion in test file'
+  # oracle: engine header — unjustified negative assertion exits 1 with reason.
+  run_guard "tests/bashunit/smoke_test.sh" 'assert_not_contains "$palette" "worktrunk"'
+  assert_failure
+  assert_output --partial "without a named oracle"
+  assert_output --partial "line 1"
+}
+
+function test_oracle_guard_003_oracle_comment_within_three_lines_passes() {
+  _bats_test_init 3 'oracle comment within three lines passes'
+  # oracle: engine header — the "oracle:" escape hatch admits justified lines.
+  local fixture='# oracle: deployed uninstall boundary, seeded stale plugin
+assert_not_contains "$active_plugins" "legacy-tool"'
+  run_guard "tests/bashunit/smoke_test.sh" "$fixture"
+  assert_success
+  assert_output ""
+}
+
+function test_oracle_guard_004_oracle_comment_farther_than_three_lines_does_not_cover() {
+  _bats_test_init 4 'oracle comment farther than three lines does not cover'
+  # oracle: engine header — the escape hatch spans the flagged line plus 3 above.
+  local fixture='# oracle: too far away to count
+line two
+line three
+line four
+assert_not_contains "$palette" "worktrunk"'
+  run_guard "tests/bashunit/smoke_test.sh" "$fixture"
+  assert_failure
+  assert_output --partial "line 5"
+}
+
+function test_oracle_guard_005_positive_assertions_pass_untouched() {
+  _bats_test_init 5 'positive assertions pass untouched'
+  # oracle: engine header — only negative-assertion patterns are gated; this
+  # control keeps the guard from blocking ordinary test edits.
+  local fixture='assert_file_contains "$HOME/.zshrc" "starship init"
+assert_success
+assert_output --partial "applied"'
+  run_guard "tests/bashunit/smoke_test.sh" "$fixture"
+  assert_success
+  assert_output ""
+}
+
+function test_oracle_guard_006_missing_path_fails_open() {
+  _bats_test_init 6 'missing path fails open'
+  # oracle: engine header — fails open so a broken adapter never blocks edits.
+  run bash -c 'printf "x\n" | bash "$0"' "$GUARD"
+  assert_success
+}
+
+function set_up_before_script() {
+  :
+}
+
+function tear_down_after_script() {
+  _bats_file_cleanup
+}
+
+function tear_down() { _bats_run_teardown; }

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -30,8 +30,8 @@ USAGE
 }
 
 case "${1:-}" in
-  full)      files="smoke scripts palette platform idempotent" ;;
-  host-safe) files="smoke scripts palette platform" ;;
+  full)      files="smoke scripts palette platform oracle_guard idempotent" ;;
+  host-safe) files="smoke scripts palette platform oracle_guard" ;;
   *) usage; exit 2 ;;
 esac
 

--- a/tests/test_post_apply_suite_contract.py
+++ b/tests/test_post_apply_suite_contract.py
@@ -42,6 +42,7 @@ class TestPostApplySuiteContract(unittest.TestCase):
                 str(GENERATED / "scripts_test.sh"),
                 str(GENERATED / "palette_test.sh"),
                 str(GENERATED / "platform_test.sh"),
+                str(GENERATED / "oracle_guard_test.sh"),
                 str(GENERATED / "idempotent_test.sh"),
             ],
             "full mode must run every suite file sequentially with 8 workers",
@@ -53,6 +54,7 @@ class TestPostApplySuiteContract(unittest.TestCase):
                 str(GENERATED / "scripts_test.sh"),
                 str(GENERATED / "palette_test.sh"),
                 str(GENERATED / "platform_test.sh"),
+                str(GENERATED / "oracle_guard_test.sh"),
             ],
             "host-safe mode must keep the idempotent suite excluded",
         )


### PR DESCRIPTION
## Summary

Agents can no longer silently land absence-grep tests: an edit that adds a negative assertion (`assert_not_contains`, `refute_*`, `! grep`, …) to a test file is now mechanically blocked in Claude Code, OpenCode, and Pi unless a nearby comment names the independent oracle that justifies it.

The prose rules against tautological tests already existed and were read — and still got overridden by test-first workflow pressure ("the test fails before implementation, so it's valuable"). This moves enforcement to the moment of writing: one shared engine, `~/.local/bin/test-oracle-guard`, checks the proposed edit content, and three thin client adapters call it — a Claude Code `PreToolUse` hook on `Edit|Write|MultiEdit` (deny with reason), an OpenCode `tool.execute.before` plugin (throw), and a Pi `tool_call` extension (`{ block, reason }`). The same adapter-over-shared-engine shape as the existing `herdr-task-sync` integration.

## Design decisions

- **Silent when clean.** The engine exits 0 with no output for non-test files and for edits without negative assertions, so the gate costs zero agent context until it actually catches something. The deny message itself is the teaching moment: it asks for the consumer, the observable failure, and an oracle independent of the patch.
- **Escape hatch instead of a hard wall.** A comment containing `oracle:` on the flagged line or within 3 lines above it lets a genuinely load-bearing negative assertion through, and leaves the justification in the test for reviewers.
- **Fail open everywhere.** A missing or broken engine never blocks an edit — every adapter checks existence and swallows spawn failures.
- **Instructions updated too, not instead.** The global CLAUDE.md test rules (shared with OpenCode and Pi via their `AGENTS.md` symlinks) now state that proof-first is subordinate to the oracle gate, and that removing a dependency does not by itself justify an absence assertion. The mechanical gate is the backstop for exactly the case where prose loses.

## Validation

- `tests/bashunit/oracle_guard_test.sh` (new, wired into `tests/run-post-apply.sh` and its contract test) covers the engine's exit contract: flags in test files, passes non-test files, honors the escape hatch and its 3-line bound, ignores positive assertions, fails open on missing arguments.
- End-to-end simulation of the Claude hook against a fake `$HOME`: deny JSON for a weak absence edit, silence for a justified one, silence for non-test files, fail-open with the engine removed.
- `make lint` and full `make test-ubuntu` pass with the new suite included in the Docker run.

Separately, `docs/issues/2026-09-02-001` records a pre-existing flake found while validating: the herdr-child descriptor probe test asserts on a rendered test-name line that bashunit truncates to terminal width, so it fails in narrow panes.
