### PR TITLE
docs(issues): close eight tautological-test follow-up issues

### DIFF
--- a/docs/issues/2026-08-21-022-brew-auto-update-failures-are-invisible.md
+++ b/docs/issues/2026-08-21-022-brew-auto-update-failures-are-invisible.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "agent-platform"
 tags: ["agent-platform","follow-up"]
 date: "2026-08-21"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -69,3 +70,7 @@ Both decisions below are settled; this section records the chosen policy.
   already used by `home/dot_pi/agent/extensions/agents-local` for a
   degraded-but-not-fatal condition. The manual command's non-failure terminal
   outcomes (`skipped`, `contended`, up-to-date, updated) notify at `info`.
+
+## Resolution
+
+Merged in PR #135. Both updater entry points now surface their result: failures always notify at warning level regardless of trigger, the manual command reports every terminal outcome, and startup stays silent only on routine no-op runs while still never aborting Pi startup. The tests that required empty notifications were inverted into consumer-visible assertions, proved red against the unfixed code and green after. UpdateUi.setStatus was deleted as an interface member nothing called, verified safe with tsc against the real Pi types. The contended message no longer claims another process holds the lock when the same process's startup run does. The headless no-op is recorded as 2026-09-02-007.

--- a/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
+++ b/docs/issues/2026-09-01-002-define-contracts-for-inventory-and-literal-tests.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","source-ownership","literal-contracts"]
 date: "2026-09-01"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -45,3 +46,7 @@ An assertion that fits neither shape — no external tool consumes the exact tex
 Every replacement above carries a mutation proof: the regression it should catch was reproduced against the real deployed `$HOME`, the test was rerun and observed red, then the file was restored and reverified green.
 
 This settles the repository-wide answer this issue asked for. The four child issues still own their own findings.
+
+## Resolution
+
+All four children are closed (2026-09-02-002 through 2026-09-02-005), and the repository-wide open decision this issue reserved for itself was settled in PR #142: a deployment assertion earns its slot only by pinning a literal that a tool outside this repository parses verbatim, or by comparing two independently maintained sides. Assertions fitting neither were strengthened to exercise a named consumer or deleted. Nine smoke tests were reclassified under that rule; peer review then caught that the rewritten hook test fed a payload the hook rejects before dispatch, so it proved neither dispatch nor silence, fixed and mutation-proved in both directions before merge.

--- a/docs/issues/2026-09-01-003-remove-source-mirror-assertions-with-stronger-behavioral-owners.md
+++ b/docs/issues/2026-09-01-003-remove-source-mirror-assertions-with-stronger-behavioral-owners.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","duplicate-coverage","source-ownership"]
 date: "2026-09-01"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -29,3 +30,7 @@ Run the narrow shell suites and confirm each deleted assertion had no distinct c
 
 - Whether the Pi package assertion in `smoke_test.sh` should be deleted as a duplicate or repaired as the deployment owner. The modifier tests prove the stdin-to-stdout transform; only the smoke test proves the packages reached the applied `~/.pi/agent/settings.json`, and `CLAUDE.md` reserves the smoke suite for exactly that deployed cross-component behavior. Deleting it therefore removes the only delivery evidence. The default is to keep the assertion and fix the drift, deriving the expected package set from the deployed settings' independent consumer rather than restating a hand-maintained list.
 - If implementation reveals an externally consumed module or package-membership contract not covered by the retained owners, stop and move that assertion under `2026-09-01-002` instead of deleting it.
+
+## Resolution
+
+Merged in PR #138. Test 269 keeps its sourceability, no-output, shell-state, redefinition and global-mutation checks and drops the module source-order, function-ownership and allowed-globals inventories copied from the implementation; the test was renamed to match what it now proves. The Pi package smoke assertion was repaired rather than deleted: it derives the expected set by running the modifier and requires the deployed settings to contain it, guarded against a vacuous pass on an empty set. Deliberate trade-off recorded in the PR: leaks of new module symbols are no longer detected, while redefinition and mutation of existing ones still are.

--- a/docs/issues/2026-09-01-004-exercise-pi-extensions-through-their-registered-consumer-boundaries.md
+++ b/docs/issues/2026-09-01-004-exercise-pi-extensions-through-their-registered-consumer-boundaries.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "agent-platform"
 tags: ["pi","semantic-testing","behavioral-coverage"]
 date: "2026-09-01"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Strengthen the existing tests rather than adding duplicate suites. Invoke before
 ## Open decisions
 
 Settled: private diagnostic status strings (`candidate`, `skipped-preferred-agents`, `skipped-broken-symlink`, `skipped-outside-project`, `skipped-too-large`, `skipped-not-file`, `skipped-unreadable`, etc.) are not a supported testing interface. A repo-wide search found no consumer of `LocalInstructionDiagnostic`/`selection.diagnostics` outside `home/dot_pi/agent/extensions/agents-local.ts` itself and its test file. The `selection.diagnostics.map(...).toEqual([...])` deep-equality inventories in `tests/pi-agents-local-extension.test.ts` were removed; the suite keeps assertions on which file was selected (`selection.selected?.name`) and on user-visible warning text (`selection.warnings`), now backed by direct `before_agent_start` prompt-content assertions using independent sentinels. If a real external consumer of the diagnostic-status vocabulary is added later, restore targeted status assertions at that boundary rather than reintroducing the full-array inventory.
+
+## Resolution
+
+Merged in PR #137. The returned systemPrompt is asserted against independent sentinels, extension-snapshot coverage is split into package.json-only, lock-file-only and unrelated-file controls, every updater subprocess is required to receive an injected timeout distinct from the production default, and the registered brew-auto-update-now handler is invoked through registerBrewAutoUpdater with its command sequence observed. Each closed path carries a mutation proof. Diagnostic-status inventories were removed after a repository search found no consumer of that vocabulary outside the extension and its own test.

--- a/docs/issues/2026-09-02-002-prove-ci-event-policy-and-post-apply-failure-propagation-independently.md
+++ b/docs/issues/2026-09-02-002-prove-ci-event-policy-and-post-apply-failure-propagation-independently.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","ci","source-ownership"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Pin the CI event policy independently of the workflow file, then compare the wor
 ## Open decisions
 
 Whether post-apply suite eligibility should be derived from file metadata, from a canonical manifest consumed by the runner, or from another independent rule.
+
+## Resolution
+
+Merged in PR #136. The CI event policy is pinned independently and compared against the workflow, including MMS_CI_MINIMAL's trigger condition, which had no coverage at all before. Post-apply suites are discovered on disk with set equality that fails in both directions, and failure propagation is exercised through the wrapper, each compose service command script under stubs, and the Makefile recipe. Review caught a false green in the discovery heuristic: a comment mentioning a suite filename hid an unwired suite, proven with a decoy. The remaining design concern about host-safe eligibility is recorded as 2026-09-02-008.

--- a/docs/issues/2026-09-02-003-give-onchange-hash-and-palette-fallback-tests-independent-fixtures.md
+++ b/docs/issues/2026-09-02-003-give-onchange-hash-and-palette-fallback-tests-independent-fixtures.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","command-palette","chezmoi"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Render the onchange template before and after mutating each declared dependency 
 ## Open decisions
 
 None.
+
+## Resolution
+
+Merged in PR #133. The onchange test now renders the template, mutates each declared dependency and requires the rendered hash to change, with an unrelated-file control proving it can tell changed from unchanged. The palette fallback-parser test reads a fixture the test writes itself instead of production commands.toml, and its malformed-shortcuts control is pinned to the shortcuts-specific rejection reason rather than any nonzero exit. Mutation-proved by dropping an include and by disabling array detection in parse_toml_value.

--- a/docs/issues/2026-09-02-004-assert-git-ignore-behavior-and-bats-checker-reachability-through-their-real-authorities.md
+++ b/docs/issues/2026-09-02-004-assert-git-ignore-behavior-and-bats-checker-reachability-through-their-real-authorities.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","source-ownership"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -28,3 +29,7 @@ Which sourced shell-helper classes the Bats assertion checker must cover; the im
 Widening the scan surfaced three real violations, all the same shape — a bare `[[ ]]` as the final statement of a boolean-predicate helper function, whose exit status is the function's return value and is consumed explicitly by every call site (`if is_macos; then`, `is_macos || skip ...`, `_hts_engine_pid_live ... || continue`): `tests/helpers/common.bash` (`is_macos`, `is_linux`) and `tests/helpers/herdr_task_sync.bash` (`_hts_engine_pid_live`). Fixed by appending `|| return 1` to each, matching the `[[ cond ]] || return N` idiom already used throughout these same files (e.g. `herdr_task_sync.bash:76`) and the vendored `tests/lib/bashunit`. No false positives were found in the widened scope.
 
 **Addendum (2026-09-02, from cross-model review):** `tests/bashunit/test-dsl.bash` must also be scanned. It is the shared bashunit ERR-trap DSL every `tests/bashunit/*_test.sh` suite sources, and its own header names this checker's exact target hazard as applying to itself (`docs/issues/2026-08-27-002-bare-mid-test-assertions-are-silently-inert-in-bats.md`). It matched neither existing `bashunit/` glob (no `_test.sh` suffix) nor the new `helpers/*.bash` glob (wrong directory), so the original widening left the single most widely-sourced file in `tests/` unreached. Added `tests_dir.rglob("bashunit/*.bash")` to `scanned_files()` and a matching reachability fixture. No violations exist in the file today.
+
+## Resolution
+
+Merged in PR #134. Ignore behavior is asserted through git check-ignore and git ls-files with controls in both directions plus a nonexistent-child probe, so a future directory-only rule cannot hide files while leaving the directory visible. The Bats assertion checker gained per-class reachability fixtures, and its scan was widened to tests/helpers/*.bash and tests/bashunit/*.bash, including test-dsl.bash, whose own header names the hazard the checker exists for. Three predicate helpers got an explicit '|| return 1' rather than teaching the checker an exemption that would blind it to a bare conditional at the end of a test body.

--- a/docs/issues/2026-09-02-005-decide-the-herdr-task-sync-glyph-contract-and-test-it-independently.md
+++ b/docs/issues/2026-09-02-005-decide-the-herdr-task-sync-glyph-contract-and-test-it-independently.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "testing-ci"
 tags: ["semantic-testing","herdr","source-ownership"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Establish which of the two the glyph set is, then act on it. If exact glyphs are
 ## Open decisions
 
 Settled: Herdr's exact `$git_ref` glyph set (`ICON_BRANCH`, `ICON_WORKTREE`, `ICON_COMMIT`, `ICON_FOLDER`, `ICON_STALE` in `home/dot_local/bin/executable_herdr-task-sync`) is stable user-facing policy, not replaceable presentation. Evidence: the glyphs render directly into the pane label a user reads (`home/dot_local/bin/executable_herdr-task-sync:1186-1195`); the engine's own "Environment overrides" comment block (lines 21-23) lists `HERDR_TASK_SYNC_PI_MODEL`, `HERDR_TASK_SYNC_CLAUDE_MODEL`, `HERDR_TASK_SYNC_TIMEOUT`, and `HERDR_TASK_SYNC_STATE_DIR` as the only overridable inputs — no `ICON_*` override exists, unlike `LABEL_SEPARATOR`, which does have one (`HERDR_TASK_SYNC_SEPARATOR`); and a repo-wide search of `home/private_dot_config/herdr/` found no config key, theme, or plugin that reads or sets these glyphs. `tests/helpers/herdr_task_sync.bash` now pins `HTS_ICON_*` as independent literals, the same treatment already given to `HTS_GIT_BEHIND`/`HTS_GIT_AHEAD`, and `hts_icon()` (the extraction that derived them from the engine) has been removed.
+
+## Resolution
+
+Merged in PR #140. The exact glyph set was confirmed to be user-facing policy: the engine offers an override for the label separator but none for ICON_*, and no herdr config key reads them. The test helper stopped sed-extracting glyphs from the engine it guards and pins them as independent literals, matching the treatment the git status symbols already had. Changing one codepoint in the engine now fails 19 assertions that previously could not fail. The solutions doc that documented the opposite pattern was updated with the discriminator instead of being left to mislead the next reader.


### PR DESCRIPTION
Closes out the tautological-test cleanup batch: the eight issues below all had their fixes merged already, so this only records that in `docs/issues/` — status flips to `done` and each gets a `## Resolution` section (via `python3 scripts/issues close`). No code changes.

The batch replaced tests that could not fail — assertions derived from the code under test, inventories copied straight from the implementation, checks that only proved a file exists or a word appears — with tests that exercise a named consumer and were each proved by mutation (red before the fix, green after).

## Closed

- `2026-09-01-002` (parent registry for the dependent-oracle audit) — #142
- `2026-09-01-003` (remove source-mirror assertions) — #138
- `2026-09-01-004` (Pi extensions through consumer boundaries) — #137
- `2026-08-21-022` (Pi brew auto-updater never surfaced failures) — #135
- `2026-09-02-002` (CI event policy and post-apply failure propagation) — #136
- `2026-09-02-003` (onchange hash and palette fallback fixtures) — #133
- `2026-09-02-004` (git-ignore behavior and Bats checker reachability) — #134
- `2026-09-02-005` (Herdr task-sync glyph contract) — #140

Each issue's own `## Resolution` section has the detail on what changed and how it was mutation-proved; see the individual files rather than this description.

## Left open on purpose

Five follow-ups from the same batch are not part of this PR:

- `2026-09-02-006` (palette `-j 8` flake)
- `2026-09-02-007` (Pi `ui.notify` no-op in headless mode)
- `2026-09-02-008` (host-safe suite eligibility inferred from marker text)
- `2026-09-02-009` (herdr-child barrier test flake)
- `2026-09-02-010` (degraded OpenCode review leg)

## Verification

`python3 scripts/issues validate` is clean, and `make test-issues` is green (49 tests, OK).
