### PR TITLE
fix(herdr): resolve the repo root for palette worktree actions

### DIFF
--- a/home/private_dot_config/herdr/command-palette/commands.toml
+++ b/home/private_dot_config/herdr/command-palette/commands.toml
@@ -46,13 +46,20 @@ shortcuts = ["ws", "цы"]
 description = "Choose and focus a workspace"
 type = "workspace_picker"
 
+# herdr refuses `worktree create` and `worktree open` when the source is a
+# linked worktree: "New and open worktree actions start from the repo parent
+# workspace." {target_cwd} is whatever pane the palette was opened from, and
+# that is usually a worktree -- the case where you most want these commands.
+# So resolve the primary checkout first. `git worktree list --porcelain` names
+# it on the first line, the same rule the worktree-setup plugin uses.
 [[commands]]
 group = "Worktrees"
 title = "New worktree"
 description = "Create and focus a worktree from the current repository"
 type = "form"
-run_type = "herdr"
-args = ["worktree", "create", "--cwd", "{target_cwd}", "--branch", "{value}", "--focus"]
+run_type = "shell"
+pause = false
+command = "root=$(git -C {target_cwd_q} worktree list --porcelain | head -n 1 | cut -d ' ' -f 2-); if [ -z \"$root\" ]; then printf '%s\\n' 'Not inside a Git repository.' >&2; exit 1; fi; exec \"$HERDR_BIN_PATH\" worktree create --cwd \"$root\" --branch {value_q} --focus"
 prompt = "Branch name for the new worktree"
 placeholder = "worktree/my-feature"
 
@@ -61,8 +68,9 @@ group = "Worktrees"
 title = "Open worktree"
 description = "Open and focus an existing worktree by branch name"
 type = "form"
-run_type = "herdr"
-args = ["worktree", "open", "--cwd", "{target_cwd}", "--branch", "{value}", "--focus"]
+run_type = "shell"
+pause = false
+command = "root=$(git -C {target_cwd_q} worktree list --porcelain | head -n 1 | cut -d ' ' -f 2-); if [ -z \"$root\" ]; then printf '%s\\n' 'Not inside a Git repository.' >&2; exit 1; fi; exec \"$HERDR_BIN_PATH\" worktree open --cwd \"$root\" --branch {value_q} --focus"
 prompt = "Existing worktree branch"
 placeholder = "feature/my-feature"
 

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1343,6 +1343,141 @@ PY
   assert_success
 }
 
+# ===========================================
+# Worktree commands -- the source herdr is handed
+# ===========================================
+
+# herdr rejects `worktree create`/`open` when the source resolves to a linked
+# worktree, and the palette's target cwd is the pane it was opened from -- so
+# the shipped commands have to resolve the repository's primary checkout
+# themselves. That resolution is this repo's code and this repo's to prove;
+# herdr's own refusal is upstream behaviour and is not asserted here.
+#
+# The expectations come from the fixture, not from commands.toml: the test
+# creates a primary checkout under a path containing a space, adds a linked
+# worktree with `git worktree add`, runs the shipped command from inside that
+# linked worktree against a `herdr` stub that logs one argument per line, and
+# reads back which arguments herdr actually received. One argument per line is
+# what makes the boundaries visible -- these commands interpolate the branch
+# the user typed into a shell string, so a quoting regression would split it
+# across arguments or run the text after a `;` instead of passing it on.
+palette_worktree_stub() {
+  local fixture="$1"
+  mkdir -p "$fixture/bin"
+  cat > "$fixture/bin/herdr" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >> "$fixture/herdr.log"
+exit 0
+STUB
+  chmod +x "$fixture/bin/herdr"
+}
+
+# Run one shipped palette command with $value as the form input, printing
+# "code=<status>" plus the command's output.
+palette_run_worktree_command() {
+  local fixture="$1" title="$2" cwd="$3" value="$4"
+  env HERDR_BIN_PATH="$fixture/bin/herdr" HERDR_TARGET_CWD="$cwd" \
+    HERDR_COMMAND_PALETTE_CONFIG="$REAL_COMMANDS" \
+    PALETTE_COMMAND_TITLE="$title" PALETTE_COMMAND_VALUE="$value" python3 - <<'PY'
+import os
+
+import palette_boot
+
+palette = palette_boot.palette()
+herdr = os.environ["HERDR_BIN_PATH"]
+config_path, commands = palette.load_commands()
+command = next(c for c in commands if c.title == os.environ["PALETTE_COMMAND_TITLE"])
+child_raw = palette.interactive_run_raw(command)
+child = palette.Command(
+    command.title,
+    command.description,
+    palette.command_kind(child_raw),
+    command.group,
+    child_raw,
+    command.origin,
+    command.source,
+)
+variables = palette.variables_with_value(
+    palette.context_vars(config_path, herdr), os.environ["PALETTE_COMMAND_VALUE"]
+)
+code, output, _ = palette.run_command_with_variables(child, config_path, variables, herdr)
+print(f"code={code}")
+print(output)
+PY
+}
+
+function test_palette_064_worktree_commands_hand_herdr_the_primary_checkou() {
+  _bats_test_init 64 'worktree commands hand herdr the primary checkout as one argument'
+  # The space in the fixture path is load-bearing: an unquoted {target_cwd_q}
+  # or "$root" would arrive as two arguments instead of one.
+  local fixture="$PALETTE_WORK/worktree source"
+  local primary="$fixture/repo" linked="$fixture/linked"
+  mkdir -p "$primary"
+
+  run git init -q -b main "$primary"
+  assert_success
+  run git -C "$primary" -c user.email=t@example.com -c user.name=T \
+    commit -q --allow-empty -m init
+  assert_success
+  run git -C "$primary" worktree add -q -b fixture/linked "$linked"
+  assert_success
+  palette_worktree_stub "$fixture"
+
+  # git may resolve the fixture through a symlinked temp dir (/tmp on macOS),
+  # so take the expected path from git's own view of the primary checkout
+  # rather than from the string the shell composed above.
+  local expected
+  expected="$(git -C "$primary" worktree list --porcelain | head -n 1 | cut -d ' ' -f 2-)"
+  [[ -n "$expected" ]] || fail "fixture has no primary worktree"
+
+  # A branch name carrying a space and a shell metacharacter. If the value
+  # reached the shell unquoted, `touch` would run and the argument would split.
+  local branch="feat/a b; touch $fixture/PWNED #"
+  local title
+  for title in "Open worktree" "New worktree"; do
+    : > "$fixture/herdr.log"
+    run palette_run_worktree_command "$fixture" "$title" "$linked" "$branch"
+    assert_success
+    assert_line "code=0"
+
+    run cat "$fixture/herdr.log"
+    assert_success
+    assert_line "--cwd"
+    assert_line "$expected"
+    assert_line "--branch"
+    assert_line "$branch"
+
+    # oracle: the marker is created only by the injected `touch`, so its
+    # absence is the observable proof that {value_q} kept the branch inert.
+    if [[ -e "$fixture/PWNED" ]]; then
+      fail "$title let the branch value run a command"
+    fi
+  done
+}
+
+function test_palette_065_worktree_commands_refuse_a_target_outside_a_repo() {
+  _bats_test_init 65 'worktree commands refuse a target outside a repository instead of calling herdr'
+  local fixture="$PALETTE_WORK/worktree-no-repo"
+  local plain="$fixture/plain"
+  mkdir -p "$plain"
+  palette_worktree_stub "$fixture"
+
+  local title
+  for title in "Open worktree" "New worktree"; do
+    : > "$fixture/herdr.log"
+    run palette_run_worktree_command "$fixture" "$title" "$plain" "some/branch"
+    assert_success
+    assert_line "code=1"
+
+    # oracle: the stub appends a line per argument on every call, so an empty
+    # log is the observable proof that herdr was never invoked -- an empty
+    # --cwd must not reach it.
+    if [[ -s "$fixture/herdr.log" ]]; then
+      fail "$title invoked herdr without a repository"
+    fi
+  done
+}
+
 function set_up_before_script() {
   :
 }


### PR DESCRIPTION
## Summary

The herdr command palette's `Open worktree` and `New worktree` entries now work from a pane inside a linked worktree, which is where you reach for them most: previously both always failed there, while herdr's own repository context menu did the same thing successfully.

Both entries passed the palette pane's own directory as `--cwd` to `herdr worktree open` / `create`. herdr resolves the source workspace from that path, and when it is a linked worktree it refuses the action outright — `linked_worktree_source`, "New and open worktree actions start from the repo parent workspace" — before it ever reads `--branch`. The context menu is invoked on the repository group header, so its source is already the parent workspace and the check never fires.

Both commands now resolve the repository's primary checkout with `git worktree list --porcelain` before invoking herdr, the same rule `mainRepository()` already uses in `home/private_dot_config/herdr/plugins/worktree-setup/setup.ts`. A target outside any Git repository is refused with a message instead of handing herdr an empty path.

Resolution needs a shell, so both entries move from `run_type = "herdr"` (argv list) to `run_type = "shell"`. That shifts the branch name the user typed from an argv slot into a shell string, so it goes through the palette's existing `{value_q}` quoting — the palette's validator rejects a bare `{value}` in a shell command for exactly this reason.

## Tests

`tests/bashunit/palette_test.sh` gains two cases, both red on the previous config:

- **064** builds a real primary checkout plus a `git worktree add` linked worktree under a path containing a space, runs both shipped commands from inside the linked worktree against a `herdr` stub that logs one argument per line, and asserts the primary checkout arrives as a single `--cwd` argument and a branch value containing a space and `; touch …` arrives as a single inert `--branch` argument.
- **065** points the same commands at a plain non-Git directory and asserts they exit non-zero without invoking herdr at all.

Verified with `make test-ubuntu` (exit 0, both new cases passing inside Docker) and `make lint`.

## Unapplied review findings
- [ ] P3 — home/private_dot_config/herdr/command-palette/commands.toml:62 — Line-oriented `git worktree list --porcelain` parsing does not support a checkout path containing a newline. Advisory; no supported requirement for such paths today.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
