### PR TITLE
fix(tests): make post-apply eligibility explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ test-local:
 # redundant defense behind that file's MMS_DISPOSABLE_HOME guard. The guard
 # makes direct host runs inert, but the exclusion keeps this host-safe target
 # from reaching the real apply commands at all. Use `make test-ubuntu` to run
-# the full five-file suite against a disposable $$HOME.
+# the full suite against a disposable $$HOME.
 #
-# Second, sharper limit: these four files assert against the deployed $$HOME,
+# Second, sharper limit: the host-safe files assert against the deployed $$HOME,
 # and this target deliberately applies nothing. So it reports on whatever was
 # last applied to this machine, NOT on the working checkout -- an edit under
 # home/ that has not been applied is invisible here, and the run still goes

--- a/docs/issues/2026-09-02-008-host-safe-suite-eligibility-is-inferred-from-marker-text-not-an-explicit-contract.md
+++ b/docs/issues/2026-09-02-008-host-safe-suite-eligibility-is-inferred-from-marker-text-not-an-explicit-contract.md
@@ -1,12 +1,13 @@
 ---
 title: "Host-safe suite eligibility is inferred from marker text, not an explicit contract"
-short_description: "tests/test_post_apply_suite_contract.py:49-54 excludes idempotent_test.sh from host-safe mode by grepping the file's text for MMS_DISPOSABLE_HOME and GITHUB_ACTIONS together, instead of the runner consuming a real eligibility declaration."
+short_description: "Each post-apply suite now declares ordered host eligibility in a leading machine-readable tag that tests/run-post-apply.sh consumes and validates at runtime; the contract test verifies the runner's observed partition."
 type: "follow-up"
 category: "testing-ci"
 tags: ["post-apply-suite","test-discovery","semantic-testing"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-02"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Design and implement an explicit eligibility declaration for tests/bashunit/*_te
 ## Open decisions
 
 Whether the eligibility declaration lives as a per-file comment convention (grep-friendly, no new file format) or a small YAML/JSON manifest (more structured, another file to keep in sync). Whether run-post-apply.sh should validate the declaration at runtime (fail loudly on a malformed or missing tag) or only the test suite enforces it statically.
+
+## Resolution
+
+Added ordered per-file post-apply eligibility declarations, made the runner discover and validate them for full and host-safe modes, and replaced marker-text inference with observed runner behavior plus malformed-declaration coverage. Verified with make test-issues, make lint, and make test-suite.

--- a/tests/bashunit/bashunit_late_output_probe_test.sh
+++ b/tests/bashunit/bashunit_late_output_probe_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: excluded
 # Dedicated one-test fixture for the local bashunit patch "payload-marker
 # result parsing" (docs/issues/2026-08-29-003-pinned-bashunit-carries-a-local-
 # patch-payload-marker-result-parsing): a test's background child that

--- a/tests/bashunit/herdr_child_descriptor_probe_test.sh
+++ b/tests/bashunit/herdr_child_descriptor_probe_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: excluded
 # Dedicated one-test file for the herdr-child descriptor probe: proves a
 # detached launch closes the launcher's inherited descriptors and owns its
 # process group, so a watcher can never hold a test runner's pipes open.

--- a/tests/bashunit/herdr_task_sync_descriptor_probe_test.sh
+++ b/tests/bashunit/herdr_task_sync_descriptor_probe_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: excluded
 # Dedicated one-test file for the herdr-task-sync descriptor probe. The
 # bounded-invocation driver in scripts_test.sh runs it under a nested
 # tests/lib/bashunit so the guard covers setup plus the probe itself rather

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 60 needs-disposable-home
 # bashunit: no-parallel-tests
 # idempotent post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.

--- a/tests/bashunit/oracle_guard_test.sh
+++ b/tests/bashunit/oracle_guard_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 50 host-safe
 # test-oracle-guard suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 #

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 30 host-safe
 # palette post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 # Migrated from palette.bats; parity evidence: docs/benchmarks/bashunit-full-suite-experiment.md.

--- a/tests/bashunit/platform_test.sh
+++ b/tests/bashunit/platform_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 40 host-safe
 # platform post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 # Migrated from platform.bats; parity evidence: docs/benchmarks/bashunit-full-suite-experiment.md.
@@ -48,4 +49,3 @@ function set_up_before_script() {
 function tear_down_after_script() {
   _bats_file_cleanup
 }
-

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 20 host-safe
 # scripts post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 # Migrated from scripts.bats; parity evidence: docs/benchmarks/bashunit-full-suite-experiment.md.

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: 10 host-safe
 # smoke post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 # Migrated from smoke.bats; parity evidence: docs/benchmarks/bashunit-full-suite-experiment.md.

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# post-apply: excluded
 # templates post-apply suite — bashunit source. Vocabulary (run, assert_*,
 # skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
 # Migrated from templates.bats; parity evidence: docs/benchmarks/bashunit-full-suite-experiment.md.

--- a/tests/run-post-apply.sh
+++ b/tests/run-post-apply.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Post-apply suite runner. tests/bashunit/*_test.sh are the source of truth,
-# written against tests/bashunit/test-dsl.bash, executed with the pinned
-# bashunit at tests/lib/bashunit — measured at ~24% less wall-clock than the
-# previous bats runner with per-scenario behavioral parity (403/403 on macOS
-# and Ubuntu). Evidence: docs/benchmarks/bashunit-full-suite-experiment.md.
+# Post-apply suite runner. Leading '# post-apply:' declarations select the
+# tests/bashunit/*_test.sh files, which are written against
+# tests/bashunit/test-dsl.bash and executed with the pinned bashunit at
+# tests/lib/bashunit — measured at ~24% less wall-clock than the previous bats
+# runner with per-scenario behavioral parity (403/403 on macOS and Ubuntu).
+# Evidence: docs/benchmarks/bashunit-full-suite-experiment.md.
 #
 # Execution shape: files run sequentially, tests within a file run with up to
 # $MMS_BASHUNIT_JOBS workers (idempotent serializes itself via its
@@ -16,7 +17,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 JOBS="${MMS_BASHUNIT_JOBS:-8}"
-GEN="$ROOT/tests/bashunit"
+# Overridable so the suite contract test can exercise invalid declarations.
+GEN="${MMS_BASHUNIT_SUITE_DIR:-$ROOT/tests/bashunit}"
 # Overridable so the suite contract test can substitute a recording stub.
 BASHUNIT_BIN="${MMS_BASHUNIT_BIN:-$ROOT/tests/lib/bashunit}"
 
@@ -30,10 +32,79 @@ USAGE
 }
 
 case "${1:-}" in
-  full)      files="smoke scripts palette platform oracle_guard idempotent" ;;
-  host-safe) files="smoke scripts palette platform oracle_guard" ;;
+  full|host-safe) mode="$1" ;;
   *) usage; exit 2 ;;
 esac
+
+suite_declaration() {
+  local file="$1" line payload order eligibility extra declaration=""
+  while IFS= read -r line; do
+    case "$line" in
+      '# post-apply:'*)
+        [ -z "$declaration" ] || {
+          echo "duplicate post-apply declaration: $file" >&2
+          return 1
+        }
+        payload="${line#\# post-apply: }"
+        if [ "$payload" = excluded ]; then
+          declaration=excluded
+          continue
+        fi
+        read -r order eligibility extra <<EOF
+$payload
+EOF
+        [[ "$order" =~ ^[1-9][0-9]*$ ]] || {
+          echo "invalid post-apply declaration: $file" >&2
+          return 1
+        }
+        case "$eligibility" in
+          host-safe|needs-disposable-home) ;;
+          *) echo "invalid post-apply declaration: $file" >&2; return 1 ;;
+        esac
+        [ -z "${extra:-}" ] && [ "$line" = "# post-apply: $order $eligibility" ] || {
+          echo "invalid post-apply declaration: $file" >&2
+          return 1
+        }
+        declaration="$order $eligibility"
+        ;;
+      '#!'*|'#'*|'') ;;
+      *) break ;;
+    esac
+  done < "$file"
+  [ -n "$declaration" ] || {
+    echo "missing post-apply declaration: $file" >&2
+    return 1
+  }
+  printf '%s\n' "$declaration"
+}
+
+declarations=""
+for file in "$GEN"/*_test.sh; do
+  [ -e "$file" ] || continue
+  declaration="$(suite_declaration "$file")" || exit $?
+  [ "$declaration" != excluded ] || continue
+  declarations="${declarations}${declaration} ${file##*/}
+"
+done
+[ -n "$declarations" ] || {
+  echo "no declared post-apply suites found in $GEN" >&2
+  exit 1
+}
+
+files=""
+previous_order=""
+while read -r order eligibility name; do
+  [ -z "$previous_order" ] || [ "$order" != "$previous_order" ] || {
+    echo "duplicate post-apply order: $order" >&2
+    exit 1
+  }
+  previous_order="$order"
+  if [ "$mode" = full ] || [ "$eligibility" = host-safe ]; then
+    files="$files ${name%_test.sh}"
+  fi
+done <<EOF
+$(printf '%s' "$declarations" | sort -n -k1,1)
+EOF
 
 rc=0
 for base in $files; do

--- a/tests/test_post_apply_suite_contract.py
+++ b/tests/test_post_apply_suite_contract.py
@@ -12,6 +12,10 @@ WORKFLOW = REPOSITORY / ".github" / "workflows" / "test-dotfiles.yml"
 COMPOSE = REPOSITORY / "docker" / "docker-compose.yml"
 RUNNER = REPOSITORY / "tests" / "run-post-apply.sh"
 GENERATED = REPOSITORY / "tests" / "bashunit"
+POST_APPLY_DECLARATION = re.compile(
+    r"^# post-apply: (?P<order>[1-9][0-9]*) "
+    r"(?P<eligibility>host-safe|needs-disposable-home)$"
+)
 
 
 class TestPostApplySuiteContract(unittest.TestCase):
@@ -39,27 +43,9 @@ class TestPostApplySuiteContract(unittest.TestCase):
         suite_files = self.discovered_suite_files()
         self.assertTrue(suite_files, "no post-apply suite files discovered on disk")
 
-        # idempotent_test.sh is the only discovered file whose own hard-fail
-        # guard reads both markers together (lines ~178-179): it refuses to
-        # run for real unless MMS_DISPOSABLE_HOME=1 *and* it can tell this is
-        # a real CI/container environment via GITHUB_ACTIONS. scripts_test.sh
-        # also mentions MMS_DISPOSABLE_HOME (it parameterizes an unrelated
-        # script under test), but never GITHUB_ACTIONS, so the AND of both
-        # markers isolates the file this wrapper must keep host-unsafe
-        # without naming it.
-        guarded = [
-            f
-            for f in suite_files
-            if "MMS_DISPOSABLE_HOME" in f.read_text(encoding="utf-8")
-            and "GITHUB_ACTIONS" in f.read_text(encoding="utf-8")
-        ]
-        self.assertEqual(
-            len(guarded),
-            1,
-            "exactly one discovered suite file should carry the disposable-home "
-            "hard-fail guard, found: %s" % [f.name for f in guarded],
-        )
-        guarded_path = str(guarded[0])
+        declarations = {f: self.post_apply_declaration(f) for f in suite_files}
+        orders = [order for order, _ in declarations.values()]
+        self.assertEqual(len(orders), len(set(orders)), "post-apply order values must be unique")
 
         full_invocations = self.wrapper_invocations("full")
         host_safe_invocations = self.wrapper_invocations("host-safe")
@@ -70,31 +56,92 @@ class TestPostApplySuiteContract(unittest.TestCase):
         host_safe_files = [argv[-1] for argv in host_safe_invocations]
 
         self.assertEqual(
-            set(full_files),
-            {str(f) for f in suite_files},
-            "full mode must run every suite file discovered on disk -- a new "
-            "tests/bashunit/*_test.sh file must be wired into the runner or "
-            "this fails",
+            full_files,
+            [str(f) for f in sorted(suite_files, key=lambda f: declarations[f][0])],
+            "full mode must run every discovered suite once in declared order -- "
+            "a new tests/bashunit/*_test.sh file must be explicitly classified",
         )
         self.assertEqual(
             len(full_files),
             len(set(full_files)),
             "full mode must not run any suite file twice",
         )
-        self.assertNotIn(
-            guarded_path,
-            host_safe_files,
-            "host-safe mode must exclude the disposable-home-guarded suite",
-        )
-        # host-safe's file set is checked against full's *observed* order
-        # (not a hardcoded list) so this only asserts the partition
-        # relationship, not an order copied from the runner's source.
         self.assertEqual(
             host_safe_files,
-            [f for f in full_files if f != guarded_path],
-            "host-safe mode must run exactly the full-mode set minus the "
-            "guarded suite, in the same relative order",
+            [
+                f
+                for f in full_files
+                if declarations[Path(f)][1] == "host-safe"
+            ],
+            "host-safe mode must follow the eligibility declarations consumed "
+            "by the runner, in full-mode order",
         )
+
+    def test_runner_rejects_a_malformed_post_apply_declaration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            (temp_path / "valid_test.sh").write_text(
+                "#!/usr/bin/env bash\n# post-apply: 10 host-safe\n",
+                encoding="utf-8",
+            )
+            fake_bashunit = temp_path / "bashunit"
+            fake_bashunit.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_bashunit.chmod(0o755)
+            env = os.environ.copy()
+            env["MMS_BASHUNIT_BIN"] = str(fake_bashunit)
+            env["MMS_BASHUNIT_SUITE_DIR"] = str(temp_path)
+
+            control = subprocess.run(
+                [str(RUNNER), "full"],
+                cwd=REPOSITORY,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            (temp_path / "broken_test.sh").write_text(
+                "#!/usr/bin/env bash\n# post-apply: 20a host-safe\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [str(RUNNER), "full"],
+                cwd=REPOSITORY,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(control.returncode, 0, control.stderr)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("invalid post-apply declaration", completed.stderr)
+
+    def test_runner_rejects_a_missing_post_apply_declaration(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            (temp_path / "valid_test.sh").write_text(
+                "#!/usr/bin/env bash\n# post-apply: 10 host-safe\n",
+                encoding="utf-8",
+            )
+            (temp_path / "missing_test.sh").write_text(
+                "#!/usr/bin/env bash\n# no eligibility declaration\n",
+                encoding="utf-8",
+            )
+            fake_bashunit = temp_path / "bashunit"
+            fake_bashunit.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            fake_bashunit.chmod(0o755)
+            env = os.environ.copy()
+            env["MMS_BASHUNIT_BIN"] = str(fake_bashunit)
+            env["MMS_BASHUNIT_SUITE_DIR"] = str(temp_path)
+
+            completed = subprocess.run(
+                [str(RUNNER), "full"],
+                cwd=REPOSITORY,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("missing post-apply declaration", completed.stderr)
 
     def discovered_suite_files(self):
         """Suite files this wrapper is responsible for driving, found on disk
@@ -112,6 +159,27 @@ class TestPostApplySuiteContract(unittest.TestCase):
             if not self.wired_outside_the_wrapper(f.name, outside_sources)
             and not self.nested_inside_a_sibling(f.name, texts)
         ]
+
+    def post_apply_declaration(self, path):
+        declarations = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("# post-apply:"):
+                declarations.append(POST_APPLY_DECLARATION.fullmatch(line))
+            elif line and not line.startswith("#"):
+                break
+        self.assertEqual(
+            len(declarations),
+            1,
+            f"{path.name} must have exactly one post-apply declaration",
+        )
+        self.assertIsNotNone(
+            declarations[0],
+            f"{path.name} has an invalid post-apply declaration",
+        )
+        return (
+            int(declarations[0].group("order")),
+            declarations[0].group("eligibility"),
+        )
 
     def wired_outside_the_wrapper(self, name, outside_sources):
         """templates_test.sh is the case in point: the Makefile, workflow,


### PR DESCRIPTION
## Summary

Host-safe post-apply runs now select suites from validated per-file declarations instead of inferring safety from unrelated marker text. The runner fails closed when a suite omits or malforms its declaration, while preserving execution order and keeping disposable-home tests out of workstation runs.

## Validation

- `make test-issues` (51 tests)
- `make lint`
- `make test-suite`
- Repeated the original regression probe: adding `GITHUB_ACTIONS` to an unrelated comment no longer changes suite eligibility

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
