### PR TITLE
fix(agents): gate every test-writing path on a declared oracle line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Adding a managed config, step by step:
 1. Check `home/.chezmoiexternal.toml` — skills and configs managed there (e.g., `linear-cli`, `improve-claude-md`) must NOT be duplicated in `home/`, or chezmoi reports "inconsistent state".
 2. `chezmoi add ~/.config/tool` — creates the source file in `home/`.
 3. Add a `.tmpl` suffix if the file needs OS branching or secrets; OS-specific files also need a rule in `home/.chezmoiignore`.
-4. Add or extend the narrowest test that proves deployment behavior; use `tests/bashunit/smoke_test.sh` only for cross-component coverage.
+4. Coverage passes the test-oracle gate first: state the oracle line (consumer, observable failure, oracle independent of this change) — when it cannot be completed, zero new tests is the correct outcome. When it can, extend the narrowest test that proves deployment behavior; use `tests/bashunit/smoke_test.sh` only for cross-component coverage.
 5. Verify: `make test-local` (diff only), then `make test-ubuntu`.
 
 `modify_` scripts (e.g., `modify_dot_claude.json`) read the existing file from stdin and output a modified version — don't treat them as regular templates.

--- a/docs/issues/2026-09-02-011-test-oracle-guard-misses-positive-tautological-tests.md
+++ b/docs/issues/2026-09-02-011-test-oracle-guard-misses-positive-tautological-tests.md
@@ -1,0 +1,22 @@
+---
+title: "test-oracle-guard misses positive tautological tests"
+short_description: "The shared guard engine denies only negative-assertion patterns, so the 2026-09-02 ghostty-shortcuts incident's positive tests with expected values from the same patch passed all three client hooks silently; extending it needs a low-false-positive signal such as requiring an oracle: comment on new test functions."
+type: "follow-up"
+category: "testing-ci"
+tags: ["test-oracle","hooks"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The shared engine `home/dot_local/bin/executable_test-oracle-guard` fires only on negative-assertion patterns (`assert_not_contains`, `refute_match`, `! grep`, ...). In the 2026-09-02 ghostty-workspace-shortcuts session, an agent added two positive tests to `tests/bashunit/palette_test.sh` whose expected values (new command-kind names) came from the same patch that introduced them — the textbook tautology the CLAUDE.md gate forbids — and all three client hooks (Claude Code, OpenCode, Pi) stayed silent because no negative pattern was present. Prose alone did not stop it; the enforcement layer has a structural blind spot.
+
+## Scope
+
+Extend the engine with a low-false-positive signal for positive tautologies, or explicitly decide the class stays prose-only. Candidate mechanism: require an `oracle:` comment within N lines above every *new* test function in a proposed edit (the existing escape-hatch convention, applied at function granularity instead of only on flagged negative lines). Weigh blast radius per `docs/solutions/design-patterns/gate-bias-follows-blast-radius.md` — this would touch every new test in every repo across all three clients. Update the three thin adapters only if the engine's stdin/argv contract changes.
+
+## Open decisions
+
+Whether requiring `oracle:` on every new test function is acceptable friction, or whether the requirement should apply only to test files touched in the same session as non-test files (needs session state the stateless hook does not have today).

--- a/home/private_dot_agents/skills/se-code-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-code-review/SKILL.md
@@ -48,7 +48,9 @@ When the `testing` persona is selected, append this criterion to its prompt:
 source, prompt, config, or fixture text and would stay green while the intended
 behavior is broken. Require behavioral replacement or removal. Exact-text
 assertions are valid only when they exercise an externally consumed literal
-contract."
+contract. A finding that requests new coverage must name the consumer and the
+observable failure the missing test would catch; report it as advisory when it
+cannot name both."
 
 Run the complete reviewer selection, persona dispatch, validation, merge, and
 JSON output flow. Return the final raw JSON report.
@@ -98,6 +100,7 @@ In default mode, the parent is the only apply owner. Mirror `ce-code-review` Sta
 - Judge consensus and unique findings on their merits. A unique source is not a deny condition.
 - Treat `autofix_class` as routing signal, not apply permission. Do not mechanically apply every `gated_auto` finding.
 - Do not apply contradictions, design decisions, taste calls, advisory findings, or findings the parent determines are wrong.
+- A finding that asks for a new test passes the test-oracle gate before apply: state the oracle line (consumer, observable failure, oracle independent of the reviewed diff). When the line cannot be completed, keep the finding advisory and report the reason instead of writing the test.
 - Apply only when the current working tree is the tree that both peers reviewed.
 - Run targeted tests and lint after each coherent fix group. Broaden checks when the change touches shared behavior.
 - Revert a fix that makes verification fail; never leave the tree red.

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -57,12 +57,19 @@ Every skill's own description already carries its triggers. These four lines res
 
 </important>
 
-<important if="you are adding or reviewing tests">
+<important if="you are adding or reviewing tests, or a skill, plan, or workflow step tells you to write tests">
 
-- **Tautological tests considered harmful: require an independent oracle.** Name the consumer and observable failure. A useful test fails when the protected behavior breaks and stays green through harmless source refactors.
+- **Declare the oracle before the first test edit.** Before the first Edit/Write to any test file, write one line in your visible response naming the consumer, the observable failure, and an oracle independent of the files this patch changes. If you cannot complete the line, write zero new tests and say so. A useful test fails when the protected behavior breaks and stays green through harmless source refactors.
+- **This gate outranks every skill's step list.** A "write failing tests first" step in ce-debug, ce-work, or any other workflow does not waive it: a red test proves nothing when its expected value comes from the same patch or inspects source shape. Without the oracle line, the correct output of that step is zero tests.
 - Reject expected values copied from source, prompt, config, fixture, or inventory changed by the same patch. Prefer one behavioral, deployment, or validation owner; keep exact text only for externally consumed literal contracts and inventories only when they compare independent sides of a relationship.
-- **Proof-first is subordinate to this gate.** A test failing before implementation proves nothing when its expected value is copied from the same patch or it inspects source shape. When the consumer, the observable failure, and an independent oracle cannot be named, the correct output of a "write tests first" step is zero new tests.
+- Behavior owned by an upstream system — a tool you route input to, a library you call — has no valid local oracle. Do not reimplement it locally to make it testable; route to its real interface and leave its semantics untested here.
 - Removing a dependency, command, config entry, or file does not by itself justify an absence assertion. Test the capability that remains, or exercise the real deployment/runtime transition that clears stale state — never a source grep.
+
+</important>
+
+<important if="the interface, hook, or dispatch point you need does not exist in the system that owns the behavior">
+
+A missing interface is a finding to report, not permission to reimplement the owning system's behavior locally. Stop, name the missing interface, and ask. A local clone of upstream behavior — plus tests for the clone — is the expensive wrong turn.
 
 </important>
 


### PR DESCRIPTION
## Summary

Every instruction that mandates test *quantity* sits at the point of action — a skill's "write failing tests first" step, the managed-config checklist's "add a test", a reviewer's missing-coverage finding — while the rule about test *quality* lived in one distant CLAUDE.md block, so agents kept producing tautological tests whose expected values came from their own patch. Each of those paths now runs through the same gate: before writing any test, the agent states an oracle line — the consumer, the observable failure, and an oracle independent of the change — and writing zero tests becomes the correct, reportable outcome when the line cannot be completed.

This continues the tautological-test cleanup: #128 made the shared guard block absence assertions without a named oracle, and #137, #138, and #142 reworked existing suites. Two residuals from the incident that motivated this change: the guard engine still passes *positive* tautologies silently — that blind spot and a candidate fix are recorded in `docs/issues/2026-09-02-011-test-oracle-guard-misses-positive-tautological-tests.md` as follow-on work — and the same session had reimplemented upstream Herdr behavior locally and then tested the clone, which is why the global instructions gain a second rule: a missing upstream interface is a finding to report, not permission to rebuild the owning system's behavior.

## Verification and deployment

`make test-issues` passes (issue schema validation plus 51 CLI tests). No Docker suite was run: the change edits the content of already-managed files, and deployment shape — paths, templates, ignore rules — is unchanged. No new tests, by the rule this PR strengthens: instruction prose has no independent oracle.

The two files under `home/` go live only after merge, chezmoi source-clone sync, `chezmoi apply`, and a client restart. The repo `CLAUDE.md` line takes effect in each checkout on merge.
