### PR TITLE
test(smoke): enforce named-consumer rule for deployment assertions

### DIFF
--- a/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
+++ b/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
@@ -30,4 +30,18 @@ Close this issue once the four children are closed and no further dependent orac
 
 ## Open decisions
 
-- Which remaining deployment inventories in the smoke and template suites are deliberate machine-setup policy rather than a mirror of the current source tree. This one is not delegated to a child; it needs a repository-wide answer.
+**Settled.** A deployment assertion in the smoke or template suites is legitimate machine-setup policy when it fits one of two independent-oracle shapes; otherwise it is a source-shape mirror that should be strengthened or deleted.
+
+1. **Literal consumed outside the repository.** The exact text is parsed verbatim by a tool this repo does not own and cannot invoke cheaply in CI — herdr's own TOML config parser, Pi's/OpenCode's directory-based module loader, Claude Code's hook runner. There is no cheaper oracle available, so the literal (or, better, the mechanism that consumes it) is the assertion. Kept, now documented at each site: `test_smoke_006` and `test_smoke_010` (herdr TOML keys herdr's parser reads at startup), `test_smoke_009` (herdr's trusted-owners allowlist — also fixed to read the deployed `$HOME` copy instead of `$SOURCE_ROOT`, which had made it a source-shape check wearing a deployment test's name), and `test_smoke_015` (Pi's `APPEND_SYSTEM.md` filename convention, which — unlike Claude's and OpenCode's adapters — has no separate settings.json toggle to check instead).
+2. **Cross-reference between two independently maintained sides.** Neither side is copied from the other by the same change, so they can only agree by actually staying in sync. `test_smoke_022` replaced its hand-copied list of `~/.claude/shared/*.md` filenames with a two-directional check: every `~/.claude/shared/*.md` pointer written in a deployed skill, agent, or `CLAUDE.md` must resolve to a real file (forward — catches a renamed or deleted shared file), and every deployed shared file except the directory's own README index must be reachable from at least one such pointer (reverse — catches an orphaned file nothing loads).
+
+Neither shape is "the deployed file matches its rendered source" — that check fires on an unrelated, unapplied checkout and stays out of scope by design (see `docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md`).
+
+An assertion that fits neither shape — no external tool consumes the exact text, and nothing outside the test itself would notice a silent drift from reality — proves nothing and does not earn a slot just to keep a count up:
+
+- **A cheap real consumer exists → exercise it directly.** `test_smoke_061` now runs the deployed Claude Code hook the same way `settings.json` invokes it and asserts the silent, exit-0 contract its own header comment already commits to, instead of checking existence and the execute bit (Claude Code always invokes it through `bash`, so the execute bit was never load-bearing). `test_smoke_063`, `test_smoke_065`, and `test_smoke_067` now dynamically import the deployed Pi extension, Pi brew-updater extension, and OpenCode plugin the same way each host's directory-based loader would, and assert the export shape the loader requires — catching a truncated or malformed deployed copy that bare `assert_file_exists` could not.
+- **No consumer can be named → delete.** `test_smoke_021`'s check that `writing-for-agents/SKILL.md` contains the phrase `'vendored under its MIT License'` protected prose nothing reads programmatically; a search of `scripts/` and `docs/` for `vendored` found nothing depending on that exact wording, so the assertion was removed rather than kept for its own sake.
+
+Every replacement above carries a mutation proof: the regression it should catch was reproduced against the real deployed `$HOME`, the test was rerun and observed red, then the file was restored and reverified green.
+
+This settles the repository-wide answer this issue asked for. The four child issues still own their own findings.

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -599,10 +599,13 @@ function test_smoke_021_agent_skills_are_deployed_with_their_scripts_and() {
 # already implies; it drifts silently when a shared file is renamed and its
 # entry here is forgotten. Cross-check both independent sides instead: every
 # ~/.claude/shared/*.md pointer written anywhere in the deployed agent surface
-# (CLAUDE.md, skills, the herdr child-launch lib) must resolve to a real file,
-# and conversely every deployed shared file except the directory's own README
-# index must be reachable from at least one such pointer, or it is dead weight
-# nothing loads.
+# (CLAUDE.md, skills, agents, hooks, output-styles, rules, and the herdr
+# child-launch lib) must resolve to a real file, and conversely every deployed
+# shared file except the directory's own README index must be reachable from
+# at least one such pointer, or it is dead weight nothing loads. The scanned
+# paths are chezmoi-managed content dirs only (see home/private_dot_claude/*)
+# — runtime state like sessions or telemetry is deliberately excluded, since a
+# pointer written only there was never part of the wiring this repo deploys.
 function test_smoke_022_shared_references_form_a_closed_reference_set() {
   _bats_test_init 22 'shared references form a closed reference set with the deployed agent surface'
   local shared_dir="$HOME/.claude/shared"
@@ -610,7 +613,9 @@ function test_smoke_022_shared_references_form_a_closed_reference_set() {
 
   local pointers
   pointers="$(grep -rho '~/\.claude/shared/[A-Za-z0-9._-]*\.md' \
-    "$HOME/.claude/CLAUDE.md" "$HOME/.agents" "$HOME/.local/lib" 2>/dev/null | sort -u)"
+    "$HOME/.claude/CLAUDE.md" "$HOME/.agents" "$HOME/.local/lib" \
+    "$HOME/.claude/agents" "$HOME/.claude/hooks" "$HOME/.claude/output-styles" \
+    "$HOME/.claude/rules" 2>/dev/null | sort -u)"
   [ -n "$pointers" ] || fail "no ~/.claude/shared pointer found in the deployed agent surface"
 
   local pointer missing=""

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -901,12 +901,20 @@ function test_smoke_059_herdr_task_and_child_engines_are_deployed_and_ex() {
 # promise, instead of only checking it is present and has the execute bit.
 #
 # An empty `{}` payload never proves this: the hook requires session_id
-# before it reaches either dispatch branch (herdr-task-sync-hook.sh's own
+# before it reaches any dispatch branch (herdr-task-sync-hook.sh's own
 # `[ -n "$session_id" ] || exit 0` guard), so a payload without one exits
 # silently before the real engine call a broken dispatch would corrupt. Send
-# the fields Claude actually supplies, and put a stub `herdr-task-sync` ahead
-# on PATH so the real engine -- which would rename this very live pane -- is
-# never invoked, while still proving the hook reached and called it.
+# the fields Claude actually supplies for all three wired events -- prompt,
+# session, compact -- and put a stub `herdr-task-sync` ahead on PATH so the
+# real engine -- which would rename this very live pane -- is never invoked,
+# while still proving the hook reached and called it with the right args.
+#
+# The stub also writes a distinctive marker straight to its own real
+# stdout/stderr, outside the redirection it uses to record invocations. That
+# marker is what the hook's own `>/dev/null 2>&1` must swallow: without a
+# real, unconditional leak to silence, a stub that never produces output in
+# the first place would make the "stays silent" assertion pass trivially even
+# if the hook dropped its redirect entirely.
 function test_smoke_061_herdr_task_sync_claude_code_hook_stays_silent_and() {
   _bats_test_init 61 'herdr-task-sync Claude Code hook stays silent and exits 0'
   local hook="$HOME/.claude/hooks/herdr-task-sync-hook.sh"
@@ -917,6 +925,8 @@ function test_smoke_061_herdr_task_sync_claude_code_hook_stays_silent_and() {
   invocation_log="$stub_dir/invocations.log"
   cat > "$stub_dir/herdr-task-sync" <<'STUB'
 #!/usr/bin/env bash
+printf 'STUB-STDOUT-LEAK\n'
+printf 'STUB-STDERR-LEAK\n' >&2
 { printf '%s\n' "$*"; cat >/dev/null; } >> "$HERDR_TASK_SYNC_STUB_LOG"
 STUB
   chmod +x "$stub_dir/herdr-task-sync"
@@ -931,9 +941,14 @@ STUB
   assert_success
   assert_output ""
 
+  run env PATH="$stub_dir:$PATH" HERDR_TASK_SYNC_STUB_LOG="$invocation_log" \
+    bash "$hook" compact <<< '{"session_id":"smoke-061","transcript_path":"/tmp/smoke-061.jsonl"}'
+  assert_success
+  assert_output ""
+
   assert_file_exists "$invocation_log"
   run wc -l "$invocation_log"
-  assert_output --partial "2 "
+  assert_output --partial "3 "
   assert_file_contains "$invocation_log" \
     '\-\-agent claude \-\-session smoke-061 \-\-transcript /tmp/smoke-061.jsonl'
 

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -191,6 +191,9 @@ function test_smoke_005_gitignore_ignores_the_agent_trash_directory() {
   assert_success
 }
 
+# Literal consumed outside this repo: herdr's own TOML parser reads this exact
+# key at startup and binds the palette open action to it. No code here calls
+# herdr to observe the binding, so the deployed literal is the whole contract.
 function test_smoke_006_herdr_command_palette_keybinding_is_configured() {
 _bats_test_init 6 'herdr command palette keybinding is configured'
 assert_file_contains "$HOME/.config/herdr/config.toml" "seigi.command-palette.open"
@@ -260,15 +263,22 @@ SH
   assert_output --partial "failed to inspect obsolete plugin artisann.zed-herdr"
 }
 
+# Literal consumed outside this repo: herdr's auto-update plugin reads
+# `trusted_owners` at runtime and only auto-installs plugin updates from that
+# allowlist — a real security boundary, not decoration. Reads the deployed
+# $HOME copy (not $SOURCE_ROOT) so this actually proves chezmoi placed the
+# file, matching every other assertion in this suite.
 function test_smoke_009_herdr_plugin_updates_are_automatic_and_owner_res() {
   _bats_test_init 9 'herdr plugin updates are automatic and owner-restricted'
-  local config="$SOURCE_ROOT/private_dot_config/herdr/plugins/config/herdr-auto-update/config.toml"
+  local config="$HOME/.config/herdr/plugins/config/herdr-auto-update/config.toml"
 
   assert_file_exists "$config"
   assert_file_contains "$config" 'auto_update = true'
   assert_file_contains "$config" 'trusted_owners = \["dio16"\]'
 }
 
+# Literal consumed outside this repo: herdr's plugin manifest parser matches
+# this exact `id` to register the palette entry, same category as test 006.
 function test_smoke_010_herdr_lazygit_popup_entrypoint_is_configured() {
   _bats_test_init 10 'herdr lazygit popup entrypoint is configured'
   assert_file_contains "$HOME/.config/herdr/plugins/command-palette/herdr-plugin.toml" 'id = "lazygit"'
@@ -396,6 +406,10 @@ function test_smoke_014_writing_style_output_style_is_deployed_and_enabl() {
   assert_success
 }
 
+# Pi appends this exact filename to its system prompt by convention, with no
+# settings.json toggle to check the way Claude (test 014) and OpenCode (test
+# 018) have — so unlike those two, the deployed path itself is the entire
+# wiring contract for Pi and there is nothing cheaper to verify against.
 function test_smoke_015_pi_append_system_md_is_deployed() {
   _bats_test_init 15 'pi APPEND_SYSTEM.md is deployed'
   assert_file_exists "$HOME/.pi/agent/APPEND_SYSTEM.md"
@@ -576,20 +590,42 @@ function test_smoke_021_agent_skills_are_deployed_with_their_scripts_and() {
   assert_file_executable "$HOME/.agents/skills/markdown-new/scripts/jina-read.sh"
   assert_file_executable "$HOME/.agents/skills/markdown-new/scripts/jina-search.sh"
   assert_file_executable "$HOME/.agents/skills/markdown-new/scripts/tavily-search.sh"
-  assert_file_contains "$HOME/.agents/skills/writing-for-agents/SKILL.md" 'vendored under its MIT License'
 
   # The retired per-agent scripts directory must stay deleted.
   assert_dir_not_exists "$HOME/.agents/skills/ask-in-herdr/scripts/agents"
 }
 
-function test_smoke_022_shared_references_are_deployed() {
-  _bats_test_init 22 'shared references are deployed'
-  assert_file_exists "$HOME/.claude/shared/README.md"
-  assert_file_exists "$HOME/.claude/shared/pf-cycle.md"
-  assert_file_exists "$HOME/.claude/shared/herdr-peer-launch.md"
-  assert_file_exists "$HOME/.claude/shared/decision-brief.md"
-  assert_file_exists "$HOME/.claude/shared/child-agent-contract.md"
-  assert_file_exists "$HOME/.claude/shared/long-running-work.md"
+# A hand-copied list here can only restate what test 075 (CLAUDE.md pointers)
+# already implies; it drifts silently when a shared file is renamed and its
+# entry here is forgotten. Cross-check both independent sides instead: every
+# ~/.claude/shared/*.md pointer written anywhere in the deployed agent surface
+# (CLAUDE.md, skills, the herdr child-launch lib) must resolve to a real file,
+# and conversely every deployed shared file except the directory's own README
+# index must be reachable from at least one such pointer, or it is dead weight
+# nothing loads.
+function test_smoke_022_shared_references_form_a_closed_reference_set() {
+  _bats_test_init 22 'shared references form a closed reference set with the deployed agent surface'
+  local shared_dir="$HOME/.claude/shared"
+  assert_dir_exists "$shared_dir"
+
+  local pointers
+  pointers="$(grep -rho '~/\.claude/shared/[A-Za-z0-9._-]*\.md' \
+    "$HOME/.claude/CLAUDE.md" "$HOME/.agents" "$HOME/.local/lib" 2>/dev/null | sort -u)"
+  [ -n "$pointers" ] || fail "no ~/.claude/shared pointer found in the deployed agent surface"
+
+  local pointer missing=""
+  while IFS= read -r pointer; do
+    [ -f "$HOME/${pointer#\~/}" ] || missing="$missing $pointer"
+  done <<< "$pointers"
+  [ -z "$missing" ] || fail "dangling ~/.claude/shared pointers:$missing"
+
+  local f name orphans=""
+  for f in "$shared_dir"/*.md; do
+    name="$(basename "$f")"
+    [ "$name" = "README.md" ] && continue
+    grep -qF "shared/$name" <<< "$pointers" || orphans="$orphans $name"
+  done
+  [ -z "$orphans" ] || fail "orphaned ~/.claude/shared files referenced by nothing:$orphans"
 }
 
 # A shared file that is renamed or moved keeps the deployment tests above green
@@ -853,10 +889,23 @@ function test_smoke_059_herdr_task_and_child_engines_are_deployed_and_ex() {
 # Test 60 was removed as tautological: deployment of these docs is owned by
 # test 21's manifest, the marker wire format by scripts_test.sh test 058.
 
-function test_smoke_061_herdr_task_sync_claude_code_hook_is_deployed_and() {
-  _bats_test_init 61 'herdr-task-sync Claude Code hook is deployed and executable'
-  assert_file_exists "$HOME/.claude/hooks/herdr-task-sync-hook.sh"
-  assert_file_executable "$HOME/.claude/hooks/herdr-task-sync-hook.sh"
+# Claude Code injects a UserPromptSubmit hook's stdout straight into the
+# conversation, so the hook's own header comment commits to writing nothing
+# and always exiting 0. Run it the same way settings.json invokes it (test
+# 062 proves that wiring) and check the deployed script actually keeps that
+# promise, instead of only checking it is present and has the execute bit.
+function test_smoke_061_herdr_task_sync_claude_code_hook_stays_silent_and() {
+  _bats_test_init 61 'herdr-task-sync Claude Code hook stays silent and exits 0'
+  local hook="$HOME/.claude/hooks/herdr-task-sync-hook.sh"
+  assert_file_exists "$hook"
+
+  run bash "$hook" prompt <<< '{}'
+  assert_success
+  assert_output ""
+
+  run bash "$hook" session <<< '{}'
+  assert_success
+  assert_output ""
 }
 
 function test_smoke_062_claude_settings_wire_the_task_sync_hook_to_promp() {
@@ -883,10 +932,18 @@ PY
   assert_success
 }
 
+# Pi discovers extensions by directory, not a manifest: it dynamically
+# imports every file under ~/.pi/agent/extensions/ and calls its default
+# export. File existence alone would still pass on a truncated or corrupted
+# copy that Pi's own loader could never load; import it the same way Pi does
+# and check the shape its loader requires instead.
 function test_smoke_063_herdr_task_sync_pi_extension_is_deployed_beside() {
   _bats_test_init 63 'herdr-task-sync pi extension is deployed beside herdr'\''s own'
   local ext="$HOME/.pi/agent/extensions/herdr-task-sync.ts"
   assert_file_exists "$ext"
+
+  run bun -e "const m = await import(\"$ext\"); if (typeof m.default !== \"function\") throw new Error(\"no default export\")"
+  assert_success
 }
 
 function test_smoke_064_pi_local_private_instructions_focused_tests_pass() {
@@ -896,10 +953,19 @@ function test_smoke_064_pi_local_private_instructions_focused_tests_pass() {
   assert_success
 }
 
+# Test 066 behaviorally exercises this extension's logic against the
+# checkout copy, not the deployed one (SOURCE_ROOT). Prove the *deployed*
+# copy is what test 066 actually tested, by importing it the way Pi's own
+# directory-based loader would and checking it exports the same names
+# test 066 imports — not a content diff against the checkout, just that the
+# deployed file loads and has the shape a corrupted or stale copy would lack.
 function test_smoke_065_pi_brew_auto_updater_is_deployed() {
   _bats_test_init 65 'Pi brew auto updater is deployed'
   local ext="$HOME/.pi/agent/extensions/brew-auto-update/index.ts"
   assert_file_exists "$ext"
+
+  run bun -e "const m = await import(\"$ext\"); for (const k of [\"default\", \"captureExtensionSnapshot\", \"runBrewAutoUpdate\"]) if (typeof m[k] !== \"function\") throw new Error(\"missing export: \" + k)"
+  assert_success
 }
 
 function test_smoke_066_pi_brew_auto_updater_focused_tests_pass() {
@@ -908,10 +974,16 @@ function test_smoke_066_pi_brew_auto_updater_focused_tests_pass() {
   assert_success
 }
 
+# OpenCode also loads plugins by directory, not a manifest. Same rationale
+# as test 063: import the deployed file and check its named export, the
+# shape OpenCode's own loader requires, instead of only checking it exists.
 function test_smoke_067_herdr_task_sync_opencode_plugin_is_deployed() {
   _bats_test_init 67 'herdr-task-sync opencode plugin is deployed'
   local plugin="$HOME/.config/opencode/plugins/herdr-task-sync.ts"
   assert_file_exists "$plugin"
+
+  run bun -e "const m = await import(\"$plugin\"); if (typeof m.HerdrTaskSyncPlugin !== \"function\") throw new Error(\"no HerdrTaskSyncPlugin export\")"
+  assert_success
 }
 
 assert_herdr_sidebar_deployment_contract() {

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -615,7 +615,7 @@ function test_smoke_022_shared_references_form_a_closed_reference_set() {
   pointers="$(grep -rho '~/\.claude/shared/[A-Za-z0-9._-]*\.md' \
     "$HOME/.claude/CLAUDE.md" "$HOME/.agents" "$HOME/.local/lib" \
     "$HOME/.claude/agents" "$HOME/.claude/hooks" "$HOME/.claude/output-styles" \
-    "$HOME/.claude/rules" 2>/dev/null | sort -u)"
+    "$HOME/.claude/rules" "$HOME/.claude/skills" 2>/dev/null | sort -u)"
   [ -n "$pointers" ] || fail "no ~/.claude/shared pointer found in the deployed agent surface"
 
   local pointer missing=""
@@ -899,18 +899,45 @@ function test_smoke_059_herdr_task_and_child_engines_are_deployed_and_ex() {
 # and always exiting 0. Run it the same way settings.json invokes it (test
 # 062 proves that wiring) and check the deployed script actually keeps that
 # promise, instead of only checking it is present and has the execute bit.
+#
+# An empty `{}` payload never proves this: the hook requires session_id
+# before it reaches either dispatch branch (herdr-task-sync-hook.sh's own
+# `[ -n "$session_id" ] || exit 0` guard), so a payload without one exits
+# silently before the real engine call a broken dispatch would corrupt. Send
+# the fields Claude actually supplies, and put a stub `herdr-task-sync` ahead
+# on PATH so the real engine -- which would rename this very live pane -- is
+# never invoked, while still proving the hook reached and called it.
 function test_smoke_061_herdr_task_sync_claude_code_hook_stays_silent_and() {
   _bats_test_init 61 'herdr-task-sync Claude Code hook stays silent and exits 0'
   local hook="$HOME/.claude/hooks/herdr-task-sync-hook.sh"
   assert_file_exists "$hook"
 
-  run bash "$hook" prompt <<< '{}'
+  local stub_dir invocation_log
+  stub_dir="$(mktemp -d)"
+  invocation_log="$stub_dir/invocations.log"
+  cat > "$stub_dir/herdr-task-sync" <<'STUB'
+#!/usr/bin/env bash
+{ printf '%s\n' "$*"; cat >/dev/null; } >> "$HERDR_TASK_SYNC_STUB_LOG"
+STUB
+  chmod +x "$stub_dir/herdr-task-sync"
+
+  run env PATH="$stub_dir:$PATH" HERDR_TASK_SYNC_STUB_LOG="$invocation_log" \
+    bash "$hook" prompt <<< '{"session_id":"smoke-061","prompt":"hi","transcript_path":"/tmp/smoke-061.jsonl"}'
   assert_success
   assert_output ""
 
-  run bash "$hook" session <<< '{}'
+  run env PATH="$stub_dir:$PATH" HERDR_TASK_SYNC_STUB_LOG="$invocation_log" \
+    bash "$hook" session <<< '{"session_id":"smoke-061","transcript_path":"/tmp/smoke-061.jsonl"}'
   assert_success
   assert_output ""
+
+  assert_file_exists "$invocation_log"
+  run wc -l "$invocation_log"
+  assert_output --partial "2 "
+  assert_file_contains "$invocation_log" \
+    '\-\-agent claude \-\-session smoke-061 \-\-transcript /tmp/smoke-061.jsonl'
+
+  rm -rf "$stub_dir"
 }
 
 function test_smoke_062_claude_settings_wire_the_task_sync_hook_to_promp() {


### PR DESCRIPTION
## Summary

`tests/bashunit/smoke_test.sh` had several "deployment" assertions that only proved a file exists or a word appears in it — they stayed green on an empty, truncated, stale, or unused file. Test 009, named as a deployment test, actually read `$SOURCE_ROOT` instead of the deployed `$HOME` copy, so it never tested deployment at all. This PR replaces those checks with one enforced rule: an assertion earns its place only by pinning a literal an external tool parses verbatim, or by cross-referencing two independently maintained sides. Everything else is strengthened to exercise a named consumer, or removed.

### Kept as externally-consumed literals

Tests 006, 009, 010, and 015 stay as literal checks, each now documenting which outside tool reads the value — herdr's TOML config parser (006, 010) and Pi's `APPEND_SYSTEM.md` filename convention (015). Test 009 (herdr's trusted-owners allowlist) is repointed at the deployed `$HOME` copy instead of `$SOURCE_ROOT`.

### Rewritten as a cross-reference

Test 022 no longer hand-copies a list of `~/.claude/shared/*.md` filenames. It now checks both directions over the deployed Claude surface (skills, agents, hooks, output-styles, rules, `CLAUDE.md`): every shared-file pointer it finds must resolve to a real file, and every deployed shared file except the directory's own README index must be reachable from at least one pointer.

### Upgraded to run the real consumer

Tests 061, 063, 065, and 067 moved from existence checks to actually invoking the deployed artifact: the Claude Code hook runs the way `settings.json` invokes it for all three of its wired events (prompt, session, compact), with the stub engine leaking a marker on its own real stdout/stderr so the hook's `>/dev/null 2>&1` redirect has something real to swallow. The Pi extensions and OpenCode plugin are imported the way each host's directory-based loader would — catching a truncated or malformed deployed copy that `assert_file_exists` could not.

### Deleted

Test 021's check for the phrase `'vendored under its MIT License'` in `writing-for-agents/SKILL.md` is removed — a search of `scripts/` and `docs/` found nothing that reads that exact wording, so it protected prose no consumer depends on.

## Verification

`tests/lib/bashunit -j 8 tests/bashunit/smoke_test.sh` → 50 passed, 207 assertions (2 pre-existing risky no-assertion tests, unrelated to this change).

Mutation-tested against the real deployed `$HOME`:
- Test 022: adding an unreferenced `~/.claude/shared/zz-mutation-probe.md` made the test fail, naming that exact file; removing it returned the suite to green. An earlier commit here also closed a related false positive in the same test — the pointer scan didn't cover `~/.claude/skills`, so a shared file referenced only from a deployed Claude skill would have been misreported as an orphan.
- Test 061: against scratch copies of the deployed hook (the live hook in `~/.claude/hooks` was never modified), emptying out the dispatch case statement makes the test fail (the stub's invocation log is never created), and dropping the hook's `>/dev/null 2>&1` around the engine call makes the test fail on the stub's leaked stdout/stderr markers — confirming the "stays silent" assertion is now backed by a real redirect, not an already-silent stub.

`make test-suite` passes clean (57 passed, 1 pre-existing risky test, 196 assertions); `make lint` passes with no output.
