### PR TITLE
fix(herdr): keep lifecycle shortcuts working in navigate mode

### DIFF
--- a/home/private_dot_config/ghostty/config
+++ b/home/private_dot_config/ghostty/config
@@ -67,7 +67,7 @@ keybind = cmd+n=unbind
 keybind = cmd+shift+KeyN=text:\x02G
 keybind = cmd+shift+n=unbind
 # palette: Tabs & workspaces | ⌘⇧O | Open worktree
-keybind = cmd+shift+KeyO=text:\x02O
+keybind = cmd+shift+KeyO=text:\x1b[111;10u
 keybind = cmd+shift+o=unbind
 # palette: Panes | ⌘D | Split right
 keybind = cmd+KeyD=text:\x02v
@@ -106,7 +106,7 @@ keybind = cmd+shift+w=unbind
 keybind = cmd+KeyK=text:\x02W
 keybind = cmd+k=unbind
 # palette: Tabs & workspaces | ⌘⇧K | Delete worktree checkout
-keybind = cmd+shift+KeyK=text:\x02Y
+keybind = cmd+shift+KeyK=text:\x1b[107;10u
 keybind = cmd+shift+k=unbind
 keybind = cmd+KeyL=text:\x02T
 keybind = cmd+l=unbind

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -14,8 +14,8 @@ allow_nested = true
 [keys]
 switch_workspace = "ctrl+shift+1..9"
 new_worktree = "prefix+shift+g"
-open_worktree = "prefix+shift+o"
-remove_worktree = "prefix+shift+y"
+open_worktree = ["prefix+shift+o", "cmd+shift+o", "prefix+cmd+shift+o"]
+remove_worktree = ["prefix+shift+y", "cmd+shift+k", "prefix+cmd+shift+k"]
 previous_workspace = "prefix+{"
 next_workspace = "prefix+}"
 focus_pane_left = "shift+alt+left"


### PR DESCRIPTION
`⌘⇧O` and `⌘⇧K` now open the Herdr worktree actions from both terminal mode and sidebar Navigate mode. Previously, Ghostty translated these shortcuts into tmux-prefix sequences, so Navigate mode consumed the prefix and sent the trailing key to the shell. Kitty modified-key events preserve the original shortcut while direct and prefix-dispatch bindings cover both Herdr input paths.

Validated with `ghostty +validate-config`, `herdr config check`, `make lint`, and `make test-ubuntu`. Runtime checks confirmed both shortcuts in terminal and Navigate modes; the delete confirmation was cancelled without removing a worktree.

Related: #149
