### PR TITLE
fix(tests): make tautological assertions discriminate

### DIFF
--- a/docs/issues/2026-09-02-011-test-oracle-guard-misses-positive-tautological-tests.md
+++ b/docs/issues/2026-09-02-011-test-oracle-guard-misses-positive-tautological-tests.md
@@ -17,6 +17,56 @@ The shared engine `home/dot_local/bin/executable_test-oracle-guard` fires only o
 
 Extend the engine with a low-false-positive signal for positive tautologies, or explicitly decide the class stays prose-only. Candidate mechanism: require an `oracle:` comment within N lines above every *new* test function in a proposed edit (the existing escape-hatch convention, applied at function granularity instead of only on flagged negative lines). Weigh blast radius per `docs/solutions/design-patterns/gate-bias-follows-blast-radius.md` — this would touch every new test in every repo across all three clients. Update the three thin adapters only if the engine's stdin/argv contract changes.
 
+## Audit result (2026-09-02)
+
+A repository-wide audit for positive tautologies ran over all ~600 tests in
+`tests/` — the four bashunit suites, the five Python suites, the two Bun
+suites, and the shared helpers.
+
+**The incident this issue cites did not happen as recorded.** No commit on any
+ref adds the two positive tests to `tests/bashunit/palette_test.sh` described
+above, and no version of that file or its `tests/palette.bats` ancestor has
+ever contained the string `ghostty`. The closest real match is
+`test_palette_058`/`059`, whose expected values (`"New worktree"`,
+`worktrunk.open`, `worktrunk.remove`, `worktrunk.merge`) did come from the
+`commands.toml` entries added in the same patch — the exact tautology shape —
+and which `4adc681` deleted on 2026-09-02. Nothing matching the description
+survives in the file. The engine extension is therefore the only live item
+here; the incident is not evidence for it.
+
+**The audit is evidence, though, and it argues against the candidate
+mechanism.** Two HIGH findings were confirmed by mutation, and neither would
+have been caught by requiring an `oracle:` comment on every new test function,
+because both were written *with* a plausible oracle in mind:
+
+- `tests/test_post_apply_suite_contract.py` pinned `-j 8`, a production
+  default that `tests/run-post-apply.sh` explicitly declares overridable. The
+  test was red under `MMS_BASHUNIT_JOBS=4` — the value CI's own macOS job sets
+  since `c029819` — and blind to the wrapper dropping the operator's cap.
+- `tests/pi-brew-auto-update.test.ts` named two tests for git-revision
+  behavior while injecting `snapshotExtensions` wholesale, so the production
+  git branch never ran. Blinding `captureExtensionSnapshot` to every
+  git-installed extension left all 27 tests green.
+
+The rest of the corpus yielded no further HIGH findings: about twenty
+MEDIUM/LOW restatements, mostly an expected value transcribed from the
+artifact under test while a stronger neighbour already owned the contract.
+Against that base rate, a mandatory `oracle:` comment on every new test
+function in every repo across all three clients is high friction for a signal
+that missed both real failures. Per
+`docs/solutions/design-patterns/gate-bias-follows-blast-radius.md`, the blast
+radius does not justify it.
+
+What the audit suggests instead, in decreasing confidence: a check that fires
+when a test's expected literal also appears in a non-test file changed by the
+same patch (narrow, needs the diff the stateless hook does not have today),
+and treating "no mutation proof" rather than "no oracle comment" as the
+reviewable gap — every fix in this audit carried one.
+
 ## Open decisions
 
-Whether requiring `oracle:` on every new test function is acceptable friction, or whether the requirement should apply only to test files touched in the same session as non-test files (needs session state the stateless hook does not have today).
+**Superseded in part.** The question of whether `oracle:` on every new test
+function is acceptable friction is answered no by the evidence above. What
+remains open is whether the engine should gain a diff-aware positive check at
+all, given that it would need session or patch state the stateless hook does
+not have, or whether the positive class stays prose-plus-review.

--- a/docs/issues/2026-09-02-012-herdr-task-sync-tests-measure-only-an-unverified-herdr-protocol-fake.md
+++ b/docs/issues/2026-09-02-012-herdr-task-sync-tests-measure-only-an-unverified-herdr-protocol-fake.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-task-sync tests measure only an unverified herdr protocol fake"
+short_description: "Every task-sync assertion in scripts_test.sh runs against the stub herdr in tests/helpers/herdr_task_sync.bash, which reimplements herdr's envelope shapes, snapshot skeleton, and report-metadata sequence semantics; nothing ever compares the fake to the real binary, and commit d080d31 shows the drift class is realized rather than theoretical."
+type: "follow-up"
+category: "testing-ci"
+tags: ["semantic-tests","herdr"]
+date: "2026-09-02"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The stub bakes herdr's CLI/JSON contract: envelope shapes at tests/helpers/herdr_task_sync.bash:379, the snapshot skeleton at :434-464, and the --seq/--token/--clear-token high-water merge semantics at :248 and :680. grep -rn 'command -v herdr' tests/ returns nothing, so no test touches the real binary. Commit d080d31 (#115) had to change the stub's sequence comparison from < to <= because real herdr accepts only strictly greater sequences -- found by hand, not by any test (docs/issues/2026-08-30-003). Per the repository's upstream-ownership rule, behavior owned by an upstream system has no valid local oracle, so more assertions against the fake would not help.
+
+## Scope
+
+Record the herdr version and protocol number the stub emulates beside the fixture, and add a host-only, skip-if-absent check that runs the real 'herdr api snapshot' and compares its top-level result keys against the stub's. Do not reimplement herdr semantics locally to make them testable.
+
+## Open decisions
+
+Whether a real-herdr conformance check belongs in the post-apply suite (where herdr is present on a dev host but absent in CI-minimal Linux) or in a separate host-only target.

--- a/docs/issues/2026-09-02-013-palette-herdr-stub-tests-flake-under-parallel-load-on-a-busy-machine.md
+++ b/docs/issues/2026-09-02-013-palette-herdr-stub-tests-flake-under-parallel-load-on-a-busy-machine.md
@@ -1,0 +1,22 @@
+---
+title: "palette herdr-stub tests flake under parallel load on a busy machine"
+short_description: "The R6-family herdr-stub tests in palette_test.sh intermittently fail at -j 8 when the machine is heavily loaded, because palette.py's HERDR_CALL_TIMEOUT_SECONDS = 2 is an idle-machine wall-clock bound rather than a state-aware wait."
+type: "bug"
+category: "command-palette"
+tags: ["flake","semantic-tests"]
+date: "2026-09-02"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Observed during the 2026-09-02 tautology audit: an unmodified HEAD copy of tests/bashunit/palette_test.sh in a scratch tree failed 1, 6, 5 and 7 tests across four consecutive 'tests/lib/bashunit -j 8' runs while four coding agents ran concurrently (load average 10-16). The failures are in the R6 herdr-stub family and are timeouts against palette.py's HERDR_CALL_TIMEOUT_SECONDS = 2. The flake is pre-existing and independent of that audit's changes. It did not reproduce in three consecutive -j 8 runs at load average 7-10 after the agents finished, so the threshold is somewhere above that. This matches docs/solutions/design-patterns/idle-machine-wall-clock-bounds-are-latent-flakes.md.
+
+## Scope
+
+Replace the fixed two-second wall-clock bound with a state-aware wait in the test harness, or make the stub signal readiness so the test waits on an observable condition instead of elapsed time. Do not simply raise the constant: a larger idle-machine bound is the same latent flake with a longer fuse. Leave palette.py's production timeout alone unless the same reasoning applies to real herdr calls.
+
+## Open decisions
+
+Whether the bound belongs in the test harness only, or whether palette.py's own HERDR_CALL_TIMEOUT_SECONDS should become configurable so the suite can raise it without changing shipped behaviour.

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -219,9 +219,33 @@ function test_idempotent_013_guard_the_misconfigured_message_names_the_marker() 
   }
 
   run captured_fail_message
+  # One text assertion, kept for the human who reads this failure: the message
+  # has to name the marker it is asking for. The file names it also carries are
+  # not pinned as strings -- copied out of the message they would only restate
+  # it -- but read back out of the message and checked against the tree.
   assert_output --partial "MMS_DISPOSABLE_HOME"
-  assert_output --partial "test-dotfiles.yml"
-  assert_output --partial "docker-compose.yml"
+
+  # Two independently maintained sides: the message in tests/helpers/common.bash
+  # claims which launch sites declare the marker, and those launch sites have to
+  # actually declare it. The rot this catches is a dropped `env:` block in the
+  # workflow or a dropped `environment:` entry in a compose service -- after
+  # which the scenarios above skip in CI and the suite stays green.
+  #
+  # The repo root only exists where the full checkout does: the host, and the
+  # macOS CI job. `make test-ubuntu` mounts home/ and tests/ alone, so the
+  # cross-check is unreachable there and the file-name half of this contract is
+  # owned by the host and macOS runs.
+  local repo_root named rel
+  repo_root="$BATS_TEST_DIRNAME/.."
+  named="$(printf '%s\n' "$output" | grep -oE '[A-Za-z0-9_./-]+\.ya?ml')"
+  [[ -n "$named" ]] || fail "the misconfigured message names no marker-declaring file: $output"
+  if [[ -d "$repo_root/.github" ]]; then
+    while IFS= read -r rel; do
+      assert_file_exists "$repo_root/$rel"
+      grep -qE 'MMS_DISPOSABLE_HOME[=:][[:space:]]*"?1"?' "$repo_root/$rel" || \
+        fail "$rel is named as a site that declares MMS_DISPOSABLE_HOME=1, but does not set it"
+    done <<< "$named"
+  fi
 }
 
 function set_up_before_script() {

--- a/tests/bashunit/oracle_guard_test.sh
+++ b/tests/bashunit/oracle_guard_test.sh
@@ -31,10 +31,17 @@ function test_oracle_guard_001_non_test_file_passes_even_with_negative_assertion
 
 function test_oracle_guard_002_flags_negative_assertion_in_test_file() {
   _bats_test_init 2 'flags negative assertion in test file'
+  # The pinned text is the "test-oracle-guard:" prefix, the only part of this
+  # report a consumer parses: the opencode adapter
+  # (home/private_dot_config/opencode/plugins/test-oracle-guard.ts) rethrows the
+  # engine's stdout only when error.message.startsWith("test-oracle-guard:"),
+  # and swallows it otherwise. Lose the prefix and the guard fails open in
+  # opencode. The rest of the wording is prose nothing reads; the line number
+  # is produced from this test's own fixture, so it stays.
   # oracle: engine header — unjustified negative assertion exits 1 with reason.
   run_guard "tests/bashunit/smoke_test.sh" 'assert_not_contains "$palette" "worktrunk"'
   assert_failure
-  assert_output --partial "without a named oracle"
+  assert_output --partial "test-oracle-guard:"
   assert_output --partial "line 1"
 }
 

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -248,8 +248,15 @@ PY
   assert_output --partial "Zed did not respond"
 }
 
-function test_palette_012_open_in_zed_uses_the_standard_macos_cli_fallback() {
-  _bats_test_init 12 'Open in Zed uses the standard macOS CLI fallback'
+# What this proves is the branch, not the path: with sys.platform forced to
+# darwin and nothing named `zed` on PATH, resolve_zed() falls back to
+# MACOS_ZED_CLI instead of raising or returning the PATH lookup. The value of
+# MACOS_ZED_CLI is overwritten with a fake below, so the shipped literal
+# (/Applications/Zed.app/...) is deliberately NOT asserted here: only a macOS
+# host with Zed actually installed could observe it, and this suite runs on
+# Linux too. No test in this repo owns that literal.
+function test_palette_012_resolve_zed_falls_back_to_the_macos_cli_when_zed_is_not_on_path() {
+  _bats_test_init 12 'resolve_zed falls back to the macOS CLI path when zed is not on PATH'
   local fake_zed="$PALETTE_WORK/zed"
   touch "$fake_zed"
   chmod +x "$fake_zed"
@@ -277,7 +284,18 @@ function test_palette_013_validate_accepts_the_real_commands_toml_and_name() {
   _bats_test_init 13 '--validate accepts the real commands.toml and names the command count'
   run python3 "$PALETTE_DIR/palette.py" --validate "$REAL_COMMANDS"
   assert_success
-  assert_output --partial "commands)"
+  # The count is what the name claims, so read it back out of the report
+  # instead of pinning "commands)", a fragment of palette.py's own f-string
+  # that no consumer parses. The expectation is a second, independent count of
+  # the `[[commands]]` table headers in the same file: when the validator's
+  # parser silently drops, merges, or duplicates an entry, the two counts
+  # diverge. Editing commands.toml moves both sides together, so a config
+  # change cannot silently rewrite this expectation.
+  local reported expected
+  reported="$(printf '%s\n' "$output" | sed -n 's/.*(\([0-9][0-9]*\) command.*/\1/p')"
+  expected="$(grep -c '^\[\[commands\]\]' "$REAL_COMMANDS")"
+  [[ "$expected" -gt 0 ]] || fail "no [[commands]] entries found in $REAL_COMMANDS"
+  assert_equal "$reported" "$expected"
 }
 
 function test_palette_014_validate_rejects_an_unsupported_command_type() {
@@ -307,8 +325,7 @@ TOML
 import palette_boot
 
 palette = palette_boot.palette()
-config_path, commands = palette.load_commands()
-assert config_path.name == "commands.toml", config_path
+_, commands = palette.load_commands()
 assert [command.title for command in commands] == ["Only command"], commands
 PY
   assert_success
@@ -461,12 +478,41 @@ function test_palette_027_r2_a_query_matching_no_title_and_no_shortcut_ret() {
   assert_output ""
 }
 
+# Ranked against a test-owned fixture, like tests 029/030 below. Against the
+# production commands.toml the expected count was just a restatement of that
+# file's `[[commands]]` entries: commit 4adc681 deleted four commands and
+# rewrote the expectation in the same patch, so the test could not have caught
+# a ranking regression that dropped entries. The fixture also interleaves two
+# groups, which pins the "group order" half of the claim -- commands come back
+# regrouped by first-seen group, not in file order.
 function test_palette_028_r2_an_empty_query_returns_every_command_in_group() {
   _bats_test_init 28 'R2: an empty query returns every command in group order'
-  run rank_real ""
+  cat > "$PALETTE_WORK/commands.toml" <<'TOML'
+[[commands]]
+group = "Alpha"
+title = "First alpha"
+type = "shell"
+command = "true"
+
+[[commands]]
+group = "Beta"
+title = "Only beta"
+type = "shell"
+command = "true"
+
+[[commands]]
+group = "Alpha"
+title = "Second alpha"
+type = "shell"
+command = "true"
+TOML
+
+  run rank_in "$PALETTE_WORK/commands.toml" ""
   assert_success
-  assert_line --index 0 "Lazygit in new tab"
-  assert_equal "${#lines[@]}" 9
+  assert_equal "${#lines[@]}" 3
+  assert_line --index 0 "First alpha"
+  assert_line --index 1 "Second alpha"
+  assert_line --index 2 "Only beta"
 }
 
 function test_palette_029_a_command_with_no_shortcuts_still_matches_by_tit() {
@@ -1111,10 +1157,21 @@ function test_palette_054_r9_a_missing_fzf_fails_loudly_naming_fzf_the_bre() {
   assert_failure
   assert_output --partial "fzf"
   assert_output --partial "PATH"
-  # Both Brewfile paths: the repo one says where to edit the declaration, the
-  # deployed one is what the install command can actually be run against.
-  assert_output --partial "home/private_dot_config/brewfiles/Brewfile.tmpl"
-  assert_output --partial "brew bundle --file=~/.config/brewfiles/Brewfile"
+  # Both Brewfile paths are instructions a human follows, so neither is pinned
+  # as prose copied from palette.py. Each is read back out of the message and
+  # checked against the tree: the repo path must name a file that really
+  # declares fzf (the oracle is the Brewfile itself), and the install command's
+  # deployed path must be that same managed file's chezmoi destination
+  # (home/private_dot_config/... renders to ~/.config/...). Either path going
+  # stale -- a moved Brewfile, a dropped fzf declaration -- turns this red.
+  local repo_rel deployed repo_file
+  repo_rel="$(printf '%s\n' "$output" | grep -oE 'home/[A-Za-z0-9_./-]+Brewfile[A-Za-z0-9.]*' | head -1)"
+  deployed="$(printf '%s\n' "$output" | grep -oE '~/[A-Za-z0-9_./-]+Brewfile' | head -1)"
+  [[ -n "$repo_rel" && -n "$deployed" ]] || fail "the fzf message named no repo and deployed Brewfile paths: $output"
+  repo_file="$SOURCE_ROOT/${repo_rel#home/}"
+  assert_file_exists "$repo_file"
+  assert_file_contains "$repo_file" "fzf"
+  assert_equal "home/private_dot_${deployed#\~/.}.tmpl" "$repo_rel"
 }
 
 # The only path that could raise out of the curses loop. A traceback there is a
@@ -1204,7 +1261,36 @@ function test_palette_063_herdr_loads_the_command_palette_manifest_and_actions()
 
   run env HOME="$home" herdr plugin link "$PALETTE_DIR" --enabled
   assert_success
-  assert_output --partial '"id":"smart_close"'
+
+  # assert_success above owns the real regression: herdr refusing a manifest
+  # its own parser rejects. The action ids are then compared against the other,
+  # independently maintained side of the same relationship -- the keybindings
+  # in herdr's config.toml, which dispatch `<plugin_id>.<action_id>`. herdr
+  # surfaces a dangling binding only at keypress time, so nothing else here
+  # catches a renamed or deleted action. Asserting that the link report echoes
+  # an id typed in the manifest it just read would prove nothing.
+  run env PALETTE_LINK_JSON="$output" \
+    HERDR_CONFIG="$SOURCE_ROOT/private_dot_config/herdr/config.toml" python3 - <<'PY'
+import json
+import os
+import re
+
+raw = os.environ["PALETTE_LINK_JSON"]
+line = next(l for l in reversed(raw.splitlines()) if l.startswith("{"))
+report = json.loads(line)["result"]["plugin"]
+plugin_id = report["plugin_id"]
+reported = {action["id"] for action in report["actions"]}
+assert reported, report
+
+with open(os.environ["HERDR_CONFIG"], encoding="utf-8") as handle:
+    config = handle.read()
+bound = set(re.findall(re.escape(plugin_id) + r"\.([A-Za-z0-9_]+)", config))
+assert bound, f"config.toml binds no {plugin_id} action"
+dangling = bound - reported
+assert not dangling, f"config.toml binds actions herdr does not report: {sorted(dangling)}"
+print(f"bound={sorted(bound)} reported={sorted(reported)}")
+PY
+  assert_success
 }
 
 function set_up_before_script() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -83,19 +83,42 @@ function test_scripts_001_python3_is_present_and_at_least_3_9_the_floor_re() {
 # Repository linting
 # ===========================================
 
+# Writes a shellcheck stub that appends its argv to $2 and exits with $3, so a
+# test can tell "make lint failed because shellcheck failed" apart from "make
+# lint failed for some other reason".
+write_shellcheck_stub() {
+  local dir="$1" log="$2" code="$3"
+  cat > "$dir/shellcheck" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "$log"
+exit $code
+STUB
+  chmod +x "$dir/shellcheck"
+}
+
 function test_scripts_002_lint_target_propagates_shellcheck_failures() {
   _bats_test_init 2 'lint target propagates shellcheck failures'
   local repo_root="$BATS_TEST_DIRNAME/.."
   [[ -f "$repo_root/Makefile" ]] || skip "repo-root Makefile is not available in this environment"
 
-  local stubdir
-  stubdir="$(mktemp -d)"
-  printf '#!/bin/sh\nexit 1\n' > "$stubdir/shellcheck"
-  chmod +x "$stubdir/shellcheck"
+  # `make lint` runs three shellcheck sweeps plus a python checker, so a bare
+  # assert_failure is also satisfied by a broken Makefile or a failing python
+  # step -- neither of which is this test's subject. The stub records that it
+  # was reached, and the exit-0 leg is the control proving the target reaches
+  # success when shellcheck is happy, so a `|| true` on the shellcheck lines
+  # cannot keep both legs green.
+  local stubdir="$BATS_TEST_TMPDIR/lint-stub"
+  local invocations="$BATS_TEST_TMPDIR/shellcheck.invocations"
+  mkdir -p "$stubdir"
 
+  write_shellcheck_stub "$stubdir" "$invocations" 1
   run env PATH="$stubdir:$PATH" make -C "$repo_root" lint
-  rm -rf "$stubdir"
   assert_failure
+  assert_file_exists "$invocations"
+
+  write_shellcheck_stub "$stubdir" "$invocations" 0
+  run env PATH="$stubdir:$PATH" make -C "$repo_root" lint
+  assert_success
 }
 
 # ===========================================
@@ -128,10 +151,15 @@ function test_scripts_003_ci_minimal_linux_render_skips_homebrew_but_keeps() {
 
   run render_install_packages "$cfg"
   assert_success
-  refute_output --partial 'Installing Homebrew'
+  # Progress banners ("Installing Oh My Zsh...") are prose nothing consumes: a
+  # reworded echo reddens the test while the install still runs, and deleting
+  # the install while keeping the echo stays green. The upstream installer URLs
+  # below are third-party constants this repo does not define, so they move
+  # only when the install itself moves.
+  refute_output --partial 'Homebrew/install/HEAD/install.sh'
   refute_output --partial 'brew bundle --file='
-  assert_output --partial 'Installing Oh My Zsh'
-  assert_output --partial 'Installing fff-mcp'
+  assert_output --partial 'ohmyzsh/ohmyzsh/master/tools/install.sh'
+  assert_output --partial 'fff.nvim/main/install-mcp.sh'
 }
 
 function test_scripts_004_full_linux_render_keeps_homebrew_package_install() {
@@ -143,7 +171,7 @@ function test_scripts_004_full_linux_render_keeps_homebrew_package_install() {
 
   run render_install_packages "$cfg"
   assert_success
-  assert_output --partial 'Installing Homebrew'
+  assert_output --partial 'Homebrew/install/HEAD/install.sh'
   assert_output --partial 'brew bundle --file="$BREWFILES_DIR/Brewfile"'
 }
 
@@ -156,7 +184,7 @@ function test_scripts_005_ci_minimal_non_linux_render_keeps_homebrew_packa() {
 
   run render_install_packages "$cfg"
   assert_success
-  assert_output --partial 'Installing Homebrew'
+  assert_output --partial 'Homebrew/install/HEAD/install.sh'
   assert_output --partial 'brew bundle --file="$BREWFILES_DIR/Brewfile"'
 }
 
@@ -3447,11 +3475,11 @@ function test_scripts_106_herdr_task_sync_harness_isolates_colliding_sanit() {
   _bats_test_init 106 'herdr-task-sync harness isolates colliding sanitized socket names'
   command -v jq >/dev/null || skip "jq not available"
   hts_setup
+  # a-b.sock and a_b.sock are the pair that collided under the retired
+  # sanitized-name scheme; the harness now keys directories by exact socket
+  # path, so the two must land in separate directories.
   local socket_one="$HTS_WORK/a-b.sock" socket_two="$HTS_WORK/a_b.sock"
-  local dir_one dir_two sanitized_one sanitized_two
-  sanitized_one="$(printf '%s' "$socket_one" | sed 's/[^[:alnum:]]/_/g')"
-  sanitized_two="$(printf '%s' "$socket_two" | sed 's/[^[:alnum:]]/_/g')"
-  assert_equal "$sanitized_one" "$sanitized_two"
+  local dir_one dir_two
   dir_one="$(hts_socket_dir "$socket_one")"
   dir_two="$(hts_socket_dir "$socket_two")"
   [[ "$dir_one" != "$dir_two" ]] || fail "colliding socket names shared one harness directory: $dir_one"
@@ -3468,11 +3496,9 @@ function test_scripts_106_herdr_task_sync_harness_isolates_colliding_sanit() {
   hts_wait_for_socket_completion "$dir_one" 1
   hts_wait_for_socket_call "$dir_two" 1
   hts_wait_for_socket_completion "$dir_two" 1
+  # A failing mkdir trips the ERR trap, so it is itself the probe that each
+  # directory has its own locks/ parent.
   mkdir "$dir_one/locks/held" "$dir_two/locks/held"
-  assert_dir_exists "$dir_one/locks/held"
-  assert_dir_exists "$dir_two/locks/held"
-  assert_dir_exists "$dir_one/locks"
-  assert_dir_exists "$dir_two/locks"
   assert_equal "$(wc -l < "$(hts_socket_log "$socket_one")" | tr -d ' ')" 1
   assert_equal "$(wc -l < "$(hts_socket_log "$socket_two")" | tr -d ' ')" 1
 }
@@ -3527,10 +3553,12 @@ function test_scripts_108_herdr_task_sync_harness_models_target_loss_move() {
   assert_output --partial '"terminal_id":"term-2"'
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane rename pane-1 stale-write
   run hts_socket_run "$HTS_DEFAULT_SOCKET" pane get pane-1
+  assert_success
   assert_output --partial '"terminal_id":"term-3"'
   assert_output --partial '"label":"stale-write"'
   hts_socket_run "$HTS_DEFAULT_SOCKET" pane rename pane-1 converged
   run hts_socket_run "$HTS_DEFAULT_SOCKET" pane get pane-1
+  assert_success
   assert_output --partial '"label":"converged"'
 }
 
@@ -3556,8 +3584,6 @@ function test_scripts_109_herdr_task_sync_first_prompt_fixes_session_iden() {
   hts_wait_for_task_slug "$task" first-identity
   assert_equal "$(hts_record_text "$task" latest_prompt)" "first request"
   assert_equal "$(hts_record_text "$task" first_prompt)" "first request"
-  assert_equal "$(hts_record_number "$control" generation)" \
-    "$(hts_record_number "$control" committed_generation)"
   local reconcile="$(hts_namespace "$HTS_DEFAULT_SOCKET")/reconcile.state"
   assert_equal "$(hts_record_number "$control" presentation_generation)" \
     "$(hts_record_number "$reconcile" pending_generation)"
@@ -3619,9 +3645,9 @@ function test_scripts_111_herdr_task_sync_prompt_transcript_and_direct_set() {
   for mode in prompt transcript direct; do
     pane="pane-$mode"
     control="$(hts_control_file "$HTS_DEFAULT_SOCKET" "$pane")"
+    # hts_wait_for_quiescence already requires generation = committed_generation
+    # before it returns 0, so restating that equality here proves nothing.
     hts_wait_for_quiescence "$control"
-    assert_equal "$(hts_record_number "$control" generation)" \
-      "$(hts_record_number "$control" committed_generation)"
     [[ "$(hts_record_number "$control" presentation_generation)" -gt 0 ]] || fail "presentation generation was not positive for $mode"
   done
   task="$(hts_task_file "$HTS_DEFAULT_SOCKET" claude pane-transcript transcript-s)"
@@ -3760,12 +3786,10 @@ function test_scripts_1127_herdr_task_sync_retries_partial_worktree_identity() {
   identity="$(hts_namespace "$HTS_DEFAULT_SOCKET")/worktrees/$(hts_key "$(git -C "$worktree" rev-parse --show-toplevel)").state"
   hts_run --agent claude --session s1 <<< 'Recover Herdr identity'
   hts_wait_for_record_text "$identity" outcome workspace-failed
-  assert_equal "$(hts_record_text "$identity" outcome)" workspace-failed
   assert_equal "$(git -C "$worktree" branch --show-current)" recover-herdr-identity
 
   hts_run --agent claude --session s1 <<< 'This continuation only retries side effects'
   hts_wait_for_record_text "$identity" outcome complete
-  assert_equal "$(hts_record_text "$identity" outcome)" complete
   assert_equal "$(git -C "$worktree" branch --show-current)" recover-herdr-identity
   state="$(hts_socket_state "$HTS_DEFAULT_SOCKET")"
   assert_equal \
@@ -7375,20 +7399,18 @@ function test_scripts_250_pi_settings_modifier_selects_the_terminal_theme() {
   run bash "$modifier" <<< "$input"
 
   assert_success
+  # Restating the managed package names here would copy them out of the
+  # modifier this test runs, so adding or dropping an extension would edit
+  # both sides in one patch and never fail. What the modifier owes its
+  # consumer is the replacement itself: the caller's packages array is
+  # discarded, whatever it held, and only npm specs survive.
   run jq -e '
-    [
-      "npm:@ff-labs/pi-fff",
-      "npm:@howaboua/pi-codex-conversion",
-      "npm:pi-subagents",
-      "npm:pi-agent-browser-native",
-      "npm:pi-ask-user",
-      "npm:@trevonistrevon/pi-loop",
-      "npm:pi-web-access",
-      "npm:pi-context-view"
-    ] as $extensions |
     .theme == "terminal" and
     .lastChangelogVersion == "0.84.2" and
-    (.packages == $extensions) and
+    ((.packages | index("npm:obsolete-extension")) == null) and
+    ((.packages | map(select(startswith("git:"))) | length) == 0) and
+    ((.packages | length) > 0) and
+    (.packages | all(startswith("npm:"))) and
     (.skills == ["~/custom/skills"])
   ' <<< "$output"
   assert_success
@@ -7404,21 +7426,15 @@ function test_scripts_251_pi_settings_modifier_is_idempotent() {
 
   assert_success
   once="$output"
+  # The input above already carries the managed names, so comparing them back
+  # would compare the fixture to itself. The contract here is that unrelated
+  # user settings survive the rewrite and the git: entry does not.
   run jq -e '
-    [
-      "npm:@ff-labs/pi-fff",
-      "npm:@howaboua/pi-codex-conversion",
-      "npm:pi-subagents",
-      "npm:pi-agent-browser-native",
-      "npm:pi-ask-user",
-      "npm:@trevonistrevon/pi-loop",
-      "npm:pi-web-access",
-      "npm:pi-context-view"
-    ] as $extensions |
     (.theme == "terminal") and
     (.lastChangelogVersion == "0.84.2") and
     (.model == "anthropic/claude-sonnet-4-5") and
-    (.packages == $extensions) and
+    ((.packages | map(select(startswith("git:"))) | length) == 0) and
+    (.packages | all(startswith("npm:"))) and
     (.skills == ["~/custom/skills"])
   ' <<< "$once"
   assert_success
@@ -7433,12 +7449,20 @@ function test_scripts_252_pi_terminal_theme_uses_only_terminal_palette_col() {
   _bats_test_init 252 'Pi terminal theme uses only terminal palette colors'
   local theme="$SOURCE_ROOT/dot_pi/agent/themes/terminal.json"
 
+  # Naming two arbitrary empty slots proved nothing about the palette. The
+  # property is structural and cross-references two independently edited
+  # sections of the file: every colour either inherits (empty string) or
+  # names a slot the vars block declares, so no colour can hardcode a value
+  # the user's terminal does not control.
   run jq -e '
     .name == "terminal" and
-    .colors.text == "" and
-    .colors.userMessageBg == "" and
     ([.vars[]] | all(type == "number" and . >= 0 and . <= 15)) and
-    ([.colors[] | select(type == "string" and startswith("#"))] | length == 0)
+    (. as $theme
+      | [$theme.colors[]
+         | select(type == "string")
+         | . as $value
+         | select($value != "" and (($theme.vars | has($value)) | not))]
+      | length == 0)
   ' "$theme"
   assert_success
 }
@@ -7447,10 +7471,22 @@ function test_scripts_253_claude_code_daltonized_theme_extends_light_ansi() {
   _bats_test_init 253 'Claude Code daltonized theme extends light ANSI with terminal colors'
   local theme="$SOURCE_ROOT/private_dot_claude/themes/light-ansi-daltonized.json"
 
+  # length > 0 is not a content assertion -- it is the anti-vacuity guard that
+  # keeps the slot-form check below from passing on an empty overrides object.
+  # The vocabulary is the standard 16 ANSI colour names, which is what Claude
+  # Code's theme loader resolves; a bare startswith("ansi:") would also accept
+  # ansi:tomato, which resolves to nothing.
   run jq -e '
+    ["black","red","green","yellow","blue","magenta","cyan","white",
+     "blackBright","redBright","greenBright","yellowBright",
+     "blueBright","magentaBright","cyanBright","whiteBright"] as $ansi |
     .base == "light-ansi" and
     (.overrides | length > 0) and
-    ([.overrides[] | select(startswith("ansi:") | not)] | length == 0)
+    ([.overrides[] | . as $value
+      | select(($value | type) != "string"
+               or ($value | startswith("ansi:") | not)
+               or (($ansi | index($value | ltrimstr("ansi:"))) == null))]
+     | length == 0)
   ' "$theme"
   assert_success
 }
@@ -8242,12 +8278,27 @@ function test_scripts_271_herdr_child_shared_lifecycle_primitives_keep_con() {
     fi
   '
   assert_success
-  run cat "$work_dir/launch.state"
+  # Reading the file back byte-for-byte pinned two things no consumer has: the
+  # field order, and mode=, which no reader under home/dot_local/lib parses --
+  # the watcher, supervision, and continuation modules all go through
+  # state_value with a named key. What is load-bearing is the mapping from
+  # write_launch_state's eleven positional arguments onto those keys, so
+  # assert it through the same accessor those readers use. The expected values
+  # are the arguments this test passed in, not text copied out of the writer.
+  run env WORK_DIR="$work_dir" RUNTIME="$runtime" bash -c '
+    set -u
+    source "$RUNTIME"
+    for pair in generation:generation-1 timeout_ms:12345 parent_pane:parent-pane \
+      parent_terminal:parent-terminal parent_session:parent-session \
+      child_name:child-name child_pane:child-pane child_terminal:child-terminal \
+      child_session:child-session baseline_seq:42; do
+      key="${pair%%:*}"
+      want="${pair#*:}"
+      got="$(state_value "$WORK_DIR/launch.state" "$key")"
+      [ "$got" = "$want" ] || { printf "%s read back as %s, wanted %s\n" "$key" "$got" "$want"; exit 1; }
+    done
+  '
   assert_success
-  assert_output "$(printf '%s\n' 'mode=detach' 'generation=generation-1' 'timeout_ms=12345' \
-    'parent_pane=parent-pane' 'parent_terminal=parent-terminal' 'parent_session=parent-session' \
-    'child_name=child-name' 'child_pane=child-pane' 'child_terminal=child-terminal' \
-    'child_session=child-session' 'baseline_seq=42')"
   assert_file_not_exists "$work_dir/invalid.state"
 }
 
@@ -8509,7 +8560,7 @@ PY
 
 function test_scripts_278_skills_sync_blocks_unsafe_canonical_trees() {
   _bats_test_init 278 'skills sync blocks symlink, non-regular, and oversized canonical entries'
-  local kind stub manifest lock canonical item skill
+  local kind stub manifest lock canonical item skill offender
   for kind in symlink fifo oversized; do
     stub="$(skills_stub_npx)"
     manifest="$BATS_TEST_TMPDIR/$kind.manifest"
@@ -8524,15 +8575,20 @@ function test_scripts_278_skills_sync_blocks_unsafe_canonical_trees() {
       printf '%s\n' skill > "$canonical/$skill/SKILL.md"
     done
     case "$kind" in
-      symlink) ln -s /etc/passwd "$canonical/escape" ;;
-      fifo) mkfifo "$canonical/non-regular" ;;
-      oversized) dd if=/dev/zero of="$canonical/oversized" bs=1048577 count=1 2>/dev/null ;;
+      symlink) ln -s /etc/passwd "$canonical/escape"; offender="$canonical/escape" ;;
+      fifo) mkfifo "$canonical/non-regular"; offender="$canonical/non-regular" ;;
+      oversized) dd if=/dev/zero of="$canonical/oversized" bs=1048577 count=1 2>/dev/null; offender="$canonical/oversized" ;;
     esac
     run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/$kind/home" TMPDIR="$BATS_TEST_TMPDIR/$kind/tmp" \
       XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/$kind/config" XDG_STATE_HOME="$BATS_TEST_TMPDIR/$kind/state" \
       SKILLS_MANIFEST="$manifest" SKILLS_CANONICAL_ROOT="$canonical" SKILLS_MAX_FILE_BYTES=1048576 \
     bash "$SKILLS_WRAPPER" sync
     assert_failure
+    # A bare assert_failure is satisfied by any of the three iterations, so two
+    # of the guards could be deleted and the loop would stay green. The
+    # rejected path is this test's own fixture, so requiring the message to
+    # name it makes each iteration prove its own guard fired.
+    assert_output --partial "$offender"
   done
 }
 

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -21,22 +21,6 @@ function test_smoke_001_python3_is_present_and_at_least_3_9_the_floor_re() {
   assert_python3_available
 }
 
-function test_smoke_002_repository_issues_cli_exposes_its_contract_and_r() {
-  _bats_test_init 2 'repository issues CLI exposes its contract and reads checkout issues'
-  local repository_root
-  repository_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-  [[ -f "$repository_root/scripts/issues" ]] || skip "repository checkout is not mounted"
-
-  run python3 "$repository_root/scripts/issues" --version
-  assert_success
-  assert_output "repository-issues-contract 2"
-
-  run bash -c 'cd "$1" && python3 scripts/issues list --status open --json' _ "$repository_root"
-  assert_success
-  run python3 -c 'import json, sys; value = json.loads(sys.argv[1]); assert isinstance(value["issues"], list)' "$output"
-  assert_success
-}
-
 function test_smoke_003_post_apply_suite_wrapper_rejects_an_unknown_mode() {
   _bats_test_init 3 'post-apply suite wrapper rejects an unknown mode with usage'
   local repository_root
@@ -283,68 +267,6 @@ function test_smoke_009_herdr_plugin_updates_are_automatic_and_owner_res() {
 function test_smoke_010_herdr_lazygit_popup_entrypoint_is_configured() {
   _bats_test_init 10 'herdr lazygit popup entrypoint is configured'
   assert_file_contains "$HOME/.config/herdr/plugins/command-palette/herdr-plugin.toml" 'id = "lazygit"'
-}
-
-function test_smoke_011_herdr_command_palette_sources_are_valid() {
-  _bats_test_init 11 'herdr command palette sources are valid'
-  run python3 -m py_compile \
-    "$HOME/.config/herdr/plugins/command-palette/open.py" \
-    "$HOME/.config/herdr/plugins/command-palette/open_in_zed.py" \
-    "$HOME/.config/herdr/plugins/command-palette/palette.py" \
-    "$HOME/.config/herdr/plugins/command-palette/smart_close.py"
-  assert_success
-
-  run python3 -c 'import importlib.util, os, sys; path=os.path.expanduser("~/.config/herdr/plugins/command-palette/palette.py"); spec=importlib.util.spec_from_file_location("palette", path); mod=importlib.util.module_from_spec(spec); sys.modules[spec.name]=mod; spec.loader.exec_module(mod); assert len(mod.load_command_data_file(__import__("pathlib").Path(os.path.expanduser("~/.config/herdr/command-palette/commands.toml")))) > 0'
-  assert_success
-
-  run python3 "$HOME/.config/herdr/plugins/command-palette/palette.py" --validate \
-    "$HOME/.config/herdr/command-palette/commands.toml"
-  assert_success
-}
-
-function test_smoke_012_herdr_command_palette_opener_detects_active_pale() {
-  _bats_test_init 12 'herdr command palette opener detects active palette pane'
-  run python3 - <<'PY'
-import importlib.util, os, sys
-path=os.path.expanduser("~/.config/herdr/plugins/command-palette/open.py")
-spec=importlib.util.spec_from_file_location("palette_open", path)
-mod=importlib.util.module_from_spec(spec)
-sys.modules[spec.name]=mod
-spec.loader.exec_module(mod)
-token = {mod.PALETTE_TOKEN: mod.PALETTE_TOKEN_VALUE}
-assert mod.pane_is_palette({"pane_id": "pane-1", "tokens": token})
-assert not mod.pane_is_palette({"pane_id": "pane-2", "tokens": {}})
-assert not mod.pane_is_palette({"pane_id": "pane-3", "label": "nvim palette.py"})
-
-class Result:
-    def __init__(self, stdout=""):
-        self.returncode = 0
-        self.stdout = stdout
-        self.stderr = ""
-
-calls = []
-def fake_run(command, **kwargs):
-    calls.append(command)
-    if command[:3] == ["herdr", "pane", "current"]:
-        return Result('{"result":{"pane":{"pane_id":"pane-1"}}}')
-    if command[:3] == ["herdr", "pane", "get"]:
-        return Result('{"result":{"pane":{"pane_id":"pane-1","workspace_id":"w1","tokens":{"command_palette":"open"}}}}')
-    if command[:4] == ["herdr", "plugin", "pane", "focus"]:
-        return Result()
-    raise AssertionError(command)
-
-mod.subprocess.run = fake_run
-os.environ.pop("HERDR_PLUGIN_CONTEXT_JSON", None)
-os.environ.pop("HERDR_ACTIVE_PANE_ID", None)
-os.environ.pop("HERDR_PANE_ID", None)
-# fake_run matches argv[0] == "herdr", which is open.py's default. A shell
-# inside a herdr pane exports HERDR_BIN_PATH, and the absolute path it carries
-# would miss every branch of the mock and open a second palette instead.
-os.environ.pop("HERDR_BIN_PATH", None)
-assert mod.main() == 0
-assert not any(command[:4] == ["herdr", "plugin", "pane", "open"] for command in calls)
-PY
-  assert_success
 }
 
 function test_smoke_013_herdr_command_palette_loads_toml_and_project_loc() {
@@ -596,10 +518,10 @@ function test_smoke_021_agent_skills_are_deployed_with_their_scripts_and() {
   assert_dir_not_exists "$HOME/.agents/skills/ask-in-herdr/scripts/agents"
 }
 
-# A hand-copied list here can only restate what test 075 (CLAUDE.md pointers)
-# already implies; it drifts silently when a shared file is renamed and its
-# entry here is forgotten. Cross-check both independent sides instead: every
-# ~/.claude/shared/*.md pointer written anywhere in the deployed agent surface
+# A hand-copied list of shared filenames here can only restate the pointers the
+# deployed surface already writes; it drifts silently when a shared file is
+# renamed and its entry here is forgotten. Cross-check both independent sides
+# instead: every ~/.claude/shared/*.md pointer written in the deployed surface
 # (CLAUDE.md, skills, agents, hooks, output-styles, rules, and the herdr
 # child-launch lib) must resolve to a real file, and conversely every deployed
 # shared file except the directory's own README index must be reachable from
@@ -632,26 +554,6 @@ function test_smoke_022_shared_references_form_a_closed_reference_set() {
     grep -qF "shared/$name" <<< "$pointers" || orphans="$orphans $name"
   done
   [ -z "$orphans" ] || fail "orphaned ~/.claude/shared files referenced by nothing:$orphans"
-}
-
-# A shared file that is renamed or moved keeps the deployment tests above green
-# while the CLAUDE.md pointer reaching it goes dead, because those tests and the
-# pointer are edited independently. Resolving the pointer against the deployed
-# tree is what fails on that split.
-function test_smoke_075_claude_md_pointers_into_shared_resolve() {
-  _bats_test_init 75 'CLAUDE.md pointers into ~/.claude/shared resolve'
-  local claude_md="$HOME/.claude/CLAUDE.md"
-  assert_file_exists "$claude_md"
-
-  local pointers
-  pointers="$(grep -o '~/\.claude/shared/[A-Za-z0-9._-]*\.md' "$claude_md" | sort -u)"
-  [ -n "$pointers" ] || fail "no ~/.claude/shared pointer found in $claude_md"
-
-  local pointer missing=""
-  while IFS= read -r pointer; do
-    [ -f "$HOME/${pointer#\~/}" ] || missing="$missing $pointer"
-  done <<< "$pointers"
-  [ -z "$missing" ] || fail "CLAUDE.md points at missing files:$missing"
 }
 
 # ===========================================
@@ -736,12 +638,34 @@ function test_smoke_028_kitty_herdr_bindings_survive_a_non_latin_keyboar() {
   [ -z "$risky" ] || fail "bindings missing --allow-fallback: $risky"
 }
 
+# The real consumer is the palette's own hint parser: load_key_binding_groups()
+# reads `# palette: Group | Key | Description` comments out of the terminal
+# config and builds the panel from them, silently dropping any line that does
+# not split into three non-empty fields. Grepping the literal comment cannot
+# see that drop, so run the deployed parser over the deployed kitty config
+# (pinned via HERDR_COMMAND_PALETTE_KEYBINDINGS_CONFIG, which is the parser's
+# own override, so the result does not depend on which terminal hosts the run)
+# and assert the entries it actually produces.
 function test_smoke_029_kitty_carries_command_palette_hints_for_the_herd() {
-  _bats_test_init 29 'kitty carries command-palette hints for the herdr plugin (macOS only)'
+  _bats_test_init 29 'kitty command-palette hints parse into palette key-binding groups (macOS only)'
   is_macos || skip "Not on macOS"
-  local config="$HOME/.config/kitty/herdr.conf"
-  assert_file_contains "$config" "^# palette: Tabs & workspaces | ⌘T | New tab$"
-  assert_file_contains "$config" "^# palette: Panes | ⌘D | Split right$"
+  run env \
+    HERDR_COMMAND_PALETTE_KEYBINDINGS_CONFIG="$HOME/.config/kitty/herdr.conf" \
+    PYTHONPYCACHEPREFIX="$BATS_TEST_TMPDIR/pycache" \
+    python3 - <<'PY'
+import importlib.util, os, sys
+
+path = os.path.expanduser("~/.config/herdr/plugins/command-palette/palette.py")
+spec = importlib.util.spec_from_file_location("palette", path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+groups = dict(mod.load_key_binding_groups())
+assert ("⌘T", "New tab") in groups.get("Tabs & workspaces", []), groups
+assert ("⌘D", "Split right") in groups.get("Panes", []), groups
+PY
+  assert_success
 }
 
 function test_smoke_030_lazygit_config_keeps_russian_layout_keybindings() {
@@ -794,10 +718,17 @@ function test_smoke_032_focus_notify_plugin_compiles_and_declares_its_ru() {
   assert_success
 
   # The manifest wires the status event and the interpreter as argv arrays.
-  assert_file_contains "$FOCUS_NOTIFY_DIR/herdr-plugin.toml" \
-    '^on = "pane.agent_status_changed"$'
-  assert_file_contains "$FOCUS_NOTIFY_DIR/herdr-plugin.toml" \
-    '^command = \["python3", "notify.py"\]$'
+  # Literal consumed outside this repo: herdr's plugin loader parses these two
+  # keys to decide which event fires the plugin and how to exec it. Assert the
+  # deployed copy, not $SOURCE_ROOT — reading the checkout here would be a
+  # source grep wearing a smoke test's name and would stay green when chezmoi
+  # never placed the file (same fix as test 009 in commit 50654e2). The plugin
+  # is darwin-only per home/.chezmoiignore, so it only deploys on macOS.
+  is_macos || return 0
+  local manifest="$HOME/.config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml"
+  assert_file_exists "$manifest"
+  assert_file_contains "$manifest" '^on = "pane.agent_status_changed"$'
+  assert_file_contains "$manifest" '^command = \["python3", "notify.py"\]$'
 }
 
 function test_smoke_033_focus_notify_builds_a_safely_quoted_click_comman() {
@@ -1038,14 +969,14 @@ assert_herdr_sidebar_deployment_contract() {
   local config="$1"
   local width
 
-  assert_file_contains "$config" '^sidebar_min_width = 32$'
   assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
   # Tab labels stay names-only. Built-in workspace and pane tokens retain their
   # distinct Herdr styles; the Git row stays aggregate to avoid separators.
   assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\], \["\$git_line"\]\]$'
   run grep -E '\$location_label|\$location_status' "$config"
   assert_failure
-  # The awk scope proves the key sits inside [ui], which the grep above cannot.
+  # Sole owner of sidebar_min_width: the awk scope proves the key both carries
+  # the value herdr reads and sits inside [ui], which a flat file grep cannot.
   # No width-derived assertions here: nothing consumes a "width - 4" budget.
   width="$(awk '
     $0 == "[ui]" { in_ui = 1; next }

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -76,12 +76,6 @@ function test_templates_003_chezmoi_init_binds_email_from_env_var() {
 # dot_gitconfig.tmpl
 # ===========================================
 
-function test_templates_004_gitconfig_template_renders_successfully() {
-  _bats_test_init 4 'gitconfig template renders successfully'
-  run render_template "$SOURCE_ROOT/dot_gitconfig.tmpl"
-  assert_success
-}
-
 # "name = " / "email = " are unconditional boilerplate in the template;
 # asserting them proves nothing about substitution — hence the probe values.
 function test_templates_005_gitconfig_renders_the_config_name_into_user_name() {
@@ -104,26 +98,6 @@ function test_templates_006_gitconfig_renders_the_config_email_into_user_ema() {
   assert_success
   assert_output --partial "email = gitconfig-probe@env.example"
   refute_output --partial '{{'
-}
-
-# ===========================================
-# dot_zshenv.tmpl
-# ===========================================
-
-function test_templates_007_zshenv_template_renders_without_op_in_path() {
-  _bats_test_init 7 'zshenv template renders without op in PATH'
-  run render_template "$SOURCE_ROOT/dot_zshenv.tmpl"
-  assert_success
-}
-
-# ===========================================
-# dot_zshrc.tmpl
-# ===========================================
-
-function test_templates_008_zshrc_template_renders_successfully() {
-  _bats_test_init 8 'zshrc template renders successfully'
-  run render_template "$SOURCE_ROOT/dot_zshrc.tmpl"
-  assert_success
 }
 
 # ===========================================
@@ -252,14 +226,6 @@ PROBE
 # opencode.json.tmpl
 # ===========================================
 
-function test_templates_011_opencode_json_tmpl_renders_valid_json() {
-  _bats_test_init 11 'opencode.json.tmpl renders valid JSON'
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_config/opencode/opencode.json.tmpl" > "$BATS_TEST_TMPFILE"
-  run python3 -m json.tool "$BATS_TEST_TMPFILE"
-  assert_success
-}
-
 # opencode.json.tmpl has zero template directives, so asserting its other
 # literals would only mirror the source. These two are consumed verbatim as
 # a security contract: `executor mcp` speaks stdio, so OpenCode never holds
@@ -299,18 +265,6 @@ function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
     assert_success
     assert_file_exists "$output"
   done <<< "$entries"
-}
-
-# ===========================================
-# private_settings.json.tmpl (Claude Code settings)
-# ===========================================
-
-function test_templates_015_private_settings_json_tmpl_renders_valid_json() {
-  _bats_test_init 15 'private_settings.json.tmpl renders valid JSON'
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
-  run python3 -m json.tool "$BATS_TEST_TMPFILE"
-  assert_success
 }
 
 # ===========================================
@@ -625,6 +579,17 @@ function test_templates_031_agent_skills_clients_use_portable_providers() {
   run jq -e 'has("plugin")' <<< "$opencode"
   assert_failure
 
+  # These five names are copied from the template this test renders, so treat
+  # them as the control fixture for the three rejections above, not as an
+  # independent oracle: with an empty `enabledPlugins` every `assert_failure`
+  # would pass, and the retirement checks would prove nothing. The protected
+  # regression is therefore silent *removal* — a settings edit that drops a
+  # plugin Claude still needs for its non-skill functionality.
+  #
+  # docs/agent-setup-inventory.md names the same five and would be the
+  # independent side, but the template-test container mounts only home/,
+  # tests/, docs/issues, Makefile and README.md (docker/docker-compose.yml), so
+  # that file does not exist where this suite runs and cannot be read here.
   run jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"] and .enabledPlugins["playwright@claude-plugins-official"] and .enabledPlugins["plugin-dev@claude-plugins-official"] and .enabledPlugins["security-guidance@claude-plugins-official"] and .enabledPlugins["typescript-lsp@claude-plugins-official"]' <<< "$claude"
   assert_success
 }

--- a/tests/pi-brew-auto-update.test.ts
+++ b/tests/pi-brew-auto-update.test.ts
@@ -135,6 +135,54 @@ describe("captureExtensionSnapshot", () => {
     expect(before).toBeDefined();
     expect(after).toEqual(before);
   });
+
+  // Authored here, never read from the extension source: whatever `git
+  // rev-parse HEAD` prints is what the snapshot must carry, and the trailing
+  // newline is part of what a real rev-parse emits.
+  const FIRST_REVISION = "1111111111111111111111111111111111111111";
+  const SECOND_REVISION = "2222222222222222222222222222222222222222";
+
+  async function gitExtensionListing(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "pi-git-extension-snapshot-test-"));
+    cleanupPaths.push(root);
+    const checkoutPath = join(root, "compound-engineering-plugin");
+    await mkdir(checkoutPath, { recursive: true });
+    return `User packages:\n  git:github.com/EveryInc/compound-engineering-plugin\n    ${checkoutPath}\n`;
+  }
+
+  test("carries the git checkout's reported revision and changes when it advances", async () => {
+    const listing = await gitExtensionListing();
+    let revisions = 0;
+    const exec: BrewAutoUpdateDependencies["exec"] = async (command) => {
+      if (command === "pi") return { code: 0, stdout: listing, stderr: "", killed: false };
+      revisions += 1;
+      return {
+        code: 0,
+        stdout: `${revisions === 1 ? FIRST_REVISION : SECOND_REVISION}\n`,
+        stderr: "",
+        killed: false,
+      };
+    };
+
+    const before = await captureExtensionSnapshot(exec, 300_000);
+    const after = await captureExtensionSnapshot(exec, 300_000);
+
+    expect([...(before ?? []).values()]).toEqual([FIRST_REVISION]);
+    expect([...(after ?? []).values()]).toEqual([SECOND_REVISION]);
+  });
+
+  test("reports an unverifiable snapshot when the git revision command is killed", async () => {
+    const listing = await gitExtensionListing();
+    const exec: BrewAutoUpdateDependencies["exec"] = async (command) =>
+      command === "pi"
+        ? { code: 0, stdout: listing, stderr: "", killed: false }
+        : { code: null, stdout: "", stderr: "", killed: true };
+
+    // A partial snapshot would compare unequal to the other side and announce
+    // an extension update that never happened, so an unreachable revision must
+    // surface as "unknown" rather than as a value.
+    expect(await captureExtensionSnapshot(exec, 300_000)).toBeUndefined();
+  });
 });
 
 describe("brew auto update sequence", () => {
@@ -158,11 +206,7 @@ describe("brew auto update sequence", () => {
     const result = await runBrewAutoUpdate("startup", ui, deps);
 
     expect(result.status).toBe("complete");
-    expect(calls).toEqual([
-      ["brew", ["update"]],
-      ["brew", ["upgrade", "pi-coding-agent"]],
-      ["pi", ["update", "--extensions"]],
-    ]);
+    expect(calls).toHaveLength(3);
     expect(notifications).toEqual([]);
   });
 
@@ -187,7 +231,7 @@ describe("brew auto update sequence", () => {
     }
   });
 
-  test("stays silent at startup when a git extension remains on the same revision", async () => {
+  test("stays silent at startup when the injected extension snapshot is unchanged", async () => {
     const unchanged = new Map([["git:compound-engineering", "unchanged-commit"]]);
     const { deps } = await dependencies({
       snapshotExtensions: async () => new Map(unchanged),
@@ -231,7 +275,7 @@ describe("brew auto update sequence", () => {
     expect(notifications).toEqual([{ message: "Pi is up to date.", level: "info" }]);
   });
 
-  test("notifies when a git extension advances to a new revision", async () => {
+  test("notifies when the injected extension snapshot differs across the update", async () => {
     let snapshots = 0;
     const { deps } = await dependencies({
       snapshotExtensions: async () => {
@@ -566,9 +610,7 @@ test("registers session_start to run the update sequence in the background, only
   const handlers = new Map<string, Function>();
   const fakePi = {
     on: (event: string, handler: Function) => handlers.set(event, handler),
-    registerCommand: (name: string) => {
-      expect(name).toBe("brew-auto-update-now");
-    },
+    registerCommand: () => {},
   };
   let finishExec!: () => void;
   const { deps, calls } = await dependencies({
@@ -585,9 +627,9 @@ test("registers session_start to run the update sequence in the background, only
   const startup = handlers.get("session_start")!;
   const ctx = { ui: fakeUi().ui };
 
-  expect(startup({ reason: "reload" }, ctx)).toBeUndefined();
+  startup({ reason: "reload" }, ctx);
   expect(calls).toEqual([]);
-  expect(startup({ reason: "startup" }, ctx)).toBeUndefined();
+  startup({ reason: "startup" }, ctx);
   while (!finishExec) await Bun.sleep(1);
   expect(calls).toHaveLength(1);
   finishExec();

--- a/tests/test_docker_contract.py
+++ b/tests/test_docker_contract.py
@@ -89,20 +89,27 @@ class TestDockerContract(unittest.TestCase):
         self.assertRegex(script, r"(?m)^\s*chezmoi apply\b")
         self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
 
-    def test_apply_services_run_the_full_post_apply_suite(self):
-        for name in self.apply_service_names():
-            with self.subTest(service=name):
-                script = self.service_command_script(self.service_block(name))
-                self.assertRegex(script, r"(?m)^\s*tests/run-post-apply\.sh full\b")
-
     def test_apply_services_declare_disposable_home_and_frozen_brew_bundle(self):
-        # idempotent_test.sh hard-fails in a container without
-        # MMS_DISPOSABLE_HOME; without HOMEBREW_BUNDLE_NO_UPGRADE a revert to
-        # drift-chasing surfaces only as wall-clock/network flakiness.
+        # HOMEBREW_BUNDLE_NO_UPGRADE is parsed verbatim by Homebrew, a tool
+        # this repo does not own and cannot cheaply invoke in CI, and without
+        # it a revert to drift-chasing surfaces only as wall-clock/network
+        # flakiness. That is the externally-consumed-literal shape, kept.
+        #
+        # MMS_DISPOSABLE_HOME is consumed inside this repo, so trusting the
+        # spelling here would be a source copy. Cross-check it against its
+        # reader instead: tests/helpers/disposable-home.bash is what lets
+        # idempotent_test.sh run its real chezmoi commands, and a rename there
+        # that missed compose would drop that coverage silently.
+        marker = "MMS_DISPOSABLE_HOME"
+        self.assertIn(
+            marker,
+            (REPOSITORY / "tests" / "helpers" / "disposable-home.bash").read_text(encoding="utf-8"),
+            "%s must be the marker tests/helpers/disposable-home.bash reads" % marker,
+        )
         for name in self.apply_service_names():
             with self.subTest(service=name):
                 env = self.service_env(self.service_block(name))
-                self.assertEqual(env.get("MMS_DISPOSABLE_HOME"), "1")
+                self.assertEqual(env.get(marker), "1")
                 self.assertEqual(env.get("HOMEBREW_BUNDLE_NO_UPGRADE"), "1")
 
     def stage_service_volumes(self, service, root, overrides=None):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -3,6 +3,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -184,10 +185,37 @@ class ReadTests(IssueFixtures):
         self.assertIn("[high] 2026-08-21-002 - High", result.stdout)
 
     def test_formats_terminal_priority_id_title_and_description_styles(self):
+        # Transcribing the escape sequences would copy PRIORITY_COLORS and the
+        # four wrapper templates out of scripts/issues, so recolouring the CLI
+        # would edit both sides in one patch and never fail, while a harmless
+        # palette change would fail for no consumer-visible reason. The two
+        # properties below need no palette knowledge: the plain branch is the
+        # independent oracle for the coloured one, and priorities that share a
+        # colour are indistinguishable to the reader the colour exists for.
+        module = self.module()
+        sgr = re.compile(r"\x1b\[[0-9;]*m")
         value = {"id": "2026-08-21-002-high", "priority": "high", "short_description": "High desc", "title": "High"}
-        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh desc\x1b[0m", self.module().format_issue_summary(value, color=True))
+
+        colored = module.format_issue_summary(value, color=True)
+        plain = module.format_issue_summary(value, color=False)
+        self.assertNotIn("\x1b[", plain)
+        self.assertIn("\x1b[", colored)
+        self.assertEqual(plain, sgr.sub("", colored))
+
+        # Each of the four fields carries its own SGR pair, so one field losing
+        # its reset cannot leak styling into the next.
+        self.assertEqual(4, len(sgr.findall(colored)) // 2)
+        self.assertTrue(colored.endswith("\x1b[0m"))
+
+        # A description identical to the title must still render on its own
+        # line rather than being deduplicated away.
         value["short_description"] = "High"
-        self.assertEqual("\x1b[31m[high]\x1b[0m \x1b[36m2026-08-21-002\x1b[0m - \x1b[1mHigh\x1b[0m\n\x1b[2mHigh\x1b[0m", self.module().format_issue_summary(value, color=True))
+        head, _, tail = sgr.sub("", module.format_issue_summary(value, color=True)).partition("\n")
+        self.assertTrue(head.endswith("High"), head)
+        self.assertEqual("High", tail)
+
+        colors = {p: module.PRIORITY_COLORS[p] for p in module.PRIORITIES}
+        self.assertEqual(len(colors), len(set(colors.values())), "priorities must not share a colour")
 
     def test_searches_title_description_and_arbitrary_body_in_stable_order(self):
         self.write_issue("2026-08-21-002-body.md", issue_text(title="Other", short_description="Nothing") + b"\xffNeedle in body.\xfe\n")

--- a/tests/test_post_apply_suite_contract.py
+++ b/tests/test_post_apply_suite_contract.py
@@ -22,23 +22,49 @@ class TestPostApplySuiteContract(unittest.TestCase):
     def test_post_apply_suite_uses_one_wrapper_with_two_explicit_modes(self):
         makefile = MAKEFILE.read_text(encoding="utf-8")
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        compose = COMPOSE.read_text(encoding="utf-8")
 
-        self.assertEqual(
-            workflow.count("run: tests/run-post-apply.sh full"),
-            2,
-            "both GitHub Actions post-apply steps must call the shared full-suite wrapper",
-        )
-        self.assertEqual(
-            compose.count("tests/run-post-apply.sh full"),
-            2,
-            "both Docker full-suite services must call the shared full-suite wrapper",
-        )
-        self.assertEqual(
-            makefile.count("tests/run-post-apply.sh host-safe"),
-            1,
-            "make test-suite must call the host-safe wrapper mode exactly once",
-        )
+        # Counting occurrences pinned "how many exist today" -- a number with
+        # no origin outside the file being read -- and the workflow count also
+        # pinned the YAML spelling `run: `, so reformatting a step to `run: |`
+        # broke it with no behaviour change. What the wrapper actually owes CI
+        # is a relationship between two independently maintained sides:
+        # whatever applies the dotfiles must then run the suite against them.
+        # The compose side of the same rule is owned by
+        # tests/test_docker_contract.py's
+        # test_apply_service_scripts_propagate_a_failing_post_apply_suite,
+        # which executes each applying service's script against a stubbed
+        # wrapper and requires the exit code to survive -- strictly stronger
+        # than counting the command's occurrences.
+        jobs = re.search(r"^jobs:\n(?P<body>.*)\Z", workflow, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(jobs, "workflow must declare a jobs block")
+        job_names = re.findall(r"^  ([a-zA-Z0-9_-]+):\n", jobs.group("body"), re.MULTILINE)
+        self.assertTrue(job_names, "no jobs parsed from the workflow")
+
+        applying = []
+        for name in job_names:
+            block = re.search(
+                r"^  %s:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)" % re.escape(name),
+                workflow,
+                re.MULTILINE | re.DOTALL,
+            )
+            body = block.group("body")
+            if "chezmoi apply" not in body:
+                continue
+            applying.append(name)
+            self.assertIn(
+                "tests/run-post-apply.sh full",
+                body,
+                "job %s applies the dotfiles but never runs the post-apply suite" % name,
+            )
+        # An empty selection would let the loop above pass vacuously.
+        self.assertGreaterEqual(len(applying), 2, "expected at least two applying CI jobs, got %r" % applying)
+
+        # make test-suite is host-safe by design: it must reach the wrapper,
+        # and must not reach the full mode, which runs real apply tests.
+        recipe = re.search(r"^test-suite:.*?(?=^\S|\Z)", makefile, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(recipe, "Makefile must define the test-suite target")
+        self.assertRegex(recipe.group(0), r"(?m)^\t.*tests/run-post-apply\.sh host-safe\b")
+        self.assertNotRegex(recipe.group(0), r"(?m)^\t.*tests/run-post-apply\.sh full\b")
 
         suite_files = self.discovered_suite_files()
         self.assertTrue(suite_files, "no post-apply suite files discovered on disk")
@@ -47,10 +73,24 @@ class TestPostApplySuiteContract(unittest.TestCase):
         orders = [order for order, _ in declarations.values()]
         self.assertEqual(len(orders), len(set(orders)), "post-apply order values must be unique")
 
-        full_invocations = self.wrapper_invocations("full")
-        host_safe_invocations = self.wrapper_invocations("host-safe")
-        self.assert_invocation_shape(full_invocations, "full mode")
-        self.assert_invocation_shape(host_safe_invocations, "host-safe mode")
+        # "3" is this test's own value, unrelated to the wrapper's default, so
+        # a wrapper that hardcoded its worker count instead of reading
+        # MMS_BASHUNIT_JOBS fails here.
+        full_invocations = self.wrapper_invocations("full", jobs="3")
+        host_safe_invocations = self.wrapper_invocations("host-safe", jobs="3")
+        self.assert_invocation_shape(full_invocations, "full mode", "3")
+        self.assert_invocation_shape(host_safe_invocations, "host-safe mode", "3")
+
+        # The unset case must still reach bashunit with a positive integer, so
+        # the default cannot silently become empty or 0.
+        default_invocations = self.wrapper_invocations("host-safe")
+        self.assertTrue(default_invocations, "wrapper ran no suite file by default")
+        for argv in default_invocations:
+            self.assertEqual(argv[0], "-j", "default worker flag")
+            self.assertTrue(
+                argv[1].isdigit() and int(argv[1]) > 0,
+                "default worker count must be a positive integer, got %r" % argv[1],
+            )
 
         full_files = [argv[-1] for argv in full_invocations]
         host_safe_files = [argv[-1] for argv in host_safe_invocations]
@@ -228,18 +268,27 @@ class TestPostApplySuiteContract(unittest.TestCase):
                     return True
         return False
 
-    def assert_invocation_shape(self, invocations, message):
+    def assert_invocation_shape(self, invocations, message, expected_jobs):
         for argv in invocations:
             # The report path is a fresh mktemp file per invocation, so assert
-            # the flag positions but not the path itself. -j 8 and
-            # --report-json are the wrapper's own operational contract
-            # (worker count and the bashunit report flag), independent of
-            # which suite files exist.
+            # the flag positions but not the path itself. --report-json is the
+            # wrapper's own operational contract: its inline failure-name
+            # reporter reads that file back.
+            #
+            # The worker count is asserted against the value THIS TEST chose
+            # via MMS_BASHUNIT_JOBS, never against the wrapper's default.
+            # run-post-apply.sh declares that default overridable, and CI's
+            # macOS job really does set MMS_BASHUNIT_JOBS=4
+            # (.github/workflows/test-dotfiles.yml), so pinning the literal 8
+            # made this test red for a supported configuration while staying
+            # blind to the regression that matters -- the wrapper dropping the
+            # operator's cap on the floor.
             self.assertEqual(len(argv), 5, message)
-            self.assertEqual(argv[0:2], ["-j", "8"], message)
+            self.assertEqual(argv[0], "-j", message)
+            self.assertEqual(argv[1], expected_jobs, message)
             self.assertEqual(argv[2], "--report-json", message)
 
-    def wrapper_invocations(self, mode):
+    def wrapper_invocations(self, mode, jobs=None):
         if not RUNNER.exists():
             self.fail("tests/run-post-apply.sh must own the post-apply suite command")
 
@@ -259,6 +308,10 @@ class TestPostApplySuiteContract(unittest.TestCase):
             env = os.environ.copy()
             env["BASHUNIT_ARGV_FILE"] = str(argv_file)
             env["MMS_BASHUNIT_BIN"] = str(fake_bashunit)
+            if jobs is None:
+                env.pop("MMS_BASHUNIT_JOBS", None)
+            else:
+                env["MMS_BASHUNIT_JOBS"] = jobs
             subprocess.run(
                 [str(RUNNER), mode],
                 cwd=REPOSITORY,


### PR DESCRIPTION
## Summary

The test suite now fails for two regressions it was blind to, and stops failing for changes that break nothing. An audit of every test in `tests/` for **positive tautology** — an expected value with no origin independent of the artifact under test — found two assertions that could not fail for the behaviour they named, and about twenty that restated a literal a stronger neighbour already owned.

A tautological test is worse than a missing one: it looks like evidence and suppresses further investigation. Both of the serious findings below were confirmed by reproducing the regression and watching the test stay green.

## The two that could not fail

**`tests/run-post-apply.sh` worker count.** `test_post_apply_suite_contract.py` pinned `-j 8`. That 8 is a production default the wrapper explicitly declares overridable (`JOBS="${MMS_BASHUNIT_JOBS:-8}"`), so the test was red under `MMS_BASHUNIT_JOBS=4` — the value CI's own macOS job has set since c029819 — while never noticing the wrapper dropping the operator's cap. `MMS_BASHUNIT_JOBS=4 make test-issues` failed on `main`. CI never caught it because that `env:` block is scoped to the macOS job's post-apply *step*, so the Python suite in the earlier `make test-issues` step never saw the override — the breakage was latent, waiting for anyone who exported the documented variable in their own shell. It now drives the wrapper with a worker count the *test* chooses and asserts the env-var-to-argv relationship, plus a positive-integer floor for the unset case.

**Pi brew updater git snapshot.** Two tests were named for git-revision behaviour but injected `snapshotExtensions` wholesale, so the production git branch never ran and no test reached `captureExtensionSnapshot`'s `git rev-parse HEAD` path. Replacing the revision read with a constant — permanently blinding the updater to every git-installed Pi extension, so a real update is never announced — left all 27 tests green. This adds a real git-snapshot case and a killed-exec case, and renames the two tests to what they actually cover.

## What changed elsewhere

The rest follow the named-consumer rule settled in `docs/issues/2026-09-01-002`: an assertion earns its slot by pinning a literal a tool outside this repo parses verbatim, or by comparing two independently maintained sides.

| Was | Is |
|---|---|
| Pi package list copied from the modifier under test | The replacement behaviour: the caller's array is discarded, no `git:` entry survives |
| Two named theme colour slots asserted `== ""` | Every colour either inherits or names a slot the theme's own `vars` block declares |
| `startswith("ansi:")` on Claude Code overrides | The 16 ANSI colour names — `ansi:tomato` is now rejected, it was not before |
| `launch.state` compared byte-for-byte | Read back through `state_value`, the accessor its real consumers use |
| Bare `assert_failure` on `make lint` | An invocation log plus an exit-0 control, so any unrelated failure no longer passes |
| One `assert_failure` shared by three skills-sync guards | Each iteration asserts its own rejected path |
| Progress-banner greps (`Installing Oh My Zsh`) | The upstream installer URLs, which move only when the install does |
| Literal `# palette:` hint strings in the kitty config | The deployed parser's output, which also catches a hint it silently drops |
| `focus-notify` manifest read from `$SOURCE_ROOT` | Read from the deployed `$HOME` copy, per the test 009 precedent in 50654e2 |
| Transcribed ANSI escape sequences in the issues formatter | Structure: plain output is the oracle for the coloured branch, priorities keep distinct colours |
| `workflow.count("run: tests/run-post-apply.sh full") == 2` | Every CI job that applies the dotfiles must run the suite — derived, not counted |

Nine tests are deleted rather than rewritten, each naming the owner that already covered it at a stronger boundary: four smoke tests owned by `palette_test.sh` or `tests/test_issues.py`, and five bare-`assert_success` template renders owned by a sibling in the same file.

## Verification

Every change carries a mutation proof — the regression it should catch was reproduced, the test observed red, the source restored, and green reverified. Several were also proved green under the harmless change that previously turned them red:

| Mutation | Before | After |
|---|---|---|
| `MMS_BASHUNIT_JOBS=4` (a supported config) | red | green |
| Wrapper ignores `MMS_BASHUNIT_JOBS` | green | red |
| `captureExtensionSnapshot` blinded to git revisions | green | red |
| Harmless recolour of `PRIORITY_COLORS` | red | green |
| Coloured branch drops the title's reset | green | red |
| `launch.state` fields reordered, mapping intact | red | green |
| `launch.state` two arguments swapped | green | red |
| Workflow step reformatted to `run: \|` | red | green |
| An applying CI job stops running the suite | green | red |

Suites: `make test-suite` exit 0 (382 passed, 1 skipped, 6 risky), `make test-issues` 50 tests OK, `make test-templates` in Docker exit 0 (21 passed, 1 risky), `bun test tests/pi-brew-auto-update.test.ts` 29 pass, `make lint` clean.

## Deliberately not done

Four `assert_equal "$(cat "$HTS_LOG")" ""` refutations can pass because the harness never started, not because the guard held. That is negative-assertion vacuity, a different class from the positive tautologies this pass targets, and `scripts_test.sh` already documents the fix pattern in place at test 216.

`docs/issues/2026-09-02-011` asked whether the shared `test-oracle-guard` engine should gain a positive-tautology signal. Its cited incident does not survive checking — no commit on any ref adds the tests it describes — and the audit argues against the candidate mechanism: both HIGH findings were written *with* a plausible oracle in mind, so an `oracle:` comment requirement on every new test function would have caught neither, at the cost of touching every new test in every repo across all three clients. Recorded on the issue, which stays open on the narrower question.

Two new issues record what this pass could not fix: `2026-09-02-012` (every herdr-task-sync assertion is measured against a stub that reimplements herdr's protocol, and nothing compares the fake to the real binary) and `2026-09-02-013` (a pre-existing `palette_test.sh` flake at `-j 8` under load, reproduced against an unmodified `HEAD` copy).

Related: `docs/issues/2026-09-02-011`, `docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md`

