### PR TITLE
fix(agents): stop the status=$? idiom from fabricating exit codes

### DIFF
--- a/docs/issues/2026-09-02-014-make-test-ubuntu-stages-a-worktree-without-scripts-check-bats-assertions-py.md
+++ b/docs/issues/2026-09-02-014-make-test-ubuntu-stages-a-worktree-without-scripts-check-bats-assertions-py.md
@@ -1,0 +1,41 @@
+---
+title: "make test-ubuntu stages a worktree without scripts/check_bats_assertions.py"
+short_description: "The test-full and test-ubuntu compose services mount only ../scripts/issues, so the staged /home/testuser/worktree lacks scripts/check_bats_assertions.py and the Makefile lint target it drives; scripts_test.sh:99 therefore fails in Docker and make test-ubuntu always exits non-zero, while CI stays green because it runs the suite against the real checkout."
+type: "bug"
+category: "testing-ci"
+tags: ["docker","lint","test-harness"]
+date: "2026-09-02"
+status: "open"
+priority: "high"
+---
+
+## Why this exists
+
+`make test-ubuntu` and `make test-docker` stage a writable copy of the repository inside the container before running `tests/run-post-apply.sh full`. The staging step in `docker/docker-compose.yml` copies `home/`, `tests/`, `docs/issues/`, `Makefile`, `README.md`, and exactly one file out of `scripts/`:
+
+```
+- ../scripts/issues:/home/testuser/issues-cli:ro
+...
+cp /home/testuser/issues-cli /home/testuser/worktree/scripts/issues
+```
+
+`Makefile:75` (`lint`) ends with `python3 scripts/check_bats_assertions.py tests`, and that file is never staged. Inside the container the target dies with:
+
+```
+python3: can't open file '/home/testuser/worktree/scripts/check_bats_assertions.py': [Errno 2] No such file or directory
+make: *** [Makefile:75: lint] Error 2
+```
+
+`tests/bashunit/scripts_test.sh:99` (`lint target propagates shellcheck failures`) runs `make -C "$repo_root" lint` twice with a stubbed `shellcheck`. Its second leg asserts success, which the missing file makes impossible, so the case fails and `make test-ubuntu` exits non-zero on every run regardless of the change under test.
+
+Impact: the target that repository policy names as the proof for a change to a managed file cannot report a clean verdict. Every user of it has to read the failure list and decide by hand whether the one red case is theirs. Observed on 2026-09-02 while verifying the zsh-reserved-name guard: 282 passed, 1 failed, and the single failure was this one.
+
+CI is unaffected. `.github/workflows/test-dotfiles.yml` runs `tests/run-post-apply.sh full` and `make lint` against the real checkout, where `scripts/check_bats_assertions.py` exists, so the workflow stays green and the defect is visible only in the local Docker path.
+
+## Scope
+
+Stage the whole `scripts/` directory into the container worktree instead of the single `scripts/issues` file, in both the `test-full` and `test-ubuntu` services, and keep the existing `scripts/issues` destination path intact so `make test-issues` coverage does not move. Then confirm `tests/bashunit/scripts_test.sh:99` passes under `make test-ubuntu`.
+
+## Open decisions
+
+Whether the container should stage the repository by an allowlist at all. Every new repo-root file that `make lint` or a test target reads has to be added in two places, and this is the second such omission. Copying the tracked file set once would remove the class, at the cost of a larger container payload.

--- a/home/dot_local/bin/executable_zsh-reserved-name-guard
+++ b/home/dot_local/bin/executable_zsh-reserved-name-guard
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# zsh-reserved-name-guard — reserved-parameter gate shared by the Claude Code
+# hook, the opencode plugin, and the pi extension of the same name.
+#
+# Every client runs its bash tool through the login shell, which is zsh on this
+# machine, and herdr panes are zsh too. zsh reserves parameter names that bash
+# leaves free: `status` is a readonly alias of `$?`, `path` and `argv` are tied
+# to PATH and the positional parameters. So `cmd; status=$?; exit $status`
+# does not merely print "read-only variable: status" — the failed assignment
+# leaves `$?` at 1, and the `exit $status` that follows reports a fabricated
+# failure for a command that succeeded. That silent wrong verdict, not the
+# error line, is what this gate exists to stop.
+#
+# Usage: zsh-reserved-name-guard        (command text on stdin)
+#   exit 0  no reserved-name assignment; no output
+#   exit 1  flagged; human-readable reason on stdout
+#
+# Only assignment is gated. Reading `$status` is legal zsh and passes.
+#
+# Heredoc bodies are skipped, because a script written into a file through
+# `cat <<'EOF'` runs under its own interpreter, not under this zsh.
+# Escape hatch: a "zsh-ok:" comment anywhere in the command declares that the
+# assignment runs under bash (a `bash -c` body, a bash script sourced inline)
+# and lets the command through.
+# Fails open: missing input or tooling exits 0 so a broken guard never blocks
+# an agent.
+
+set -uo pipefail
+
+command=$(cat) || exit 0
+[ -n "$command" ] || exit 0
+
+case "$command" in
+  *zsh-ok:*) exit 0 ;;
+esac
+
+readonly_names="status options ARGC PPID HISTCMD LINENO TTYIDLE ZSH_SUBSHELL ZSH_EVAL_CONTEXT zsh_eval_context"
+tied_names="path argv"
+
+flagged=$(printf '%s\n' "$command" | awk -v RESERVED="$readonly_names $tied_names" '
+  BEGIN {
+    n = split(RESERVED, list, " ")
+    for (i = 1; i <= n; i++) reserved[list[i]] = 1
+    Q = sprintf("%c", 39)
+    DQ = sprintf("%c", 34)
+    heredoc = ""
+  }
+  {
+    line = $0
+
+    if (heredoc != "") {
+      body = line
+      sub(/^[ \t]*/, "", body)
+      sub(/[ \t]*$/, "", body)
+      if (body == heredoc) heredoc = ""
+      next
+    }
+
+    if (match(line, /<<-?[ \t]*/)) {
+      rest = substr(line, RSTART + RLENGTH)
+      if (match(rest, /^[^ \t;&|<>()]+/)) {
+        delim = substr(rest, RSTART, RLENGTH)
+        gsub(Q, "", delim)
+        gsub(DQ, "", delim)
+        if (delim ~ /^[A-Za-z_][A-Za-z0-9_]*$/) heredoc = delim
+      }
+    }
+
+    stripped = line
+    sub(/^[ \t]*/, "", stripped)
+    if (substr(stripped, 1, 1) == "#") next
+
+    # Command position is what makes an assignment an assignment. Splitting on
+    # the separators that start a new command keeps `echo "status=$rc"` and
+    # `--status=x` out of the report, while still reaching the inner commands
+    # of a one-liner handed to a herdr pane.
+    segments = line
+    gsub(/[;&|(){}`]/, "\n", segments)
+    m = split(segments, parts, "\n")
+    for (j = 1; j <= m; j++) {
+      s = parts[j]
+      sub(/^[ \t]*/, "", s)
+      while (s ~ /^(local|typeset|declare|export|readonly|integer|float|if|then|else|elif|while|until|do)[ \t]+/ || s ~ /^-[A-Za-z]+[ \t]+/) {
+        sub(/^[^ \t]+[ \t]+/, "", s)
+      }
+      if (match(s, /^[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?\+?=/)) {
+        name = substr(s, 1, RLENGTH)
+        sub(/(\[[^]]*\])?\+?=$/, "", name)
+        if (name in reserved) {
+          shown = stripped
+          if (length(shown) > 120) shown = substr(shown, 1, 117) "..."
+          printf "%s\tline %d: %s\n", name, NR, shown
+          break
+        }
+      }
+    }
+  }
+') || exit 0
+
+[ -n "$flagged" ] || exit 0
+
+lines=$(printf '%s\n' "$flagged" | cut -f2- | sed 's/^/  /')
+names=$(printf '%s\n' "$flagged" | cut -f1 | sort -u | tr '\n' ' ')
+
+hit_readonly=""
+hit_tied=""
+for name in $names; do
+  case " $readonly_names " in *" $name "*) hit_readonly="$hit_readonly $name" ;; esac
+  case " $tied_names " in *" $name "*) hit_tied="$hit_tied $name" ;; esac
+done
+
+{
+  printf 'zsh-reserved-name-guard: this command assigns to a parameter zsh reserves:\n'
+  printf '%s\n' "$lines"
+  if [ -n "$hit_readonly" ]; then
+    printf 'zsh makes%s readonly. The assignment fails AND leaves $? at 1, so a following `exit $status` or `FINAL_EXIT:$status` marker reports a fabricated failure for a command that actually succeeded.\n' "$hit_readonly"
+  fi
+  if [ -n "$hit_tied" ]; then
+    printf 'zsh ties%s to PATH and the positional parameters. Assigning it silently destroys them for the rest of the command.\n' "$hit_tied"
+  fi
+  printf 'Fix: rename the variable — `rc`, `st`, `exit_code`, `dir`. Reading $status is legal zsh and is not blocked, only assignment is. If this assignment genuinely runs under bash rather than this zsh, add a "zsh-ok:" comment to the command and retry.\n'
+}
+exit 1

--- a/home/dot_pi/agent/extensions/zsh-reserved-name-guard.ts
+++ b/home/dot_pi/agent/extensions/zsh-reserved-name-guard.ts
@@ -1,0 +1,49 @@
+// pi adapter for zsh-reserved-name-guard.
+//
+// Thin wrapper over ~/.local/bin/zsh-reserved-name-guard: on a bash tool call
+// it feeds the proposed command to the shared engine and blocks the call
+// ({ block: true, reason }) when the command assigns to a parameter zsh
+// reserves. The engine owns the name list, the command-position rule, the
+// heredoc skip, and the "zsh-ok:" escape hatch, so all agent clients enforce
+// one contract.
+//
+// Fails open: a missing or broken engine must never block a pi command.
+// @ts-nocheck
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const ENGINE_NAME = "zsh-reserved-name-guard";
+
+function enginePath(): string | undefined {
+  const home = process.env.HOME;
+  if (!home) return undefined;
+  const local = path.join(home, ".local", "bin", ENGINE_NAME);
+  return existsSync(local) ? local : undefined;
+}
+
+export default function (pi) {
+  pi.on("tool_call", (event) => {
+    if (event?.toolName !== "bash") return;
+
+    const command = event?.input?.command;
+    if (typeof command !== "string" || command === "") return;
+
+    const engine = enginePath();
+    if (!engine) return;
+
+    try {
+      const result = spawnSync(engine, [], {
+        input: command,
+        encoding: "utf8",
+        timeout: 3000,
+      });
+      if (result.status === 1 && result.stdout && result.stdout.trim() !== "") {
+        return { block: true, reason: result.stdout.trim() };
+      }
+    } catch {
+      // Engine failures (spawn error, timeout) fail open.
+    }
+  });
+}

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -105,6 +105,7 @@ Pick one (more recent / more tested), state why in one line, and flag the other 
 - `~/.scratchpad` is the trash directory only. Temporary working files still go to the per-session scratchpad path that the system prompt gives you.
 - Nothing empties `~/.scratchpad` automatically. If you moved anything there during a task, say so in your final report and give the user this command: `rm -rf ~/.scratchpad/*`. You cannot run it yourself; the deny list blocks it.
 - Monitor/Bash scripts run under zsh, system bash is 3.2: no `declare -A`, no unquoted word-splitting. Use `cmd | while read -r x` + scratchpad state files. After arming a monitor, verify the first event arrives.
+- zsh reserves parameter names bash leaves free. Never assign to `status`, `path`, or `argv`: `status=$?` fails *and* leaves `$?` at 1, so the `exit $status` after it reports a fabricated failure for a command that succeeded; `path=`/`argv=` silently destroy PATH and the arguments. Use `rc=$?`. Reading `$status` is fine. The same applies to a one-liner you hand to a herdr pane — the pane is zsh too.
 
 **Long-running work**
 

--- a/home/private_dot_claude/hooks/executable_zsh-reserved-name-guard.sh
+++ b/home/private_dot_claude/hooks/executable_zsh-reserved-name-guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# PreToolUse guard for Bash.
+#
+# Thin Claude Code adapter over ~/.local/bin/zsh-reserved-name-guard: feeds the
+# proposed command to the shared engine and denies the call when it assigns to
+# a parameter zsh reserves. The engine owns the name list, the command-position
+# rule, the heredoc skip, and the "zsh-ok:" escape hatch, so all agent clients
+# enforce one contract.
+#
+# Fails open: any missing dependency, unreadable input, or parse error exits 0
+# and the call proceeds.
+
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+guard="$HOME/.local/bin/zsh-reserved-name-guard"
+[ -x "$guard" ] || exit 0
+
+input=$(cat) || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "$cmd" ] || exit 0
+
+if reason=$(printf '%s' "$cmd" | "$guard" 2>/dev/null); then
+  exit 0
+fi
+[ -n "$reason" ] || exit 0
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -61,6 +61,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '{{ .chezmoi.homeDir }}/.claude/hooks/zsh-reserved-name-guard.sh'",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/home/private_dot_config/opencode/plugins/zsh-reserved-name-guard.ts
+++ b/home/private_dot_config/opencode/plugins/zsh-reserved-name-guard.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+// Type checking is off here for the same reason herdr's own managed extensions
+// turn it off: this file is checked out in a plain dotfiles repo with no
+// node_modules, and only resolves its imports once deployed under
+// ~/.config/opencode/, where opencode's own dependencies live.
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+// opencode adapter for zsh-reserved-name-guard.
+//
+// Thin wrapper over ~/.local/bin/zsh-reserved-name-guard: on a bash call it
+// feeds the proposed command to the shared engine and blocks the call (throw)
+// when the command assigns to a parameter zsh reserves. opencode has no shell
+// config key, so its bash tool follows process.env.SHELL — zsh here — and
+// `status=$?` both fails and corrupts the exit code the agent then reports.
+// The engine owns the name list, the command-position rule, the heredoc skip,
+// and the "zsh-ok:" escape hatch, so all agent clients enforce one contract.
+//
+// Fails open: a missing or broken engine must never block an opencode command.
+
+const ENGINE_NAME = "zsh-reserved-name-guard"
+
+function enginePath(): string | undefined {
+  const home = process.env.HOME
+  if (!home) return undefined
+  const local = path.join(home, ".local", "bin", ENGINE_NAME)
+  return existsSync(local) ? local : undefined
+}
+
+export const ZshReservedNameGuardPlugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input?.tool !== "bash") return
+
+      const command = (output?.args ?? {}).command
+      if (typeof command !== "string" || command === "") return
+
+      const engine = enginePath()
+      if (!engine) return
+
+      try {
+        const result = spawnSync(engine, [], {
+          input: command,
+          encoding: "utf8",
+          timeout: 3000,
+        })
+        if (result.status === 1 && result.stdout && result.stdout.trim() !== "") {
+          throw new Error(result.stdout.trim())
+        }
+      } catch (error: any) {
+        if (error instanceof Error && error.message.startsWith("zsh-reserved-name-guard:")) {
+          throw error
+        }
+        // Engine failures (spawn error, timeout) fail open.
+      }
+    },
+  }
+}

--- a/tests/bashunit/zsh_reserved_name_guard_test.sh
+++ b/tests/bashunit/zsh_reserved_name_guard_test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# post-apply: 55 host-safe
+# zsh-reserved-name-guard suite — bashunit source. Vocabulary (run, assert_*,
+# skip, BATS_* contract) comes from tests/bashunit/test-dsl.bash.
+#
+# Consumer: the Claude Code hook, opencode plugin, and pi extension all shell
+# out to this engine and trust its exit contract. Observable failure: the
+# engine stops flagging reserved-name assignments (agents keep shipping
+# `cmd; status=$?; exit $status`, whose failed assignment leaves $? at 1 so the
+# exit reports a fabricated failure) or starts flagging ordinary commands
+# (every agent Bash call gets denied). Oracle: live zsh — it is zsh, not this
+# repo, that decides which names are readonly or tied — plus the usage contract
+# in the engine's header, exercised with fixture command strings.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+load 'helpers/common'
+
+GUARD="$SOURCE_ROOT/dot_local/bin/executable_zsh-reserved-name-guard"
+
+run_guard() {
+  run bash -c 'printf "%s\n" "$1" | bash "$0"' "$GUARD" "$1"
+}
+
+function test_zsh_reserved_001_flags_the_status_capture_idiom() {
+  _bats_test_init 1 'flags the status capture idiom'
+  # The pinned text is the "zsh-reserved-name-guard:" prefix, the only part of
+  # this report a consumer parses: the opencode adapter
+  # (home/private_dot_config/opencode/plugins/zsh-reserved-name-guard.ts)
+  # rethrows the engine's stdout only when
+  # error.message.startsWith("zsh-reserved-name-guard:"), and swallows it
+  # otherwise. Lose the prefix and the guard fails open in opencode. The rest
+  # of the wording is prose nothing reads; the line number is produced from
+  # this test's own fixture, so it stays.
+  run_guard 'make test-ubuntu; status=$?; print -- FINAL_EXIT:$status; exit $status'
+  assert_failure
+  assert_output --partial "zsh-reserved-name-guard:"
+  assert_output --partial "line 1"
+}
+
+function test_zsh_reserved_002_reading_status_is_not_an_assignment() {
+  _bats_test_init 2 'reading status is not an assignment'
+  # Control for the whole gate: the marker one-liner an agent hands to a herdr
+  # pane reads $status and must keep working, or the guard blocks the very
+  # pattern it is meant to make safe.
+  run_guard 'print -- ALIAS_MERGE_UBUNTU_FINAL_EXIT:$status; sleep 30; exit $status'
+  assert_success
+  assert_output ""
+}
+
+function test_zsh_reserved_003_reserved_name_outside_command_position_passes() {
+  _bats_test_init 3 'reserved name outside command position passes'
+  # Control for the command-position rule: quoted output and long options carry
+  # "status=" without assigning anything.
+  run_guard 'rc=$?; echo "status=$rc"; gh run view --status=completed'
+  assert_success
+  assert_output ""
+}
+
+function test_zsh_reserved_004_heredoc_body_passes() {
+  _bats_test_init 4 'heredoc body passes'
+  # A script written into a file runs under its own interpreter, not under the
+  # zsh executing this command, so its assignments are none of the gate's
+  # business.
+  local fixture='cat > /tmp/probe.sh <<EOF
+make check
+status=$?
+exit $status
+EOF'
+  run_guard "$fixture"
+  assert_success
+  assert_output ""
+}
+
+function test_zsh_reserved_005_zsh_ok_comment_releases_the_command() {
+  _bats_test_init 5 'zsh-ok comment releases the command'
+  # oracle: engine header — the documented escape hatch for an assignment that
+  # genuinely runs under bash.
+  run_guard 'bash -c "true; status=\$?; exit \$status"  # zsh-ok: bash -c body'
+  assert_success
+  assert_output ""
+}
+
+function test_zsh_reserved_006_empty_input_fails_open() {
+  _bats_test_init 6 'empty input fails open'
+  # oracle: engine header — fails open so a broken adapter never blocks a call.
+  run bash -c 'printf "" | bash "$0"' "$GUARD"
+  assert_success
+}
+
+function test_zsh_reserved_007_every_blocked_name_is_one_zsh_rejects() {
+  _bats_test_init 7 'every blocked name is one zsh rejects'
+  # The two sides are independent: zsh decides which parameters are readonly,
+  # the engine decides what to block. This asserts they agree, so a name the
+  # engine quietly drops — or one zsh stops reserving — fails the suite.
+  command -v zsh >/dev/null || skip "zsh not available"
+  local name
+  for name in status ARGC PPID HISTCMD LINENO; do
+    run zsh -c "$name=1"
+    assert_failure
+
+    run_guard "$name=1"
+    assert_failure
+    assert_output --partial "zsh-reserved-name-guard:"
+  done
+}
+
+function test_zsh_reserved_008_an_ordinary_name_zsh_accepts_is_not_blocked() {
+  _bats_test_init 8 'an ordinary name zsh accepts is not blocked'
+  # Control paired with test 7: the replacement the report recommends must
+  # survive both zsh and the engine, or the guard has no usable escape.
+  command -v zsh >/dev/null || skip "zsh not available"
+  run zsh -c 'rc=1; exit $rc'
+  assert_failure  # exit 1 comes from the assignment's value, not from zsh refusing it
+  assert_output ""
+
+  run_guard 'make check; rc=$?; exit $rc'
+  assert_success
+  assert_output ""
+}
+
+function test_zsh_reserved_009_assigning_path_destroys_PATH_and_is_blocked() {
+  _bats_test_init 9 'assigning path destroys PATH and is blocked'
+  # zsh ties `path` to PATH; the damage is observable, which is why the engine
+  # gates a name that is not readonly.
+  command -v zsh >/dev/null || skip "zsh not available"
+  run zsh -c 'path=/nonexistent-guard-probe; printf "%s\n" "$PATH"'
+  assert_success
+  assert_output "/nonexistent-guard-probe"
+
+  run_guard 'path=/usr/bin; ls'
+  assert_failure
+  assert_output --partial "zsh-reserved-name-guard:"
+}
+
+function set_up_before_script() {
+  :
+}
+
+function tear_down_after_script() {
+  _bats_file_cleanup
+}
+
+function tear_down() { _bats_run_teardown; }


### PR DESCRIPTION
## Summary

An agent that writes `make check; status=$?; exit $status` now has the command refused before it runs, instead of getting a green build reported as a failure. Under zsh — the login shell every agent client here inherits, and the shell every herdr pane runs — `status` is a readonly alias of `$?`. The assignment fails *and* leaves `$?` at 1, so the `exit $status` after it returns 1 for a command that succeeded, and the agent acts on the fabricated verdict.

This is not hypothetical or rare. Five Claude Code sessions across four repositories hit it, and `opencode.db` holds 37 bash tool parts with the same idiom. The worst of them is `git stash push … && vitest; status=$?; git stash pop; exit $status`, where the wrong exit code is the entire result of the run.

## Why a gate and not a bash shell

Making the agent shell bash would remove the class outright, and Claude Code supports it — `CLAUDE_CODE_SHELL` accepts a bash path and the binary honours it. It was still rejected:

| Surface | Can it be moved to bash? |
|---|---|
| Claude Code bash tool | Yes, via `CLAUDE_CODE_SHELL` |
| OpenCode bash tool | No — `opencode.ai/config.json` has no shell key; it follows `process.env.SHELL` |
| herdr panes | No — panes are interactive zsh regardless |

One surface out of three, paid for by abandoning the zsh environment contract the repo documents (the `.zshenv` PATH, the `dust`/`duf` aliases, `pipestatus`). A gate covers all three instead.

## What it blocks

The gate refuses **assignment only**. Reading is legal zsh and passes untouched, including the pane marker one-liners this repo's agents rely on:

```
blocked:  make test; status=$?; exit $status
passes:   print -- FINAL_EXIT:$status; exit $status
passes:   rc=$?; echo "status=$rc"; gh run view --status=completed
```

Names come in two kinds. zsh *rejects* `status`, `options`, `ARGC`, `PPID`, `HISTCMD`, `LINENO`, `TTYIDLE`, `ZSH_SUBSHELL`, `ZSH_EVAL_CONTEXT` — loud, then wrong. It *ties* `path` to `PATH` and `argv` to the positional parameters — silent, and worse: `path=/usr/bin` leaves `$PATH` as exactly `/usr/bin` for the rest of the command.

Quoted text and long options are not assignments, so the scan splits on command separators rather than matching the name anywhere on a line. Heredoc bodies are skipped, because a script written into a file runs under its own interpreter. A `zsh-ok:` comment releases a command that genuinely runs under bash.

Enforcement is one engine plus three thin adapters, the shape `test-oracle-guard` already established here: Claude Code sees it as a `PreToolUse` deny on `Bash`, OpenCode as a plugin throw, pi as a blocked tool call. Every adapter fails open — a missing or broken engine never blocks a command. Global `CLAUDE.md` carries the same rule as prose, for the herdr pane one-liners no `PreToolUse` hook ever sees.

## New concepts

**zsh special parameters.** bash lets you name a variable almost anything. zsh reserves a set of parameter names for the shell's own state, in two flavours: *readonly* ones the shell refuses to let you write (`status`, `LINENO`, `PPID`), and *tied* ones that are live views of something else (`path` is `PATH` as an array, `argv` is `$@`). Both make ordinary-looking variable names hostile, and neither exists in bash — which is why a habit formed in bash scripts breaks here and nowhere else.

The damage is not the error message; it is what happens after. A failed readonly assignment is itself a command that returned 1, so `$?` is now 1 no matter what ran before it. Any later `exit $status` or status marker reports that instead of the real result. A tied assignment does not even error — it just quietly replaces `PATH`.

Rule of thumb for anything that will run under zsh: capture exit codes into `rc`, `st`, or `exit_code`, and never `status`. It does not apply to a bash script you write into a file, which is exactly the exemption the guard's heredoc skip and `zsh-ok:` hatch encode.

## Validation

The test suite's oracle is live zsh, not the engine's own list: for each blocked name it asserts both that `zsh -c '<name>=1'` fails and that the engine flags it, with `rc` as the accepted control, and it observes `PATH` collapse to the assigned value under `path=`. Two independently maintained sides, so a name silently dropped from the engine turns the suite red.

- 9/9 locally, and 9/9 inside the Ubuntu container after a real `chezmoi apply`
- `make test-suite` exit 0 (282 passed), `make test-templates` in Docker exit 0, `make lint` clean
- Three mutations proved red, green reverified after each restore: dropping `status` from the name list, disabling the heredoc skip, treating quotes as command separators
- The Claude hook exercised end-to-end with a real `PreToolUse` payload — deny carrying the reason, a clean command silent, a missing engine failing open

`make test-ubuntu` exits 2, on one failure that predates this branch and is unrelated to it: the container stages its worktree from an allowlist that copies a single file out of `scripts/`, so `scripts/check_bats_assertions.py` is missing and the `make lint` step of `scripts_test.sh:99` cannot reach its exit-0 control leg. CI is unaffected — it runs the same suite against the real checkout. The second commit records this as `docs/issues/2026-09-02-014-make-test-ubuntu-stages-a-worktree-without-scripts-check-bats-assertions-py.md`.

## Deployment

The gate is inert until the change reaches a machine: commit here, sync into the chezmoi source clone, `chezmoi apply`, then restart Claude Code, OpenCode and pi so each client reloads its adapter.
