### PR TITLE
fix(herdr): activate worktree setup after deployment

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_4-link-herdr-worktree-setup.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_4-link-herdr-worktree-setup.sh.tmpl
@@ -21,8 +21,8 @@ if [[ ! -f "$plugin_dir/herdr-plugin.toml" ]]; then
   exit 0
 fi
 
-if herdr plugin link --enabled "$plugin_dir" >/dev/null 2>&1; then
+if herdr plugin link "$plugin_dir" >/dev/null 2>&1; then
   echo "Linked and enabled Herdr worktree-setup plugin"
 else
-  echo "Warning: failed to link Herdr worktree-setup plugin. Run manually: herdr plugin link --enabled $plugin_dir" >&2
+  echo "Warning: failed to link Herdr worktree-setup plugin. Run manually: herdr plugin link $plugin_dir" >&2
 fi

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -322,6 +322,30 @@ function test_scripts_0084_retired_worktrunk_migration_removes_only_managed_file
   assert_file_exists "$home/.config/worktrunk/user-note"
 }
 
+function test_scripts_0085_worktree_setup_relink_uses_the_herdr_cli_contract() {
+  _bats_test_init 85 'worktree setup relink uses the Herdr CLI contract'
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_4-link-herdr-worktree-setup.sh.tmpl"
+  local home="$BATS_TEST_TMPDIR/worktree-link-home"
+  local stub="$BATS_TEST_TMPDIR/worktree-link-bin"
+  mkdir -p "$home/.config/herdr/plugins/worktree-setup" "$stub"
+  printf '%s\n' 'id = "seigi.worktree-setup"' \
+    > "$home/.config/herdr/plugins/worktree-setup/herdr-plugin.toml"
+  cat > "$stub/herdr" <<'SH'
+#!/bin/sh
+expected="$HOME/.config/herdr/plugins/worktree-setup"
+if [ "$#" -eq 3 ] && [ "$1" = plugin ] && [ "$2" = link ] && [ "$3" = "$expected" ]; then
+  : > "$HOME/plugin-linked"
+  exit 0
+fi
+exit 2
+SH
+  chmod +x "$stub/herdr"
+
+  run env HOME="$home" PATH="$stub:$PATH" bash "$script"
+  assert_success
+  assert_file_exists "$home/plugin-linked"
+}
+
 # ===========================================
 # ask-in-herdr skill script
 # ===========================================


### PR DESCRIPTION
New Herdr worktrees now receive their configured post-creation setup after chezmoi deployment. The relink script previously passed the unsupported `--enabled` option, so Herdr never registered the plugin and missed its `worktree.created` handler.

A regression test now exercises the deployment script against Herdr's supported `plugin link <path>` contract. Focused coverage passes with 4 tests and 17 assertions, and `make test-ubuntu` completes successfully.

Related: #129

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
