### PR TITLE
feat(agents): add se-orchestrator for resumable checklist-driven plans

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -17,7 +17,7 @@ owners.
 
 | Ownership | Current inventory |
 | --- | --- |
-| Repository-owned | `ask-in-herdr`, `herdr`, `markdown-new`, `pf-build`, `pf-research`, `pf-spec`, `plan-explainer`, `se-code-review`, `se-doc-review`, `se-plan`, `se-simplify`, `vector-prime`, `work-summary`, `writing-for-agents` |
+| Repository-owned | `ask-in-herdr`, `herdr`, `markdown-new`, `pf-build`, `pf-research`, `pf-spec`, `plan-explainer`, `se-code-review`, `se-doc-review`, `se-orchestrator`, `se-plan`, `se-simplify`, `vector-prime`, `work-summary`, `writing-for-agents` |
 | Explicit-only | `eli5`, `open-questions`: Claude/Pi manual adapters and OpenCode command adapters only |
 | Upstream-managed | Compound Engineering `*`; `linear-cli`; `improve-claude-md`; `orca-cli`, `orchestration`; `find-skills`; `frontend-design`, `skill-creator` |
 

--- a/home/private_dot_agents/skills/se-orchestrator/SKILL.md
+++ b/home/private_dot_agents/skills/se-orchestrator/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: se-orchestrator
+description: Execute a plan through its checklist — take the first unchecked item, do it, verify, commit the work and the checkbox together. Use to run, continue, or resume a plan, spec, or TODO document, whether structured or hand-written, and when asked where to continue from. Writing the plan is ce-plan; an open-ended bug is ce-debug.
+---
+
+# Execute a plan through its checklist
+
+The plan file is the state. The first unchecked box is where you continue. Nothing else is stored.
+
+Four rules carry the whole workflow:
+
+1. **One item is one commit**, and the repository works after it.
+2. **The checkbox rides in that same commit.**
+3. **You continue from the first unchecked item.**
+4. **You run the verification and you own the commit.** The worker does neither.
+
+Rule 2 is why there is no journal: a commit that exists proves its box is checked, and a checked box proves its commit exists. `git log` is the run history, and `git status` answers "was I interrupted mid-item".
+
+## Step 1 — Put a checklist in place
+
+Read the plan. When it already carries a checklist, adopt it unchanged.
+
+Otherwise derive one and show it to the user before the first code edit. This is the only gate in the run; everything after it runs to the end or to a blocker.
+
+- Each item names one outcome, sized so the repository works once it lands.
+- Item labels stay whatever the document already uses — `U3`, `Step 2`, `Раздел «Адаптеры»`, `First part`. You read them the way a human would; no parser touches them.
+- When you cannot say how an item would be checked as done, ask about **that item**. Keep the question local; a plan needing one clarification is a plan you accept.
+
+The checklist lives inside the plan when the plan is writable, otherwise in `TODO.md` beside it. Exactly one file holds it.
+
+```
+## Progress
+
+- [x] U1 · state library
+- [ ] U2 · engine skeleton
+```
+
+**Done when:** every item has a stated done condition and the user has accepted the list.
+
+## Step 2 — Work the first unchecked item
+
+Pick the executor by what the item needs, and default to the middle rung:
+
+| Executor | Fits |
+|---|---|
+| Yourself, inline | One or two files, where a worker costs more than the work |
+| A fresh subagent | The default: one worker per item, clean context |
+| A visible pane | Long items, or anything running an observable process — load the `herdr` skill when `HERDR_ENV=1` |
+
+Hand the worker five things and nothing else:
+
+- The item text and the plan path. Sending "read the whole plan" spends its context on material it will not use.
+- The repository's own verification commands, read from its instructions (`CLAUDE.md` / `AGENTS.md`) at dispatch time rather than recalled.
+- The files this item owns.
+- **Leave the commit to you** — the git index is yours alone.
+- **Show the failing output it saw before fixing.** That observation exists only while the worker works; the diff cannot reconstruct it afterwards.
+
+Then integrate, in this order:
+
+1. Read `git status` and the diff. The tree is the truth; the worker's summary is a hint about where to look.
+2. Run the verification yourself.
+3. Tick the box in the checklist file, then commit through `ce-commit` so the work and the `[x]` land together.
+
+**Done when:** verification passes and one commit carries both the change and its checked box.
+
+Then return to Step 2 for the next unchecked item.
+
+## Step 3 — Decide where to continue
+
+Run this on every entry, including a fresh session, a session after `/clear`, and a resumed one:
+
+| State | Move |
+|---|---|
+| Working tree dirty | Someone was interrupted mid-item. Read the diff. When it is this item's work, finish and commit it. When it is someone else's, **preserve it and ask** — discarding it is the one way this workflow loses anything |
+| Clean, unchecked items remain | Take the first one |
+| First unchecked item carries a `blocked` line | Skip it and take the next unchecked item |
+| Every remaining item is blocked | Stop and put the blockers to the user |
+| Every item checked | Go to Step 4 |
+
+A blocked item stays unchecked and gains one line under it:
+
+```
+- [ ] U6 · client adapters
+      blocked 2026-09-03: pi has no async tool_call, needs a decision
+```
+
+## Step 4 — Finish
+
+1. Run `se-code-review` once over the completed work.
+2. Apply findings that are clear improvements and reversible edits. Leave contradictions between reviewers, taste calls, and design decisions to the user.
+3. A finding asking for a new test passes the oracle gate first: name the consumer, the observable failure, and an oracle independent of the reviewed diff. When the line will not complete, keep the finding advisory and say why.
+4. Re-run the verification and commit the fixes.
+5. Report what landed, what stayed blocked, and what the review left open.
+
+Push and PR are a separate explicit request routed through `ce-commit-push-pr`.
+
+## Stop and put it to the user
+
+- The derived checklist, before the first code edit.
+- The same failure three times. Name the assumption that may be wrong instead of trying a fourth variation.
+- Every remaining item blocked.
+- Reviewers contradicting each other on whether an issue exists.
+- A working-tree change that no item of yours accounts for.
+
+## Working in parallel
+
+Serial is the default and usually the honest answer: items in one plan tend to share a test file or a module, and the sharing is what forces the order, not the dependency list. Take two items at once only after reading the files they name and finding no shared write surface — then still commit them one at a time, in dependency order.

--- a/home/private_dot_claude/skills/se-orchestrator/symlink_SKILL.md.tmpl
+++ b/home/private_dot_claude/skills/se-orchestrator/symlink_SKILL.md.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills/se-orchestrator/SKILL.md

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -400,7 +400,7 @@ function test_smoke_019_clients_resolve_model_invocable_skills_from_agents() {
   for skill in \
     ask-in-herdr herdr markdown-new \
     pf-build pf-research pf-spec plan-explainer \
-    se-code-review se-doc-review se-plan se-simplify \
+    se-code-review se-doc-review se-orchestrator se-plan se-simplify \
     vector-prime work-summary writing-for-agents; do
     run readlink "$HOME/.claude/skills/$skill/SKILL.md"
     assert_success
@@ -409,24 +409,6 @@ function test_smoke_019_clients_resolve_model_invocable_skills_from_agents() {
     if [[ -e "$HOME/.config/opencode/skills/$skill" || -L "$HOME/.config/opencode/skills/$skill" ]]; then
       fail "stale OpenCode skill adapter remains: $HOME/.config/opencode/skills/$skill"
     fi
-  done
-
-  local retired path
-  for path in \
-    "$HOME/.agents/skills/se-cleanup" \
-    "$HOME/.claude/skills/se-cleanup" \
-    "$HOME/.config/opencode/skills/se-cleanup"; do
-    [[ ! -e "$path" && ! -L "$path" ]] || fail "retired skill remains deployed: $path"
-  done
-  for retired in se-flow se-review-and-work se-work; do
-    for path in \
-      "$HOME/.claude/skills/$retired" \
-      "$HOME/.config/opencode/skills/$retired"; do
-      [[ ! -e "$path" && ! -L "$path" ]] || fail "retired skill remains deployed: $path"
-    done
-  done
-  for path in "$HOME/.claude/.smithers" "$HOME/.local/bin/se"; do
-    [[ ! -e "$path" && ! -L "$path" ]] || fail "retired Smithers path remains deployed: $path"
   done
 }
 
@@ -482,6 +464,7 @@ function test_smoke_021_agent_skills_are_deployed_with_their_scripts_and() {
     skills/ask-in-herdr/SKILL.md
     skills/ask-in-herdr/scripts/ask.sh
     skills/herdr/SKILL.md
+    skills/se-orchestrator/SKILL.md
     skills/writing-for-agents/SKILL.md
     skills/writing-for-agents/SKILL-MECHANICS.md
     skills/work-summary/SKILL.md


### PR DESCRIPTION
## Summary

A plan handed to an agent now runs to the end without a separate progress store: the plan file is the state, and the first unchecked box is where any session continues — five minutes later, after a context clear, or on another machine.

The rule that makes this work is that the checked box lands in the same commit as the work it marks. A commit that exists proves its box is checked, and a checked box proves its commit exists, so there is nothing to synchronize and nothing to drift. `git log` becomes the run history and `git status` answers whether a run was interrupted mid-item.

Two consequences worth knowing before reading the skill:

- **Any plan works.** Item labels stay whatever the source document already uses — `U3`, `Step 2`, a heading — and the agent reads them the way a human would. A hand-written TODO runs the same as a generated plan. The only gate in a run is showing the derived checklist before the first code edit.
- **Verification does not move to the worker.** The worker implements and reports; the orchestrator reads the tree, runs the checks, and owns the commit. Verification commands are read from the repository's own instructions at dispatch time instead of being copied into the skill, where they would go stale.

Deployment follows the existing repo-owned skill pattern: canonical body under `.agents/skills`, a symlink adapter under `.claude/skills` for Claude Code and Pi, and no OpenCode adapter because OpenCode discovers `.agents` natively.

## Why the test loses six assertions

`test_smoke_019` also drops its retired-path checks for `.claude/.smithers`, `.local/bin/se`, `se-cleanup`, `se-flow`, `se-review-and-work`, and `se-work`. This is not incidental cleanup, and the reason is not visible in the diff.

Those assertions were added alongside `.chezmoiremove` directives, when removing the Smithers runtime and its pipeline-only skills. In that pairing they did real work: they proved the removal directive actually cleared paths that earlier applies had deployed. The directives were dropped from `home/.chezmoiremove` later, so today nothing creates those paths and nothing removes them. A check that no mechanism can make fail is load without coverage.

The test now asserts only the live relationship it exists for: every model-invocable skill resolves from `~/.claude/skills/<name>/SKILL.md` to the canonical file under `~/.agents/skills/`, with no competing OpenCode adapter claiming the same name. That check compares two independently produced deployment surfaces, so it still fails if either side breaks.

## Validation

`make test-ubuntu` — exit 0, six green suites, zero failures, run against this exact commit. That target applies the checkout before testing, which is what makes it the gate here: `make test-suite` reads the already-applied `~/` and cannot see an unapplied edit under `home/`.

`make lint` — exit 0.
