### PR TITLE
fix(agents): deliver peer answers through files instead of pane scrapes

### DIFF
--- a/docs/issues/2026-09-03-003-opencode-child-launch-intermittently-fails-with-agent-prompt-stalled.md
+++ b/docs/issues/2026-09-03-003-opencode-child-launch-intermittently-fails-with-agent-prompt-stalled.md
@@ -1,0 +1,83 @@
+---
+title: "Cold opencode and pi child launches fail with agent_prompt_stalled"
+short_description: "A cold first-of-session opencode or pi child reproducibly fails `herdr-child start` with `agent_prompt_stalled`: herdr's 5000 ms first-state-change window elapses before the agent accepts input, while all warm launches of both kinds and cold claude succeed (2 of 2 cold non-claude stalled, 0 of 8 warm), and the stall path additionally destroys the pane so the transcript is lost."
+type: "bug"
+category: "agent-platform"
+tags: ["herdr-child","opencode","agent-startup","intermittent"]
+date: "2026-09-03"
+status: "open"
+priority: "high"
+---
+
+## Why this exists
+
+The first opencode or pi child launched in a session reproducibly fails `herdr-child start`
+on herdr 0.8.2:
+
+```
+{"error":{"code":"agent_prompt_stalled","message":"agent prompt produced no observed
+state change within 5000 ms; status is idle and state_change_seq remained 2149"},
+"id":"cli:agent:prompt"}
+herdr-child: initial prompt stalled
+```
+
+`agent start` returns `"interactive_ready":true` first, so herdr believes the pane is ready.
+`start_child` then sends the initial prompt immediately, and for a cold opencode or pi the
+agent has not yet reached the point where it reacts to input. The 5000 ms first-state-change
+window elapses and the launch is treated as fatal.
+
+This is the launch path behind the `ask-in-herdr` skill, so it also carries the OpenCode leg
+of `se-code-review`, `se-doc-review`, and `se-plan`. The practical effect is that the first
+cross-model consult of any session fails, and the second succeeds. The failure is loud
+(exit 1 plus error JSON), so it degrades review coverage rather than corrupting a result.
+
+Two properties make each occurrence hard to diagnose:
+
+1. `home/dot_local/lib/herdr-child-launch.sh:522-529` treats a stalled initial prompt as
+   fatal in `wait` mode: it prints the message, calls `cleanup_pane prompt-failure`, and
+   returns 1. The pane is destroyed, so the transcript that would show what the agent was
+   doing during those 5000 ms is gone before anyone can read it.
+2. The `agent start` retry loop above it matches only `agent_pane_busy`. There is no retry
+   for a stalled first prompt.
+
+## Scope
+
+Decide whether the initial prompt should retry on `agent_prompt_stalled`, wait longer before
+prompting a kind known to be slow, or verify readiness by a signal stronger than
+`interactive_ready`. Regardless of that choice, preserve diagnosability: a stalled initial
+prompt should capture the child transcript, or keep the pane, before cleanup.
+
+Measurements on 2026-09-03, herdr 0.8.2, same repository checkout:
+
+| Kind | State | Runs | Stalls |
+|---|---|---:|---:|
+| claude | cold (first of session) | 1 | 0 |
+| opencode | cold (first of session) | 1 | **1** |
+| opencode | warm | 7 | 0 |
+| pi | cold (first of session) | 1 | **1** |
+| pi | warm | 1 | 0 |
+
+Every cold non-claude launch stalled; every warm launch succeeded. The warm opencode set
+includes three runs launched concurrently with a claude child, so concurrency is not the
+trigger.
+
+Hypotheses eliminated:
+
+- Not concurrency. Three concurrent claude+opencode pairs all succeeded.
+- Not prompt length or an absolute file path in the prompt. A manually started OpenCode
+  given the identical file-reading prompt completed it in 15.8 s.
+- Not an agent crash. A manually started OpenCode stayed alive and idle throughout, and its
+  pane showed all five MCP servers connected.
+- Not claude-specific tooling. Cold claude succeeded; the two kinds that stall are the two
+  that are slower to become responsive.
+
+Remaining unknown: what exactly consumes the cold-start time. OpenCode connects five MCP
+servers (deepwiki, executor, fff, jina, tavily-mcp) during startup, which is a plausible
+cost, but this was not instrumented and pi's cold path was not inspected at all.
+
+## Open decisions
+
+- Whether the fix belongs in `herdr-child` (retry, or a longer pre-prompt wait for kinds
+  known to start slowly) or should be reported upstream to the agent CLIs.
+- Whether a stalled initial prompt should keep the pane open by default, or capture a
+  transcript into the run directory and then clean up as it does today.

--- a/docs/issues/2026-09-03-004-file-backed-ask-and-reply-payloads-need-a-run-directory-lifetime-redesign-first.md
+++ b/docs/issues/2026-09-03-004-file-backed-ask-and-reply-payloads-need-a-run-directory-lifetime-redesign-first.md
@@ -1,0 +1,73 @@
+---
+title: "File-backed ask and reply payloads need a run-directory lifetime redesign first"
+short_description: "Moving ask/reply message bodies onto the child's generation-scoped run directory is blocked by six defects a three-envelope review found: the watcher deletes the directory on marker delivery, attached children get no generation at all, `ask_parent` gates on a hardcoded `mode=detach`, `atomic_write` cannot preserve bytes, retirement has no owner that survives an unreaped pane, and nothing distinguishes a complete payload from a truncated one."
+type: "follow-up"
+category: "agent-platform"
+tags: ["herdr-child","payload-transport","deferred"]
+date: "2026-09-03"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+A plan to move all four inter-agent message bodies — task, ask, reply, report — onto the
+child's `$STATE_DIR/runs/<generation>/` directory went through a three-envelope review
+(six local personas, a fresh Claude peer, a fresh OpenCode peer, plus a cross-model pass
+inside the Claude peer). The review returned one P0 and roughly fifteen P1 findings. The
+report direction was split out and shipped separately on a caller-owned transport; the
+ask/reply direction is blocked on the defects below.
+
+Six blocking findings, each confirmed against the source:
+
+1. **The watcher deletes the run directory on the delivery success path.**
+   `herdr-child-watcher.sh:351-358` calls `remove_supervision_run` immediately after a
+   marker is delivered, then exits. The parent is turn-based and its turn begins after
+   `herdr agent prompt` returns, so a body placed there is unlinked inside that window.
+   This is `docs/issues/2026-08-15-007` on the success path instead of an unlucky one.
+2. **Attached children have no generation and no run directory.** The whole block is
+   gated on `if [ "$mode" = detach ]` at `herdr-child-launch.sh:359`. `ask-in-herdr` is
+   attached-only.
+3. **`ask_parent` gates on a hardcoded detach mode.** It exits 1 with "detached child
+   metadata is unavailable or inconsistent" unless `child_mode` is exactly `detach`
+   (`herdr-child-continuation.sh:237-242`), and `write_launch_state`
+   (`herdr-child-runtime.sh:156`) hardcodes `mode=detach`. Giving attached children a run
+   directory without addressing this leaves them with a directory they cannot legally reach.
+4. **`atomic_write` cannot carry a message body.** It is `printf '%s\n' "$content"` with a
+   shell-string argument, so it always appends a newline and cannot round-trip bytes. It
+   remains correct for the small state records it was built for.
+5. **Retirement has no owner that survives an unreaped pane.** Handing teardown to `reap`
+   fails because `reap_children` returns early once the pane is gone — the exact case where
+   a body must still be readable. No sweep exists anywhere in `home/dot_local/lib/`.
+6. **Nothing distinguishes a complete payload from a truncated one.** The marker carries
+   identity coordinates, a path and a summary; none of that lets a reader tell a short
+   valid body from a cut-off one, so a typed truncated status cannot fire.
+
+## Scope
+
+Decide whether ask and reply bodies need file transport at all, and if so, redesign
+run-directory lifetime before any body is written there.
+
+Secondary findings the same review raised, worth carrying into that work:
+
+- A child's own exit trap can delete the run directory; moving the watcher's teardown does
+  not constrain the child process.
+- A payload written just before the writing child dies, with no marker ever delivered, has
+  no defined outcome.
+- Two attached asks in one exchange collide on a `generation`-plus-fixed-name path with no
+  event component.
+- Path-string validation does not prove the object is a regular file; a child that can write
+  the directory can leave a symlink there.
+- `[child-ask v1]` carries no event id, so two attached asks cannot be keyed or deduplicated.
+
+Related: `docs/issues/2026-08-30-007` (abandoned `in-progress` callback claims poll forever)
+and `docs/issues/2026-08-30-010` (which asks that the liveness, abandoned-callback and
+pane-retry defects be resolved before current race behavior is treated as a contract). Both
+are prerequisites rather than side concerns.
+
+## Open decisions
+
+- Whether ask and reply bodies justify the lifetime redesign at all, given that the report
+  direction — the motivating case — did not need it.
+- Whether run-directory retirement should leave a tombstone so a late reader can tell
+  "retired after consumption" from "settled without writing".

--- a/docs/issues/2026-09-03-005-sidebar-row-assertion-contradicts-the-committed-two-row-config.md
+++ b/docs/issues/2026-09-03-005-sidebar-row-assertion-contradicts-the-committed-two-row-config.md
@@ -1,0 +1,64 @@
+---
+title: "Sidebar row assertion contradicts the committed two-row config"
+short_description: "Smoke tests 1058 and 1059 failed on both the source and the deployed config because commit a25c20f moved the herdr sidebar to the intended two-row layout while assert_herdr_sidebar_deployment_contract still pinned the single-row arrangement; the helper now asserts the three identity fields and their order without pinning the row grouping."
+type: "bug"
+category: "testing-ci"
+tags: ["smoke-test","herdr-sidebar","stale-assertion"]
+date: "2026-09-03"
+status: "done"
+priority: "medium"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+`assert_herdr_sidebar_deployment_contract` in `tests/bashunit/smoke_test.sh:939` pins the
+sidebar layout literally:
+
+```
+assert_file_contains "$config" 'rows = \[\["state_icon", "workspace", "pane"\]\]'
+```
+
+Commit a25c20f ("Update config.toml", 2026-09-03) changed
+`home/private_dot_config/herdr/config.toml:63` to a two-row layout:
+
+```
+-rows = [["state_icon", "workspace", "pane"]]
++rows = [["state_icon", "workspace"], ["pane"]]
+```
+
+The assertion was not updated, so both callers of the shared helper fail:
+
+- `test_smoke_1058` against the source tree `home/private_dot_config/herdr/config.toml`
+- `test_smoke_1059` against the deployed `~/.config/herdr/config.toml`
+
+Measured on 2026-09-03 with `tests/lib/bashunit -j 8 tests/bashunit/smoke_test.sh`:
+47 passed, 2 failed. The two failures are exactly 1058 and 1059, and both name the same
+regex. Nothing else in the suite touches the sidebar row layout.
+
+Impact is a persistently red smoke suite, which masks a real regression the same helper
+would otherwise catch: the helper also guards the codicon octal escapes and the
+ownership boundaries, and a reader who has learned to expect two failures stops reading
+the rest.
+
+## Scope
+
+Decide which layout is intended, then make the config and the assertion agree.
+
+- If the two-row layout is intended, relax or re-pin the assertion to it. The assertion
+  is a source-shape pin with no behavioral oracle, so consider whether it should assert
+  the presence of the three fields rather than one exact arrangement.
+- If the single-row layout is intended, revert the config line.
+
+Either way, run `tests/lib/bashunit -j 8 tests/bashunit/smoke_test.sh` and confirm 49
+passed, 0 failed.
+
+## Open decisions
+
+None. The owner confirmed the two-row layout is correct, and the exact-string pin was
+relaxed for the same reason: the row grouping is a presentation preference, not a
+contract.
+
+## Resolution
+
+The two-row layout is the intended one. assert_herdr_sidebar_deployment_contract now asserts that the rows declaration carries state_icon, workspace, and pane in that order without pinning how they are grouped into rows, and the verbatim duplicate of the same pin later in the helper was removed. The sidebar's real guard against location metadata stays: the adjacent grep for $git_ref, $location_label, and $location_status still asserts failure. tests/bashunit/smoke_test.sh now reports 49 passed, 0 failed.

--- a/docs/issues/2026-09-03-006-peer-report-transport-accepts-a-symlinked-report-file.md
+++ b/docs/issues/2026-09-03-006-peer-report-transport-accepts-a-symlinked-report-file.md
@@ -1,0 +1,55 @@
+---
+title: "Peer report transport accepts a symlinked report file"
+short_description: "recover_peer_report in the shared herdr peer lifecycle validates the peer report with [ -f ] and [ -s ], which follow symlinks, so a peer that leaves a symlink at claude.report or opencode.report makes the review silently synthesize whatever that link targets; ask.sh gained an explicit -L rejection reported as bad-report with exit 5 for the same class of coherence failure, and the shared lifecycle should match it."
+type: "follow-up"
+category: "agent-platform"
+tags: ["report-transport","herdr-peer-launch","coherence-guard"]
+date: "2026-09-03"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+`recover_peer_report` in `home/private_dot_claude/shared/herdr-peer-launch.md:126-135`
+decides whether a peer delivered its report with two tests:
+
+```
+[ -f "$report_path" ] && [ -s "$report_path" ] && return 0
+```
+
+Both follow symlinks. A peer that writes a symlink at `claude.report` or
+`opencode.report` instead of a file passes, and the caller then reads and
+synthesizes the link's target. The peer picks the target, so the review can
+silently ingest an unrelated file the user can read, attributed to that peer.
+
+`ask-in-herdr` now rejects the same shape explicitly. `classify_report` in
+`home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh` tests
+`[ ! -L "$report_path" ]` first and reports `bad-report` with exit 5 without
+ever opening the path. The two transports otherwise agree: both `mktemp -d` a
+`chmod 700` directory, both instruct a `.tmp` write plus rename, and both make
+exactly one bounded recovery request before giving up.
+
+This is a coherence guard, not a containment boundary. A peer runs as the same
+user and can read those files directly, so the guard buys an honest failure
+rather than a silently wrong review, exactly as it does in `ask.sh`.
+
+Impact is low: no occurrence has been observed, and every peer in use today
+writes a regular file. It is filed because the two transports should not
+disagree about what counts as a delivered report.
+
+## Scope
+
+Bring the shared lifecycle's acceptance test in line with `classify_report`:
+reject a symlink and a non-regular file before reading, and report that
+rejection distinctly from "missing" and "empty" so a malformed peer is not
+retried as if it had simply not answered yet.
+
+`se-code-review`, `se-doc-review`, and `se-simplify` delegate the whole
+transport to this lifecycle and name no path of their own, so they need no
+change.
+
+## Open decisions
+
+- Whether the shared lifecycle should also distinguish empty from missing the
+  way `ask.sh` does, or keep collapsing both into one recovery attempt.

--- a/docs/issues/2026-09-03-006-peer-report-transport-accepts-a-symlinked-report-file.md
+++ b/docs/issues/2026-09-03-006-peer-report-transport-accepts-a-symlinked-report-file.md
@@ -1,12 +1,13 @@
 ---
 title: "Peer report transport accepts a symlinked report file"
-short_description: "recover_peer_report in the shared herdr peer lifecycle validates the peer report with [ -f ] and [ -s ], which follow symlinks, so a peer that leaves a symlink at claude.report or opencode.report makes the review silently synthesize whatever that link targets; ask.sh gained an explicit -L rejection reported as bad-report with exit 5 for the same class of coherence failure, and the shared lifecycle should match it."
+short_description: "The shared herdr peer lifecycle validated the peer report with [ -f ] and [ -s ], which follow symlinks, so a peer that left a symlink at claude.report or opencode.report made the review silently synthesize whatever that link targeted; the acceptance test now rejects -L before opening the path and treats it as a terminal malformed delivery, matching classify_report in ask.sh."
 type: "follow-up"
 category: "agent-platform"
 tags: ["report-transport","herdr-peer-launch","coherence-guard"]
 date: "2026-09-03"
-status: "open"
+status: "done"
 priority: "low"
+closed: "2026-09-03"
 ---
 
 ## Why this exists
@@ -51,5 +52,10 @@ change.
 
 ## Open decisions
 
-- Whether the shared lifecycle should also distinguish empty from missing the
-  way `ask.sh` does, or keep collapsing both into one recovery attempt.
+None. The shared lifecycle keeps collapsing missing and empty into one recovery
+attempt: unlike `ask.sh` it has no exit code to report the difference through,
+and both are answered by the same recovery prompt.
+
+## Resolution
+
+The shared herdr peer lifecycle now refuses a symlinked report path without opening it. report_is_delivered rejects -L before the -f and -s tests, and recover_peer_report treats that rejection as terminal rather than sending a recovery prompt, so a malformed delivery is never retried as a missing one. This matches classify_report in ask.sh. The open decision was settled the other way: the shared lifecycle keeps collapsing missing and empty into one recovery attempt, because unlike ask.sh it has no distinct exit code to report the difference through.

--- a/docs/issues/2026-09-03-007-herdr-peer-alias-leaks-a-broken-pipe-message-when-it-stops-reading-candidates.md
+++ b/docs/issues/2026-09-03-007-herdr-peer-alias-leaks-a-broken-pipe-message-when-it-stops-reading-candidates.md
@@ -1,0 +1,78 @@
+---
+title: "herdr-peer-alias leaks a broken-pipe message when it stops reading candidates"
+short_description: "herdr-peer-alias read herdr_alias_candidates through a process substitution and exited at the first free alias, so with SIGPIPE inherited as ignored the producer took EPIPE and bash printed 1019 broken-pipe lines on the stderr the caller captured, which is how scripts_test 1401 failed on the CI macos runner while passing on a workstation where SIGPIPE has its default disposition; the script now reads the pool with one command substitution, which also stops discarding the producer's exit status."
+type: "bug"
+category: "testing-ci"
+tags: ["flaky-test","herdr-aliases","epipe"]
+date: "2026-09-03"
+status: "done"
+priority: "medium"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+`home/dot_local/bin/executable_herdr-peer-alias` read candidate aliases from a process
+substitution and stopped at the first free one:
+
+```
+while IFS= read -r candidate; do
+  if ! printf '%s\n' "$taken" | grep -qxF "$candidate"; then
+    printf '%s\n' "$candidate"
+    exit 0
+  fi
+done < <(herdr_alias_candidates "$seed")
+```
+
+`herdr_alias_candidates` (`home/dot_local/lib/herdr-aliases.sh:135-141`) emits all 1024
+pool members in a loop, so the reader closed the pipe with about a thousand lines still
+unwritten.
+
+What happens next depends on the **inherited disposition of SIGPIPE**, not on the pipe
+buffer:
+
+- Default disposition: the producer subshell is killed by SIGPIPE and dies silently. This
+  is a workstation shell, which is why the test always passed locally.
+- Ignored disposition, inherited from whatever started the shell: `printf` gets EPIPE
+  instead, and bash reports `printf: write error: Broken pipe` on the stderr it inherited
+  from `herdr-peer-alias` — once per unwritten line.
+
+Measured on 2026-09-03 with the pre-fix script, `trap '' PIPE` standing in for the
+inherited disposition: **1019 broken-pipe lines**. With SIGPIPE at its default: silent,
+across 20 runs.
+
+`bashunit`'s `run` captures stderr into `$output`, so
+`test_scripts_1401_herdr_peer_alias_skips_live_and_reserved_aliase` compared an alias
+against an alias plus that line. CI run 33754209087, `test-macos`:
+
+```
+-- output does not match (exact) --
+expected : ochre-bear
+actual   : ochre-bear
+.../home/dot_local/bin/../lib/herdr-aliases.sh: line 137: printf: write error: Broken pipe
+```
+
+The allocated alias was correct on both sides; only the leaked stderr differed.
+
+The same construct hid a second defect. A process substitution discards its producer's
+exit status, so a pool that failed `herdr_alias_validate_pool` reached the reader as zero
+lines and was reported as `alias pool is exhausted` — a wrong diagnosis for a validation
+failure.
+
+## Scope
+
+Read the pool once with a command substitution, then scan it from a here-string. No pipe
+exists, so no writer can take EPIPE regardless of the inherited disposition, and the
+producer's failure is now caught and reported as `could not build the alias pool`. The
+empty-pool case keeps its previous meaning by falling through to the existing exhausted
+branch instead of yielding an empty alias from `<<<`.
+
+## Open decisions
+
+None. The fix is in `herdr-peer-alias`, the reader that closes the pipe, because removing
+the pipe also recovers the producer's exit status. `herdr_alias_candidates` has no other
+caller that closes its output early.
+
+## Resolution
+
+herdr-peer-alias now reads the alias pool with one command substitution and scans it from a here-string, so no writer can take EPIPE regardless of the inherited SIGPIPE disposition, and a failed pool build is reported instead of being misdiagnosed as an exhausted pool. Negative control under an ignored SIGPIPE: the pre-fix script reproduces the CI failure exactly, including the broken-pipe line, and the post-fix script passes. tests/bashunit/scripts_test.sh reports 249 passed, 1 skipped, 0 failed. No test was added: a message assertion would copy its expected value out of the patched file, and the behavioural property was not deterministic before the fix, which is what made the original failure flaky.

--- a/docs/plans/2026-09-03-1217-feat-ask-in-herdr-report-file-plan.md
+++ b/docs/plans/2026-09-03-1217-feat-ask-in-herdr-report-file-plan.md
@@ -1,0 +1,248 @@
+---
+title: "Ask-in-Herdr Report File - Plan"
+type: "feat"
+date: "2026-09-03"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Ask-in-Herdr Report File - Plan
+
+## Goal Capsule
+
+- **Objective:** Someone who asks a peer agent for a review or an answer receives it whole — not cut off at 200 lines, not silently replaced by an empty result, and still readable after the peer's pane is gone.
+- **Means:** The peer writes its answer to a file the caller created and owns (KTD1).
+- **Authority:** Requirements govern behavior. KTDs govern mechanism inside those requirements. Units override neither.
+- **Stop conditions:** Stop and ask if a read-only child cannot write the transport file through its shell — that is the default consult path and the whole feature rests on it. Stop if the caller cannot both clean up its transport and leave it intact for a child that is still working.
+- **Execution profile:** Sequential, three units, one script plus its docs and tests.
+- **Tail ownership:** This plan ends when `ask.sh` returns file-backed answers. It changes no protocol and touches no library.
+
+---
+
+## Product Contract
+
+### Summary
+
+Give `ask.sh` a caller-owned report transport. The script creates a private directory, names the report path inside the question it sends, and reads the answer from that file. The 200-line pane scrape becomes a diagnostic on failure paths only.
+
+The transport is modelled on `home/private_dot_claude/shared/herdr-peer-launch.md`, which already does this for the `se-*` peer legs and is the only file-backed answer path in the repository that works today.
+
+### Problem Frame
+
+`home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh:115` reads the peer's answer with `herdr agent read --source visible --lines 200`. Anything longer is cut. Wrapped lines and alternate-screen content are lost. The transcript dies with the pane, so an answer that was produced but not yet read is unrecoverable.
+
+An earlier version of this plan moved all four inter-agent message bodies — task, ask, reply, report — onto the child's generation-scoped run directory. Review found that directory is deleted by the watcher at the moment a marker is delivered, that attached children have no generation at all, and that the ordering `ask.sh` needs is impossible there: it composes its question at line 72 and starts the child at line 86, so no generation exists when the report path must be named. The report direction needs none of that machinery. This plan keeps only the report direction and drops the rest.
+
+### Key Decisions
+
+- **The caller owns the transport; the child only writes into it.** (session-settled: user-directed — chosen over the child's generation-scoped run directory: the run directory is destroyed on marker delivery, does not exist for attached children, and cannot be named before the question is composed.) Governs R1, R5.
+
+### Requirements
+
+**Answer integrity**
+
+- R1. A peer's answer reaches the caller whole, with no truncation or loss from terminal capture.
+- R2. An answer stays readable after the peer's pane closes, until the caller removes its own transport.
+- R3. A report that is absent, empty, or not a regular file is a typed failure with its own status. None of them is reported as an empty answer, and none as a timeout.
+- R4. The transport never sits inside the repository, a worktree, or any child's working directory.
+
+**Transport mechanics**
+
+- R5. The caller creates the transport directory before it composes the question, so the question can name the report path.
+- R6. The report-writing instruction directs the child to write through its shell, because the default consult posture removes the child's file-writing tools.
+- R7. A report appears at its final path only when complete. The caller never reads a partially written file.
+
+**Lifetime**
+
+- R8. The caller removes its transport only when no child can still write to it. When the script returns while the child is still working, it retains the transport and reports its path.
+- R9. A settled child that wrote no report gets exactly one bounded request to persist its answer before the failure status is returned.
+
+### Scope Boundaries
+
+- `home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh`, its `SKILL.md`, and the tests that own them.
+
+**Deferred to Follow-Up Work**
+
+- Ask and reply bodies as files, marker versioning, and the run-directory lifetime change they require. Review found six blocking problems in that direction; they are recorded in a repository issue rather than carried here.
+- The `wait-any` fan-out utility and model-tier configuration. Both were bundled into the earlier draft and neither serves this plan's Objective.
+- `docs/issues/2026-09-03-003` — cold opencode and pi launches stall. It affects the first consult of a session regardless of this plan.
+
+**Outside this plan's identity**
+
+- Any change to `herdr-child`, its libraries, or the child-agent contract. This plan is one script.
+- Converging the two child-launch stacks.
+
+### Sources
+
+- `home/private_dot_claude/shared/herdr-peer-launch.md` — the working transport this plan copies: `PEER_REPORT_DIR` created before the prompts, `[peer-report-transport]` naming an explicit shell write-and-rename, `recover_peer_report` for one bounded retry, and the rule that a pane read is diagnostic only.
+- `home/dot_local/lib/herdr-child-launch.sh:281` — the read-only posture strips `Edit Write NotebookEdit` from a claude child; `:156` denies `edit` for opencode. Both keep the shell.
+- `home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh:28,60` — `RW=0` and `posture=ro` are the defaults, so the stripped-tools path is the ordinary one.
+- `docs/issues/2026-08-15-007` — a question file removed by its writer's `EXIT` trap while the reader was still starting produced a fake 30-minute timeout in zero seconds.
+- `tests/bashunit/smoke_test.sh:835` — asserts the literal reap-hint string this plan's output changes.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Transport under `TMPDIR`, created by `ask.sh` before the question is composed.** `mktemp -d` plus `chmod 700`, matching `PEER_REPORT_DIR`. This is what makes the ordering work at all, and it keeps the transport out of every repository and worktree. Governs R4, R5.
+- KTD2. **The atomic rename is the completeness witness.** The child writes `<path>.tmp` and renames it. A file present at the final path is complete by construction, so no digest, byte count, or separate completion record is needed. Governs R7.
+- KTD3. **The transport instruction names shell commands, not a write tool.** A read-only claude child has no `Write`, and a read-only opencode child has `edit` denied; both keep the shell for the callback channel. The instruction mirrors `[peer-report-transport]` wording. Governs R6.
+- KTD4. **An empty report is a failure, not an empty answer.** The Objective names a silently empty result as the thing to prevent, so zero bytes at the final path reports its own status rather than returning success. Governs R3.
+- KTD5. **The transport outlives the script when the child is still working.** On the `working` outcome the script prints the transport path and removes nothing. Removing it there reproduces `docs/issues/2026-08-15-007` exactly. Governs R8.
+- KTD6. **The reader rejects anything that is not a regular file.** The child can write into the transport, so it can leave a symlink at the report path. The check is a coherence guard against a misbehaving child, not a containment boundary — a same-user child is not contained by it. Governs R3.
+
+### High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+    participant A as ask.sh
+    participant C as child peer
+    A->>A: mktemp -d, chmod 700
+    A->>A: compose question + report path
+    A->>C: herdr-child start --prompt ... --wait
+    C->>C: work
+    C->>C: write report.tmp, rename to report
+    C-->>A: settles
+    A->>A: read report (regular file, non-empty)
+    alt report missing or empty
+        A->>C: one bounded re-persist request
+        C->>C: write report
+    end
+    A->>A: print answer, remove transport
+```
+
+### Assumptions
+
+- A read-only child can write a file through its shell. The posture branches keep the shell deliberately, and `herdr-peer-launch.md` relies on the same thing for its claude peer — but that peer runs with permission bypass, so the read-only case is unproven and U1 verifies it first.
+- `mktemp -d` under `TMPDIR` is outside every repository and worktree on this machine.
+- The child obeys a written instruction to use tmp-plus-rename. When it does not, the file simply never appears and R3's typed failure covers it.
+
+### Sequencing
+
+U1 establishes the transport and proves the read-only write works. U2 replaces the read path and its outcomes. U3 updates the documentation and the tests that assert on this script's literal output.
+
+---
+
+## Implementation Units
+
+### U1. Caller-owned transport and the write instruction
+
+**Goal:** `ask.sh` creates a private transport before composing its question, and a read-only child writes its answer there.
+
+**Requirements:** R4, R5, R6, R7. Implements KTD1, KTD2, KTD3.
+
+**Dependencies:** none.
+
+**Files:**
+- `home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh`
+- `tests/bashunit/scripts_test.sh`
+
+**Approach:**
+1. Create the transport with `mktemp -d` and `chmod 700` before the question file is composed, so the report path exists in time to be named in the question.
+2. Append a transport instruction to the question that names the absolute report path and directs an explicit shell write to `<path>.tmp` followed by a rename. Mirror the `[peer-report-transport]` wording rather than inventing new phrasing.
+3. Leave the existing `--wait` start call and its arguments unchanged.
+
+**Execution note:** Before writing the instruction wording, run one read-only claude child and one read-only opencode child that write a file through the shell. The Assumptions record this as unproven, and every later unit depends on it.
+
+**Patterns to follow:** `PEER_REPORT_DIR` creation and the `[peer-report-transport]` block in `home/private_dot_claude/shared/herdr-peer-launch.md`.
+
+**Test scenarios:**
+- A read-only claude child asked for an answer writes a non-empty file at the report path.
+- A read-only opencode child does the same.
+- The transport directory is created with mode 700 and sits outside the repository checkout.
+- The question sent to the child contains the absolute report path.
+- The report path is named in the question even when the caller passes `--cwd` inside a worktree.
+
+**Verification:** Both default-posture kinds produce a file-backed answer, and the transport is outside any checkout.
+
+### U2. Read the answer from the file, with typed outcomes
+
+**Goal:** The answer comes from the transport file, and every way that can fail has its own status.
+
+**Requirements:** R1, R2, R3, R8, R9. Implements KTD4, KTD5, KTD6.
+
+**Dependencies:** U1.
+
+**Files:**
+- `home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh`
+- `tests/bashunit/scripts_test.sh`
+
+**Approach:**
+1. Read the answer from the report path. Require a regular file; reject a symlink or any non-regular object.
+2. Send one bounded re-persist request when a settled child left no usable report, then re-read once before giving up.
+3. Extend the script's status vocabulary rather than folding new failures into `undelivered`: a missing report after recovery, an empty report, and a non-regular report each get their own status and exit code, and none reuses the timeout code.
+4. Demote `herdr agent read` to a diagnostic printed on failure statuses only, never as the answer.
+5. Remove the transport on every path where the child cannot still write to it. On the `working` outcome, print the transport path and remove nothing.
+6. Keep `answered`, `blocked`, `working`, `undelivered` and `refused` on their current exit codes.
+
+**Execution note:** Add the failing test for the empty-report status before changing the read path — today an empty scrape and an empty answer are indistinguishable, and that is the behavior this unit must make impossible.
+
+**Test scenarios:**
+- An answer longer than 200 lines returns complete, byte-for-byte identical to the file the child wrote.
+- An answer is still returned when the child's pane was closed before the read.
+- A settled child that wrote nothing triggers exactly one re-persist request; when that produces a report, the answer is returned normally.
+- A settled child that still wrote nothing after the re-persist request returns the missing-report status, not `undelivered` and not `working`.
+- A zero-byte report at the final path returns the empty-report status, paired with a one-byte report that returns success.
+- A symlink at the report path is rejected with the non-regular status and its target is never read.
+- On the `working` outcome the transport directory still exists after the script exits, and its path appears on stderr.
+- On every terminal outcome the transport directory is gone.
+- The five existing statuses keep their current exit codes.
+
+**Verification:** A long answer arrives intact; every failure mode has a test that produces it and a control that does not; no failure path reuses the timeout code.
+
+### U3. Documentation and deployed-contract tests
+
+**Goal:** The skill document describes the new flag and outcomes, and the tests that assert on this script's literal output match it.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** U2.
+
+**Files:**
+- `home/private_dot_agents/skills/ask-in-herdr/SKILL.md`
+- `tests/bashunit/smoke_test.sh`
+
+**Approach:**
+1. Document the new statuses and exit codes in the outcome-contract table, and describe the transport in one paragraph.
+2. Correct the four invocation lines, which name `~/.claude/skills/ask-in-herdr/scripts/ask.sh` while chezmoi deploys the script to `~/.agents/skills/ask-in-herdr/scripts/ask.sh`.
+3. Update the smoke-test assertions that pin literal strings from this script, including the reap hint at `tests/bashunit/smoke_test.sh:835`.
+
+**Test scenarios:** Test expectation: none -- documentation and assertion updates; the behavior is covered by U1 and U2.
+
+**Verification:** `SKILL.md` lists every status the script can return, and no smoke-test assertion pins a string the script no longer prints.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Applies to |
+|---|---|---|
+| Shell lint | `make lint` | U1-U3 |
+| Owning suite during development | `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh` | U1, U2 |
+| Full suite with apply | `make test-ubuntu` | U1-U3 |
+
+`make test-suite` reads the already-applied `~/` and cannot see an unapplied edit under `home/`. Every unit here edits `home/`, so `make test-ubuntu` is the gate that proves them.
+
+Declare the test oracle before the first test edit. For this plan the oracle is available and independent: the bytes the child wrote to the transport file, compared against what the script returned. Do not assert on the presence of new function names in the script.
+
+## Definition of Done
+
+**Global**
+
+- `make test-ubuntu` passes.
+- `make lint` passes.
+- No answer path reads the terminal; `herdr agent read` appears only on failure diagnostics.
+- Every status in R3 has a test that produces it and a control that does not.
+- Abandoned experimental code is removed, not left in the diff.
+
+**Per unit**
+
+| Unit | Done when |
+|---|---|
+| U1 | A read-only claude child and a read-only opencode child each write a file-backed answer |
+| U2 | A long answer arrives intact and survives pane closure; no failure reuses the timeout code |
+| U3 | `SKILL.md` matches the shipped statuses and deployed path; no stale literal assertion remains |

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -25,3 +25,8 @@ Library/marta
 .claude/hooks/herdr-task-sync-hook.sh
 .config/opencode/plugins/herdr-task-sync.ts
 .pi/agent/extensions/herdr-task-sync.ts
+
+# ask-in-herdr's script deploys under .agents now; only the SKILL.md symlink
+# stays under .claude. Earlier applies left a stale copy of the script at the
+# old path, where it would still run without the report transport.
+.claude/skills/ask-in-herdr/scripts

--- a/home/dot_local/bin/executable_herdr-peer-alias
+++ b/home/dot_local/bin/executable_herdr-peer-alias
@@ -53,12 +53,25 @@ for reserved in "$@"; do
 $reserved"
 done
 
-while IFS= read -r candidate; do
-  if ! printf '%s\n' "$taken" | grep -qxF "$candidate"; then
-    printf '%s\n' "$candidate"
-    exit 0
-  fi
-done < <(herdr_alias_candidates "$seed")
+# Read the whole pool before scanning it. A process substitution here left the
+# producer writing 1024 candidates into a pipe that this loop closes at the
+# first free alias; the remainder is around the size of a pipe buffer, so the
+# producer sometimes took EPIPE and bash reported the broken pipe on the stderr
+# it inherited from us. It also discarded the producer's exit status, so a pool
+# that failed validation was reported as exhausted instead.
+candidates="$(herdr_alias_candidates "$seed")" || {
+  printf 'herdr-peer-alias: could not build the alias pool\n' >&2
+  exit 1
+}
+
+if [ -n "$candidates" ]; then
+  while IFS= read -r candidate; do
+    if ! printf '%s\n' "$taken" | grep -qxF "$candidate"; then
+      printf '%s\n' "$candidate"
+      exit 0
+    fi
+  done <<< "$candidates"
+fi
 
 printf 'herdr-peer-alias: alias pool is exhausted\n' >&2
 exit 1

--- a/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
+++ b/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
@@ -12,7 +12,7 @@ Read `~/.claude/shared/child-agent-contract.md` before handling a callback from 
 ## Invocation
 
 ```bash
-bash ~/.claude/skills/ask-in-herdr/scripts/ask.sh <agent> "<question>" [flags]
+bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh <agent> "<question>" [flags]
 ```
 
 `<agent>` is `claude`, `opencode`, or `pi`.
@@ -40,17 +40,28 @@ If the caller supplies no model, opencode uses `openai/gpt-5.5` and pi uses `ope
 
 Read-only means no file-writing tools. It is not an enforced write boundary because every started claude or opencode child keeps an unscoped shell. Filesystem containment belongs to the child sandbox work.
 
+## Answer transport
+
+The answer travels through a file, not through the pane. Before the question is composed, the script creates a private temporary directory and appends a `[report-transport]` block that names `<dir>/answer.report`. The child writes its exact answer there with its shell, to `answer.report.tmp` first and then renames it, so a reader never sees a half-written file. The instruction names shell commands on purpose: the default read-only posture strips the file-editing tools but keeps Bash.
+
+The file is the answer, so it is not truncated at the 200 lines the pane scrape returns, it does not lose wrapped or alternate-screen content, and it survives the pane closing. Pane text is still captured, but for a settled child it is evidence of what happened, never the answer.
+
+If a settled child left no usable report, the script makes exactly one bounded follow-up request asking it to persist the same answer, then classifies the file again. The transport directory is deleted when the script exits. On an outcome where the child may still be writing — `working` and `blocked` — the directory is kept instead, and its path is printed on stderr.
+
 ## Outcome contract
 
-The answer or partial answer is on stdout. The last stderr line is always one of these status lines:
+Only `status=answered` puts an answer on stdout, and it comes from the report file. Every other outcome puts captured pane text on stdout or stderr as evidence. The last stderr line is always one of these status lines:
 
 | Status line | Exit | Meaning |
 |---|---:|---|
-| `ask.sh: status=answered` | 0 | The child settled at `idle` or `done`, and the answer was read. |
-| `ask.sh: status=blocked` | 1 | The child settled at `blocked`. |
-| `ask.sh: status=working` | 124 | The wait did not settle. The child pane remains live, and stdout can be partial. |
+| `ask.sh: status=answered` | 0 | The child settled at `idle` or `done`, and its report file was read. |
+| `ask.sh: status=blocked` | 1 | The child settled at `blocked`. The transport is retained. |
+| `ask.sh: status=working` | 124 | The wait did not settle. The child pane remains live, stdout can be partial, and the transport is retained. |
 | `ask.sh: status=undelivered` | 1 | The pane, start, or initial prompt failed before a usable answer existed. |
 | `ask.sh: status=refused` | 2 | Arguments or the requested posture are invalid. |
+| `ask.sh: status=no-report` | 3 | The child settled, but no report file existed after the recovery request. |
+| `ask.sh: status=empty-report` | 4 | The report file existed but was empty after the recovery request. |
+| `ask.sh: status=bad-report` | 5 | The report path was a symlink or not a regular file. It was never read. |
 
 The script prints a close hint on stderr before the status line. `herdr-child` allocates the alias; the script consumes the returned alias-plus-pane pair and verifies its terminal identity before exposing output. Keep the pane for a managed follow-up, or close it with the reported `herdr-child reap --to <alias> --pane <pane-id>` command. Use `herdr-child prompt --to <alias> --pane <pane-id> --wait '<task>'` for that attached follow-up.
 
@@ -60,15 +71,15 @@ For `status=answered`, the script also submits a cleanup reminder to the parent 
 
 ```bash
 # Read-only opencode review.
-bash ~/.claude/skills/ask-in-herdr/scripts/ask.sh opencode \
+bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh opencode \
   "Review the current diff. Report only actionable findings." --cwd "$PWD"
 
 # Read-write pi task. Pi requires --rw.
-bash ~/.claude/skills/ask-in-herdr/scripts/ask.sh pi \
+bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh pi \
   "Add the missing null check and run the focused test." --rw --cwd "$PWD"
 
 # Claude consult with an extra skill directory.
-bash ~/.claude/skills/ask-in-herdr/scripts/ask.sh claude \
+bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh claude \
   "Check this herdr procedure for errors." --skills ~/.claude/skills/herdr
 ```
 

--- a/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh
+++ b/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh
@@ -60,6 +60,14 @@ fi
 posture=ro
 [ "$RW" -eq 0 ] || posture=rw
 
+# The transport directory must exist before the question is composed, so the
+# question can name the report path. Mirrors PEER_REPORT_DIR in
+# ~/.claude/shared/herdr-peer-launch.md, the only file-backed answer path
+# in this repository that works today.
+report_dir="$(mktemp -d "${TMPDIR:-/tmp}/ask-in-herdr.XXXXXX")"
+chmod 700 "$report_dir"
+report_path="$report_dir/answer.report"
+
 question_file="$(mktemp)"
 start_out="$(mktemp)"
 start_err="$(mktemp)"
@@ -68,8 +76,19 @@ read_err="$(mktemp)"
 pane_out="$(mktemp)"
 agent_out="$(mktemp)"
 agent_err="$(mktemp)"
-trap 'rm -f "$question_file" "$start_out" "$start_err" "$read_out" "$read_err" "$pane_out" "$agent_out" "$agent_err"' EXIT
-printf '%s' "$QUESTION" > "$question_file"
+trap 'rm -f "$question_file" "$start_out" "$start_err" "$read_out" "$read_err" "$pane_out" "$agent_out" "$agent_err"; [ "${RETAIN_TRANSPORT:-0}" = 1 ] || { rm -f "$report_path" "$report_path.tmp"; rmdir "$report_dir" 2>/dev/null || true; }' EXIT
+# A read-only child has no file-writing tool: the ro posture strips Edit, Write
+# and NotebookEdit from claude and denies edit for opencode. Both keep the shell,
+# so the instruction names shell commands. Verified on 2026-09-03 with one
+# read-only child of each kind.
+{
+  printf '%s\n\n' "$QUESTION"
+  printf '%s\n' '[report-transport]'
+  printf 'Before ending this turn, write your exact complete answer, byte-for-byte, to %s.\n' "$report_path"
+  printf 'Use your shell to do it: write the text to %s.tmp and then rename that file to %s.\n' "$report_path" "$report_path"
+  printf 'Do not use a file-editing tool. After the file is durable, return the same answer as usual.\n'
+  printf 'Do not write any other file.\n'
+} > "$question_file"
 
 args=(start --kind "$AGENT" --posture "$posture" --cwd "$CWD" \
   --prompt-file "$question_file" --wait --timeout 1800000)
@@ -130,11 +149,36 @@ if [ "$read_status" -ne 0 ]; then
   cat "$read_err" >&2
   status_exit undelivered 1
 fi
-cat "$read_out"
-printf 'ask.sh: consult is in herdr pane %s (left open; close with: herdr-child reap --to %s --pane %s)\n' "$pane" "$started_name" "$pane" >&2
+close_hint() {
+  printf 'ask.sh: consult is in herdr pane %s (left open; close with: herdr-child reap --to %s --pane %s)\n' \
+    "$pane" "$started_name" "$pane" >&2
+}
+
+# The child can still write its report on every non-terminal outcome, so the
+# transport outlives this script there. Removing it while the child works is the
+# failure recorded in docs/issues/2026-08-15-007.
+retain_transport() {
+  RETAIN_TRANSPORT=1
+  printf 'ask.sh: child may still write its report; transport retained at %s\n' "$report_dir" >&2
+}
+
+# 0 usable, 3 absent, 4 present but empty, 5 present but not a regular file.
+# A child that can write the transport can leave a symlink there. This is a
+# coherence guard against a misbehaving child, not a containment boundary: a
+# same-user child is not contained by it.
+classify_report() {
+  [ ! -L "$report_path" ] || return 5
+  if [ -e "$report_path" ] && [ ! -f "$report_path" ]; then return 5; fi
+  [ -e "$report_path" ] || return 3
+  [ -s "$report_path" ] || return 4
+  return 0
+}
 
 if [ "$start_status" -eq 124 ]; then
+  cat "$read_out"
+  close_hint
   cat "$start_err" >&2
+  retain_transport
   status_exit working 124
 fi
 
@@ -146,6 +190,9 @@ labels=pane.get("state_labels") or {}
 raise SystemExit(0 if any(str(v)=="waiting for parent" for v in labels.values()) else 1)' < "$pane_out" 2>/dev/null && printf yes || true)"
 fi
 if [ "$waiting_label" = yes ]; then
+  cat "$read_out"
+  close_hint
+  retain_transport
   status_exit blocked 1
 fi
 
@@ -156,6 +203,33 @@ fi
 agent_status="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["result"]["agent"]["agent_status"])' < "$agent_out" 2>/dev/null || true)"
 case "$agent_status" in
   idle|done)
+    set +e
+    classify_report
+    report_state=$?
+    set -e
+    if [ "$report_state" -eq 3 ] || [ "$report_state" -eq 4 ]; then
+      # One bounded request to persist an answer the child already produced,
+      # mirroring recover_peer_report in ~/.claude/shared/herdr-peer-launch.md.
+      herdr-child prompt --to "$started_name" --pane "$pane" --wait --timeout 120000 \
+        "The report transport file at $report_path is missing or empty. Write your exact complete previous answer, byte-for-byte, using your shell: write it to $report_path.tmp and then rename that file to $report_path. Do not use a file-editing tool. Then reply with only the path." \
+        >/dev/null 2>&1 || true
+      set +e
+      classify_report
+      report_state=$?
+      set -e
+    fi
+    if [ "$report_state" -ne 0 ]; then
+      # The pane text is evidence of what happened, never the answer.
+      cat "$read_out" >&2
+      close_hint
+      case "$report_state" in
+        3) status_exit no-report 3 ;;
+        4) status_exit empty-report 4 ;;
+        *) status_exit bad-report 5 ;;
+      esac
+    fi
+    cat "$report_path"
+    close_hint
     printf -v reminder '%s\n\n%s\n%s\n%s\n%s\n%s' \
       "[child-settled v1 agent=$started_name pane=$pane]" \
       "The child is $agent_status and its initial answer has been read." \
@@ -168,7 +242,7 @@ case "$agent_status" in
     fi
     status_exit answered 0
     ;;
-  blocked) status_exit blocked 1 ;;
-  working|unknown) status_exit working 124 ;;
-  *) status_exit undelivered 1 ;;
+  blocked) cat "$read_out"; close_hint; retain_transport; status_exit blocked 1 ;;
+  working|unknown) cat "$read_out"; close_hint; retain_transport; status_exit working 124 ;;
+  *) cat "$read_out" >&2; close_hint; status_exit undelivered 1 ;;
 esac

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -120,18 +120,29 @@ herdr agent wait "$CLAUDE_PANE" --timeout 1800000
 herdr agent wait "$OPENCODE_PANE" --timeout 1800000
 ```
 
-The report files are the primary transport. A settled peer that did not create a non-empty regular report file gets one bounded recovery prompt to persist its previous answer:
+The report files are the primary transport. A settled peer that did not create a non-empty regular report file gets one bounded recovery prompt to persist its previous answer. A symlink left at the report path is refused outright and never retried: it is a malformed delivery, not a missing one.
 
 ```bash
+report_is_delivered() {
+  local report_path="$1"
+  # -f and -s follow symlinks, so a peer could point the report at any file the
+  # caller can read and have its content synthesized as that peer's review.
+  # Refuse the path without opening it. This is a coherence guard, not a
+  # containment boundary: a same-user peer is not contained by it.
+  [ ! -L "$report_path" ] || return 1
+  [ -f "$report_path" ] && [ -s "$report_path" ]
+}
+
 recover_peer_report() {
   local pane="$1" report_path="$2"
-  [ -f "$report_path" ] && [ -s "$report_path" ] && return 0
+  [ ! -L "$report_path" ] || return 1
+  report_is_delivered "$report_path" && return 0
 
   herdr agent prompt "$pane" \
     "The report transport file is missing or empty. Write your exact complete previous report, byte-for-byte, atomically through $report_path.tmp and rename it to $report_path. Then reply with only the path." \
     --wait --timeout 120000 || return 1
 
-  [ -f "$report_path" ] && [ -s "$report_path" ]
+  report_is_delivered "$report_path"
 }
 
 CLAUDE_TRANSPORT_OK=1

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -563,8 +563,43 @@ printf '%q ' "$@" >> "$CHILD_STUB/child.log"; printf '\n' >> "$CHILD_STUB/child.
 printf 'child ' >> "$CHILD_STUB/order.log"; printf '%q ' "$@" >> "$CHILD_STUB/order.log"; printf '\n' >> "$CHILD_STUB/order.log"
 case "${1:-}" in
   start)
+    stub_pf=""; stub_prev=""
+    for stub_arg in "$@"; do
+      [ "$stub_prev" != "--prompt-file" ] || stub_pf="$stub_arg"
+      stub_prev="$stub_arg"
+    done
+    [ -z "$stub_pf" ] || cp "$stub_pf" "$CHILD_STUB/prompt.txt"
+    stub_rp=""
+    [ -z "$stub_pf" ] || stub_rp="$(grep -o '/[^ ]*/answer\.report' "$stub_pf" | head -1)"
+    printf '%s' "$stub_rp" > "$CHILD_STUB/report-path"
+    if [ -n "$stub_rp" ]; then
+      case "${STUB_REPORT:-write}" in
+        write)
+          if [ -n "${STUB_REPORT_LINES:-}" ]; then
+            : > "$stub_rp"
+            stub_i=1
+            while [ "$stub_i" -le "$STUB_REPORT_LINES" ]; do
+              printf 'report line %s\n' "$stub_i" >> "$stub_rp"
+              stub_i=$((stub_i + 1))
+            done
+          else
+            printf '%s\n' "${STUB_REPORT_BODY:-ANSWER from child}" > "$stub_rp"
+          fi
+          ;;
+        empty) : > "$stub_rp" ;;
+        symlink) ln -s /etc/hosts "$stub_rp" ;;
+        none) : ;;
+      esac
+    fi
     printf '{"agent":"red-wolf","pane":"wT:p9"}\n'
     [ "${STUB_CHILD_STATUS:-0}" -eq 0 ] || { printf 'child-start-error\n' >&2; exit "$STUB_CHILD_STATUS"; }
+    ;;
+  prompt)
+    printf 'prompt ' >> "$CHILD_STUB/recover.log"; printf '\n' >> "$CHILD_STUB/recover.log"
+    if [ "${STUB_RECOVER:-0}" = 1 ]; then
+      stub_rp2=""; [ ! -f "$CHILD_STUB/report-path" ] || read -r stub_rp2 < "$CHILD_STUB/report-path"
+      [ -z "$stub_rp2" ] || printf '%s\n' "${STUB_REPORT_BODY:-RECOVERED answer}" > "$stub_rp2"
+    fi
     ;;
   verify)
     count=0; [ ! -f "$CHILD_STUB/verify-count" ] || read -r count < "$CHILD_STUB/verify-count"
@@ -829,6 +864,136 @@ function test_scripts_1063_ask_sh_maps_child_start_failures_to_refused_or_undeli
     bash "$ASK_HERDR_SCRIPT" claude question
   assert_failure 1
   assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=undelivered"
+}
+
+function test_scripts_1064_ask_sh_names_a_report_path_outside_the_checkout_in_the_de() {
+  _bats_test_init 1064 'ask.sh names a report path outside the checkout in the delivered question'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude 'what is set -e'
+  assert_success
+
+  # The child is the consumer of this text: without a report path in the question it
+  # has nowhere to write, and the caller silently keeps the 200-line pane scrape.
+  assert_file_exists "$CHILD_STUB/prompt.txt"
+  assert_file_contains "$CHILD_STUB/prompt.txt" '\[report-transport\]'
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'answer\.report'
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'what is set -e'
+
+  report_line="$(grep -o '/[^ ]*/answer\.report' "$CHILD_STUB/prompt.txt" | head -1)"
+  [ -n "$report_line" ]
+  case "$report_line" in
+    "$SOURCE_ROOT"*) printf 'report path is inside the checkout: %s\n' "$report_line" >&2; return 1 ;;
+  esac
+}
+
+function test_scripts_1065_ask_sh_tells_a_read_only_child_to_write_the_report_throug() {
+  _bats_test_init 1065 'ask.sh tells a read-only child to write the report through its shell'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_success
+
+  # The default posture is ro, which strips Edit/Write from claude and denies edit
+  # for opencode. An instruction that assumes a write tool produces no report at all.
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'Use your shell'
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'answer\.report\.tmp'
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'rename'
+  assert_file_contains "$CHILD_STUB/prompt.txt" 'Do not use a file-editing tool'
+}
+
+function test_scripts_1066_ask_sh_removes_its_report_transport_when_it_exits() {
+  _bats_test_init 1066 'ask.sh removes its report transport when it exits'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_success
+
+  report_line="$(grep -o '/[^ ]*/answer\.report' "$CHILD_STUB/prompt.txt" | head -1)"
+  [ -n "$report_line" ]
+  transport_dir="$(dirname "$report_line")"
+  assert_dir_not_exists "$transport_dir"
+}
+
+function test_scripts_1067_ask_sh_returns_the_transport_file_not_the_pane_text() {
+  _bats_test_init 1067 'ask.sh returns the transport file, not the pane text'
+  ask_live_stub
+  # The stub emits a different string from `herdr agent read` than it writes to
+  # the transport, so only the file can be the source of the returned answer.
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT_LINES=250 HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_success
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=answered"
+  assert_output --partial 'report line 1'
+  assert_output --partial 'report line 250'
+  refute_output --partial 'ANSWER from child'
+}
+
+function test_scripts_1068_ask_sh_reports_no_report_after_one_failed_recovery() {
+  _bats_test_init 1068 'ask.sh reports no-report after one failed recovery'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=none HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_failure 3
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=no-report"
+  # Exactly one bounded recovery attempt, and the pane text is evidence only.
+  assert_file_exists "$CHILD_STUB/recover.log"
+  run grep -c 'prompt' "$CHILD_STUB/recover.log"
+  assert_output '1'
+}
+
+function test_scripts_1069_ask_sh_returns_a_recovered_report_as_a_normal_answer() {
+  _bats_test_init 1069 'ask.sh returns a recovered report as a normal answer'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=none STUB_RECOVER=1 HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_success
+  assert_output --partial 'RECOVERED answer'
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=answered"
+}
+
+function test_scripts_1070_ask_sh_reports_an_empty_report_as_its_own_status() {
+  _bats_test_init 1070 'ask.sh reports an empty report as its own status'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=empty HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_failure 4
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=empty-report"
+
+  # Control: one byte at the same path reaches the success path.
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT_BODY=x HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_success
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=answered"
+}
+
+function test_scripts_1071_ask_sh_refuses_a_report_that_is_not_a_regular_file() {
+  _bats_test_init 1071 'ask.sh refuses a report that is not a regular file'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=symlink HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_failure 5
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=bad-report"
+  # The symlink target is never read.
+  refute_output --partial 'localhost'
+}
+
+function test_scripts_1072_ask_sh_retains_the_transport_while_the_child_may_still_wr() {
+  _bats_test_init 1072 'ask.sh retains the transport while the child may still write'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=none STUB_AGENT_STATUS=working HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question
+  assert_failure 124
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=working"
+  assert_output --partial 'transport retained at'
+
+  report_line="$(grep -o '/[^ ]*/answer\.report' "$CHILD_STUB/prompt.txt" | head -1)"
+  [ -n "$report_line" ]
+  transport_dir="$(dirname "$report_line")"
+  assert_dir_exists "$transport_dir"
+  rm -f "$report_line" "$report_line.tmp"
+  rmdir "$transport_dir"
 }
 
 # ===========================================

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -904,7 +904,9 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
   # Pane and tab identity stay stable when Git state changes. Location metadata
   # remains available to integrations, but the sidebar renders identity only.
-  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\]\]$'
+  # The three identity fields and their order are the contract; how they are
+  # grouped into rows is a presentation preference the user changes directly.
+  assert_file_contains "$config" '^rows = \[\[.*"state_icon".*"workspace".*"pane".*\]\]$'
   run grep -E '\$git_ref|\$location_label|\$location_status' "$config"
   assert_failure
   # Sole owner of sidebar_min_width: the awk scope proves the key both carries
@@ -936,7 +938,6 @@ assert_herdr_sidebar_deployment_contract() {
   run grep -hEi 'state_icon|(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
     "$config" "${writer_files[@]}"
   assert_success
-  assert_file_contains "$config" 'rows = \[\["state_icon", "workspace", "pane"\]\]'
   assert_file_contains "$config" '"state_icon"'
   # The engine builds the five codicon glyphs of the $git_ref grammar from
   # bash 3.2-safe octal printf sequences. Raw PUA glyphs are easily lost when


### PR DESCRIPTION
## Summary

A consulted peer's answer now arrives as a file the peer wrote, instead of a screenshot of its terminal. The old path scraped 200 visible lines out of the child's pane, so a long answer was cut off, wrapped and alternate-screen text was lost, and closing the pane destroyed the answer — silently, because a truncated scrape looks exactly like a complete one.

The wider version of this idea — moving the `[child-ask]` / `[parent-reply]` protocol payloads to files too — was rejected during planning and is recorded in `docs/issues/2026-09-03-004`, with the six findings that blocked it. Only the answer path changes here.

## What changes for a caller

`ask-in-herdr` creates a private transport directory before it composes the question, and tells the child to write its answer to `answer.report` through a `.tmp` file and a rename. The instruction names shell commands deliberately: the default read-only posture strips file-editing tools but keeps Bash, so a read-only child can still deliver. Verified live before the code was written: a read-only claude child and a read-only opencode child both wrote their report through the shell, with no permission prompt.

Pane text is still captured, but for a settled child it is now evidence of what happened, never the answer.

A settled child that left no usable report gets exactly one bounded request to persist the same answer. What is still wrong after that is reported rather than guessed:

| Status | Exit | Condition |
|---|---:|---|
| `no-report` | 3 | Nothing at the report path |
| `empty-report` | 4 | The file exists and is empty |
| `bad-report` | 5 | The path is a symlink or not a regular file; it is never read |

The transport is deleted when the script exits, except on `working` and `blocked` — there the child may still be writing, so the directory survives and its path is printed.

## The same guard in the shared peer lifecycle

`se-code-review`, `se-doc-review`, and `se-simplify` delegate their whole transport to `~/.claude/shared/herdr-peer-launch.md`, so they need no changes. That lifecycle did accept a symlinked report, though: `[ -f ]` and `[ -s ]` both follow symlinks, so a peer could point `claude.report` at any file the caller can read and have its content synthesized as that peer's review. It is refused now, before the path is opened, and not retried — a symlink is a malformed delivery, not a missing one.

Both guards buy an honest failure, not containment. A peer runs as the same user and can read those files directly either way.

## Deployment

Earlier applies left a pre-`.agents` copy of `ask.sh` at `.claude/skills/ask-in-herdr/scripts`, dated 27 August and five lines shorter. An agent following the old documented path would have run it with none of this. `.chezmoiremove` drops it, and the four invocation lines that pointed there are corrected.

## Unrelated fixes in the same branch

`herdr-peer-alias` read its 1024 candidate aliases from a process substitution and exited at the first free one, leaving about a thousand lines unwritten. Where SIGPIPE arrives ignored rather than at its default, the producer got EPIPE instead of dying, and bash reported `printf: write error: Broken pipe` once per unwritten line — on the stderr the caller captures. That is why `scripts_test` 1401 failed on the CI macos runner in this PR's first run while passing on a workstation: both sides of the assertion held the same alias, and only the leaked stderr differed. The pool is now read once with a command substitution, so no writer can take EPIPE whatever the ambient disposition. It also recovers the producer's exit status, which the process substitution discarded — a pool that failed validation used to be reported as an exhausted pool.


`assert_herdr_sidebar_deployment_contract` pinned `rows = [["state_icon", "workspace", "pane"]]` verbatim, so commit a25c20f's move to a two-row sidebar left smoke tests 1058 and 1059 red against both the source and the deployed config. The two-row layout is intended, so the helper now asserts the three identity fields and their order without pinning the grouping. The guard it exists for is untouched: `$git_ref`, `$location_label`, and `$location_status` still cannot reach the sidebar.

## Validation

- `make test-ubuntu` at `dd1cd21`: exit 0, zero failures. It applies the checkout first, which is what makes it the gate for an edit under `home/` — `make test-suite` reads the already-applied `~/` and cannot see one.
- `tests/bashunit/scripts_test.sh`: 250 passed. New coverage asserts the report path is outside the checkout, that the instruction names shell commands, that a 250-line answer survives while contradicting pane text is refuted, that recovery fires exactly once, and that a symlinked report is never read.
- `tests/bashunit/smoke_test.sh`: 49 passed, 0 failed (was 47/2).
- `make lint` and `make test-issues` clean.

Negative controls were run for the new coverage: removing `classify_report`'s body turns four of the new tests red, so they fail for the intended reason.

## Related

- Plan: `docs/plans/2026-09-03-1217-feat-ask-in-herdr-report-file-plan.md` (U1–U3, all landed here)
- Closed by this branch: `docs/issues/2026-09-03-005`, `docs/issues/2026-09-03-006`, `docs/issues/2026-09-03-007`
- Left open: `docs/issues/2026-09-03-003` (cold opencode and pi children fail `herdr-child start` with `agent_prompt_stalled`; 2 of 2 cold non-claude launches stalled, 0 of 8 warm), `docs/issues/2026-09-03-004`

