### PR TITLE
fix(ci): cap macOS post-apply workers at the runner's core count

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -297,7 +297,22 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
 
+      # This runner has 3 cores, so the suite's default of 8 workers
+      # oversubscribes it nearly 3:1. The herdr-task-sync tests bound their
+      # waits in wall clock -- a claim gives up after ~200 ms, a git probe
+      # after its budget, the fail-open guard after a scaled baseline -- and
+      # under that oversubscription those bounds lose to the scheduler rather
+      # than to behavior, so the worktree-identity tests failed here on every
+      # run while Ubuntu passed. Raising the individual bounds does not fix it
+      # and trades one failure for another: a claim ceiling large enough to
+      # survive 8 workers makes the engine spin 8.4 s where the fail-open
+      # guard allows 8.1, so the promptness tests fail instead. Measured on
+      # macos-latest against the full post-apply suite: 8 workers 6 failures,
+      # 6 workers 3 failures, 4 workers 0 failures in 422 s -- faster than the
+      # 8-worker run it replaces. Ubuntu keeps the default; it passes there.
       - name: Run post-apply tests
+        env:
+          MMS_BASHUNIT_JOBS: "4"
         run: tests/run-post-apply.sh full
 
       # Save-only keeps scheduled and manual full-Brewfile runs useful as cache

--- a/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
+++ b/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
@@ -1,6 +1,6 @@
 ---
 title: "herdr-task-sync gives up on worktree identity after a 200 ms claim bound, silently"
-short_description: "acquire_claim retries INBOX_LOCK_ATTEMPTS=20 times at 10 ms, so a contended claim is abandoned after ~200 ms, and every caller in apply_worktree_identity converts that into a bare return 0 that leaves no trace."
+short_description: "acquire_claim retries INBOX_LOCK_ATTEMPTS=20 times at 10 ms, so a contended claim is abandoned after ~200 ms and every caller in apply_worktree_identity converts that into a bare return 0 that leaves no trace; simply raising the count breaks the engine fail-open promptness guarantee instead."
 type: "bug"
 category: "herdr"
 tags: ["herdr-task-sync","worktree-identity","observability"]
@@ -11,12 +11,14 @@ priority: "medium"
 
 ## Why this exists
 
-On a loaded machine herdr-task-sync can silently skip naming a generated worktree. home/dot_local/bin/executable_herdr-task-sync:130 sets INBOX_LOCK_ATTEMPTS=20 and acquire_claim (:354) sleeps 0.01 between attempts, so acquiring a claim is abandoned after roughly 200 ms of wall clock. A single agent session drives several engine processes -- the event, the naming worker, the presentation coordinator -- that contend for the same identity and repository claims, so the bound is reachable in normal use, not only under artificial load. Every caller then turns the failure into a silent return 0 (:1922, :2316, :2364, :2485), so the branch is not renamed, no record is written, and nothing is logged. This was measured on the GitHub macOS runner: with the shipped bound the full scripts suite at --jobs 8 failed six worktree-identity tests on every run, and raising only HERDR_TASK_SYNC_LOCK_ATTEMPTS made all six pass. The test harness now raises the ceiling for its own runs, which fixes CI but leaves the shipped bound and the silent failure untouched.
+On a loaded machine herdr-task-sync can silently skip naming a generated worktree. home/dot_local/bin/executable_herdr-task-sync:130 sets INBOX_LOCK_ATTEMPTS=20 and acquire_claim (:354) sleeps 0.01 between attempts, so acquiring a claim is abandoned after roughly 200 ms of wall clock. A single agent session drives several engine processes -- the event, the naming worker, the presentation coordinator -- that contend for the same identity and repository claims, so the bound is reachable in normal use, not only under artificial load. Every caller then turns the failure into a silent return 0 (:1922, :2316, :2364, :2485), so the branch is not renamed, no record is written, and nothing is logged. This surfaced on the GitHub macOS runner (3 cores), where the post-apply suite ran 8 workers: the worktree-identity tests failed on every run because the claim bound lost to the scheduler. That CI symptom is fixed by matching the worker count to the runner instead, so the shipped bound and the silent failure are untouched and still reachable on a loaded developer machine.
+
+Raising the bound is NOT the remedy, and the measurement says why. A harness ceiling of 2000 attempts (~20 s) was tried first: at 8 workers it fixed two of the six tests, broke a fail-open promptness test, and left five failing; at 4 workers it still failed one, with the engine reporting `elapsed_ms=8395 allowed_ms=8136` -- it spun in the retry loop for 8.4 s where the fail-open guard allows 8.1. So a claim ceiling large enough to survive contention violates the promptness guarantee the engine is separately required to keep. Any fix here has to reconcile those two obligations rather than trade one for the other.
 
 ## Scope
 
-Decide and implement a production-appropriate claim bound for the herdr-task-sync engine, and make an exhausted claim observable rather than silent. Covers home/dot_local/bin/executable_herdr-task-sync only; the test harness default in tests/helpers/herdr_task_sync.bash is already handled.
+Decide and implement a production-appropriate claim bound for the herdr-task-sync engine, and make an exhausted claim observable rather than silent. Covers home/dot_local/bin/executable_herdr-task-sync only. The CI failure that exposed it is fixed separately by capping the macOS post-apply worker count, and the test harness carries no compensating override.
 
 ## Open decisions
 
-Whether the fix is a larger attempt count, an escalating backoff, or a wall-clock deadline separate from the attempt count. Whether an exhausted claim should emit a diagnostic line and, if so, on which channel given the engine must stay silent outside herdr. Whether apply_worktree_identity should distinguish give-up from not-applicable, since return 0 currently means both.
+Whether the fix is an escalating backoff, a wall-clock deadline separate from the attempt count, or a bound that yields to the caller instead of spinning -- a larger attempt count alone is ruled out by the measurement above. Whether an exhausted claim should emit a diagnostic line and, if so, on which channel given the engine must stay silent outside herdr. Whether apply_worktree_identity should distinguish give-up from not-applicable, since return 0 currently means both.

--- a/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
+++ b/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-task-sync gives up on worktree identity after a 200 ms claim bound, silently"
+short_description: "acquire_claim retries INBOX_LOCK_ATTEMPTS=20 times at 10 ms, so a contended claim is abandoned after ~200 ms, and every caller in apply_worktree_identity converts that into a bare return 0 that leaves no trace."
+type: "bug"
+category: "herdr"
+tags: ["herdr-task-sync","worktree-identity","observability"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+On a loaded machine herdr-task-sync can silently skip naming a generated worktree. home/dot_local/bin/executable_herdr-task-sync:130 sets INBOX_LOCK_ATTEMPTS=20 and acquire_claim (:354) sleeps 0.01 between attempts, so acquiring a claim is abandoned after roughly 200 ms of wall clock. A single agent session drives several engine processes -- the event, the naming worker, the presentation coordinator -- that contend for the same identity and repository claims, so the bound is reachable in normal use, not only under artificial load. Every caller then turns the failure into a silent return 0 (:1922, :2316, :2364, :2485), so the branch is not renamed, no record is written, and nothing is logged. This was measured on the GitHub macOS runner: with the shipped bound the full scripts suite at --jobs 8 failed six worktree-identity tests on every run, and raising only HERDR_TASK_SYNC_LOCK_ATTEMPTS made all six pass. The test harness now raises the ceiling for its own runs, which fixes CI but leaves the shipped bound and the silent failure untouched.
+
+## Scope
+
+Decide and implement a production-appropriate claim bound for the herdr-task-sync engine, and make an exhausted claim observable rather than silent. Covers home/dot_local/bin/executable_herdr-task-sync only; the test harness default in tests/helpers/herdr_task_sync.bash is already handled.
+
+## Open decisions
+
+Whether the fix is a larger attempt count, an escalating backoff, or a wall-clock deadline separate from the attempt count. Whether an exhausted claim should emit a diagnostic line and, if so, on which channel given the engine must stay silent outside herdr. Whether apply_worktree_identity should distinguish give-up from not-applicable, since return 0 currently means both.

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -622,7 +622,7 @@ hts_run_for_socket() {
     HERDR_TASK_SYNC_TEST_NO_WORKER="${HERDR_TASK_SYNC_TEST_NO_WORKER:-}" \
     HERDR_TASK_SYNC_TEST_NO_PRESENTATION="${HERDR_TASK_SYNC_TEST_NO_PRESENTATION:-}" \
     HERDR_TASK_SYNC_TEST_NOW_SEQ="${HERDR_TASK_SYNC_TEST_NOW_SEQ:-}" \
-    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-}" \
+    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-$HTS_LOCK_ATTEMPTS}" \
     bash "$HTS_ENGINE" "$@"
 }
 
@@ -638,7 +638,7 @@ hts_worker_run() {
     HERDR_TASK_SYNC_TEST_BRANCH_BARRIER_RELEASE="${HERDR_TASK_SYNC_TEST_BRANCH_BARRIER_RELEASE:-}" \
     HERDR_TASK_SYNC_TEST_NO_PRESENTATION="${HERDR_TASK_SYNC_TEST_NO_PRESENTATION:-}" \
     HERDR_TASK_SYNC_TEST_NOW_SEQ="${HERDR_TASK_SYNC_TEST_NOW_SEQ:-}" \
-    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-}" \
+    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-$HTS_LOCK_ATTEMPTS}" \
     bash "$HTS_ENGINE" --worker --pane pane-1
 }
 
@@ -783,6 +783,22 @@ HTS_WORKTREE_GIT_BUDGET="${HTS_WORKTREE_GIT_BUDGET:-10}"
 # generous here: a stub probe under --jobs load must not lose the race and
 # flake every counts assertion. A test that wants a timeout sets it low.
 HTS_STATUS_BUDGET="${HTS_STATUS_BUDGET:-2}"
+# The engine's own claim bound (INBOX_LOCK_ATTEMPTS, default 20) retries every
+# 10 ms, so it gives up after ~200 ms. That is a wall-clock bound on acquiring
+# a claim, and a single test drives several engine processes -- the event, the
+# naming worker, the presentation coordinator -- that contend for the same
+# identity and repository claims. Under the full suite at --jobs 8 on a CI
+# runner with fewer cores than workers, 200 ms is not enough: acquire_claim
+# fails, and every caller in apply_worktree_identity turns that into a silent
+# `return 0`, so the branch is never renamed and the mutation tests time out
+# against their 60 s wait ceiling. This is machine speed, not behavior, so the
+# harness raises the ceiling rather than letting scheduler contention decide.
+# 2000 attempts is ~20 s, still inside HTS_WAIT_CEILING_SECONDS, and it is a
+# ceiling reached only under contention -- an uncontended claim returns on the
+# first attempt, so the uncontended suite pays nothing for it. The three tests
+# that assert contention behavior pin HERDR_TASK_SYNC_LOCK_ATTEMPTS=1
+# themselves and keep it.
+HTS_LOCK_ATTEMPTS="${HTS_LOCK_ATTEMPTS:-2000}"
 
 # Behavioral budget for the "fails open promptly rather than hanging" assertions.
 # The helper below scales a same-run process-launch baseline before enforcing this,

--- a/tests/helpers/herdr_task_sync.bash
+++ b/tests/helpers/herdr_task_sync.bash
@@ -622,7 +622,7 @@ hts_run_for_socket() {
     HERDR_TASK_SYNC_TEST_NO_WORKER="${HERDR_TASK_SYNC_TEST_NO_WORKER:-}" \
     HERDR_TASK_SYNC_TEST_NO_PRESENTATION="${HERDR_TASK_SYNC_TEST_NO_PRESENTATION:-}" \
     HERDR_TASK_SYNC_TEST_NOW_SEQ="${HERDR_TASK_SYNC_TEST_NOW_SEQ:-}" \
-    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-$HTS_LOCK_ATTEMPTS}" \
+    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-}" \
     bash "$HTS_ENGINE" "$@"
 }
 
@@ -638,7 +638,7 @@ hts_worker_run() {
     HERDR_TASK_SYNC_TEST_BRANCH_BARRIER_RELEASE="${HERDR_TASK_SYNC_TEST_BRANCH_BARRIER_RELEASE:-}" \
     HERDR_TASK_SYNC_TEST_NO_PRESENTATION="${HERDR_TASK_SYNC_TEST_NO_PRESENTATION:-}" \
     HERDR_TASK_SYNC_TEST_NOW_SEQ="${HERDR_TASK_SYNC_TEST_NOW_SEQ:-}" \
-    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-$HTS_LOCK_ATTEMPTS}" \
+    HERDR_TASK_SYNC_LOCK_ATTEMPTS="${HERDR_TASK_SYNC_LOCK_ATTEMPTS:-}" \
     bash "$HTS_ENGINE" --worker --pane pane-1
 }
 
@@ -783,22 +783,6 @@ HTS_WORKTREE_GIT_BUDGET="${HTS_WORKTREE_GIT_BUDGET:-10}"
 # generous here: a stub probe under --jobs load must not lose the race and
 # flake every counts assertion. A test that wants a timeout sets it low.
 HTS_STATUS_BUDGET="${HTS_STATUS_BUDGET:-2}"
-# The engine's own claim bound (INBOX_LOCK_ATTEMPTS, default 20) retries every
-# 10 ms, so it gives up after ~200 ms. That is a wall-clock bound on acquiring
-# a claim, and a single test drives several engine processes -- the event, the
-# naming worker, the presentation coordinator -- that contend for the same
-# identity and repository claims. Under the full suite at --jobs 8 on a CI
-# runner with fewer cores than workers, 200 ms is not enough: acquire_claim
-# fails, and every caller in apply_worktree_identity turns that into a silent
-# `return 0`, so the branch is never renamed and the mutation tests time out
-# against their 60 s wait ceiling. This is machine speed, not behavior, so the
-# harness raises the ceiling rather than letting scheduler contention decide.
-# 2000 attempts is ~20 s, still inside HTS_WAIT_CEILING_SECONDS, and it is a
-# ceiling reached only under contention -- an uncontended claim returns on the
-# first attempt, so the uncontended suite pays nothing for it. The three tests
-# that assert contention behavior pin HERDR_TASK_SYNC_LOCK_ATTEMPTS=1
-# themselves and keep it.
-HTS_LOCK_ATTEMPTS="${HTS_LOCK_ATTEMPTS:-2000}"
 
 # Behavioral budget for the "fails open promptly rather than hanging" assertions.
 # The helper below scales a same-run process-launch baseline before enforcing this,


### PR DESCRIPTION
## Summary

The macOS CI job is green again. After "feat(herdr): keep generated worktree identity stable" (#141) landed, six `herdr-task-sync` worktree-identity tests failed on every macOS run while Ubuntu and lint passed — because that runner has 3 cores and the post-apply suite ran 8 workers, so the tests' wall-clock waits were losing to the scheduler rather than to behavior.

The `herdr-task-sync` tests bound themselves in wall clock at several points: a claim gives up after ~200 ms, a git probe after its budget, the fail-open guard after a scaled baseline. Oversubscribing the runner nearly 3:1 pushes past those bounds, `acquire_claim` fails, and each caller in `apply_worktree_identity` turns the failure into a bare `return 0` — so the branch is never renamed and the test waits out its 60 s ceiling with nothing to show. The two sibling tests that assert *no* mutation kept passing, because a silent no-op satisfies them. That asymmetry is what made this look like a defect in the feature.

### Why the bounds were not the thing to raise

Three attempts tuned individual bounds and none worked: two earlier commits raised the worktree git budget, and the first commit on this branch raised the harness claim ceiling to 2000 attempts (~20 s). That third attempt is reverted here, because measuring it showed the approach is self-defeating — at 8 workers it fixed two of the six tests and broke a fail-open promptness test; at 4 workers it still failed one, with the engine reporting `elapsed_ms=8395 allowed_ms=8136`. It spun in the retry loop for 8.4 s where the fail-open guard allows 8.1. A claim ceiling large enough to survive the contention violates the promptness guarantee the engine has to keep separately.

Capping the worker count removes the contention instead, so every bound is measured against the behavior it was written for.

### Measurements

Full post-apply suite on `macos-latest` (3 cores), one variable per run:

| Workers | Harness claim ceiling | Failures | Elapsed |
|---|---|---|---|
| 8 | shipped | 6 | ~11m24s |
| 6 | shipped | 3 | 549 s |
| 6 | raised | 2 | 529 s |
| 4 | raised | 1 | 545 s |
| **4** | **shipped** | **0** | **422 s** |

The chosen configuration is also faster than the 8-worker run it replaces, because oversubscription was costing more than it bought. Ubuntu keeps the default of 8 and passes.

### Deliberately not fixed here

The shipped 200 ms claim bound and its silent give-up are real on a loaded developer machine, not only in CI: `herdr-task-sync` can skip naming a generated worktree and leave no trace of having tried. They are recorded in `docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md` (committed here), including the measurement above showing that raising the attempt count is not an available remedy. This PR changes no shipped engine behavior.

Related: #141

### Verification

`make test-issues` passed (51 tests). The configuration in this PR was measured directly on a `macos-latest` runner against the full post-apply suite — the 4-worker/shipped-bounds row above — and this PR's own `test-macos` job re-runs it on the real workflow. `make lint` fails on `origin/main` too and flags nothing in the changed files, so it is pre-existing.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
