### PR TITLE
docs(issues): fix 003 line citations, split 002 into four sub-issues

### DIFF
--- a/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
+++ b/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
@@ -1,6 +1,6 @@
 ---
 title: "Define contracts for inventory and literal tests"
-short_description: "The audit confirmed dependent oracles in CI event policy, post-apply routing and inventory, Herdr glyph and relink wiring, Git ignore behavior, palette fallback parsing, and Bats scan scope; each needs an independent consumer boundary."
+short_description: "The audit's seven confirmed dependent oracles are now split across four implementation issues (2026-09-02-002 through 2026-09-02-005); this issue remains the registry of the shared rule and closes when all four land."
 type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","source-ownership","literal-contracts"]
@@ -11,35 +11,23 @@ priority: "medium"
 
 ## Why this exists
 
-The 2026-09-01 test audit removed source-copy assertions only where behavioral or deployment owners already existed. A repository-wide follow-up audit then confirmed these dependent oracles:
+The 2026-09-01 test audit removed source-copy assertions only where behavioral or deployment owners already existed. A repository-wide follow-up audit then confirmed seven dependent oracles. Each can stay green while its consumer-visible behavior breaks, or fail after a harmless source refactor.
 
-- `tests/test_ci_workflow.py:65-100` derives expected cache events from the workflow expression under test.
-- `tests/test_post_apply_suite_contract.py:17-58` counts command text and copies the runner's suite inventory; `tests/test_docker_contract.py:70-94` accepts a matching command even when its failure is suppressed.
-- `tests/helpers/herdr_task_sync.bash:12-34` extracts expected user-facing glyphs from the implementation that emits them.
-- `tests/bashunit/smoke_test.sh:956-968` greps onchange-template includes without proving that dependency changes alter the rendered hash.
-- `tests/test_issues.py:518-522` inspects `.gitignore` source instead of Git's effective decision.
-- `tests/bashunit/palette_test.sh:527-555` exercises the fallback parser with expected values copied from mutable production configuration.
-- `tests/test_bats_assertion_contract.py:128-136` accepts the checker's own file inventory without an independent reachability fixture for every supported test-shell surface.
-
-Each test can stay green while its consumer-visible behavior breaks, or fail after a harmless source refactor. Architecture inventory tests and exact literals remain valid only when they compare independent sides or protect a literal consumed externally.
+The shared rule they violate: architecture inventory tests and exact literals are valid only when they compare independent sides of a relationship, or protect a literal consumed outside the repository.
 
 ## Scope
 
-Replace the confirmed dependent oracles at their strongest consumer boundaries:
+This issue owns the rule and the split, not the code. The seven findings are implemented under four children:
 
-- Pin the CI event policy independently, then compare workflow conditions with the explicit minimal and full event sets.
-- Discover post-apply consumers and eligible suites independently; execute a failing wrapper through each gate and require nonzero status to propagate.
-- Define stable Herdr glyphs independently if exact glyphs are a user contract; otherwise assert semantic token roles without copying implementation literals.
-- Render the onchange template before and after mutating each dependency and require its hash to change.
-- Use `git check-ignore` and tracked-path evidence for ignore behavior.
-- Give the fallback TOML parser a minimal fixed fixture independent of `commands.toml`.
-- Add reachability fixtures for every shell-file class the Bats assertion checker claims to protect.
+- `2026-09-02-002` — CI cache event policy (`tests/test_ci_workflow.py:65-100`), post-apply suite inventory (`tests/test_post_apply_suite_contract.py:17-58`), and suppressed Docker failure (`tests/test_docker_contract.py:70-94`).
+- `2026-09-02-003` — onchange template hash (`tests/bashunit/smoke_test.sh:956-968`) and palette fallback parser fixture (`tests/bashunit/palette_test.sh:527-555`).
+- `2026-09-02-004` — Git ignore behavior (`tests/test_issues.py:517-521`) and Bats assertion checker reachability (`tests/test_bats_assertion_contract.py:128-136`).
+- `2026-09-02-005` — Herdr task-sync glyphs (`tests/helpers/herdr_task_sync.bash:12-34`).
 
-Keep and document externally consumed command, transport, schema, symlink, and rendered-config literals. Keep one behavioral, deployment, or validation owner per contract. Safe deletions belong to `2026-09-01-003`; Pi hook and updater coverage gaps belong to `2026-09-01-004`; updater failure notifications belong to `2026-08-21-022`.
+Across all four: keep and document externally consumed command, transport, schema, symlink, and rendered-config literals, and keep exactly one behavioral, deployment, or validation owner per contract. Safe deletions belong to `2026-09-01-003`; Pi hook and updater coverage gaps belong to `2026-09-01-004`; updater failure notifications belong to `2026-08-21-022`.
+
+Close this issue once the four children are closed and no further dependent oracle remains from the audit list.
 
 ## Open decisions
 
-- Whether Herdr's exact glyph set is stable user-facing policy or replaceable presentation.
-- Whether post-apply suite eligibility should be derived from file metadata, a canonical manifest consumed by the runner, or another independent rule.
-- Which sourced shell-helper classes must be covered by the Bats assertion checker.
-- Which remaining deployment inventories in smoke and template suites are deliberate machine-setup policy rather than current source-tree shape.
+- Which remaining deployment inventories in the smoke and template suites are deliberate machine-setup policy rather than a mirror of the current source tree. This one is not delegated to a child; it needs a repository-wide answer.

--- a/docs/issues/2026-09-01-003-remove-source-mirror-assertions-with-stronger-behavioral-owners.md
+++ b/docs/issues/2026-09-01-003-remove-source-mirror-assertions-with-stronger-behavioral-owners.md
@@ -1,6 +1,6 @@
 ---
 title: "Remove source-mirror assertions with stronger behavioral owners"
-short_description: "The test audit found internal module inventories and a stale duplicate Pi package smoke check that add correlated maintenance without detecting failures beyond existing lifecycle and modifier tests."
+short_description: "The herdr-child module inventory inside scripts_test.sh test 269 duplicates coverage that command-level lifecycle tests already own, while the Pi package assertion in smoke_test.sh has drifted two packages behind the modifier and still needs a deployment owner decision."
 type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","duplicate-coverage","source-ownership"]
@@ -11,12 +11,21 @@ priority: "medium"
 
 ## Why this exists
 
-The repository-wide tautological-test audit identified assertions that can be deleted without losing an independently observable verdict. tests/bashunit/scripts_test.sh:7501-7653 hardcodes herdr-child module source order, function ownership, and allowed globals even though command-level lifecycle tests already exercise launch, supervision, continuation, and reap behavior. tests/bashunit/smoke_test.sh:402-416 duplicates the Pi package inventory owned by the settings modifier test and has already drifted by omitting npm:pi-ask-user.
+The repository-wide tautological-test audit identified assertions that can be deleted without losing an independently observable verdict.
+
+`tests/bashunit/scripts_test.sh:7657-7813` (test 269, `herdr-child modules load in order without source-time effects`) hardcodes the herdr-child module source order, the exact function set each module owns, and the exact globals each module initializes, even though command-level lifecycle tests already exercise launch, supervision, continuation, and reap behavior. Those three inventories are copied from the implementation they guard: they fail on a harmless module rename or helper extraction and stay green when the commands themselves break.
+
+`tests/bashunit/smoke_test.sh:404-418` (test 16, `pi settings include all managed packages`) asserts a package list that has already drifted: it names 7 packages while `home/dot_pi/agent/modify_settings.json` declares 9, omitting `npm:pi-ask-user` and `git:github.com/EveryInc/compound-engineering-plugin`.
 
 ## Scope
 
-Remove the herdr-child source-order, function-ownership, and global-ownership inventories while retaining the sourceability, no-output, shell-state, redefinition, and global-mutation checks at tests/bashunit/scripts_test.sh:7538-7618. Remove the duplicate Pi package inventory from smoke_test.sh and keep tests/bashunit/scripts_test.sh:6883-6943 as the single modifier transformation and idempotency owner. Run the narrow shell suites and confirm each deleted assertion had no distinct consumer or failure mode.
+Remove the source-order, function-ownership, and global-ownership comparisons from test 269 while retaining the sourceability, no-output, shell-state, function-redefinition, and global-mutation checks that live in the same test body (`tests/bashunit/scripts_test.sh:7724-7790`). This is an edit inside one test function, not a deletion of the test.
+
+Resolve the Pi package assertion in `smoke_test.sh` according to the open decision below. The Pi settings modifier transformation and its idempotency are owned by `tests/bashunit/scripts_test.sh:7039-7090` (tests 250 and 251); the smoke assertion is a different owner and covers the deployed `~/.pi/agent/settings.json` rather than the modifier transform.
+
+Run the narrow shell suites and confirm each deleted assertion had no distinct consumer or failure mode.
 
 ## Open decisions
 
-None. If implementation reveals an externally consumed module or package-membership contract not covered by the retained owners, stop and move that assertion under the replacement-oracle issue instead of deleting it.
+- Whether the Pi package assertion in `smoke_test.sh` should be deleted as a duplicate or repaired as the deployment owner. The modifier tests prove the stdin-to-stdout transform; only the smoke test proves the packages reached the applied `~/.pi/agent/settings.json`, and `CLAUDE.md` reserves the smoke suite for exactly that deployed cross-component behavior. Deleting it therefore removes the only delivery evidence. The default is to keep the assertion and fix the drift, deriving the expected package set from the deployed settings' independent consumer rather than restating a hand-maintained list.
+- If implementation reveals an externally consumed module or package-membership contract not covered by the retained owners, stop and move that assertion under `2026-09-01-002` instead of deleting it.

--- a/docs/issues/2026-09-02-002-prove-ci-event-policy-and-post-apply-failure-propagation-independently.md
+++ b/docs/issues/2026-09-02-002-prove-ci-event-policy-and-post-apply-failure-propagation-independently.md
@@ -1,0 +1,22 @@
+---
+title: "Prove CI event policy and post-apply failure propagation independently"
+short_description: "tests/test_ci_workflow.py derives its expected cache events from the workflow expression it checks, and the post-apply and Docker contract tests copy the runner's suite inventory while accepting a command whose failure is suppressed, so a wrong event set or a swallowed nonzero status stays green."
+type: "follow-up"
+category: "testing-ci"
+tags: ["semantic-testing","ci","source-ownership"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Split from 2026-09-01-002. Two confirmed dependent oracles share one boundary: what CI and the post-apply runner must actually do when inputs change or a suite fails. tests/test_ci_workflow.py:65-100 reads the workflow expression under test and rebuilds the expected event list from it, so any event added or dropped in the workflow is mirrored into the expectation. tests/test_post_apply_suite_contract.py:17-58 counts command text and copies the runner's own suite inventory instead of discovering eligible suites independently. tests/test_docker_contract.py:70-94 accepts a matching command even when its failure is suppressed, so a suite whose nonzero status never propagates still passes.
+
+## Scope
+
+Pin the CI event policy independently of the workflow file, then compare the workflow conditions against the explicit minimal and full event sets. Discover post-apply consumers and eligible suites through an independent rule, execute a failing wrapper through each gate, and require the nonzero status to propagate to the caller. Keep externally consumed command and transport literals and document why each stays. Do not add a parallel suite: strengthen the existing tests. Verify with the narrow python suites, then make test-suite.
+
+## Open decisions
+
+Whether post-apply suite eligibility should be derived from file metadata, from a canonical manifest consumed by the runner, or from another independent rule.

--- a/docs/issues/2026-09-02-003-give-onchange-hash-and-palette-fallback-tests-independent-fixtures.md
+++ b/docs/issues/2026-09-02-003-give-onchange-hash-and-palette-fallback-tests-independent-fixtures.md
@@ -1,0 +1,22 @@
+---
+title: "Give onchange hash and palette fallback tests independent fixtures"
+short_description: "The onchange smoke test greps template includes without rendering the template, and the palette fallback parser test copies its expected values from the mutable production commands.toml, so a broken dependency hash or a regressed fallback parser stays green."
+type: "follow-up"
+category: "testing-ci"
+tags: ["semantic-testing","command-palette","chezmoi"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Split from 2026-09-01-002. tests/bashunit/smoke_test.sh:956-968 asserts that the onchange template includes its dependencies but never proves that changing a dependency changes the rendered hash, which is the only property the onchange mechanism relies on. tests/bashunit/palette_test.sh:527-555 exercises the fallback TOML parser with expected command names and values copied from home/private_dot_config/herdr/commands.toml, so editing production configuration silently rewrites the test expectation.
+
+## Scope
+
+Render the onchange template before and after mutating each declared dependency and require the rendered hash to change; keep a control that proves an unrelated edit does not change it. Replace the palette fallback parser input with a minimal fixed fixture that is independent of commands.toml and covers the parser's real branches, including at least one malformed-input control. Strengthen the existing tests instead of adding new suites. Verify with tests/lib/bashunit on the two touched files, then make test-suite.
+
+## Open decisions
+
+None.

--- a/docs/issues/2026-09-02-004-assert-git-ignore-behavior-and-bats-checker-reachability-through-their-real-authorities.md
+++ b/docs/issues/2026-09-02-004-assert-git-ignore-behavior-and-bats-checker-reachability-through-their-real-authorities.md
@@ -1,0 +1,22 @@
+---
+title: "Assert Git ignore behavior and Bats checker reachability through their real authorities"
+short_description: "tests/test_issues.py inspects .gitignore text instead of Git's effective decision, and tests/test_bats_assertion_contract.py accepts the checker's own file inventory without a reachability fixture per supported test-shell surface."
+type: "follow-up"
+category: "testing-ci"
+tags: ["semantic-testing","source-ownership"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Split from 2026-09-01-002. tests/test_issues.py:517-521 reads .gitignore line by line, so a rule that is present but overridden, or a path that is ignored through another mechanism, produces the same verdict as correct behavior. tests/test_bats_assertion_contract.py:128-136 trusts the checker's own list of files it claims to scan, so a shell-file class the checker silently stops reaching keeps passing.
+
+## Scope
+
+Replace the .gitignore text assertions with git check-ignore results and tracked-path evidence for the same paths, keeping one ignored and one tracked control. Add a reachability fixture for every shell-file class the Bats assertion checker claims to protect: plant a known violation in each class and require the checker to report it, with a clean control per class. Strengthen the existing tests instead of adding new suites. Verify with the two python suites, then make test-issues.
+
+## Open decisions
+
+Which sourced shell-helper classes the Bats assertion checker must cover; the implementation should enumerate the classes it currently reaches and state any it deliberately excludes.

--- a/docs/issues/2026-09-02-005-decide-the-herdr-task-sync-glyph-contract-and-test-it-independently.md
+++ b/docs/issues/2026-09-02-005-decide-the-herdr-task-sync-glyph-contract-and-test-it-independently.md
@@ -1,0 +1,22 @@
+---
+title: "Decide the Herdr task-sync glyph contract and test it independently"
+short_description: "tests/helpers/herdr_task_sync.bash extracts the expected user-facing glyphs from the implementation that emits them, so the glyph assertions cannot fail when the rendered status vocabulary changes."
+type: "follow-up"
+category: "testing-ci"
+tags: ["semantic-testing","herdr","source-ownership"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+Split from 2026-09-01-002. tests/helpers/herdr_task_sync.bash:12-34 derives the expected glyph set from the implementation under test, so every glyph test compares the implementation against itself. Whether that is fixable by pinning literals depends on whether the glyph set is a user-facing contract or replaceable presentation.
+
+## Scope
+
+Establish which of the two the glyph set is, then act on it. If exact glyphs are user-facing policy, pin them in the test as independent literals with a short comment naming the consumer that depends on them. Otherwise assert semantic token roles (a status has a distinct, stable marker per state) without copying implementation literals. Default to the semantic-role reading unless an external consumer of the exact glyphs is found. Strengthen the existing helper and its callers instead of adding a new suite. Verify with the herdr task-sync bashunit files, then make test-suite.
+
+## Open decisions
+
+Whether Herdr's exact glyph set is stable user-facing policy or replaceable presentation; record the answer in the issue before closing it.


### PR DESCRIPTION
Two entries in the test-audit issue tracker (`docs/issues/`) pointed reviewers at the wrong code and bundled too much scope into one ticket; both are now accurate and independently actionable.

## 2026-09-01-003: corrected line citations

The herdr-child module inventory this issue targets is test 269 at `tests/bashunit/scripts_test.sh:7657-7813`, not the previously cited `7501-7653`. The checks worth retaining (sourceability, no-output, shell-state, redefinition, global-mutation) live inside that same test body at lines `7724-7790`. The Pi settings modifier transform is owned by tests 250/251 at `tests/bashunit/scripts_test.sh:7039-7090`, not `6883-6943` — that earlier range is the Claude settings modifier, a different test.

The issue also gained an open decision: the Pi package assertion in `tests/bashunit/smoke_test.sh:404-418` is the only test proving packages actually reached the deployed `~/.pi/agent/settings.json` (the modifier tests only prove the stdin-to-stdout transform). It has drifted — 7 packages listed against 9 declared in `home/dot_pi/agent/modify_settings.json`, missing `npm:pi-ask-user` and `git:github.com/EveryInc/compound-engineering-plugin`. The recommended default is now to repair the drift rather than delete the assertion as a duplicate.

## 2026-09-01-002: split into four sub-issues

`2026-09-01-002` previously tried to prescribe fixes for all seven confirmed dependent-oracle findings from the audit in one issue. It's now a registry that delegates each finding to a scoped implementation issue and closes when all four land:

- `2026-09-02-002` — CI event policy and post-apply/Docker failure propagation
- `2026-09-02-003` — onchange hash and palette fallback test fixtures
- `2026-09-02-004` — Git ignore behavior and Bats checker reachability
- `2026-09-02-005` — Herdr task-sync glyph contract

Docs only — no code or test behavior changes. `python3 scripts/issues validate` passes.
