### PR TITLE
feat(herdr): name generated worktrees from task prompts

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -10,6 +10,9 @@ The agreement between a parent agent and child agents launched into sibling pane
 ### Sandbox-scoped takeover
 A Herdr intervention that attaches the operator to an agent inside its existing microVM. It preserves the agent's filesystem, network, and credential boundaries and never falls back to a host shell.
 
+### herdr-worktree-identity
+The component that derives a task title and multi-word branch slug from a generated worktree session's prompt, renames the authorized branch once with attribution, and labels the workspace. The alias system exclusively owns pane, tab, and agent identity. A contended claim writes a diagnostic but has no terminal outcome, so the next naming event retries it.
+
 ### Generated-worktree marker
 The marker file the worktree-setup plugin writes into a worktree's git per-worktree admin dir on `worktree.created`. It is the sole authorization boundary for automated ref mutation in that worktree: a component may rename the generated branch only when the marker is present and matches — branch name text alone never authorizes. Later lines appended to the marker carry attribution for mutations already made.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local lint clean build-docker shell-ubuntu
+.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local test-pi-herdr-worktree-identity lint clean build-docker shell-ubuntu
 
 help:
 	@echo "Chezmoi Dotfiles - Available commands:"
@@ -8,6 +8,7 @@ help:
 	@echo "  make test-suite       Run the post-apply suite in parallel (host-safe files)"
 	@echo "  make test-templates   Run template tests in Docker (may rebuild images)"
 	@echo "  make test-pi-agents-local  Run focused Pi local-instructions extension tests"
+	@echo "  make test-pi-herdr-worktree-identity  Run focused Pi worktree-identity extension tests"
 	@echo "  make test-local       Run chezmoi diff on current machine (dry-run)"
 	@echo "  make test-docker      Build and run full Docker test suite"
 	@echo "  make lint             Run shellcheck on all scripts"
@@ -33,6 +34,9 @@ test-templates: test-issues build-docker
 
 test-pi-agents-local:
 	bun test tests/pi-agents-local-extension.test.ts
+
+test-pi-herdr-worktree-identity:
+	bun test tests/pi-herdr-worktree-identity.test.ts
 
 shell-ubuntu: build-docker
 	docker compose -f docker/docker-compose.yml run --rm ubuntu /bin/zsh

--- a/docs/herdr-worktrees.md
+++ b/docs/herdr-worktrees.md
@@ -2,8 +2,9 @@
 
 Herdr is the single owner of interactive Git worktree creation, opening,
 closing, and removal. Linked checkouts are native child workspaces;
-`herdr-task-sync` owns task-derived pane labels, Git metadata, and the one-time
-rename of a newly generated branch and its workspace.
+`herdr-worktree-identity` owns task-derived Git metadata, the one-time rename
+of a newly generated branch, and its workspace title. The alias system remains
+the sole owner of pane, tab, and agent identity.
 
 - `Cmd+Shift+N` sends the existing `prefix+shift+g` transport sequence from
   Ghostty or kitty and opens Herdr's native new-worktree dialog.
@@ -23,7 +24,7 @@ keys. A repository with no table receives no setup or fresh-base mutation.
 
 On every `worktree.created` event, the plugin also records
 `herdr-generated-worktree` in that checkout's Git administrative directory.
-`herdr-task-sync` requires this lifecycle-owned marker before renaming a
+`herdr-worktree-identity` requires this lifecycle-owned marker before renaming a
 `worktree/*` branch, so a manually created branch cannot be renamed from its
 prefix alone. Git removes the marker with the linked worktree metadata.
 

--- a/docs/issues/2026-08-27-004-opencode-sessions-cannot-report-their-working-directory-to-herdr-pane-labels.md
+++ b/docs/issues/2026-08-27-004-opencode-sessions-cannot-report-their-working-directory-to-herdr-pane-labels.md
@@ -11,11 +11,11 @@ priority: "medium"
 
 ## Why this exists
 
-herdr-task-sync now sources an agent pane's effective directory from a record the agent itself writes, because no agent kind changes its process working directory when its work moves into a worktree. Claude Code can write that record from its statusline command, which receives the session directory as JSON on stdin. OpenCode has no equivalent hook, so an OpenCode pane still falls back to its process cwd and names the directory it was launched in for the rest of the session. The sidebar is then confidently wrong rather than merely uninformative.
+herdr-worktree-identity now sources an agent pane's effective directory from a record the agent itself writes, because no agent kind changes its process working directory when its work moves into a worktree. Claude Code can write that record from its statusline command, which receives the session directory as JSON on stdin. OpenCode has no equivalent hook, so an OpenCode pane still falls back to its process cwd and names the directory it was launched in for the rest of the session. The sidebar is then confidently wrong rather than merely uninformative.
 
 ## Scope
 
-Find or add an OpenCode extension point that fires on session start and on any directory change, and have it write the same one-line record the Claude statusline writes: an absolute directory path, at $HERDR_TASK_SYNC_STATE_DIR/agent-cwd/<sanitized session id>, written to a temporary file and renamed into place. The reader side needs no change. Out of scope: changing how herdr-task-sync reads the record, and any change to the Claude Code path.
+Find or add an OpenCode extension point that fires on session start and on any directory change, and have it write the same one-line record the Claude statusline writes: an absolute directory path, at $HERDR_WORKTREE_IDENTITY_STATE_DIR/agent-cwd/<sanitized session id>, written to a temporary file and renamed into place. The reader side needs no change. Out of scope: changing how herdr-worktree-identity reads the record, and any change to the Claude Code path.
 
 ## Open decisions
 

--- a/docs/issues/2026-08-27-005-pi-sessions-cannot-report-their-working-directory-to-herdr-pane-labels.md
+++ b/docs/issues/2026-08-27-005-pi-sessions-cannot-report-their-working-directory-to-herdr-pane-labels.md
@@ -11,11 +11,11 @@ priority: "low"
 
 ## Why this exists
 
-herdr-task-sync sources an agent pane's effective directory from a record the agent writes, since no agent kind changes its process working directory when work moves into a worktree. Claude Code writes that record from its statusline. Pi has neither an equivalent hook nor a worktree concept of its own, so a pi pane always falls back to its process cwd. This is lower priority than the OpenCode gap because pi has no in-session directory move to miss today; it becomes a real gap only once pi gains one.
+herdr-worktree-identity sources an agent pane's effective directory from a record the agent writes, since no agent kind changes its process working directory when work moves into a worktree. Claude Code writes that record from its statusline. Pi has neither an equivalent hook nor a worktree concept of its own, so a pi pane always falls back to its process cwd. This is lower priority than the OpenCode gap because pi has no in-session directory move to miss today; it becomes a real gap only once pi gains one.
 
 ## Scope
 
-Confirm whether pi has, or plans, an in-session directory change worth reporting. If it does, add a hook that writes the same one-line record the Claude statusline writes: an absolute directory path, at $HERDR_TASK_SYNC_STATE_DIR/agent-cwd/<sanitized session id>, written to a temporary file and renamed into place. If it does not, close this as wontfix and record that pi panes are accurate by construction. Out of scope: any change to the herdr-task-sync reader.
+Confirm whether pi has, or plans, an in-session directory change worth reporting. If it does, add a hook that writes the same one-line record the Claude statusline writes: an absolute directory path, at $HERDR_WORKTREE_IDENTITY_STATE_DIR/agent-cwd/<sanitized session id>, written to a temporary file and renamed into place. If it does not, close this as wontfix and record that pi panes are accurate by construction. Out of scope: any change to the herdr-worktree-identity reader.
 
 ## Open decisions
 

--- a/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
+++ b/docs/issues/2026-09-02-011-herdr-task-sync-gives-up-on-worktree-identity-after-a-200-ms-claim-bound-silently.md
@@ -1,24 +1,41 @@
 ---
-title: "herdr-task-sync gives up on worktree identity after a 200 ms claim bound, silently"
-short_description: "acquire_claim retries INBOX_LOCK_ATTEMPTS=20 times at 10 ms, so a contended claim is abandoned after ~200 ms and every caller in apply_worktree_identity converts that into a bare return 0 that leaves no trace; simply raising the count breaks the engine fail-open promptness guarantee instead."
+title: "herdr-worktree-identity records contention for retry"
+short_description: "The retired herdr-task-sync engine silently abandoned a contended claim after roughly 200 ms; herdr-worktree-identity now records contended as a non-terminal outcome so the next naming event retries without extending the fail-open bound."
 type: "bug"
 category: "herdr"
-tags: ["herdr-task-sync","worktree-identity","observability"]
+tags: ["worktree-identity","observability","contention"]
 date: "2026-09-02"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-03"
 ---
 
 ## Why this exists
 
-On a loaded machine herdr-task-sync can silently skip naming a generated worktree. home/dot_local/bin/executable_herdr-task-sync:130 sets INBOX_LOCK_ATTEMPTS=20 and acquire_claim (:354) sleeps 0.01 between attempts, so acquiring a claim is abandoned after roughly 200 ms of wall clock. A single agent session drives several engine processes -- the event, the naming worker, the presentation coordinator -- that contend for the same identity and repository claims, so the bound is reachable in normal use, not only under artificial load. Every caller then turns the failure into a silent return 0 (:1922, :2316, :2364, :2485), so the branch is not renamed, no record is written, and nothing is logged. This surfaced on the GitHub macOS runner (3 cores), where the post-apply suite ran 8 workers: the worktree-identity tests failed on every run because the claim bound lost to the scheduler. That CI symptom is fixed by matching the worker count to the runner instead, so the shipped bound and the silent failure are untouched and still reachable on a loaded developer machine.
+The retired `herdr-task-sync` engine could silently skip naming a generated
+worktree on a loaded machine. Its 20-attempt claim bound, with a 10 ms sleep
+between attempts, gave up after roughly 200 ms; callers then returned zero
+without a diagnostic or identity state. The bound was reachable during normal
+session contention, not only artificial load.
 
-Raising the bound is NOT the remedy, and the measurement says why. A harness ceiling of 2000 attempts (~20 s) was tried first: at 8 workers it fixed two of the six tests, broke a fail-open promptness test, and left five failing; at 4 workers it still failed one, with the engine reporting `elapsed_ms=8395 allowed_ms=8136` -- it spun in the retry loop for 8.4 s where the fail-open guard allows 8.1. So a claim ceiling large enough to survive contention violates the promptness guarantee the engine is separately required to keep. Any fix here has to reconcile those two obligations rather than trade one for the other.
+Raising the bound was not a remedy: a 2000-attempt experiment could exceed the
+fail-open promptness guard. That measurement remains historical evidence for
+the replacement design rather than behavior of the shipped component.
 
 ## Scope
 
-Decide and implement a production-appropriate claim bound for the herdr-task-sync engine, and make an exhausted claim observable rather than silent. Covers home/dot_local/bin/executable_herdr-task-sync only. The CI failure that exposed it is fixed separately by capping the macOS post-apply worker count, and the test harness carries no compensating override.
+`herdr-worktree-identity` keeps the short claim bound and implements KTD3: an
+exhausted live-owner claim writes a `contended` diagnostic and leaves no
+terminal identity outcome. The next session naming event retries the work;
+neither a larger retry ceiling nor a second long-lived retry daemon is used.
+
+The filename retains the retired component name as the historical record of the
+reported defect.
 
 ## Open decisions
 
-Whether the fix is an escalating backoff, a wall-clock deadline separate from the attempt count, or a bound that yields to the caller instead of spinning -- a larger attempt count alone is ruled out by the measurement above. Whether an exhausted claim should emit a diagnostic line and, if so, on which channel given the engine must stay silent outside herdr. Whether apply_worktree_identity should distinguish give-up from not-applicable, since return 0 currently means both.
+None. KTD3 settled the remedy before U5 implemented it.
+
+## Resolution
+
+U5 landed the KTD3 remedy in 2fe04a1: herdr-worktree-identity retains the short claim bound, records exhausted live-owner claims as contended diagnostics, and leaves the identity outcome non-terminal so the next naming event retries. This preserves fail-open promptness without a second retry daemon.

--- a/docs/issues/2026-09-03-003-detached-worktree-identity-worker-stalls-parallel-bashunit.md
+++ b/docs/issues/2026-09-03-003-detached-worktree-identity-worker-stalls-parallel-bashunit.md
@@ -1,0 +1,27 @@
+---
+title: "Detached worktree identity worker stalls parallel bashunit"
+short_description: "test_scripts_1141 leaves a blocked detached worker holding bashunit output pipes after teardown removes its release file, so make test-ubuntu never completes."
+type: "bug"
+category: "testing-ci"
+tags: ["worktree-identity","bashunit","process-lifecycle"]
+date: "2026-09-03"
+status: "done"
+priority: "high"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Updated herdr-worktree-identity detachment to close inherited descriptors above stderr before exec. The existing detached-worker regression test now completes, and the full parallel scripts_test.sh suite passed with 264 tests, 1 expected skip, and 1325 assertions in 1m28s.

--- a/docs/issues/2026-09-03-004-disposable-home-guard-is-risky-in-docker.md
+++ b/docs/issues/2026-09-03-004-disposable-home-guard-is-risky-in-docker.md
@@ -1,0 +1,27 @@
+---
+title: "Disposable-home guard is risky in Docker"
+short_description: "test_idempotent_010 reaches its Docker success path without a bashunit assertion, so --fail-on-risky makes make test-ubuntu fail despite the required MMS_DISPOSABLE_HOME=1 marker being present."
+type: "bug"
+category: "testing-ci"
+tags: ["docker","bashunit","disposable-home"]
+date: "2026-09-03"
+status: "done"
+priority: "high"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Added an explicit assert_equal for MMS_DISPOSABLE_HOME=1 on the Docker success path. The next make test-ubuntu run reported the guard as passed rather than risky; its remaining failure was an unrelated stale sidebar expectation.

--- a/docs/issues/2026-09-03-005-sidebar-deployment-smoke-expects-retired-row-layout.md
+++ b/docs/issues/2026-09-03-005-sidebar-deployment-smoke-expects-retired-row-layout.md
@@ -1,0 +1,27 @@
+---
+title: "Sidebar deployment smoke expects retired row layout"
+short_description: "assert_herdr_sidebar_deployment_contract still requires the pre-a25c20f single-row agents sidebar, so make test-ubuntu rejects both managed and deployed copies of the intentional two-row workspace/pane layout."
+type: "bug"
+category: "testing-ci"
+tags: ["herdr","smoke-test","config-drift"]
+date: "2026-09-03"
+status: "done"
+priority: "high"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Updated both sidebar-row assertions to match the intentional two-row layout introduced by a25c20f. The managed-source smoke test passed with 17 assertions; deployed coverage remains assigned to make test-ubuntu.

--- a/docs/issues/2026-09-03-006-pre-exec-descriptor-closure-can-suppress-linux-identity-worker.md
+++ b/docs/issues/2026-09-03-006-pre-exec-descriptor-closure-can-suppress-linux-identity-worker.md
@@ -1,0 +1,27 @@
+---
+title: "Pre-exec descriptor closure can suppress Linux identity worker"
+short_description: "Closing every /dev/fd entry in the launcher subshell can close Bash internal state before exec under Linux setsid, so the detached worker returns control but never reaches its pane-get readiness barrier."
+type: "bug"
+category: "testing-ci"
+tags: ["worktree-identity","linux","process-lifecycle"]
+date: "2026-09-03"
+status: "done"
+priority: "high"
+closed: "2026-09-03"
+---
+
+## Why this exists
+
+Describe the problem and its impact.
+
+## Scope
+
+Define the work that resolves this issue.
+
+## Open decisions
+
+None.
+
+## Resolution
+
+Moved inherited-descriptor closure from the launcher subshell into validated worker mode, matching executable_herdr-pane-labels. The Linux Docker reproduction passed both filtered tests with 4 assertions in 1.31s, and make lint passed.

--- a/home/dot_gitignore
+++ b/home/dot_gitignore
@@ -37,3 +37,4 @@ CLAUDE.local.md
 
 mise.toml
 .ce-doc-review-tmp/
+.smithers/

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/../lib/herdr-worktree-state.sh"
 SLUG_MAX_LEN=40
 SLUG_MAX_WORDS=5
 TITLE_MAX_LEN=48
+BRANCH_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_BRANCH_CLAIM_ATTEMPTS:-3}"
 ENGINE_TIMEOUT="${HERDR_WORKTREE_IDENTITY_TIMEOUT:-30}"
 PI_MODEL="${HERDR_WORKTREE_IDENTITY_PI_MODEL:-openai-codex/gpt-5.4-mini}"
 CLAUDE_MODEL="${HERDR_WORKTREE_IDENTITY_CLAUDE_MODEL:-claude-haiku-4-5-20251001}"
@@ -236,11 +237,12 @@ diagnostic_file_for_state() {
 
 write_identity_state() {
   local file="$1" root="$2" common="$3" workspace="$4" original="$5" outcome="$6" authorization="$7"
-  local title="${8:-}" slug="${9:-}"
+  local title="${8:-}" slug="${9:-}" branch="${10:-}"
   atomic_write "$file" "checkout_root=$(encode_value "$root")
 repository_anchor=$(encode_value "$common")
 workspace=$(encode_value "$workspace")
 original_branch=$(encode_value "$original")
+branch=$(encode_value "$branch")
 outcome=$(encode_value "$outcome")
 authorization=$(encode_value "$authorization")
 title=$(encode_value "$title")
@@ -308,7 +310,7 @@ is_linked_worktree() {
 }
 
 authorize_worktree() {
-  local root="$1" common="$2" branch marker original state observed title slug
+  local root="$1" common="$2" branch marker original state observed title slug outcome renamed_branch
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
     record_unresolved detached-head "checkout=$root"
     return 0
@@ -317,24 +319,246 @@ authorize_worktree() {
   original="$(read_state_field "$state" original_branch)"
   title="$(read_state_field "$state" title)"
   slug="$(read_state_field "$state" slug)"
+  outcome="$(read_state_field "$state" outcome)"
+  renamed_branch="$(read_state_field "$state" branch)"
   [ -n "$original" ] || original="$branch"
   marker="$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)" || {
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-path-unavailable "checkout=$root branch=$branch" || true
     return 0
   }
   if [ ! -f "$marker" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing "checkout=$root branch=$branch marker=$marker" || true
     return 0
   fi
   observed="$(head -n 1 "$marker" 2>/dev/null)"
   if [ "$observed" != "$original" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched "checkout=$root branch=$branch original_branch=$original marker_branch=$observed" || true
     return 0
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" '' authorized "$title" "$slug" || true
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$outcome" authorized "$title" "$slug" "$renamed_branch" || true
+}
+
+branch_name_available() {
+  local root="$1" candidate="$2" status remote_refs ref
+  if git -C "$root" show-ref --verify --quiet "refs/heads/$candidate"; then
+    return 1
+  else
+    status=$?
+    [ "$status" -eq 1 ] || return 2
+  fi
+  remote_refs="$(git -C "$root" for-each-ref --format='%(refname)' refs/remotes)" || return 2
+  while IFS= read -r ref; do
+    case "$ref" in
+      refs/remotes/*/"$candidate") return 1 ;;
+    esac
+  done <<< "$remote_refs"
+  return 0
+}
+
+available_branch_name() {
+  local root="$1" slug="$2" candidate suffix=2 base status
+  candidate="$slug"
+  while :; do
+    if branch_name_available "$root" "$candidate"; then
+      git -C "$root" check-ref-format --branch "$candidate" >/dev/null || return 1
+      printf '%s' "$candidate"
+      return 0
+    else
+      status=$?
+    fi
+    [ "$status" -eq 1 ] || return 1
+    [ "$suffix" -le 999 ] || return 1
+    base="$(printf '%s' "$slug" | cut -c "1-$((SLUG_MAX_LEN - ${#suffix} - 1))" | sed -e 's/-$//')"
+    candidate="$base-$suffix"
+    suffix=$((suffix + 1))
+  done
+}
+
+branch_has_upstream() {
+  local root="$1" status
+  git -C "$root" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1
+  status=$?
+  case "$status" in
+    0) return 0 ;;
+    128) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+same_checkout_identity() {
+  local root="$1" common="$2" observed_root observed_common
+  observed_root="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  observed_common="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  [ "$observed_root" = "$root" ] && [ "$observed_common" = "$common" ]
+}
+
+attribution_message() {
+  printf 'Intentional rename by herdr-worktree-identity: %s -> %s' "$1" "$2"
+}
+
+write_marker_attribution() {
+  local marker="$1" message="$2"
+  grep -Fqx "$message" "$marker" 2>/dev/null && return 0
+  printf '%s\n' "$message" >> "$marker" 2>/dev/null
+}
+
+write_branch_description() {
+  local root="$1" branch="$2" message="$3"
+  git -C "$root" config --local "branch.$branch.description" "$message"
+}
+
+write_attribution() {
+  local root="$1" original="$2" branch="$3" marker="$4" message attempts=0 marker_ok description_ok
+  message="$(attribution_message "$original" "$branch")"
+  while [ "$attempts" -lt 2 ]; do
+    attempts=$((attempts + 1))
+    marker_ok=0
+    description_ok=0
+    write_marker_attribution "$marker" "$message" && marker_ok=1
+    write_branch_description "$root" "$branch" "$message" && description_ok=1
+    [ "$marker_ok" -eq 1 ] && [ "$description_ok" -eq 1 ] && return 0
+  done
+  return 1
+}
+
+wait_for_test_barrier() {
+  local barrier="${HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER_RELEASE:-}"
+  [ -n "$barrier" ] || return 0
+  mkdir -p "$barrier" 2>/dev/null || return 1
+  : > "$barrier/$(encode_path_key "$root").$$"
+  [ -n "$release" ] || return 0
+  while [ ! -e "$release" ]; do sleep 0.01; done
+}
+
+wait_for_revalidation_test_barrier() {
+  local ready="${HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_RELEASE:-}"
+  [ -n "$ready" ] || return 0
+  : > "$ready"
+  [ -n "$release" ] || return 0
+  while [ ! -e "$release" ]; do sleep 0.01; done
+}
+
+wait_for_claim_test_barrier() {
+  local ready="${HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_READY:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_RELEASE:-}"
+  [ -n "$ready" ] || return 0
+  : > "$ready"
+  [ -n "$release" ] || return 0
+  while [ ! -e "$release" ]; do sleep 0.01; done
+}
+
+retry_attribution() {
+  local root="$1" common="$2" state="$3" original="$4" branch="$5" marker="$6" title="$7" slug="$8"
+  if write_attribution "$root" "$original" "$branch" "$marker"; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$branch" || true
+  else
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" attribution_failed authorized "$title" "$slug" "$branch" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" attribution-failed "checkout=$root branch=$branch" || true
+  fi
+}
+
+apply_branch_rename() {
+  local root="$1" common="$2" state="$3" marker="$4"
+  local original title slug outcome branch candidate lock owner claim_status upstream_status
+  original="$(read_state_field "$state" original_branch)"
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
+  outcome="$(read_state_field "$state" outcome)"
+  candidate="$(read_state_field "$state" branch)"
+  [ -n "$original" ] && [ "$(slug_word_count "$slug")" -ge 2 ] || return 0
+  branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" detached-head "checkout=$root"
+    return 0
+  }
+
+  case "$outcome" in
+    prepared) return 0 ;;
+    attribution_failed)
+      if [ "$branch" = "$candidate" ]; then
+        retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+      else
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-attribution-failure "checkout=$root branch=$branch expected_branch=$candidate" || true
+      fi
+      return 0
+      ;;
+  esac
+
+  if [ "$branch" != "$original" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved "checkout=$root branch=$branch original_branch=$original" || true
+    return 0
+  fi
+  branch_has_upstream "$root"
+  upstream_status=$?
+  case "$upstream_status" in
+    0)
+      record_diagnostic "$(diagnostic_file_for_state "$state")" branch-has-upstream "checkout=$root branch=$branch" || true
+      return 0
+      ;;
+    1) ;;
+    *)
+      record_diagnostic "$(diagnostic_file_for_state "$state")" upstream-unavailable "checkout=$root branch=$branch" || true
+      return 0
+      ;;
+  esac
+
+  wait_for_test_barrier || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-barrier-failed "checkout=$root" || true
+    return 0
+  }
+  lock="$(namespace_dir "$common")/branch-rename.claim"
+  acquire_claim "$lock" "$BRANCH_CLAIM_ATTEMPTS"
+  claim_status=$?
+  if [ "$claim_status" -ne 0 ]; then
+    if [ "$claim_status" -eq 2 ]; then
+      [ -z "${HERDR_WORKTREE_IDENTITY_TEST_CONTENDED_READY:-}" ] || : > "$HERDR_WORKTREE_IDENTITY_TEST_CONTENDED_READY"
+      record_diagnostic "$(diagnostic_file_for_state "$state")" contended "repository_anchor=$common checkout=$root" || true
+    else
+      record_diagnostic "$(diagnostic_file_for_state "$state")" branch-claim-failed "repository_anchor=$common checkout=$root" || true
+    fi
+    return 0
+  fi
+  # shellcheck disable=SC2154 # acquire_claim from the sourced state library sets this.
+  owner="$claim_owner_id"
+  wait_for_claim_test_barrier
+  candidate="$(available_branch_name "$root" "$slug")" || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-candidate-unavailable "checkout=$root slug=$slug" || true
+    release_claim "$lock" "$owner"
+    return 0
+  }
+  wait_for_revalidation_test_barrier
+  if ! same_checkout_identity "$root" "$common"; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" checkout-changed-before-rename "checkout=$root" || true
+    release_claim "$lock" "$owner"
+    return 0
+  fi
+  branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || branch=''
+  branch_has_upstream "$root"
+  upstream_status=$?
+  if [ "$branch" != "$original" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-changed-before-rename "checkout=$root branch=$branch original_branch=$original" || true
+    release_claim "$lock" "$owner"
+    return 0
+  fi
+  if [ "$upstream_status" -ne 1 ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" upstream-changed-before-rename "checkout=$root branch=$branch upstream_status=$upstream_status" || true
+    release_claim "$lock" "$owner"
+    return 0
+  fi
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$candidate" || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" prepared-state-write-failed "checkout=$root branch=$branch candidate=$candidate" || true
+    release_claim "$lock" "$owner"
+    return 0
+  }
+  if ! git -C "$root" branch -m "$candidate"; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" branch-failed authorized "$title" "$slug" "$candidate" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-rename-failed "checkout=$root branch=$branch candidate=$candidate" || true
+    release_claim "$lock" "$owner"
+    return 0
+  fi
+  retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+  release_claim "$lock" "$owner"
 }
 
 worker() {
@@ -399,8 +623,10 @@ worker() {
     identity="$(derive_identity "$prompt" "$root")"
     IFS=$'\037' read -r title slug <<< "$identity"
     write_identity_state "$state" "$root" "$common" "$workspace" \
-      "$(read_state_field "$state" original_branch)" '' authorized "$title" "$slug" || true
+      "$(read_state_field "$state" original_branch)" "$(read_state_field "$state" outcome)" authorized "$title" "$slug" \
+      "$(read_state_field "$state" branch)" || true
   fi
+  apply_branch_rename "$root" "$common" "$state" "$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)"
 }
 
 detach_worker() {

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -459,6 +459,58 @@ retry_attribution() {
   fi
 }
 
+wait_for_workspace_revalidation_test_barrier() {
+  local ready="${HERDR_WORKTREE_IDENTITY_TEST_WORKSPACE_REVALIDATE_READY:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_WORKSPACE_REVALIDATE_RELEASE:-}"
+  [ -n "$ready" ] || return 0
+  : > "$ready"
+  [ -n "$release" ] || return 0
+  while [ ! -e "$release" ]; do sleep 0.01; done
+}
+
+# Re-read the pane immediately before the external rename: the original
+# lookup can be stale after an occupant, session, or workspace change.
+label_workspace() {
+  local root="$1" common="$2" state="$3" expected_pane="$4" desired_outcome="$5"
+  local original title slug branch payload fields final_pane final_agent final_session final_workspace
+  original="$(read_state_field "$state" original_branch)"
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
+  branch="$(read_state_field "$state" branch)"
+  if [ -z "$title" ] || [ -z "$workspace" ]; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-unavailable "checkout=$root workspace=${workspace:-missing}" || true
+    return 1
+  fi
+  wait_for_workspace_revalidation_test_barrier || return 1
+  payload="$(herdr pane get "$expected_pane" 2>/dev/null)" || {
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-unreachable "pane=$expected_pane workspace=$workspace" || true
+    return 1
+  }
+  fields="$(printf '%s' "$payload" | pane_fields)" || {
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-malformed "pane=$expected_pane workspace=$workspace" || true
+    return 1
+  }
+  IFS=$'\t' read -r final_pane final_agent final_session final_workspace _ <<< "$fields"
+  if [ "$final_pane" != "$expected_pane" ] || [ "$final_agent" != "$agent" ] || \
+    [ "$final_session" != "$session" ] || [ "$final_workspace" != "$workspace" ]; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-occupant-changed "pane=$expected_pane observed_pane=$final_pane agent=$final_agent session=$final_session workspace=$final_workspace" || true
+    return 1
+  fi
+  if herdr workspace rename "$workspace" "$title" >/dev/null 2>&1; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || true
+    return 0
+  fi
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+  record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-rename-failed "pane=$expected_pane workspace=$workspace title=$title" || true
+  return 1
+}
+
+# Return 0 when a renamed branch is ready for workspace labeling, 10 when its
+# workspace can be labeled without changing the branch, and 11 when the next
+# naming event must retry before a terminal outcome is selected.
 apply_branch_rename() {
   local root="$1" common="$2" state="$3" marker="$4"
   local original title slug outcome branch candidate lock owner claim_status upstream_status
@@ -467,10 +519,10 @@ apply_branch_rename() {
   slug="$(read_state_field "$state" slug)"
   outcome="$(read_state_field "$state" outcome)"
   candidate="$(read_state_field "$state" branch)"
-  [ -n "$original" ] && [ "$(slug_word_count "$slug")" -ge 2 ] || return 0
+  [ -n "$original" ] && [ "$(slug_word_count "$slug")" -ge 2 ] || return 11
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" detached-head "checkout=$root"
-    return 0
+    return 11
   }
 
   case "$outcome" in
@@ -481,31 +533,32 @@ apply_branch_rename() {
       else
         record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-attribution-failure "checkout=$root branch=$branch expected_branch=$candidate" || true
       fi
-      return 0
+      [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
+      return 11
       ;;
   esac
 
   if [ "$branch" != "$original" ]; then
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved "checkout=$root branch=$branch original_branch=$original" || true
-    return 0
+    return 10
   fi
   branch_has_upstream "$root"
   upstream_status=$?
   case "$upstream_status" in
     0)
       record_diagnostic "$(diagnostic_file_for_state "$state")" branch-has-upstream "checkout=$root branch=$branch" || true
-      return 0
+      return 10
       ;;
     1) ;;
     *)
       record_diagnostic "$(diagnostic_file_for_state "$state")" upstream-unavailable "checkout=$root branch=$branch" || true
-      return 0
+      return 11
       ;;
   esac
 
   wait_for_test_barrier || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-barrier-failed "checkout=$root" || true
-    return 0
+    return 11
   }
   lock="$(namespace_dir "$common")/branch-rename.claim"
   acquire_claim "$lock" "$BRANCH_CLAIM_ATTEMPTS"
@@ -517,7 +570,7 @@ apply_branch_rename() {
     else
       record_diagnostic "$(diagnostic_file_for_state "$state")" branch-claim-failed "repository_anchor=$common checkout=$root" || true
     fi
-    return 0
+    return 11
   fi
   # shellcheck disable=SC2154 # acquire_claim from the sourced state library sets this.
   owner="$claim_owner_id"
@@ -525,13 +578,13 @@ apply_branch_rename() {
   candidate="$(available_branch_name "$root" "$slug")" || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-candidate-unavailable "checkout=$root slug=$slug" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 11
   }
   wait_for_revalidation_test_barrier
   if ! same_checkout_identity "$root" "$common"; then
     record_diagnostic "$(diagnostic_file_for_state "$state")" checkout-changed-before-rename "checkout=$root" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 11
   fi
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || branch=''
   branch_has_upstream "$root"
@@ -539,31 +592,33 @@ apply_branch_rename() {
   if [ "$branch" != "$original" ]; then
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-changed-before-rename "checkout=$root branch=$branch original_branch=$original" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 10
   fi
   if [ "$upstream_status" -ne 1 ]; then
     record_diagnostic "$(diagnostic_file_for_state "$state")" upstream-changed-before-rename "checkout=$root branch=$branch upstream_status=$upstream_status" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 11
   fi
   write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$candidate" || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" prepared-state-write-failed "checkout=$root branch=$branch candidate=$candidate" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 11
   }
   if ! git -C "$root" branch -m "$candidate"; then
     write_identity_state "$state" "$root" "$common" "$workspace" "$original" branch-failed authorized "$title" "$slug" "$candidate" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-rename-failed "checkout=$root branch=$branch candidate=$candidate" || true
     release_claim "$lock" "$owner"
-    return 0
+    return 11
   fi
   retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
   release_claim "$lock" "$owner"
+  [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
+  return 11
 }
 
 worker() {
   local prompt="$1" payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
-  local state identity title slug
+  local state identity title slug outcome expected_branch observed_branch branch_status desired_outcome
   command -v herdr >/dev/null 2>&1 || {
     record_unresolved herdr-unavailable "pane=${pane:-missing}"
     return 0
@@ -617,6 +672,21 @@ worker() {
   authorize_worktree "$root" "$common"
   state="$(worktree_state_file "$common" "$root")"
   [ "$(read_state_field "$state" authorization)" = authorized ] || return 0
+  outcome="$(read_state_field "$state" outcome)"
+  case "$outcome" in
+    declined | workspace-only) return 0 ;;
+    complete)
+      expected_branch="$(read_state_field "$state" branch)"
+      observed_branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || observed_branch=''
+      if [ -n "$expected_branch" ] && [ "$observed_branch" != "$expected_branch" ]; then
+        write_identity_state "$state" "$root" "$common" "$workspace" \
+          "$(read_state_field "$state" original_branch)" workspace-only authorized \
+          "$(read_state_field "$state" title)" "$(read_state_field "$state" slug)" "$expected_branch" || true
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-complete "checkout=$root branch=$observed_branch expected_branch=$expected_branch" || true
+      fi
+      return 0
+      ;;
+  esac
   title="$(read_state_field "$state" title)"
   slug="$(read_state_field "$state" slug)"
   if [ -z "$title" ] || [ "$(slug_word_count "$slug")" -lt 2 ]; then
@@ -627,6 +697,15 @@ worker() {
       "$(read_state_field "$state" branch)" || true
   fi
   apply_branch_rename "$root" "$common" "$state" "$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)"
+  branch_status=$?
+  case "$branch_status" in
+    0) label_workspace "$root" "$common" "$state" "$resolved_pane" complete || true ;;
+    10)
+      desired_outcome='workspace-only'
+      [ "$(read_state_field "$state" outcome)" = workspace-failed ] && desired_outcome=complete
+      label_workspace "$root" "$common" "$state" "$resolved_pane" "$desired_outcome" || true
+      ;;
+  esac
 }
 
 detach_worker() {

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -708,6 +708,17 @@ worker() {
   esac
 }
 
+close_inherited_fds() {
+  local fd_path fd
+  for fd_path in /dev/fd/*; do
+    fd="${fd_path##*/}"
+    case "$fd" in
+      0 | 1 | 2 | 255 | '' | *[!0-9]*) continue ;;
+    esac
+    eval "exec ${fd}>&-"
+  done
+}
+
 detach_worker() {
   local prompt_file
   local -a worker_args
@@ -717,12 +728,12 @@ detach_worker() {
   [ -z "$pane" ] || worker_args+=(--pane "$pane")
   [ -z "$workspace" ] || worker_args+=(--workspace "$workspace")
   if command -v setsid >/dev/null 2>&1; then
-    setsid "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+    (close_inherited_fds; exec setsid "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
   elif command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
-      "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+    (close_inherited_fds; exec python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+      "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
   else
-    nohup "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+    (close_inherited_fds; exec nohup "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
   fi
   rm -f "$prompt_file"
 }

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Resolve a first-prompt naming event to an authorized generated worktree.
+# Later units add derivation, ref mutation, attribution, and workspace labels.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=home/dot_local/lib/herdr-worktree-state.sh
+source "$SCRIPT_DIR/../lib/herdr-worktree-state.sh"
+
+usage() {
+  printf '%s\n' 'usage: herdr-worktree-identity [--worker] --agent NAME --session ID [--pane ID] [--workspace ID]' >&2
+}
+
+valid_identifier() {
+  case "$1" in
+    '' | *[!A-Za-z0-9:._/-]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+encode_path_key() {
+  encode_key "$1"
+}
+
+session_state_file() {
+  printf '%s/sessions/%s.state' "$HERDR_WORKTREE_IDENTITY_STATE_DIR" "$(encode_path_key "$1")"
+}
+
+worktree_state_file() {
+  local common="$1" root="$2"
+  printf '%s/worktrees/%s.state' "$(namespace_dir "$common")" "$(encode_path_key "$root")"
+}
+
+diagnostic_file_for_state() {
+  printf '%s.diagnostics.log' "${1%.state}"
+}
+
+write_identity_state() {
+  local file="$1" root="$2" common="$3" workspace="$4" original="$5" outcome="$6" authorization="$7"
+  atomic_write "$file" "checkout_root=$(encode_value "$root")
+repository_anchor=$(encode_value "$common")
+workspace=$(encode_value "$workspace")
+original_branch=$(encode_value "$original")
+outcome=$(encode_value "$outcome")
+authorization=$(encode_value "$authorization")"
+}
+
+record_unresolved() {
+  local reason="$1" observed="$2" file
+  file="$(session_state_file "$session")"
+  write_identity_state "$file" '' '' "$workspace" '' unresolved '' || true
+  record_diagnostic "$(diagnostic_file_for_state "$file")" "$reason" "$observed" || true
+}
+
+pane_fields() {
+  jq -r '
+    .result.pane as $pane
+    | if ($pane | type) != "object" then error("missing pane") else
+        [($pane.pane_id // ""), ($pane.agent // ""), ($pane.agent_session.value // ""),
+         ($pane.workspace_id // ""), ($pane.foreground_cwd // $pane.cwd // "")]
+        | map(if type == "string" then . else "" end) | @tsv
+      end
+  ' 2>/dev/null
+}
+
+pane_for_session_from_snapshot() {
+  local snapshot="$1"
+  printf '%s' "$snapshot" | jq -c --arg session "$session" --arg agent "$agent" '
+    [.result.snapshot.panes[]? | select((.agent_session.value // "") == $session and (.agent // "") == $agent)]
+    | if length == 1 then {result:{pane:.[0]}} else empty end
+  ' 2>/dev/null
+}
+
+reported_cwd() {
+  local file value
+  file="$HERDR_WORKTREE_IDENTITY_STATE_DIR/agent-cwd/$(encode_path_key "$session")"
+  [ -f "$file" ] || return 0
+  value="$(head -n 1 "$file" 2>/dev/null)"
+  case "$value" in
+    /*) ;;
+    *) return 0 ;;
+  esac
+  [ -d "$value" ] || return 0
+  (cd "$value" 2>/dev/null) || return 0
+  printf '%s' "$value"
+}
+
+resolve_pane_payload() {
+  local payload snapshot
+  if [ -n "$pane" ]; then
+    payload="$(herdr pane get "$pane" 2>/dev/null)" || return 2
+    printf '%s' "$payload"
+    return 0
+  fi
+  snapshot="$(herdr api snapshot 2>/dev/null)" || return 2
+  payload="$(pane_for_session_from_snapshot "$snapshot")" || payload=''
+  [ -n "$payload" ] || return 1
+  printf '%s' "$payload"
+}
+
+is_linked_worktree() {
+  local root="$1" git_dir
+  [ -f "$root/.git" ] || return 1
+  git_dir="$(git -C "$root" rev-parse --path-format=absolute --git-dir 2>/dev/null)" || return 1
+  [ -n "$git_dir" ] && [ "$git_dir" != "$root/.git" ]
+}
+
+authorize_worktree() {
+  local root="$1" common="$2" branch marker original state observed
+  branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
+    record_unresolved detached-head "checkout=$root"
+    return 0
+  }
+  state="$(worktree_state_file "$common" "$root")"
+  original="$(read_state_field "$state" original_branch)"
+  [ -n "$original" ] || original="$branch"
+  marker="$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)" || {
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-path-unavailable "checkout=$root branch=$branch" || true
+    return 0
+  }
+  if [ ! -f "$marker" ]; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing "checkout=$root branch=$branch marker=$marker" || true
+    return 0
+  fi
+  observed="$(head -n 1 "$marker" 2>/dev/null)"
+  if [ "$observed" != "$original" ]; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched "checkout=$root branch=$branch original_branch=$original marker_branch=$observed" || true
+    return 0
+  fi
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" '' authorized || true
+}
+
+worker() {
+  local payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
+  command -v herdr >/dev/null 2>&1 || {
+    record_unresolved herdr-unavailable "pane=${pane:-missing}"
+    return 0
+  }
+  command -v jq >/dev/null 2>&1 || {
+    record_unresolved jq-unavailable "pane=${pane:-missing}"
+    return 0
+  }
+  payload="$(resolve_pane_payload)"
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    record_unresolved pane-unreachable "pane=${pane:-missing} session=$session"
+    return 0
+  fi
+  if [ "$status" -ne 0 ]; then
+    record_unresolved pane-unresolved "pane=missing session=$session"
+    return 0
+  fi
+  fields="$(printf '%s' "$payload" | pane_fields)" || {
+    record_unresolved pane-malformed "pane=${pane:-missing} session=$session"
+    return 0
+  }
+  IFS=$'\t' read -r resolved_pane pane_agent pane_session pane_workspace pane_cwd <<< "$fields"
+  if { [ -n "$pane" ] && [ "$resolved_pane" != "$pane" ]; } || \
+    [ "$pane_agent" != "$agent" ] || [ "$pane_session" != "$session" ]; then
+    record_unresolved pane-mismatched "pane=${resolved_pane:-missing} agent=$pane_agent session=$pane_session"
+    return 0
+  fi
+  [ -n "$workspace" ] || workspace="$pane_workspace"
+  cwd="$(reported_cwd)"
+  [ -n "$cwd" ] || cwd="$pane_cwd"
+  if [ -z "$cwd" ]; then
+    record_unresolved checkout-unresolved "pane=${resolved_pane:-missing} cwd=missing"
+    return 0
+  fi
+  root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)" || {
+    record_unresolved checkout-unresolved "pane=${resolved_pane:-missing} cwd=$cwd"
+    return 0
+  }
+  if ! is_linked_worktree "$root"; then
+    local primary_state
+    primary_state="$(session_state_file "$session")"
+    write_identity_state "$primary_state" "$root" '' "$workspace" '' declined '' || true
+    record_diagnostic "$(diagnostic_file_for_state "$primary_state")" primary-checkout "checkout=$root" || true
+    return 0
+  fi
+  common="$(git -C "$root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
+    record_unresolved checkout-unresolved "checkout=$root common-dir=unavailable"
+    return 0
+  }
+  authorize_worktree "$root" "$common"
+}
+
+detach_worker() {
+  local prompt_file
+  local -a worker_args
+  prompt_file="$(umask 077; mktemp "${TMPDIR:-/tmp}/herdr-worktree-identity.XXXXXX")" || return 0
+  cat > "$prompt_file" || { rm -f "$prompt_file"; return 0; }
+  worker_args=(bash "$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")" --worker --agent "$agent" --session "$session")
+  [ -z "$pane" ] || worker_args+=(--pane "$pane")
+  [ -z "$workspace" ] || worker_args+=(--workspace "$workspace")
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+      "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+  else
+    nohup "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
+  fi
+  rm -f "$prompt_file"
+}
+
+worker_mode=0
+agent=''
+session=''
+pane=''
+workspace=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --worker) worker_mode=1; shift ;;
+    --agent) [ "$#" -ge 2 ] || { usage; exit 2; }; agent="$2"; shift 2 ;;
+    --session) [ "$#" -ge 2 ] || { usage; exit 2; }; session="$2"; shift 2 ;;
+    --pane) [ "$#" -ge 2 ] || { usage; exit 2; }; pane="$2"; shift 2 ;;
+    --workspace) [ "$#" -ge 2 ] || { usage; exit 2; }; workspace="$2"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+valid_identifier "$agent" && valid_identifier "$session" &&
+  { [ -z "$pane" ] || valid_identifier "$pane"; } &&
+  { [ -z "$workspace" ] || valid_identifier "$workspace"; } || { usage; exit 2; }
+
+if [ "$worker_mode" -eq 1 ]; then
+  # U2 does not derive identity yet, but consuming stdin keeps prompt text out
+  # of argv and preserves the foreground-to-worker handoff contract.
+  cat >/dev/null
+  worker
+else
+  detach_worker
+fi

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -8,8 +8,206 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=home/dot_local/lib/herdr-worktree-state.sh
 source "$SCRIPT_DIR/../lib/herdr-worktree-state.sh"
 
+SLUG_MAX_LEN=40
+SLUG_MAX_WORDS=5
+TITLE_MAX_LEN=48
+ENGINE_TIMEOUT="${HERDR_WORKTREE_IDENTITY_TIMEOUT:-30}"
+PI_MODEL="${HERDR_WORKTREE_IDENTITY_PI_MODEL:-openai-codex/gpt-5.4-mini}"
+CLAUDE_MODEL="${HERDR_WORKTREE_IDENTITY_CLAUDE_MODEL:-claude-haiku-4-5-20251001}"
+
 usage() {
   printf '%s\n' 'usage: herdr-worktree-identity [--worker] --agent NAME --session ID [--pane ID] [--workspace ID]' >&2
+}
+
+first_nonempty_line() {
+  printf '%s\n' "$1" | sed -e 's/\r$//' | grep -m1 '[^[:space:]]' || true
+}
+
+normalize_slug() {
+  LC_ALL=C printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -c 'a-z0-9-' '-' \
+    | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//' \
+    | cut -c "1-$SLUG_MAX_LEN" \
+    | sed -e 's/-$//'
+}
+
+limit_slug_words() {
+  awk -F- -v max="$SLUG_MAX_WORDS" '{
+    out = ""
+    for (i = 1; i <= NF && i <= max; i++) out = out (out == "" ? "" : "-") $i
+    print out
+  }'
+}
+
+slug_word_count() {
+  printf '%s' "$1" | tr '-' '\n' | grep -c '.' || true
+}
+
+normalize_title() {
+  local line
+  line="$(first_nonempty_line "$1" | tr '\t' ' ' \
+    | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  printf '%s' "$line" | cut -c "1-$TITLE_MAX_LEN" | sed -e 's/[[:space:]]*$//'
+}
+
+title_word_count() {
+  printf '%s\n' "$1" | awk '{ print NF }'
+}
+
+title_from_slug() {
+  printf '%s' "$1" | tr '-' ' ' \
+    | awk '{ if (length($0)) $0 = toupper(substr($0, 1, 1)) substr($0, 2); print }'
+}
+
+repository_discriminator() {
+  local root="$1" name
+  name="${root%/}"
+  name="${name##*/}"
+  normalize_slug "$name" | cut -c1-16 | sed -e 's/-$//'
+}
+
+ensure_slug_floor() {
+  local slug="$1" root="$2" discriminator max_base base
+  slug="$(normalize_slug "$slug" | limit_slug_words)"
+  if [ "$(slug_word_count "$slug")" -lt 2 ]; then
+    discriminator="$(repository_discriminator "$root")"
+    [ -n "$discriminator" ] || discriminator=task
+    max_base=$((SLUG_MAX_LEN - ${#discriminator} - 1))
+    if [ "$max_base" -lt 1 ]; then
+      discriminator=task
+      max_base=$((SLUG_MAX_LEN - ${#discriminator} - 1))
+    fi
+    base="$(printf '%s' "${slug:-agent}" | cut -c "1-$max_base" | sed -e 's/-$//')"
+    [ -n "$base" ] || base=agent
+    slug="$(normalize_slug "$base-$discriminator")"
+  fi
+  if [ "$(slug_word_count "$slug")" -lt 2 ]; then
+    slug='agent-task'
+  fi
+  printf '%s' "$slug"
+}
+
+ensure_title_floor() {
+  local title="$1" slug="$2"
+  title="$(normalize_title "$title")"
+  if [ -z "$title" ] || [ "$(title_word_count "$title")" -lt 2 ]; then
+    title="$(title_from_slug "$slug")"
+  fi
+  [ -n "$title" ] || title='Agent task'
+  printf '%s' "$title"
+}
+
+build_naming_prompt() {
+  local first="$1"
+  cat <<EOF
+You name a coding-agent session and its Git branch from the first user task.
+Return exactly one JSON object on one line and nothing else.
+
+Output rules:
+- title: 2 to 6 concise English words for display, preserving an issue ID when present
+- slug: the same identity as 2 to 5 lowercase English words, hyphen-separated
+  - example: {"title":"PRD-2939: Fix agent launch","slug":"prd-2939-fix-agent-launch"}
+
+Naming rules:
+- Name the overall task in the first prompt.
+- Do not describe the user, agent, or conversation.
+
+First prompt of the session:
+${first:-(none)}
+EOF
+}
+
+identity_from_output() {
+  local raw="$1" object title slug
+  object="$(printf '%s' "$raw" | jq -ce '
+    select(type == "object" and (.title | type == "string") and (.slug | type == "string"))
+  ' 2>/dev/null)" || return 1
+  case "$object" in
+    '' | *$'\n'*) return 1 ;;
+  esac
+  title="$(printf '%s' "$object" | jq -r '.title' 2>/dev/null)" || return 1
+  slug="$(printf '%s' "$object" | jq -r '.slug' 2>/dev/null)" || return 1
+  slug="$(normalize_slug "$slug" | limit_slug_words)"
+  [ "$(slug_word_count "$slug")" -ge 2 ] || return 1
+  title="$(ensure_title_floor "$title" "$slug")"
+  [ -n "$title" ] || return 1
+  printf '%s\037%s' "$title" "$slug"
+}
+
+deterministic_identity() {
+  local prompt="$1" root="$2" line title slug
+  line="$(first_nonempty_line "$prompt" | sed \
+    -e 's/^[[:space:]]*[-*#][[:space:]]*//' \
+    -e 's/^[[:space:]]*[0-9][0-9]*[.)][[:space:]]*//')"
+  slug="$(ensure_slug_floor "$(normalize_slug "$line" | limit_slug_words)" "$root")"
+  title="$(ensure_title_floor "$line" "$slug")"
+  printf '%s\037%s' "$title" "$slug"
+}
+
+run_with_timeout() {
+  local seconds="$1" infile="$2" outfile="$3" pid watchdog status=0
+  shift 3
+  "$@" < "$infile" > "$outfile" 2>/dev/null &
+  pid=$!
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os, signal, sys, time; time.sleep(float(sys.argv[1])); os.kill(int(sys.argv[2]), signal.SIGKILL)' \
+      "$seconds" "$pid" >/dev/null 2>&1 &
+  else
+    (sleep "$seconds"; kill -9 "$pid") >/dev/null 2>&1 &
+  fi
+  watchdog=$!
+  wait "$pid" || status=$?
+  kill "$watchdog" >/dev/null 2>&1 || true
+  wait "$watchdog" 2>/dev/null || true
+  return "$status"
+}
+
+call_engine_chain() {
+  local naming_prompt="$1" infile outfile raw identity
+  [ "${HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES:-}" = 1 ] && return 1
+  infile="$(umask 077; mktemp "${TMPDIR:-/tmp}/herdr-worktree-identity-in.XXXXXX")" || return 1
+  outfile="$(umask 077; mktemp "${TMPDIR:-/tmp}/herdr-worktree-identity-out.XXXXXX")" || {
+    rm -f "$infile"
+    return 1
+  }
+  printf '%s\n' "$naming_prompt" > "$infile"
+
+  # Client adapters honor this guard, so model CLIs cannot recursively name
+  # the naming worker's own prompt submission.
+  export HERDR_WORKTREE_IDENTITY_ACTIVE=1
+  if command -v pi >/dev/null 2>&1 && \
+    run_with_timeout "$ENGINE_TIMEOUT" "$infile" "$outfile" \
+      pi -p --model "$PI_MODEL" --thinking off \
+      --no-tools --no-session --no-extensions --no-skills \
+      --no-context-files --no-prompt-templates; then
+    raw="$(cat "$outfile" 2>/dev/null)"
+    identity="$(identity_from_output "$raw")" || identity=''
+    if [ -n "$identity" ]; then
+      rm -f "$infile" "$outfile"
+      printf '%s' "$identity"
+      return 0
+    fi
+  fi
+  if command -v claude >/dev/null 2>&1 && \
+    run_with_timeout "$ENGINE_TIMEOUT" "$infile" "$outfile" claude -p --model "$CLAUDE_MODEL"; then
+    raw="$(cat "$outfile" 2>/dev/null)"
+    identity="$(identity_from_output "$raw")" || identity=''
+    if [ -n "$identity" ]; then
+      rm -f "$infile" "$outfile"
+      printf '%s' "$identity"
+      return 0
+    fi
+  fi
+  rm -f "$infile" "$outfile"
+  return 1
+}
+
+derive_identity() {
+  local prompt="$1" root="$2" identity
+  identity="$(call_engine_chain "$(build_naming_prompt "$prompt")")" || identity=''
+  [ -n "$identity" ] || identity="$(deterministic_identity "$prompt" "$root")"
+  printf '%s' "$identity"
 }
 
 valid_identifier() {
@@ -38,12 +236,15 @@ diagnostic_file_for_state() {
 
 write_identity_state() {
   local file="$1" root="$2" common="$3" workspace="$4" original="$5" outcome="$6" authorization="$7"
+  local title="${8:-}" slug="${9:-}"
   atomic_write "$file" "checkout_root=$(encode_value "$root")
 repository_anchor=$(encode_value "$common")
 workspace=$(encode_value "$workspace")
 original_branch=$(encode_value "$original")
 outcome=$(encode_value "$outcome")
-authorization=$(encode_value "$authorization")"
+authorization=$(encode_value "$authorization")
+title=$(encode_value "$title")
+slug=$(encode_value "$slug")"
 }
 
 record_unresolved() {
@@ -107,35 +308,38 @@ is_linked_worktree() {
 }
 
 authorize_worktree() {
-  local root="$1" common="$2" branch marker original state observed
+  local root="$1" common="$2" branch marker original state observed title slug
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
     record_unresolved detached-head "checkout=$root"
     return 0
   }
   state="$(worktree_state_file "$common" "$root")"
   original="$(read_state_field "$state" original_branch)"
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
   [ -n "$original" ] || original="$branch"
   marker="$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)" || {
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-path-unavailable "checkout=$root branch=$branch" || true
     return 0
   }
   if [ ! -f "$marker" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing "checkout=$root branch=$branch marker=$marker" || true
     return 0
   fi
   observed="$(head -n 1 "$marker" 2>/dev/null)"
   if [ "$observed" != "$original" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' || true
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched "checkout=$root branch=$branch original_branch=$original marker_branch=$observed" || true
     return 0
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" '' authorized || true
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" '' authorized "$title" "$slug" || true
 }
 
 worker() {
-  local payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
+  local prompt="$1" payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
+  local state identity title slug
   command -v herdr >/dev/null 2>&1 || {
     record_unresolved herdr-unavailable "pane=${pane:-missing}"
     return 0
@@ -187,6 +391,16 @@ worker() {
     return 0
   }
   authorize_worktree "$root" "$common"
+  state="$(worktree_state_file "$common" "$root")"
+  [ "$(read_state_field "$state" authorization)" = authorized ] || return 0
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
+  if [ -z "$title" ] || [ "$(slug_word_count "$slug")" -lt 2 ]; then
+    identity="$(derive_identity "$prompt" "$root")"
+    IFS=$'\037' read -r title slug <<< "$identity"
+    write_identity_state "$state" "$root" "$common" "$workspace" \
+      "$(read_state_field "$state" original_branch)" '' authorized "$title" "$slug" || true
+  fi
 }
 
 detach_worker() {
@@ -228,10 +442,8 @@ valid_identifier "$agent" && valid_identifier "$session" &&
   { [ -z "$workspace" ] || valid_identifier "$workspace"; } || { usage; exit 2; }
 
 if [ "$worker_mode" -eq 1 ]; then
-  # U2 does not derive identity yet, but consuming stdin keeps prompt text out
-  # of argv and preserves the foreground-to-worker handoff contract.
-  cat >/dev/null
-  worker
+  prompt="$(cat)"
+  worker "$prompt"
 else
   detach_worker
 fi

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Resolve a first-prompt naming event to an authorized generated worktree.
-# Later units add derivation, ref mutation, attribution, and workspace labels.
+# Resolve a first-prompt naming event, rename its authorized generated worktree,
+# record attribution, and label the containing Herdr workspace.
 
 set -uo pipefail
 
@@ -12,7 +12,10 @@ SLUG_MAX_LEN=40
 SLUG_MAX_WORDS=5
 TITLE_MAX_LEN=48
 BRANCH_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_BRANCH_CLAIM_ATTEMPTS:-3}"
+FIRST_PROMPT_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_FIRST_PROMPT_CLAIM_ATTEMPTS:-3}"
+LIFECYCLE_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_LIFECYCLE_CLAIM_ATTEMPTS:-260}"
 ENGINE_TIMEOUT="${HERDR_WORKTREE_IDENTITY_TIMEOUT:-30}"
+HERDR_RPC_TIMEOUT="${HERDR_WORKTREE_IDENTITY_HERDR_TIMEOUT:-5}"
 PI_MODEL="${HERDR_WORKTREE_IDENTITY_PI_MODEL:-openai-codex/gpt-5.4-mini}"
 CLAUDE_MODEL="${HERDR_WORKTREE_IDENTITY_CLAUDE_MODEL:-claude-haiku-4-5-20251001}"
 
@@ -147,21 +150,68 @@ deterministic_identity() {
 }
 
 run_with_timeout() {
-  local seconds="$1" infile="$2" outfile="$3" pid watchdog status=0
+  local seconds="$1" infile="$2" outfile="$3"
   shift 3
-  "$@" < "$infile" > "$outfile" 2>/dev/null &
-  pid=$!
-  if command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import os, signal, sys, time; time.sleep(float(sys.argv[1])); os.kill(int(sys.argv[2]), signal.SIGKILL)' \
-      "$seconds" "$pid" >/dev/null 2>&1 &
-  else
-    (sleep "$seconds"; kill -9 "$pid") >/dev/null 2>&1 &
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 -c '
+import os
+import signal
+import subprocess
+import sys
+import time
+
+timeout, infile, outfile, *command = sys.argv[1:]
+process = None
+
+def terminate_group():
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    time.sleep(0.1)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
+
+def interrupted(signum, _frame):
+    terminate_group()
+    raise SystemExit(128 + signum)
+
+signal.signal(signal.SIGTERM, interrupted)
+signal.signal(signal.SIGINT, interrupted)
+signal.signal(signal.SIGHUP, interrupted)
+with open(infile, "rb") as source, open(outfile, "wb") as destination:
+    process = subprocess.Popen(
+        command,
+        stdin=source,
+        stdout=destination,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        raise SystemExit(process.wait(timeout=float(timeout)))
+    except subprocess.TimeoutExpired:
+        terminate_group()
+        raise SystemExit(124)
+' "$seconds" "$infile" "$outfile" "$@"
+}
+
+run_herdr() {
+  local outfile rc=0
+  outfile="$(umask 077; mktemp "${TMPDIR:-/tmp}/herdr-worktree-identity-herdr.XXXXXX")" || return 1
+  run_with_timeout "$HERDR_RPC_TIMEOUT" /dev/null "$outfile" herdr "$@" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    cat "$outfile"
   fi
-  watchdog=$!
-  wait "$pid" || status=$?
-  kill "$watchdog" >/dev/null 2>&1 || true
-  wait "$watchdog" 2>/dev/null || true
-  return "$status"
+  rm -f "$outfile"
+  return "$rc"
 }
 
 call_engine_chain() {
@@ -231,6 +281,37 @@ worktree_state_file() {
   printf '%s/worktrees/%s.state' "$(namespace_dir "$common")" "$(encode_path_key "$root")"
 }
 
+first_prompt_file() {
+  printf '%s/first-prompts/%s' "$HERDR_WORKTREE_IDENTITY_STATE_DIR" "$(encode_key "$agent:$session")"
+}
+
+recorded_first_prompt() {
+  local prompt="$1" file lock owner claim_status stored
+  file="$(first_prompt_file)"
+  stored="$(cat "$file" 2>/dev/null)"
+  if [ -n "$stored" ]; then
+    printf '%s' "$stored"
+    return 0
+  fi
+  [ -n "$(first_nonempty_line "$prompt")" ] || return 1
+  lock="$file.claim"
+  acquire_claim "$lock" "$FIRST_PROMPT_CLAIM_ATTEMPTS"
+  claim_status=$?
+  [ "$claim_status" -eq 0 ] || return 1
+  # shellcheck disable=SC2154 # acquire_claim from the sourced state library sets this.
+  owner="$claim_owner_id"
+  stored="$(cat "$file" 2>/dev/null)"
+  if [ -z "$stored" ]; then
+    atomic_write "$file" "$prompt" || {
+      release_claim "$lock" "$owner" || true
+      return 1
+    }
+    stored="$prompt"
+  fi
+  release_claim "$lock" "$owner" || true
+  printf '%s' "$stored"
+}
+
 diagnostic_file_for_state() {
   printf '%s.diagnostics.log' "${1%.state}"
 }
@@ -247,6 +328,19 @@ outcome=$(encode_value "$outcome")
 authorization=$(encode_value "$authorization")
 title=$(encode_value "$title")
 slug=$(encode_value "$slug")"
+}
+
+ensure_identity() {
+  local state="$1" root="$2" prompt="$3" title slug identity
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
+  [ -n "$title" ] && [ "$(slug_word_count "$slug")" -ge 2 ] && return 0
+  identity="$(derive_identity "$prompt" "$root")"
+  IFS=$'\037' read -r title slug <<< "$identity"
+  write_identity_state "$state" "$root" "$(read_state_field "$state" repository_anchor)" "$workspace" \
+    "$(read_state_field "$state" original_branch)" "$(read_state_field "$state" outcome)" authorized "$title" "$slug" \
+    "$(read_state_field "$state" branch)" || true
+  [ -n "$title" ] && [ "$(slug_word_count "$slug")" -ge 2 ]
 }
 
 record_unresolved() {
@@ -292,11 +386,11 @@ reported_cwd() {
 resolve_pane_payload() {
   local payload snapshot
   if [ -n "$pane" ]; then
-    payload="$(herdr pane get "$pane" 2>/dev/null)" || return 2
+    payload="$(run_herdr pane get "$pane")" || return 2
     printf '%s' "$payload"
     return 0
   fi
-  snapshot="$(herdr api snapshot 2>/dev/null)" || return 2
+  snapshot="$(run_herdr api snapshot)" || return 2
   payload="$(pane_for_session_from_snapshot "$snapshot")" || payload=''
   [ -n "$payload" ] || return 1
   printf '%s' "$payload"
@@ -424,6 +518,12 @@ write_attribution() {
   return 1
 }
 
+branch_rename_recorded() {
+  local root="$1" original="$2" candidate="$3"
+  git -C "$root" reflog --all --format='%gs' 2>/dev/null \
+    | grep -Fx "Branch: renamed refs/heads/$original to refs/heads/$candidate" >/dev/null
+}
+
 wait_for_test_barrier() {
   local barrier="${HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER_RELEASE:-}"
   [ -n "$barrier" ] || return 0
@@ -435,6 +535,14 @@ wait_for_test_barrier() {
 
 wait_for_revalidation_test_barrier() {
   local ready="${HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_RELEASE:-}"
+  [ -n "$ready" ] || return 0
+  : > "$ready"
+  [ -n "$release" ] || return 0
+  while [ ! -e "$release" ]; do sleep 0.01; done
+}
+
+wait_for_prepared_test_barrier() {
+  local ready="${HERDR_WORKTREE_IDENTITY_TEST_PREPARED_READY:-}" release="${HERDR_WORKTREE_IDENTITY_TEST_PREPARED_RELEASE:-}"
   [ -n "$ready" ] || return 0
   : > "$ready"
   [ -n "$release" ] || return 0
@@ -467,22 +575,48 @@ wait_for_workspace_revalidation_test_barrier() {
   while [ ! -e "$release" ]; do sleep 0.01; done
 }
 
+read_workspace_label() {
+  local workspace_id="$1" payload
+  payload="$(run_herdr workspace get "$workspace_id")" || return 1
+  printf '%s' "$payload" | jq -er '
+    .result.workspace as $workspace
+    | if ($workspace | type) == "object" and (($workspace.label // $workspace.name) | type) == "string"
+      then ($workspace.label // $workspace.name)
+      else error("missing workspace label")
+      end
+  ' 2>/dev/null
+}
+
 # Re-read the pane immediately before the external rename: the original
 # lookup can be stale after an occupant, session, or workspace change.
 label_workspace() {
   local root="$1" common="$2" state="$3" expected_pane="$4" desired_outcome="$5"
-  local original title slug branch payload fields final_pane final_agent final_session final_workspace
+  local original title slug branch outcome payload fields final_pane final_agent final_session final_workspace current_label
   original="$(read_state_field "$state" original_branch)"
   title="$(read_state_field "$state" title)"
   slug="$(read_state_field "$state" slug)"
   branch="$(read_state_field "$state" branch)"
+  outcome="$(read_state_field "$state" outcome)"
   if [ -z "$title" ] || [ -z "$workspace" ]; then
     write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-unavailable "checkout=$root workspace=${workspace:-missing}" || true
     return 1
   fi
+  if [ "$outcome" = workspace-prepared ]; then
+    current_label="$(read_workspace_label "$workspace")" || {
+      record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-reconcile-unavailable "workspace=$workspace" || true
+      return 1
+    }
+    if [ "$current_label" = "$title" ]; then
+      write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+        record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace title=$title" || true
+        return 1
+      }
+      return 0
+    fi
+  fi
   wait_for_workspace_revalidation_test_barrier || return 1
-  payload="$(herdr pane get "$expected_pane" 2>/dev/null)" || {
+  payload="$(run_herdr pane get "$expected_pane")" || {
     write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-unreachable "pane=$expected_pane workspace=$workspace" || true
     return 1
@@ -499,8 +633,26 @@ label_workspace() {
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-occupant-changed "pane=$expected_pane observed_pane=$final_pane agent=$final_agent session=$final_session workspace=$final_workspace" || true
     return 1
   fi
-  if herdr workspace rename "$workspace" "$title" >/dev/null 2>&1; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || true
+  write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-prepared authorized "$title" "$slug" "$branch" || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-prepared-state-write-failed "workspace=$workspace title=$title" || true
+    return 1
+  }
+  if run_herdr workspace rename "$workspace" "$title" >/dev/null; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+      record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace title=$title" || true
+      return 1
+    }
+    return 0
+  fi
+  current_label="$(read_workspace_label "$workspace")" || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-rename-ambiguous "workspace=$workspace title=$title" || true
+    return 1
+  }
+  if [ "$current_label" = "$title" ]; then
+    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+      record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace title=$title" || true
+      return 1
+    }
     return 0
   fi
   write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
@@ -513,25 +665,58 @@ label_workspace() {
 # naming event must retry before a terminal outcome is selected.
 apply_branch_rename() {
   local root="$1" common="$2" state="$3" marker="$4"
-  local original title slug outcome branch candidate lock owner claim_status upstream_status
+  local original title slug outcome branch candidate lock owner claim_status upstream_status marker_observed
   original="$(read_state_field "$state" original_branch)"
   title="$(read_state_field "$state" title)"
   slug="$(read_state_field "$state" slug)"
   outcome="$(read_state_field "$state" outcome)"
   candidate="$(read_state_field "$state" branch)"
-  [ -n "$original" ] && [ "$(slug_word_count "$slug")" -ge 2 ] || return 11
+  [ -n "$original" ] && [ -n "$title" ] && [ "$(slug_word_count "$slug")" -ge 2 ] || {
+    record_diagnostic "$(diagnostic_file_for_state "$state")" identity-not-ready "checkout=$root" || true
+    return 11
+  }
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" detached-head "checkout=$root"
     return 11
   }
 
   case "$outcome" in
-    prepared) return 0 ;;
+    prepared)
+      if [ -z "$candidate" ]; then
+        record_diagnostic "$(diagnostic_file_for_state "$state")" prepared-candidate-missing "checkout=$root branch=$branch" || true
+        return 11
+      fi
+      if [ -n "$candidate" ] && [ "$branch" = "$candidate" ]; then
+        retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+        [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
+        return 11
+      fi
+      if [ "$branch" != "$original" ]; then
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-prepare "checkout=$root branch=$branch expected_branch=$candidate" || true
+        return 10
+      fi
+      if branch_rename_recorded "$root" "$original" "$candidate"; then
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-reverted-after-prepare "checkout=$root branch=$branch expected_branch=$candidate" || true
+        return 10
+      fi
+      ;;
+    workspace-prepared)
+      [ -n "$candidate" ] && [ "$branch" = "$candidate" ] && return 0
+      return 10
+      ;;
+    workspace-failed)
+      if [ -n "$candidate" ]; then
+        [ "$branch" = "$candidate" ] && return 0
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-workspace-failure "checkout=$root branch=$branch expected_branch=$candidate" || true
+        return 10
+      fi
+      ;;
     attribution_failed)
       if [ "$branch" = "$candidate" ]; then
         retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
       else
         record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-attribution-failure "checkout=$root branch=$branch expected_branch=$candidate" || true
+        return 10
       fi
       [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
       return 11
@@ -575,11 +760,13 @@ apply_branch_rename() {
   # shellcheck disable=SC2154 # acquire_claim from the sourced state library sets this.
   owner="$claim_owner_id"
   wait_for_claim_test_barrier
-  candidate="$(available_branch_name "$root" "$slug")" || {
-    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-candidate-unavailable "checkout=$root slug=$slug" || true
-    release_claim "$lock" "$owner"
-    return 11
-  }
+  if [ "$outcome" != prepared ]; then
+    candidate="$(available_branch_name "$root" "$slug")" || {
+      record_diagnostic "$(diagnostic_file_for_state "$state")" branch-candidate-unavailable "checkout=$root slug=$slug" || true
+      release_claim "$lock" "$owner"
+      return 11
+    }
+  fi
   wait_for_revalidation_test_barrier
   if ! same_checkout_identity "$root" "$common"; then
     record_diagnostic "$(diagnostic_file_for_state "$state")" checkout-changed-before-rename "checkout=$root" || true
@@ -599,11 +786,52 @@ apply_branch_rename() {
     release_claim "$lock" "$owner"
     return 11
   fi
+  if [ ! -f "$marker" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing-before-rename "checkout=$root branch=$branch marker=$marker" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
+  marker_observed="$(head -n 1 "$marker" 2>/dev/null)"
+  if [ "$marker_observed" != "$original" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched-before-rename "checkout=$root branch=$branch original_branch=$original marker_branch=$marker_observed" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
   write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$candidate" || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" prepared-state-write-failed "checkout=$root branch=$branch candidate=$candidate" || true
     release_claim "$lock" "$owner"
     return 11
   }
+  wait_for_prepared_test_barrier
+  if ! same_checkout_identity "$root" "$common"; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" checkout-changed-at-commit "checkout=$root" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
+  branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || branch=''
+  branch_has_upstream "$root"
+  upstream_status=$?
+  if [ "$branch" != "$original" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" branch-changed-at-commit "checkout=$root branch=$branch original_branch=$original" || true
+    release_claim "$lock" "$owner"
+    return 10
+  fi
+  if [ "$upstream_status" -ne 1 ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" upstream-changed-at-commit "checkout=$root branch=$branch upstream_status=$upstream_status" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
+  if [ ! -f "$marker" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing-at-commit "checkout=$root branch=$branch marker=$marker" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
+  marker_observed="$(head -n 1 "$marker" 2>/dev/null)"
+  if [ "$marker_observed" != "$original" ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched-at-commit "checkout=$root branch=$branch original_branch=$original marker_branch=$marker_observed" || true
+    release_claim "$lock" "$owner"
+    return 11
+  fi
   if ! git -C "$root" branch -m "$candidate"; then
     write_identity_state "$state" "$root" "$common" "$workspace" "$original" branch-failed authorized "$title" "$slug" "$candidate" || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-rename-failed "checkout=$root branch=$branch candidate=$candidate" || true
@@ -616,9 +844,74 @@ apply_branch_rename() {
   return 11
 }
 
+process_worktree_locked() {
+  local prompt="$1" root="$2" common="$3" resolved_pane="$4"
+  local state title slug outcome expected_branch observed_branch branch_status
+  state="$(worktree_state_file "$common" "$root")"
+  authorize_worktree "$root" "$common"
+  [ "$(read_state_field "$state" authorization)" = authorized ] || return 0
+  outcome="$(read_state_field "$state" outcome)"
+  case "$outcome" in
+    declined | workspace-only) return 0 ;;
+    complete)
+      expected_branch="$(read_state_field "$state" branch)"
+      observed_branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || observed_branch=''
+      if [ -n "$expected_branch" ] && [ "$observed_branch" != "$expected_branch" ]; then
+        write_identity_state "$state" "$root" "$common" "$workspace" \
+          "$(read_state_field "$state" original_branch)" workspace-only authorized \
+          "$(read_state_field "$state" title)" "$(read_state_field "$state" slug)" "$expected_branch" || true
+        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-complete "checkout=$root branch=$observed_branch expected_branch=$expected_branch" || true
+      fi
+      return 0
+      ;;
+  esac
+  title="$(read_state_field "$state" title)"
+  slug="$(read_state_field "$state" slug)"
+  if [ -z "$title" ] || [ "$(slug_word_count "$slug")" -lt 2 ]; then
+    ensure_identity "$state" "$root" "$prompt" || return 0
+  fi
+  apply_branch_rename "$root" "$common" "$state" "$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)"
+  branch_status=$?
+  case "$branch_status" in
+    0) label_workspace "$root" "$common" "$state" "$resolved_pane" complete || true ;;
+    10) label_workspace "$root" "$common" "$state" "$resolved_pane" workspace-only || true ;;
+  esac
+}
+
+process_worktree() {
+  local prompt="$1" root="$2" common="$3" resolved_pane="$4"
+  local state lock owner claim_status ready release rc=0
+  state="$(worktree_state_file "$common" "$root")"
+  lock="${state%.state}.lifecycle.claim"
+  ready="${HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_ATTEMPT_READY:-}"
+  [ -z "$ready" ] || : > "$ready"
+  acquire_claim "$lock" "$LIFECYCLE_CLAIM_ATTEMPTS"
+  claim_status=$?
+  if [ "$claim_status" -ne 0 ]; then
+    record_diagnostic "$(diagnostic_file_for_state "$state")" lifecycle-contended "checkout=$root" || true
+    return 0
+  fi
+  # shellcheck disable=SC2154 # acquire_claim from the sourced state library sets this.
+  owner="$claim_owner_id"
+  ready="${HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_READY:-}"
+  release="${HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_RELEASE:-}"
+  if [ -n "$ready" ]; then
+    : > "$ready"
+    while [ -n "$release" ] && [ ! -e "$release" ]; do sleep 0.01; done
+  fi
+  process_worktree_locked "$prompt" "$root" "$common" "$resolved_pane" || rc=$?
+  release_claim "$lock" "$owner" || true
+  return "$rc"
+}
+
 worker() {
   local prompt="$1" payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
-  local state identity title slug outcome expected_branch observed_branch branch_status desired_outcome
+  local first_prompt
+  if ! first_prompt="$(recorded_first_prompt "$prompt")"; then
+    record_unresolved first-prompt-unavailable "agent=$agent session=$session"
+    return 0
+  fi
+  prompt="$first_prompt"
   command -v herdr >/dev/null 2>&1 || {
     record_unresolved herdr-unavailable "pane=${pane:-missing}"
     return 0
@@ -669,43 +962,7 @@ worker() {
     record_unresolved checkout-unresolved "checkout=$root common-dir=unavailable"
     return 0
   }
-  authorize_worktree "$root" "$common"
-  state="$(worktree_state_file "$common" "$root")"
-  [ "$(read_state_field "$state" authorization)" = authorized ] || return 0
-  outcome="$(read_state_field "$state" outcome)"
-  case "$outcome" in
-    declined | workspace-only) return 0 ;;
-    complete)
-      expected_branch="$(read_state_field "$state" branch)"
-      observed_branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || observed_branch=''
-      if [ -n "$expected_branch" ] && [ "$observed_branch" != "$expected_branch" ]; then
-        write_identity_state "$state" "$root" "$common" "$workspace" \
-          "$(read_state_field "$state" original_branch)" workspace-only authorized \
-          "$(read_state_field "$state" title)" "$(read_state_field "$state" slug)" "$expected_branch" || true
-        record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-complete "checkout=$root branch=$observed_branch expected_branch=$expected_branch" || true
-      fi
-      return 0
-      ;;
-  esac
-  title="$(read_state_field "$state" title)"
-  slug="$(read_state_field "$state" slug)"
-  if [ -z "$title" ] || [ "$(slug_word_count "$slug")" -lt 2 ]; then
-    identity="$(derive_identity "$prompt" "$root")"
-    IFS=$'\037' read -r title slug <<< "$identity"
-    write_identity_state "$state" "$root" "$common" "$workspace" \
-      "$(read_state_field "$state" original_branch)" "$(read_state_field "$state" outcome)" authorized "$title" "$slug" \
-      "$(read_state_field "$state" branch)" || true
-  fi
-  apply_branch_rename "$root" "$common" "$state" "$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)"
-  branch_status=$?
-  case "$branch_status" in
-    0) label_workspace "$root" "$common" "$state" "$resolved_pane" complete || true ;;
-    10)
-      desired_outcome='workspace-only'
-      [ "$(read_state_field "$state" outcome)" = workspace-failed ] && desired_outcome=complete
-      label_workspace "$root" "$common" "$state" "$resolved_pane" "$desired_outcome" || true
-      ;;
-  esac
+  process_worktree "$prompt" "$root" "$common" "$resolved_pane"
 }
 
 close_inherited_descriptors() {
@@ -720,10 +977,10 @@ close_inherited_descriptors() {
 }
 
 detach_worker() {
-  local prompt_file
+  local prompt="$1" prompt_file
   local -a worker_args
   prompt_file="$(umask 077; mktemp "${TMPDIR:-/tmp}/herdr-worktree-identity.XXXXXX")" || return 0
-  cat > "$prompt_file" || { rm -f "$prompt_file"; return 0; }
+  printf '%s' "$prompt" > "$prompt_file" || { rm -f "$prompt_file"; return 0; }
   worker_args=(bash "$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")" --worker --agent "$agent" --session "$session")
   [ -z "$pane" ] || worker_args+=(--pane "$pane")
   [ -z "$workspace" ] || worker_args+=(--workspace "$workspace")
@@ -762,5 +1019,8 @@ if [ "$worker_mode" -eq 1 ]; then
   prompt="$(cat)"
   worker "$prompt"
 else
-  detach_worker
+  prompt="$(cat)"
+  if first_prompt="$(recorded_first_prompt "$prompt")"; then
+    detach_worker "$first_prompt"
+  fi
 fi

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -708,14 +708,14 @@ worker() {
   esac
 }
 
-close_inherited_fds() {
-  local fd_path fd
-  for fd_path in /dev/fd/*; do
-    fd="${fd_path##*/}"
+close_inherited_descriptors() {
+  local descriptor fd
+  for descriptor in /dev/fd/*; do
+    fd="${descriptor##*/}"
     case "$fd" in
-      0 | 1 | 2 | 255 | '' | *[!0-9]*) continue ;;
+      0 | 1 | 2 | 255 | *[!0-9]*) continue ;;
     esac
-    eval "exec ${fd}>&-"
+    eval "exec ${fd}>&-" 2>/dev/null || true
   done
 }
 
@@ -728,12 +728,12 @@ detach_worker() {
   [ -z "$pane" ] || worker_args+=(--pane "$pane")
   [ -z "$workspace" ] || worker_args+=(--workspace "$workspace")
   if command -v setsid >/dev/null 2>&1; then
-    (close_inherited_fds; exec setsid "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
+    setsid "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
   elif command -v python3 >/dev/null 2>&1; then
-    (close_inherited_fds; exec python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
-      "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
+    python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' \
+      "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
   else
-    (close_inherited_fds; exec nohup "${worker_args[@]}") < "$prompt_file" >/dev/null 2>&1 &
+    nohup "${worker_args[@]}" < "$prompt_file" >/dev/null 2>&1 &
   fi
   rm -f "$prompt_file"
 }
@@ -758,6 +758,7 @@ valid_identifier "$agent" && valid_identifier "$session" &&
   { [ -z "$workspace" ] || valid_identifier "$workspace"; } || { usage; exit 2; }
 
 if [ "$worker_mode" -eq 1 ]; then
+  close_inherited_descriptors
   prompt="$(cat)"
   worker "$prompt"
 else

--- a/home/dot_local/lib/herdr-worktree-state.sh
+++ b/home/dot_local/lib/herdr-worktree-state.sh
@@ -59,77 +59,98 @@ process_start_token() {
 claim_owner_id=""
 
 # Return 0 when a stale claim was removed, 1 when it remains owned, and 2 on
-# an unexpected filesystem error. A blank process-start never proves liveness.
+# an unexpected filesystem error. Claim files are fully written before an
+# atomic hard link publishes them, so readers never observe a live blank owner.
 recover_claim() {
-  local lock="$1" attempt="$2" owner pid start current_start
-  owner="$(read_state_field "$lock/owner" owner_id)"
+  local lock="$1" attempt="$2" owner pid start current_start observed
+  [ -f "$lock" ] || {
+    [ -e "$lock" ] && return 2
+    return 0
+  }
+  observed="$(cat "$lock" 2>/dev/null)" || return 2
+  owner="$(read_state_field "$lock" owner_id)"
   if [ -z "$owner" ]; then
     [ "$attempt" -ge 3 ] || return 1
-    if [ -f "$lock/owner" ] && [ -z "$(read_state_field "$lock/owner" owner_id)" ]; then
-      rm -f "$lock/owner" 2>/dev/null || return 2
-    fi
-    rmdir "$lock" 2>/dev/null && return 0
-    [ -d "$lock" ] && return 1
+    [ "$(cat "$lock" 2>/dev/null)" = "$observed" ] || return 1
+    rm -f "$lock" 2>/dev/null && return 0
+    [ -e "$lock" ] && return 1
     return 2
   fi
-  pid="$(record_number "$lock/owner" pid)"
-  start="$(read_state_field "$lock/owner" process_start)"
+  pid="$(record_number "$lock" pid)"
+  start="$(read_state_field "$lock" process_start)"
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
     current_start="$(process_start_token "$pid")"
+    [ -n "$current_start" ] || return 1
     if [ -n "$start" ] && [ "$start" = "$current_start" ]; then
       return 1
     fi
   fi
-  [ "$(read_state_field "$lock/owner" owner_id)" = "$owner" ] || return 1
-  rm -f "$lock/owner" 2>/dev/null || return 2
-  rmdir "$lock" 2>/dev/null && return 0
-  [ -d "$lock" ] && return 1
+  [ "$(cat "$lock" 2>/dev/null)" = "$observed" ] || return 1
+  rm -f "$lock" 2>/dev/null && return 0
+  [ -e "$lock" ] && return 1
   return 2
 }
 
 # Return 0 on acquisition, 2 when a live owner exhausts the bound, and 1 for
 # invalid input or filesystem failures. Contention is intentionally retryable.
 acquire_claim() {
-  local lock="$1" attempts="$2" attempt=0 owner start owner_record recovery dir
+  local lock="$1" attempts="$2" attempt=0 owner start owner_record recovery dir candidate delay=0.01
   case "$attempts" in
     '' | *[!0-9]* | 0) return 1 ;;
   esac
   dir="$(dirname "$lock")"
   mkdir -p "$dir" 2>/dev/null || return 1
   while :; do
-    if mkdir "$lock" 2>/dev/null; then
-      owner="$$.$RANDOM"
-      start="$(process_start_token "$$")"
-      owner_record="owner_id=$(encode_value "$owner")
+    if [ -e "$lock" ]; then
+      recover_claim "$lock" "$((attempt + 1))"
+      recovery=$?
+      case "$recovery" in
+        0) continue ;;
+        2) return 1 ;;
+      esac
+      attempt=$((attempt + 1))
+      [ "$attempt" -lt "$attempts" ] || return 2
+      sleep "$delay"
+      case "$delay" in
+        0.01) delay=0.02 ;;
+        0.02) delay=0.04 ;;
+        0.04) delay=0.08 ;;
+        0.08) delay=0.16 ;;
+        *) delay=0.25 ;;
+      esac
+      continue
+    fi
+    owner="$$.$RANDOM"
+    start="$(process_start_token "$$")"
+    [ -n "$start" ] || return 1
+    owner_record="owner_id=$(encode_value "$owner")
 pid=$$
 process_start=$(encode_value "$start")"
-      if ! atomic_write "$lock/owner" "$owner_record"; then
-        rmdir "$lock" 2>/dev/null || true
-        return 1
-      fi
+    candidate="$dir/.claim.$$.$RANDOM"
+    if ! (umask 077; printf '%s\n' "$owner_record" > "$candidate") 2>/dev/null; then
+      rm -f "$candidate" 2>/dev/null || true
+      return 1
+    fi
+    if [ -d "$lock" ]; then
+      rm -f "$candidate" 2>/dev/null || true
+      return 1
+    fi
+    if ln "$candidate" "$lock" 2>/dev/null; then
+      rm -f "$candidate" 2>/dev/null || true
       # shellcheck disable=SC2034 # The process that sourced this library reads it.
       claim_owner_id="$owner"
       return 0
     fi
-    [ -d "$lock" ] || return 1
-    recover_claim "$lock" "$((attempt + 1))"
-    recovery=$?
-    case "$recovery" in
-      0) continue ;;
-      2) return 1 ;;
-    esac
-    attempt=$((attempt + 1))
-    [ "$attempt" -lt "$attempts" ] || return 2
-    sleep 0.01
+    rm -f "$candidate" 2>/dev/null || true
+    [ -e "$lock" ] || return 1
   done
 }
 
 release_claim() {
   local lock="$1" owner="$2"
   [ -n "$owner" ] || return 0
-  [ "$(read_state_field "$lock/owner" owner_id)" = "$owner" ] || return 0
-  rm -f "$lock/owner" 2>/dev/null || return 1
-  rmdir "$lock" 2>/dev/null || return 1
+  [ "$(read_state_field "$lock" owner_id)" = "$owner" ] || return 0
+  rm -f "$lock" 2>/dev/null || return 1
 }
 
 # Diagnostics are append-only evidence. No state helper reads this log.

--- a/home/dot_local/lib/herdr-worktree-state.sh
+++ b/home/dot_local/lib/herdr-worktree-state.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# State, claim, and diagnostic primitives for herdr-worktree-identity.
+
+HERDR_WORKTREE_IDENTITY_STATE_DIR="${HERDR_WORKTREE_IDENTITY_STATE_DIR:-$HOME/.cache/herdr-worktree-identity}"
+
+encode_key() {
+  printf '%s' "$1" | base64 | tr '/+' '_-' | tr -d '=\n'
+}
+
+encode_value() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+namespace_dir() {
+  [ -n "${1:-}" ] || return 1
+  printf '%s/repositories/%s' "$HERDR_WORKTREE_IDENTITY_STATE_DIR" "$(encode_key "$1")"
+}
+
+atomic_write() {
+  local file="$1" content="$2" dir tmp
+  [ ! -d "$file" ] || return 1
+  dir="$(dirname "$file")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  tmp="$(umask 077; mktemp "$dir/.record.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$content" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if [ -d "$file" ] || ! mv "$tmp" "$file" 2>/dev/null; then
+    rm -f "$tmp"
+    return 1
+  fi
+  return 0
+}
+
+read_state_field() {
+  local file="$1" key="$2" encoded
+  [ -f "$file" ] || return 0
+  encoded="$(grep -m1 "^${key}=" "$file" 2>/dev/null | cut -d= -f2-)"
+  [ -n "$encoded" ] || return 0
+  printf '%s' "$encoded" | base64 -d 2>/dev/null || true
+}
+
+record_number() {
+  local file="$1" key="$2" value
+  [ -f "$file" ] || return 0
+  value="$(sed -n "s/^${key}=//p" "$file" 2>/dev/null | head -1)"
+  case "$value" in
+    '' | *[!0-9]*) return 0 ;;
+  esac
+  printf '%s' "$value"
+}
+
+process_start_token() {
+  ps -p "$1" -o lstart= 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# shellcheck disable=SC2034 # Callers read the owner selected by acquire_claim.
+claim_owner_id=""
+
+# Return 0 when a stale claim was removed, 1 when it remains owned, and 2 on
+# an unexpected filesystem error. A blank process-start never proves liveness.
+recover_claim() {
+  local lock="$1" attempt="$2" owner pid start current_start
+  owner="$(read_state_field "$lock/owner" owner_id)"
+  if [ -z "$owner" ]; then
+    [ "$attempt" -ge 3 ] || return 1
+    if [ -f "$lock/owner" ] && [ -z "$(read_state_field "$lock/owner" owner_id)" ]; then
+      rm -f "$lock/owner" 2>/dev/null || return 2
+    fi
+    rmdir "$lock" 2>/dev/null && return 0
+    [ -d "$lock" ] && return 1
+    return 2
+  fi
+  pid="$(record_number "$lock/owner" pid)"
+  start="$(read_state_field "$lock/owner" process_start)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    current_start="$(process_start_token "$pid")"
+    if [ -n "$start" ] && [ "$start" = "$current_start" ]; then
+      return 1
+    fi
+  fi
+  [ "$(read_state_field "$lock/owner" owner_id)" = "$owner" ] || return 1
+  rm -f "$lock/owner" 2>/dev/null || return 2
+  rmdir "$lock" 2>/dev/null && return 0
+  [ -d "$lock" ] && return 1
+  return 2
+}
+
+# Return 0 on acquisition, 2 when a live owner exhausts the bound, and 1 for
+# invalid input or filesystem failures. Contention is intentionally retryable.
+acquire_claim() {
+  local lock="$1" attempts="$2" attempt=0 owner start owner_record recovery dir
+  case "$attempts" in
+    '' | *[!0-9]* | 0) return 1 ;;
+  esac
+  dir="$(dirname "$lock")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  while :; do
+    if mkdir "$lock" 2>/dev/null; then
+      owner="$$.$RANDOM"
+      start="$(process_start_token "$$")"
+      owner_record="owner_id=$(encode_value "$owner")
+pid=$$
+process_start=$(encode_value "$start")"
+      if ! atomic_write "$lock/owner" "$owner_record"; then
+        rmdir "$lock" 2>/dev/null || true
+        return 1
+      fi
+      # shellcheck disable=SC2034 # The process that sourced this library reads it.
+      claim_owner_id="$owner"
+      return 0
+    fi
+    [ -d "$lock" ] || return 1
+    recover_claim "$lock" "$((attempt + 1))"
+    recovery=$?
+    case "$recovery" in
+      0) continue ;;
+      2) return 1 ;;
+    esac
+    attempt=$((attempt + 1))
+    [ "$attempt" -lt "$attempts" ] || return 2
+    sleep 0.01
+  done
+}
+
+release_claim() {
+  local lock="$1" owner="$2"
+  [ -n "$owner" ] || return 0
+  [ "$(read_state_field "$lock/owner" owner_id)" = "$owner" ] || return 0
+  rm -f "$lock/owner" 2>/dev/null || return 1
+  rmdir "$lock" 2>/dev/null || return 1
+}
+
+# Diagnostics are append-only evidence. No state helper reads this log.
+record_diagnostic() {
+  local file="$1" reason="$2" observed_state="$3" dir
+  dir="$(dirname "$file")"
+  mkdir -p "$dir" 2>/dev/null || return 1
+  printf 'reason=%s observed_state=%s\n' "$reason" "$observed_state" >> "$file" 2>/dev/null
+}

--- a/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
+++ b/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
@@ -1,0 +1,73 @@
+// Pi prompt adapter for herdr-worktree-identity.
+// @ts-nocheck
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const ENGINE_NAME = "herdr-worktree-identity";
+const HANDSHAKE_TIMEOUT_MS = 1000;
+
+function enginePath(): string {
+  if (process.env.HERDR_WORKTREE_IDENTITY_ENGINE) return process.env.HERDR_WORKTREE_IDENTITY_ENGINE;
+  const home = process.env.HOME;
+  if (home) {
+    const local = path.join(home, ".local", "bin", ENGINE_NAME);
+    if (existsSync(local)) return local;
+  }
+  return ENGINE_NAME;
+}
+
+function sessionId(ctx: any): string | undefined {
+  try {
+    const id = ctx?.sessionManager?.getSessionId?.();
+    return typeof id === "string" && id.length > 0 ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function callEngine(args: string[], prompt: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(enginePath(), args, { stdio: ["pipe", "ignore", "ignore"] });
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        child.stdin?.destroy();
+        child.kill("SIGTERM");
+        finish();
+      }, HANDSHAKE_TIMEOUT_MS);
+      timer.unref?.();
+      child.once("error", finish);
+      child.once("close", finish);
+      child.stdin?.once("error", () => {});
+      child.stdin?.end(prompt);
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function engineArgs(id: string): string[] {
+  const args = ["--agent", "pi", "--session", id];
+  if (process.env.HERDR_PANE_ID) args.push("--pane", process.env.HERDR_PANE_ID);
+  if (process.env.HERDR_WORKSPACE_ID) args.push("--workspace", process.env.HERDR_WORKSPACE_ID);
+  return args;
+}
+
+export default function registerWorktreeIdentity(pi: any): void {
+  if (process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return;
+
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    if (ctx?.hasUI !== true) return;
+    const id = sessionId(ctx);
+    const prompt = typeof event?.prompt === "string" ? event.prompt : "";
+    if (!id || prompt.trim() === "") return;
+    await callEngine(engineArgs(id), prompt);
+  });
+}

--- a/home/private_dot_claude/hooks/executable_herdr-worktree-identity-hook.sh
+++ b/home/private_dot_claude/hooks/executable_herdr-worktree-identity-hook.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# UserPromptSubmit adapter for herdr-worktree-identity.
+#
+# The engine's foreground process only persists the prompt and forks its
+# worker. The hook timeout therefore bounds that handshake, never model work.
+# Every decline is deliberately quiet: Claude includes hook stdout in context.
+
+set -uo pipefail
+
+[ "${HERDR_ENV:-}" = 1 ] || exit 0
+[ -z "${HERDR_WORKTREE_IDENTITY_ACTIVE:-}" ] || exit 0
+
+engine="${HERDR_WORKTREE_IDENTITY_ENGINE:-$HOME/.local/bin/herdr-worktree-identity}"
+[ -x "$engine" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+input="$(cat 2>/dev/null)" || exit 0
+field() {
+  printf '%s' "$input" | jq -r "$1" 2>/dev/null
+}
+
+# A subagent belongs to its parent's pane and must not derive a new identity.
+[ -z "$(field '.agent_id // empty')" ] || exit 0
+session="$(field '.session_id // empty')"
+prompt="$(field '.prompt // empty')"
+[ -n "$session" ] && [ -n "$prompt" ] || exit 0
+
+args=(--agent claude --session "$session")
+[ -z "${HERDR_PANE_ID:-}" ] || args+=(--pane "$HERDR_PANE_ID")
+[ -z "${HERDR_WORKSPACE_ID:-}" ] || args+=(--workspace "$HERDR_WORKSPACE_ID")
+printf '%s' "$prompt" | "$engine" "${args[@]}" >/dev/null 2>&1 || true
+
+exit 0

--- a/home/private_dot_claude/hooks/executable_statusline.sh
+++ b/home/private_dot_claude/hooks/executable_statusline.sh
@@ -4,16 +4,16 @@ input=$(cat)
 # herdr labels an agent pane from the pane's OS working directory, which never
 # moves when a session enters a worktree — the claude process stays put while
 # the session works elsewhere. This payload knows better, so record the
-# session's real directory where herdr-task-sync can read it. Keyed by session
-# id, which herdr also carries on the pane. Writing a file is the whole
-# contract: herdr-task-sync stays the only process that publishes pane tokens.
+# session's real directory where herdr-worktree-identity can read it. Keyed by
+# session id, which herdr also carries on the pane. Writing a file is the whole
+# contract: herdr-worktree-identity owns its identity state.
 herdr_record_session_cwd() {
     [ "${HERDR_ENV:-}" = 1 ] || return 0
     local dir key root tmp
     IFS=$'\t' read -r dir key <<< "$(printf '%s' "$input" |
         jq -r '[(.workspace.current_dir // ""), (.session_id // "")] | @tsv' 2>/dev/null)"
     [ -n "$dir" ] && [ -n "$key" ] || return 0
-    root="${HERDR_TASK_SYNC_STATE_DIR:-$HOME/.cache/herdr-task-sync}/agent-cwd"
+    root="${HERDR_WORKTREE_IDENTITY_STATE_DIR:-$HOME/.cache/herdr-worktree-identity}/agent-cwd"
     mkdir -p "$root" 2>/dev/null || return 0
     key=$(LC_ALL=C printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-64)
     # Rename into place so a sweep reading mid-write never sees a partial path.

--- a/home/private_dot_claude/hooks/executable_statusline.sh
+++ b/home/private_dot_claude/hooks/executable_statusline.sh
@@ -9,13 +9,17 @@ input=$(cat)
 # contract: herdr-worktree-identity owns its identity state.
 herdr_record_session_cwd() {
     [ "${HERDR_ENV:-}" = 1 ] || return 0
-    local dir key root tmp
+    local dir key root state_library tmp
     IFS=$'\t' read -r dir key <<< "$(printf '%s' "$input" |
         jq -r '[(.workspace.current_dir // ""), (.session_id // "")] | @tsv' 2>/dev/null)"
     [ -n "$dir" ] && [ -n "$key" ] || return 0
     root="${HERDR_WORKTREE_IDENTITY_STATE_DIR:-$HOME/.cache/herdr-worktree-identity}/agent-cwd"
+    state_library="${HERDR_WORKTREE_IDENTITY_STATE_LIBRARY:-$HOME/.local/lib/herdr-worktree-state.sh}"
+    [ -r "$state_library" ] || return 0
+    # shellcheck source=home/dot_local/lib/herdr-worktree-state.sh
+    . "$state_library"
     mkdir -p "$root" 2>/dev/null || return 0
-    key=$(LC_ALL=C printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-64)
+    key="$(encode_key "$key")" || return 0
     # Rename into place so a sweep reading mid-write never sees a partial path.
     tmp="$root/.$key.$$"
     printf '%s\n' "$dir" > "$tmp" 2>/dev/null && mv -f "$tmp" "$root/$key" 2>/dev/null

--- a/home/private_dot_claude/private_settings.json.tmpl
+++ b/home/private_dot_claude/private_settings.json.tmpl
@@ -84,6 +84,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '{{ .chezmoi.homeDir }}/.claude/hooks/herdr-worktree-identity-hook.sh'",
+            "timeout": 2
+          }
+        ]
+      }
     ]
   },
   "disableRemoteControl": true,

--- a/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
+++ b/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+// OpenCode prompt adapter for herdr-worktree-identity. The engine detaches its
+// model worker before this foreground handshake resolves.
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+const ENGINE_NAME = "herdr-worktree-identity"
+const HANDSHAKE_TIMEOUT_MS = 1000
+
+function enginePath(): string {
+  const configured = process.env.HERDR_WORKTREE_IDENTITY_ENGINE
+  if (configured) return configured
+  const home = process.env.HOME
+  if (home) {
+    const local = path.join(home, ".local", "bin", ENGINE_NAME)
+    if (existsSync(local)) return local
+  }
+  return ENGINE_NAME
+}
+
+function callEngine(args: string[], prompt: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(enginePath(), args, { stdio: ["pipe", "ignore", "ignore"] })
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve()
+      }
+      const timer = setTimeout(() => {
+        child.stdin?.destroy()
+        child.kill("SIGTERM")
+        finish()
+      }, HANDSHAKE_TIMEOUT_MS)
+      timer.unref?.()
+      child.once("error", finish)
+      child.once("close", finish)
+      child.stdin?.once("error", () => {})
+      child.stdin?.end(prompt)
+    } catch {
+      resolve()
+    }
+  })
+}
+
+function engineArgs(sessionID: string): string[] {
+  const args = ["--agent", "opencode", "--session", sessionID]
+  if (process.env.HERDR_PANE_ID) args.push("--pane", process.env.HERDR_PANE_ID)
+  if (process.env.HERDR_WORKSPACE_ID) args.push("--workspace", process.env.HERDR_WORKSPACE_ID)
+  return args
+}
+
+export const HerdrWorktreeIdentityPlugin: Plugin = async () => {
+  if (process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return {}
+
+  const childSessions = new Set<string>()
+  return {
+    "chat.message": async (input, output) => {
+      const sessionID = input?.sessionID
+      if (!sessionID || childSessions.has(sessionID)) return
+      const prompt = (Array.isArray(output?.parts) ? output.parts : [])
+        .filter((part: any) => part?.type === "text" && typeof part.text === "string")
+        .map((part: any) => part.text)
+        .join("\n")
+      if (prompt.trim() !== "") await callEngine(engineArgs(sessionID), prompt)
+    },
+    event: async ({ event }) => {
+      const type = (event as any)?.type
+      const info = (event as any)?.properties?.info
+      if (type === "session.deleted" && info?.id) childSessions.delete(info.id)
+      else if (info?.id && info.parentID) childSessions.add(info.id)
+    },
+  }
+}

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -178,6 +178,7 @@ function test_idempotent_010_guard_every_disposable_environment_declares_the() {
 
   [[ "${MMS_DISPOSABLE_HOME:-}" == "1" ]] || \
     fail "This environment reports a disposable \$HOME (GITHUB_ACTIONS is set, or /.dockerenv exists), but MMS_DISPOSABLE_HOME is '${MMS_DISPOSABLE_HOME:-<unset>}' instead of 1. The idempotency scenarios in this file would skip here, removing that coverage without turning anything red. Declare the marker at the site that launched this suite: .github/workflows/test-dotfiles.yml (top-level env: block), or docker/docker-compose.yml (services ubuntu, test-ubuntu, test-full)."
+  assert_equal "${MMS_DISPOSABLE_HOME:-}" "1"
 }
 
 function test_idempotent_011_guard_the_marker_s_claim_covers_chezmoi_s_real_d() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -362,6 +362,7 @@ function test_scripts_1144_worktree_identity_falls_back_without_model_clis_and_c
   assert_equal "$(read_state_field "$state" slug)" json-generated
 
   rm "$state"
+  git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
   hwi_write_naming_stub pi
   printf '%s\n' '{"title":"Long model identity","slug":"unusuallylongword-verylongsecondword-verylongthirdword-verylongfourthword-verylongfifthword"}' > "$HWI_WORK/pi.output"
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
@@ -376,6 +377,203 @@ function test_scripts_1144_worktree_identity_falls_back_without_model_clis_and_c
   assert_success
   run test "$(printf '%s' "$slug" | tr '-' '\n' | grep -c '.')" -ge 2
   assert_success
+}
+
+# ===========================================
+# herdr-worktree-identity branch rename (U4)
+# ===========================================
+
+function test_scripts_1180_worktree_identity_renames_once_and_attributes_the_branch() {
+  _bats_test_init 1180 'worktree identity renames an authorized branch once with durable attribution'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Implement focused branch attribution'
+  assert_success
+  local state marker branch attribution
+  state="$(hwi_identity_state_path)"
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  branch="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  attribution="Intentional rename by herdr-worktree-identity: $HWI_BRANCH -> $branch"
+  assert_equal "$branch" implement-focused-branch-attribution
+  run git -C "$HWI_CHECKOUT" show-ref --verify --quiet "refs/heads/$HWI_BRANCH"
+  assert_failure 1
+  assert_file_contains "$marker" "^$HWI_BRANCH$"
+  assert_file_contains "$marker" "^$attribution$"
+  assert_equal "$(hwi_branch_description "$branch")" "$attribution"
+  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_equal "$(read_state_field "$state" branch)" "$branch"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Implement focused branch attribution again'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$branch"
+  assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$branch" | grep -c '^Branch: renamed ')" 1
+}
+
+function test_scripts_1181_worktree_identity_suffixes_candidates_against_local_and_remote_refs() {
+  _bats_test_init 1181 'worktree identity avoids local and remote-tracking branch candidates'
+  hwi_setup
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  git -C "$HWI_MAIN" branch implement-candidate-collision
+  hwi_add_remote_tracking_branch implement-candidate-collision-2
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Implement candidate collision'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" implement-candidate-collision-3
+  run git -C "$HWI_CHECKOUT" show-ref --verify --quiet refs/remotes/origin/implement-candidate-collision-2
+  assert_success
+}
+
+function test_scripts_1182_worktree_identity_preserves_upstream_and_agent_moved_branches() {
+  _bats_test_init 1182 'worktree identity leaves upstream and concurrently agent-moved branches untouched'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_set_upstream
+  local state diagnostics
+  state="$(hwi_identity_state_path)"
+  diagnostics="${state%.state}.diagnostics.log"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Preserve upstream branch'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_file_contains "$diagnostics" '^reason=branch-has-upstream '
+
+  git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.remote"
+  git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.merge"
+  local ready="$HWI_WORK/revalidate.ready" release="$HWI_WORK/revalidate.release"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 \
+    <<< 'Preserve agent move' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  git -C "$HWI_CHECKOUT" branch -m agent-chosen-name
+  : > "$release"
+  wait "$worker_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" agent-chosen-name
+  assert_file_contains "$diagnostics" '^reason=branch-changed-before-rename '
+}
+
+function test_scripts_1183_worktree_identity_records_branch_and_attribution_failures_for_recovery() {
+  _bats_test_init 1183 'worktree identity records rename and attribution failures and retries attribution'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_git_proxy
+  : > "$HWI_WORK/fail-git-branch-m"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Record branch failure'
+  assert_success
+  local state="$(hwi_identity_state_path)" marker branch
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" branch-failed
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=branch-rename-failed '
+  assert_file_not_contains "$marker" 'Intentional rename by herdr-worktree-identity'
+
+  rm "$HWI_WORK/fail-git-branch-m"
+  : > "$HWI_WORK/fail-git-description"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Record branch failure'
+  assert_success
+  branch="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  assert_equal "$branch" record-branch-failure
+  assert_equal "$(read_state_field "$state" outcome)" attribution_failed
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=attribution-failed '
+
+  rm "$HWI_WORK/fail-git-description"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Record branch failure'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_equal "$(hwi_branch_description "$branch")" "Intentional rename by herdr-worktree-identity: $HWI_BRANCH -> $branch"
+}
+
+function test_scripts_1184_worktree_identity_serializes_branch_mutation_with_a_barrier() {
+  _bats_test_init 1184 'worktree identity allows exactly one branch mutation after a two-process barrier'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local barrier="$HWI_WORK/branch-barrier" start_release="$HWI_WORK/start.release"
+  local claim_ready="$HWI_WORK/claim.ready" claim_release="$HWI_WORK/claim.release" contended_ready="$HWI_WORK/contended.ready"
+  mkdir "$barrier"
+  local worker_env=(PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER="$barrier" \
+    HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER_RELEASE="$start_release" \
+    HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_READY="$claim_ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_RELEASE="$claim_release" \
+    HERDR_WORKTREE_IDENTITY_TEST_CONTENDED_READY="$contended_ready")
+  env "${worker_env[@]}" bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize branch mutation' &
+  local first_pid=$!
+  env "${worker_env[@]}" bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize branch mutation' &
+  local second_pid=$! attempt=0
+  while [[ "$(find "$barrier" -type f | wc -l | tr -d ' ')" -lt 2 && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_equal "$(find "$barrier" -type f | wc -l | tr -d ' ')" 2
+  : > "$start_release"
+  attempt=0
+  while [[ ! -e "$claim_ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$claim_ready"
+  attempt=0
+  while [[ ! -e "$contended_ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$contended_ready"
+  : > "$claim_release"
+  wait "$first_pid"
+  wait "$second_pid"
+  local branch="$(git -C "$HWI_CHECKOUT" branch --show-current)" state="$(hwi_identity_state_path)"
+  assert_equal "$branch" serialize-branch-mutation
+  assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$branch" | grep -c '^Branch: renamed ')" 1
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=contended '
+}
+
+function test_scripts_1185_worktree_identity_recovers_marker_attribution_after_write_failure() {
+  _bats_test_init 1185 'worktree identity retries marker attribution after a successful rename'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  chmod a-w "$marker"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Recover marker attribution'
+  assert_success
+  local state="$(hwi_identity_state_path)" branch="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  assert_equal "$branch" recover-marker-attribution
+  assert_equal "$(read_state_field "$state" outcome)" attribution_failed
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=attribution-failed '
+
+  chmod u+w "$marker"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Recover marker attribution'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_file_contains "$marker" '^Intentional rename by herdr-worktree-identity: worktree/quiet-stone-fd75 -> recover-marker-attribution$'
 }
 
 # ===========================================

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -8,6 +8,7 @@ _bats_file_init "${BASH_SOURCE[0]}"
 
 load 'helpers/common'
 load 'helpers/herdr_pane_labels'
+load 'helpers/herdr_worktree_identity'
 
 setup() {
   unset HERDR_CHILD_NAME
@@ -27,6 +28,7 @@ setup() {
 
 teardown() {
   hpl_teardown
+  hwi_teardown
   if [[ -n "${CHILD_STUB:-}" ]]; then
     if [[ -e "$CHILD_STUB/reap-invalidated.ready" ]]; then
       : > "$CHILD_STUB/reap-invalidated.release"
@@ -66,6 +68,81 @@ teardown() {
   fi
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
   [[ -n "${CHILD_STUB:-}" ]] && rm -rf "$CHILD_STUB" || true
+}
+
+# ===========================================
+# herdr-worktree-identity state library
+# ===========================================
+
+function test_scripts_1134_worktree_identity_state_library_claims_live_owners_and_recovers_dead_owners() {
+  _bats_test_init 1134 'worktree identity claims live owners and recovers dead owners'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  local lock="$HWI_STATE/repositories/test/identity.claim" owner
+
+  hwi_start_claim_holder "$lock" || fail 'second process did not acquire its claim'
+  run acquire_claim "$lock" 3
+  assert_failure 2
+  run kill -0 "$HWI_HOLDER_PID"
+  assert_success
+
+  kill -KILL "$HWI_HOLDER_PID"
+  wait "$HWI_HOLDER_PID" 2>/dev/null || true
+  HWI_HOLDER_PID=""
+  acquire_claim "$lock" 3 || fail 'dead owner claim was not recovered'
+  owner="$claim_owner_id"
+  release_claim "$lock" "$owner"
+  assert_dir_not_exists "$lock"
+}
+
+function test_scripts_1135_worktree_identity_state_library_recovers_malformed_claims_and_distinguishes_errors() {
+  _bats_test_init 1135 'worktree identity recovers malformed claims and distinguishes contention from errors'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  local malformed="$HWI_STATE/malformed.claim" held="$HWI_STATE/held.claim"
+  mkdir -p "$malformed"
+  atomic_write "$malformed/owner" "owner_id=$(encode_value malformed-owner)
+pid=$$
+process_start=$(encode_value '')"
+
+  acquire_claim "$malformed" 3 || fail 'empty process-start claim was not recovered'
+  release_claim "$malformed" "$claim_owner_id"
+
+  hwi_start_claim_holder "$held" || fail 'second process did not acquire its claim'
+  run acquire_claim "$held" 1
+  assert_failure 2
+  : > "$HWI_WORK/not-a-directory"
+  run acquire_claim "$HWI_WORK/not-a-directory" 1
+  assert_failure 1
+}
+
+function test_scripts_1136_worktree_identity_state_library_appends_diagnostics_and_preserves_preexisting_records() {
+  _bats_test_init 1136 'worktree identity diagnostics append and failed pre-rename writes preserve records'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  local diagnostics="$HWI_STATE/worktree/diagnostics.log" record="$HWI_STATE/worktree/state"
+  local stub="$HWI_WORK/stub"
+
+  record_diagnostic "$diagnostics" marker-missing 'checkout=/tmp/first'
+  record_diagnostic "$diagnostics" contended 'claim=repository'
+  assert_file_contains "$diagnostics" '^reason=marker-missing observed_state=checkout=/tmp/first$'
+  assert_file_contains "$diagnostics" '^reason=contended observed_state=claim=repository$'
+  assert_equal "$(wc -l < "$diagnostics" | tr -d ' ')" 2
+
+  atomic_write "$record" previous
+  mkdir -p "$stub"
+  cat > "$stub/mv" <<'SH'
+#!/bin/sh
+exit 1
+SH
+  chmod +x "$stub/mv"
+  run env PATH="$stub:/usr/bin:/bin" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash -c 'source "$1"; atomic_write "$2" replacement' _ "$HWI_STATE_LIBRARY" "$record"
+  assert_failure
+  assert_file_contains "$record" '^previous$'
+  run find "$(dirname "$record")" -name '.record.*' -print
+  assert_success
+  assert_output ''
 }
 
 # ===========================================

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -404,7 +404,7 @@ function test_scripts_1180_worktree_identity_renames_once_and_attributes_the_bra
   assert_file_contains "$marker" "^$HWI_BRANCH$"
   assert_file_contains "$marker" "^$attribution$"
   assert_equal "$(hwi_branch_description "$branch")" "$attribution"
-  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_equal "$(read_state_field "$state" outcome)" complete
   assert_equal "$(read_state_field "$state" branch)" "$branch"
 
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
@@ -449,6 +449,9 @@ function test_scripts_1182_worktree_identity_preserves_upstream_and_agent_moved_
 
   git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.remote"
   git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.merge"
+  # The upstream leg reaches its terminal workspace-only outcome. Reset this
+  # fixture's independent agent-move control to a new naming lifecycle.
+  rm "$state"
   local ready="$HWI_WORK/revalidate.ready" release="$HWI_WORK/revalidate.release"
   env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY="$ready" \
@@ -501,7 +504,7 @@ function test_scripts_1183_worktree_identity_records_branch_and_attribution_fail
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Record branch failure'
   assert_success
-  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_equal "$(read_state_field "$state" outcome)" complete
   assert_equal "$(hwi_branch_description "$branch")" "Intentional rename by herdr-worktree-identity: $HWI_BRANCH -> $branch"
 }
 
@@ -572,8 +575,146 @@ function test_scripts_1185_worktree_identity_recovers_marker_attribution_after_w
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Recover marker attribution'
   assert_success
-  assert_equal "$(read_state_field "$state" outcome)" prepared
+  assert_equal "$(read_state_field "$state" outcome)" complete
   assert_file_contains "$marker" '^Intentional rename by herdr-worktree-identity: worktree/quiet-stone-fd75 -> recover-marker-attribution$'
+}
+
+# ===========================================
+# herdr-worktree-identity workspace outcomes (U5)
+# ===========================================
+
+# The independent oracle for workspace behavior is the herdr recorder: it
+# observes a workspace rename call without granting this component ownership
+# of pane, tab, or agent labels. Branch assertions read the fixture's real Git
+# state, not the identity state file.
+function test_scripts_1186_worktree_identity_labels_workspace_once_after_rename() {
+  _bats_test_init 1186 'worktree identity labels a workspace once and completes the outcome'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Label workspace independently'
+  assert_success
+  local state="$(hwi_identity_state_path)" branch="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  assert_equal "$branch" label-workspace-independently
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(cat "$HWI_WORK/workspace.label")" 'Label workspace independently'
+  assert_equal "$(hwi_workspace_rename_count)" 1
+  assert_file_not_contains "$HWI_WORK/herdr.calls" '^(pane|tab|agent) rename '
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'A later event must not rename labels'
+  assert_success
+  assert_equal "$(hwi_workspace_rename_count)" 1
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$branch"
+}
+
+function test_scripts_1187_worktree_identity_labels_workspace_only_for_upstream_and_reverted_branches() {
+  _bats_test_init 1187 'worktree identity keeps upstream and agent-reverted branches while labeling the workspace'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_set_upstream
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Preserve upstream workspace'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(cat "$HWI_WORK/workspace.label")" 'Preserve upstream workspace'
+
+  git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.remote"
+  git -C "$HWI_CHECKOUT" config --unset "branch.$HWI_BRANCH.merge"
+  rm "$state"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Keep agent reverted branch'
+  assert_success
+  local renamed="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Do not restore agent branch'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$HWI_BRANCH" | grep -c '^Branch: renamed ')" 2
+  assert_equal "$(hwi_workspace_rename_count)" 2
+  assert_file_not_contains "$HWI_WORK/herdr.calls" '^(pane|tab|agent) rename '
+  [ -n "$renamed" ] || fail 'control rename did not occur'
+}
+
+function test_scripts_1188_worktree_identity_declines_marker_and_retries_contention_and_workspace_failure() {
+  _bats_test_init 1188 'worktree identity keeps terminal declines distinct from retryable contention and workspace failures'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local state="$(hwi_identity_state_path)" marker
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  rm "$marker"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Missing marker never labels'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" declined
+  assert_equal "$(hwi_workspace_rename_count)" 0
+
+  rm "$state"
+  HERDR_PLUGIN_CONFIG_DIR="$HWI_PLUGIN_CONFIG" \
+    HERDR_PLUGIN_EVENT_JSON="{\"data\":{\"worktree\":{\"path\":\"$HWI_CHECKOUT\",\"branch\":\"$HWI_BRANCH\"}}}" \
+    bun "$HWI_WORKTREE_SETUP_PLUGIN" >/dev/null
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  state="$(hwi_identity_state_path)"
+  local lock="$(namespace_dir "$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)")/branch-rename.claim"
+  hwi_start_claim_holder "$lock" || fail 'claim holder was not ready'
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_BRANCH_CLAIM_ATTEMPTS=1 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Retry contention label'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" ''
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=contended '
+  : > "$HWI_HOLDER_RELEASE"
+  wait "$HWI_HOLDER_PID"
+  HWI_HOLDER_PID=''
+  : > "$HWI_WORK/fail-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Retry contention label'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" workspace-failed
+  rm "$HWI_WORK/fail-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later naming event retries label'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 2
+}
+
+function test_scripts_1189_worktree_identity_revalidates_occupant_before_workspace_rename() {
+  _bats_test_init 1189 'worktree identity does not relabel a workspace after its pane changes occupants'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local ready="$HWI_WORK/workspace-revalidate.ready" release="$HWI_WORK/workspace-revalidate.release"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_WORKSPACE_REVALIDATE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_WORKSPACE_REVALIDATE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Revalidate workspace occupant' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  hwi_write_pane pane-1 claude other-session workspace-1 "$HWI_CHECKOUT"
+  : > "$release"
+  wait "$worker_pid"
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-failed
+  assert_equal "$(hwi_workspace_rename_count)" 0
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=workspace-occupant-changed '
 }
 
 # ===========================================

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -7788,3 +7788,137 @@ function tear_down() {
   fi
   _bats_run_teardown
 }
+
+# ===========================================
+# herdr-worktree-identity client adapters (U6)
+# ===========================================
+
+HWI_CLAUDE_HOOK="$SOURCE_ROOT/private_dot_claude/hooks/executable_herdr-worktree-identity-hook.sh"
+HWI_OPENCODE_PLUGIN_SOURCE="$SOURCE_ROOT/private_dot_config/opencode/plugins/herdr-worktree-identity.ts"
+
+hwi_adapter_stub_engine() {
+  local root="$1"
+  mkdir -p "$root"
+  cat > "$root/engine" <<'SH'
+#!/usr/bin/env bash
+set -eu
+call="$HWI_ADAPTER_TEST_DIR/call-$$"
+mkdir "$call"
+printf '%s\n' "$@" > "$call/argv"
+cat > "$call/stdin"
+: > "$call/ready"
+(
+  while [ ! -e "$HWI_ADAPTER_TEST_DIR/release" ]; do sleep 0.01; done
+  : > "$call/released"
+) &
+exit 0
+SH
+  chmod +x "$root/engine"
+}
+
+hwi_wait_for_file() {
+  local path="$1" attempt=0
+  while [[ ! -e "$path" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  if [[ -e "$path" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+function test_scripts_1200_claude_worktree_identity_hook_hands_off_prompt_on_stdin() {
+  _bats_test_init 1200 'claude worktree identity hook passes prompt on stdin and returns after handoff'
+  local root="$BATS_TEST_TMPDIR/claude-adapter" prompt='Name this Claude task: stdin-only sentinel'
+  hwi_adapter_stub_engine "$root"
+
+  run env HERDR_ENV=1 HERDR_PANE_ID=pane-claude HERDR_WORKSPACE_ID=workspace-claude \
+    HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" HWI_ADAPTER_TEST_DIR="$root" \
+    bash "$HWI_CLAUDE_HOOK" <<< "{\"session_id\":\"session-claude\",\"prompt\":\"$prompt\"}"
+  assert_success
+  assert_output ''
+  local call
+  call="$(find "$root" -mindepth 1 -maxdepth 1 -type d -name 'call-*' | head -n 1)"
+  [[ -n "$call" ]] || fail 'the external engine did not receive the Claude prompt event'
+  assert_file_contains "$call/stdin" "^$prompt$"
+  assert_file_not_contains "$call/argv" "$prompt"
+  assert_file_contains "$call/argv" '^--agent$'
+  assert_file_contains "$call/argv" '^claude$'
+  assert_file_contains "$call/argv" '^--pane$'
+  assert_file_contains "$call/argv" '^pane-claude$'
+  hwi_wait_for_file "$call/ready" || fail 'the external engine did not enter slow derivation'
+  assert_file_not_exists "$call/released"
+  : > "$root/release"
+  hwi_wait_for_file "$call/released" || fail 'the slow derivation was not released'
+}
+
+function test_scripts_1201_claude_worktree_identity_hook_fails_open_without_engine() {
+  _bats_test_init 1201 'claude worktree identity hook is quiet when unavailable or gated'
+  run env HERDR_ENV=1 HERDR_WORKTREE_IDENTITY_ENGINE="$BATS_TEST_TMPDIR/missing-engine" \
+    bash "$HWI_CLAUDE_HOOK" <<< '{"session_id":"session-claude","prompt":"ignored"}'
+  assert_success
+  assert_output ''
+
+  local root="$BATS_TEST_TMPDIR/claude-gated"
+  hwi_adapter_stub_engine "$root"
+  run env HERDR_ENV= HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" HWI_ADAPTER_TEST_DIR="$root" \
+    bash "$HWI_CLAUDE_HOOK" <<< '{"session_id":"session-claude","prompt":"outside herdr"}'
+  assert_success
+  run env HERDR_ENV=1 HERDR_WORKTREE_IDENTITY_ACTIVE=1 HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" HWI_ADAPTER_TEST_DIR="$root" \
+    bash "$HWI_CLAUDE_HOOK" <<< '{"session_id":"session-claude","prompt":"recursive naming"}'
+  assert_success
+  run find "$root" -mindepth 1 -maxdepth 1 -type d -name 'call-*' -print
+  assert_success
+  assert_output ''
+}
+
+function test_scripts_1202_opencode_worktree_identity_plugin_uses_deployed_consumer_boundary() {
+  _bats_test_init 1202 'deployed opencode plugin gates and delivers every prompt on stdin'
+  command_exists bun || skip 'bun is required'
+  local root home deployed
+  root="$BATS_TEST_TMPDIR/opencode-adapter"
+  home="$root/home"
+  deployed="$home/.config/opencode/plugins"
+  mkdir -p "$deployed"
+  hwi_adapter_stub_engine "$root"
+  ln -s "$HWI_OPENCODE_PLUGIN_SOURCE" "$deployed/herdr-worktree-identity.ts"
+  cat > "$root/run.ts" <<'TS'
+const { HerdrWorktreeIdentityPlugin } = await import(process.env.HWI_OPENCODE_PLUGIN!);
+const plugin = await HerdrWorktreeIdentityPlugin();
+await plugin["chat.message"]?.(
+  { sessionID: "session-opencode" },
+  { parts: [{ type: "text", text: "OpenCode stdin sentinel" }] },
+);
+await plugin["chat.message"]?.(
+  { sessionID: "session-opencode" },
+  { parts: [{ type: "text", text: "Second OpenCode prompt" }] },
+);
+TS
+  run env HOME="$home" HERDR_ENV=1 HERDR_PANE_ID=pane-opencode HERDR_WORKSPACE_ID=workspace-opencode \
+    HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" HWI_ADAPTER_TEST_DIR="$root" \
+    HWI_OPENCODE_PLUGIN="$deployed/herdr-worktree-identity.ts" bun "$root/run.ts"
+  assert_success
+  local calls
+  calls="$(find "$root" -mindepth 1 -maxdepth 1 -type d -name 'call-*' | wc -l | tr -d ' ')"
+  assert_equal "$calls" 2
+  run sh -c 'cat "$1"/call-*/stdin' _ "$root"
+  assert_success
+  assert_output --partial 'OpenCode stdin sentinel'
+  assert_output --partial 'Second OpenCode prompt'
+  run sh -c 'cat "$1"/call-*/argv' _ "$root"
+  assert_success
+  refute_output --partial 'OpenCode stdin sentinel'
+  refute_output --partial 'Second OpenCode prompt'
+  assert_output --partial 'opencode'
+  : > "$root/release"
+
+  run env HOME="$home" HERDR_ENV= HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" \
+    HWI_ADAPTER_TEST_DIR="$root/gated" HWI_OPENCODE_PLUGIN="$deployed/herdr-worktree-identity.ts" bun "$root/run.ts"
+  assert_success
+  assert_file_not_exists "$root/gated"
+  run env HOME="$home" HERDR_ENV=1 HERDR_WORKTREE_IDENTITY_ACTIVE=1 HERDR_WORKTREE_IDENTITY_ENGINE="$root/engine" \
+    HWI_ADAPTER_TEST_DIR="$root/reentry" HWI_OPENCODE_PLUGIN="$deployed/herdr-worktree-identity.ts" bun "$root/run.ts"
+  assert_success
+  assert_file_not_exists "$root/reentry"
+}

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -24,6 +24,9 @@ setup() {
   unset HERDR_CHILD_TEST_NOW_SEQ
   unset HERDR_CHILD_TEST_TAKEOVER_METADATA_PUBLISHED
   unset CHILD_REAP_PID
+  # U2 exercises authorization only. Do not let an installed local model CLI
+  # turn those fixtures into live naming requests now that U3 derives names.
+  export HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES=1
 }
 
 teardown() {
@@ -68,6 +71,7 @@ teardown() {
   fi
   [[ -n "${BATS_TEST_TMPFILE:-}" ]] && rm -f "$BATS_TEST_TMPFILE" || true
   [[ -n "${CHILD_STUB:-}" ]] && rm -rf "$CHILD_STUB" || true
+  unset HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES
 }
 
 # ===========================================
@@ -273,6 +277,105 @@ function test_scripts_1141_worktree_identity_foreground_hands_off_to_a_detached_
   assert_file_exists "$HWI_WORK/pane-get.ready"
   assert_file_not_contains "$HWI_WORK/herdr.calls" 'do not place this prompt on argv'
   : > "$HWI_WORK/pane-get.release"
+}
+
+# ===========================================
+# herdr-worktree-identity naming derivation (U3)
+# ===========================================
+
+hwi_write_naming_stub() {
+  local binary="$1"
+  cat > "$HWI_STUB/$binary" <<'SH'
+#!/usr/bin/env bash
+name="${0##*/}"
+printf '%s\n' "$*" >> "$HWI_WORK/$name.calls"
+printf '%s' "${HERDR_WORKTREE_IDENTITY_ACTIVE:-}" > "$HWI_WORK/$name.guard"
+cat > "$HWI_WORK/$name.stdin"
+cat "$HWI_WORK/$name.output"
+SH
+  chmod +x "$HWI_STUB/$binary"
+}
+
+function test_scripts_1142_worktree_identity_uses_normalized_multi_word_pi_identity() {
+  _bats_test_init 1142 'worktree identity uses a normalized multi-word pi identity'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_naming_stub pi
+  hwi_write_naming_stub claude
+  printf '%s\n' '{"title":"  Normalize API Tokens  ","slug":"Normalize API Tokens"}' > "$HWI_WORK/pi.output"
+  printf '%s\n' 'unexpected claude fallback' > "$HWI_WORK/claude.output"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES=0 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Normalize API tokens from model output'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" title)" 'Normalize API Tokens'
+  assert_equal "$(read_state_field "$state" slug)" normalize-api-tokens
+  assert_file_contains "$HWI_WORK/pi.stdin" 'First prompt of the session:'
+  assert_file_not_contains "$HWI_WORK/pi.calls" 'Normalize API tokens from model output'
+  assert_equal "$(cat "$HWI_WORK/pi.guard")" 1
+  assert_file_not_exists "$HWI_WORK/claude.calls"
+}
+
+function test_scripts_1143_worktree_identity_rejects_one_word_and_non_json_model_slugs() {
+  _bats_test_init 1143 'worktree identity falls back for one-word and non-JSON model slugs'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_naming_stub pi
+  hwi_write_naming_stub claude
+  printf '%s\n' '{"title":"JSON","slug":"json"}' > "$HWI_WORK/pi.output"
+  printf '%s\n' 'not JSON' > "$HWI_WORK/claude.output"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES=0 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'json'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" title)" 'Json generated'
+  assert_equal "$(read_state_field "$state" slug)" json-generated
+  assert_file_exists "$HWI_WORK/pi.calls"
+  assert_file_exists "$HWI_WORK/claude.calls"
+}
+
+function test_scripts_1144_worktree_identity_falls_back_without_model_clis_and_caps_slugs() {
+  _bats_test_init 1144 'worktree identity falls back without model CLIs and caps long slugs'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local minimal="$HWI_WORK/minimal"
+  mkdir "$minimal"
+  ln -s "$(command -v jq)" "$minimal/jq"
+  ln -s "$(command -v git)" "$minimal/git"
+
+  run env PATH="$HWI_STUB:$minimal:/usr/bin:/bin" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES=0 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'json'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" title)" 'Json generated'
+  assert_equal "$(read_state_field "$state" slug)" json-generated
+
+  rm "$state"
+  hwi_write_naming_stub pi
+  printf '%s\n' '{"title":"Long model identity","slug":"unusuallylongword-verylongsecondword-verylongthirdword-verylongfourthword-verylongfifthword"}' > "$HWI_WORK/pi.output"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_DISABLE_ENGINES=0 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'a different prompt'
+  assert_success
+  state="$(hwi_identity_state_path)"
+  local slug="$(read_state_field "$state" slug)"
+  assert_equal "$(read_state_field "$state" title)" 'Long model identity'
+  assert_equal "${#slug}" 40
+  run test "${slug%-}" = "$slug"
+  assert_success
+  run test "$(printf '%s' "$slug" | tr '-' '\n' | grep -c '.')" -ge 2
+  assert_success
 }
 
 # ===========================================

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -146,6 +146,136 @@ SH
 }
 
 # ===========================================
+# herdr-worktree-identity engine (U2)
+# ===========================================
+
+function test_scripts_1137_worktree_identity_authorizes_a_real_plugin_marker_and_reentry_after_rename() {
+  _bats_test_init 1137 'worktree identity authorizes the plugin marker after a real branch rename'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'name this task'
+  assert_success
+  local state marker
+  state="$(hwi_identity_state_path)"
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  assert_file_contains "$marker" "^$HWI_BRANCH$"
+  assert_equal "$(read_state_field "$state" original_branch)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" authorization)" authorized
+
+  git -C "$HWI_CHECKOUT" branch -m task-derived-name
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'name this task again'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" task-derived-name
+  assert_equal "$(read_state_field "$state" original_branch)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" authorization)" authorized
+}
+
+function test_scripts_1138_worktree_identity_declines_missing_or_mismatched_markers_without_ref_mutation() {
+  _bats_test_init 1138 'worktree identity declines absent and mismatched generated-worktree markers'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local marker before state diagnostics
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  rm "$marker"
+  before="$(git -C "$HWI_CHECKOUT" branch --show-current)"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'missing marker'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$before"
+  state="$(hwi_identity_state_path)"
+  diagnostics="${state%.state}.diagnostics.log"
+  assert_equal "$(read_state_field "$state" outcome)" declined
+  assert_file_contains "$diagnostics" 'reason=marker-missing .*checkout='
+
+  printf '%s\n' different-branch > "$marker"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'mismatched marker'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$before"
+  assert_file_contains "$diagnostics" 'reason=marker-mismatched .*marker_branch=different-branch'
+}
+
+function test_scripts_1139_worktree_identity_keeps_unresolved_events_retryable_and_prefers_reported_cwd() {
+  _bats_test_init 1139 'worktree identity records unresolved pane reads and prefers reported working directories'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  : > "$HWI_WORK/fail-pane-get"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'retry later'
+  assert_success
+  local unresolved="$HWI_STATE/sessions/$(printf '%s' session-1 | base64 | tr '/+' '_-' | tr -d '=\n').state"
+  assert_equal "$(read_state_field "$unresolved" outcome)" unresolved
+  assert_file_contains "${unresolved%.state}.diagnostics.log" 'reason=pane-unreachable'
+
+  rm "$HWI_WORK/fail-pane-get"
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_MAIN"
+  mkdir -p "$HWI_STATE/agent-cwd"
+  printf '%s\n' "$HWI_CHECKOUT" > "$HWI_STATE/agent-cwd/$(printf '%s' session-1 | base64 | tr '/+' '_-' | tr -d '=\n')"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'retry now'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" checkout_root)" "$(git -C "$HWI_CHECKOUT" rev-parse --show-toplevel)"
+  assert_equal "$(read_state_field "$state" authorization)" authorized
+}
+
+function test_scripts_1140_worktree_identity_declines_primary_checkouts_and_unmatched_sessions() {
+  _bats_test_init 1140 'worktree identity declines primary checkouts and records unmatched sessions as unresolved'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_MAIN"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'primary checkout'
+  assert_success
+  local state="$HWI_STATE/sessions/$(printf '%s' session-1 | base64 | tr '/+' '_-' | tr -d '=\n').state"
+  assert_equal "$(read_state_field "$state" outcome)" declined
+  assert_file_contains "${state%.state}.diagnostics.log" 'reason=primary-checkout .*checkout='
+
+  hwi_write_snapshot_without_match
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-2 --workspace workspace-1 <<< 'no pane for this session'
+  assert_success
+  state="$HWI_STATE/sessions/$(printf '%s' session-2 | base64 | tr '/+' '_-' | tr -d '=\n').state"
+  assert_equal "$(read_state_field "$state" outcome)" unresolved
+  assert_file_contains "${state%.state}.diagnostics.log" 'reason=pane-unresolved .*pane=missing'
+
+  hwi_write_pane pane-2 codex session-3 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_snapshot_from_pane
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-3 --workspace workspace-1 <<< 'resolve from snapshot'
+  assert_success
+  assert_equal "$(read_state_field "$(hwi_identity_state_path)" authorization)" authorized
+}
+
+function test_scripts_1141_worktree_identity_foreground_hands_off_to_a_detached_worker() {
+  _bats_test_init 1141 'worktree identity foreground hands prompt processing to a detached worker'
+  hwi_setup
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  : > "$HWI_WORK/block-pane-get"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'do not place this prompt on argv'
+  assert_success
+  local attempt=0
+  while [[ ! -e "$HWI_WORK/pane-get.ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$HWI_WORK/pane-get.ready"
+  assert_file_not_contains "$HWI_WORK/herdr.calls" 'do not place this prompt on argv'
+  : > "$HWI_WORK/pane-get.release"
+}
+
+# ===========================================
 # python3 -- the declared interpreter
 # ===========================================
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -90,33 +90,59 @@ function test_scripts_1134_worktree_identity_state_library_claims_live_owners_an
   run kill -0 "$HWI_HOLDER_PID"
   assert_success
 
+  local no_ps="$HWI_WORK/no-ps"
+  mkdir "$no_ps"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$no_ps/ps"
+  chmod +x "$no_ps/ps"
+  run env PATH="$no_ps:$PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash -c 'source "$1"; acquire_claim "$2" 1' _ "$HWI_STATE_LIBRARY" "$lock"
+  assert_failure 2
+  run kill -0 "$HWI_HOLDER_PID"
+  assert_success
+
   kill -KILL "$HWI_HOLDER_PID"
   wait "$HWI_HOLDER_PID" 2>/dev/null || true
   HWI_HOLDER_PID=""
   acquire_claim "$lock" 3 || fail 'dead owner claim was not recovered'
   owner="$claim_owner_id"
   release_claim "$lock" "$owner"
-  assert_dir_not_exists "$lock"
+  assert_file_not_exists "$lock"
 }
 
 function test_scripts_1135_worktree_identity_state_library_recovers_malformed_claims_and_distinguishes_errors() {
   _bats_test_init 1135 'worktree identity recovers malformed claims and distinguishes contention from errors'
   hwi_setup
   source "$HWI_STATE_LIBRARY"
-  local malformed="$HWI_STATE/malformed.claim" held="$HWI_STATE/held.claim"
-  mkdir -p "$malformed"
-  atomic_write "$malformed/owner" "owner_id=$(encode_value malformed-owner)
+  local malformed="$HWI_STATE/malformed.claim" interrupted="$HWI_STATE/interrupted.claim" held="$HWI_STATE/held.claim"
+  atomic_write "$malformed" "owner_id=$(encode_value malformed-owner)
 pid=$$
 process_start=$(encode_value '')"
 
   acquire_claim "$malformed" 3 || fail 'empty process-start claim was not recovered'
   release_claim "$malformed" "$claim_owner_id"
 
+  : > "${interrupted}.candidate.abandoned"
+  acquire_claim "$interrupted" 3 || fail 'interrupted owner write was not recovered'
+  release_claim "$interrupted" "$claim_owner_id"
+
   hwi_start_claim_holder "$held" || fail 'second process did not acquire its claim'
   run acquire_claim "$held" 1
   assert_failure 2
-  : > "$HWI_WORK/not-a-directory"
-  run acquire_claim "$HWI_WORK/not-a-directory" 1
+  mkdir "$HWI_WORK/not-a-claim"
+  run acquire_claim "$HWI_WORK/not-a-claim" 1
+  assert_failure 1
+
+  local no_ps="$HWI_WORK/no-ps" no_link="$HWI_WORK/no-link"
+  mkdir "$no_ps" "$no_link"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$no_ps/ps"
+  printf '%s\n' '#!/bin/sh' 'exit 1' > "$no_link/ln"
+  chmod +x "$no_ps/ps" "$no_link/ln"
+  run env PATH="$no_ps:$PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash -c 'source "$1"; acquire_claim "$2" 1' _ "$HWI_STATE_LIBRARY" "$HWI_STATE/no-token.claim"
+  assert_failure 1
+  assert_file_not_exists "$HWI_STATE/no-token.claim"
+  run env PATH="$no_link:$PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash -c 'source "$1"; acquire_claim "$2" 1' _ "$HWI_STATE_LIBRARY" "$HWI_STATE/no-link.claim"
   assert_failure 1
 }
 
@@ -221,14 +247,20 @@ function test_scripts_1139_worktree_identity_keeps_unresolved_events_retryable_a
 
   rm "$HWI_WORK/fail-pane-get"
   hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_MAIN"
-  mkdir -p "$HWI_STATE/agent-cwd"
-  printf '%s\n' "$HWI_CHECKOUT" > "$HWI_STATE/agent-cwd/$(printf '%s' session-1 | base64 | tr '/+' '_-' | tr -d '=\n')"
+  local statusline="$SOURCE_ROOT/private_dot_claude/hooks/executable_statusline.sh" input
+  input="$(jq -nc --arg dir "$HWI_CHECKOUT" --arg session session-1 \
+    '{workspace:{current_dir:$dir},session_id:$session}')"
+  run env HOME="$HWI_WORK/home" HERDR_ENV=1 HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_STATE_LIBRARY="$HWI_STATE_LIBRARY" \
+    bash "$statusline" <<< "$input"
+  assert_success
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'retry now'
   assert_success
   local state="$(hwi_identity_state_path)"
   assert_equal "$(read_state_field "$state" checkout_root)" "$(git -C "$HWI_CHECKOUT" rev-parse --show-toplevel)"
   assert_equal "$(read_state_field "$state" authorization)" authorized
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" retry-later
 }
 
 function test_scripts_1140_worktree_identity_declines_primary_checkouts_and_unmatched_sessions() {
@@ -269,6 +301,10 @@ function test_scripts_1141_worktree_identity_foreground_hands_off_to_a_detached_
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'do not place this prompt on argv'
   assert_success
+  run find "$HWI_STATE/first-prompts" -type f
+  assert_success
+  local prompt_record="$output"
+  assert_file_contains "$prompt_record" '^do not place this prompt on argv$'
   local attempt=0
   while [[ ! -e "$HWI_WORK/pane-get.ready" && "$attempt" -lt 3000 ]]; do
     attempt=$((attempt + 1))
@@ -514,44 +550,40 @@ function test_scripts_1184_worktree_identity_serializes_branch_mutation_with_a_b
   source "$HWI_STATE_LIBRARY"
   hwi_create_generated_worktree
   hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
-  local barrier="$HWI_WORK/branch-barrier" start_release="$HWI_WORK/start.release"
-  local claim_ready="$HWI_WORK/claim.ready" claim_release="$HWI_WORK/claim.release" contended_ready="$HWI_WORK/contended.ready"
-  mkdir "$barrier"
-  local worker_env=(PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
-    HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER="$barrier" \
-    HERDR_WORKTREE_IDENTITY_TEST_BRANCH_BARRIER_RELEASE="$start_release" \
-    HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_READY="$claim_ready" \
-    HERDR_WORKTREE_IDENTITY_TEST_REPOSITORY_CLAIM_RELEASE="$claim_release" \
-    HERDR_WORKTREE_IDENTITY_TEST_CONTENDED_READY="$contended_ready")
-  env "${worker_env[@]}" bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize branch mutation' &
+  local ready="$HWI_WORK/lifecycle.ready" release="$HWI_WORK/lifecycle.release" attempt_ready="$HWI_WORK/lifecycle-attempt.ready"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize branch mutation' &
   local first_pid=$!
-  env "${worker_env[@]}" bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize branch mutation' &
-  local second_pid=$! attempt=0
-  while [[ "$(find "$barrier" -type f | wc -l | tr -d ' ')" -lt 2 && "$attempt" -lt 3000 ]]; do
+  local attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
     attempt=$((attempt + 1))
     sleep 0.01
   done
-  assert_equal "$(find "$barrier" -type f | wc -l | tr -d ' ')" 2
-  : > "$start_release"
+  assert_file_exists "$ready"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_ATTEMPT_READY="$attempt_ready" \
+    HERDR_WORKTREE_IDENTITY_LIFECYCLE_CLAIM_ATTEMPTS=1 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later conflicting prompt' &
+  local second_pid=$!
   attempt=0
-  while [[ ! -e "$claim_ready" && "$attempt" -lt 3000 ]]; do
+  while [[ ! -e "$attempt_ready" && "$attempt" -lt 3000 ]]; do
     attempt=$((attempt + 1))
     sleep 0.01
   done
-  assert_file_exists "$claim_ready"
-  attempt=0
-  while [[ ! -e "$contended_ready" && "$attempt" -lt 3000 ]]; do
-    attempt=$((attempt + 1))
-    sleep 0.01
-  done
-  assert_file_exists "$contended_ready"
-  : > "$claim_release"
-  wait "$first_pid"
+  assert_file_exists "$attempt_ready"
   wait "$second_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(hwi_workspace_rename_count)" 0
+  assert_file_contains "$(hwi_identity_state_path | sed 's/\.state$/.diagnostics.log/')" '^reason=lifecycle-contended '
+  : > "$release"
+  wait "$first_pid"
   local branch="$(git -C "$HWI_CHECKOUT" branch --show-current)" state="$(hwi_identity_state_path)"
   assert_equal "$branch" serialize-branch-mutation
   assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$branch" | grep -c '^Branch: renamed ')" 1
-  assert_file_contains "${state%.state}.diagnostics.log" '^reason=contended '
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 1
 }
 
 function test_scripts_1185_worktree_identity_recovers_marker_attribution_after_write_failure() {
@@ -618,12 +650,18 @@ function test_scripts_1187_worktree_identity_labels_workspace_only_for_upstream_
   hwi_create_generated_worktree
   hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
   hwi_set_upstream
+  : > "$HWI_WORK/fail-workspace-rename"
 
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Preserve upstream workspace'
   assert_success
   local state="$(hwi_identity_state_path)"
   assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-failed
+  rm "$HWI_WORK/fail-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event retries upstream workspace'
+  assert_success
   assert_equal "$(read_state_field "$state" outcome)" workspace-only
   assert_equal "$(cat "$HWI_WORK/workspace.label")" 'Preserve upstream workspace'
 
@@ -641,9 +679,431 @@ function test_scripts_1187_worktree_identity_labels_workspace_only_for_upstream_
   assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
   assert_equal "$(read_state_field "$state" outcome)" workspace-only
   assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$HWI_BRANCH" | grep -c '^Branch: renamed ')" 2
-  assert_equal "$(hwi_workspace_rename_count)" 2
-  assert_file_not_contains "$HWI_WORK/herdr.calls" '^(pane|tab|agent) rename '
+  assert_equal "$(hwi_workspace_rename_count)" 3
+  assert_file_not_contains "$HWI_WORK/herdr.calls" 'pane rename '
+  assert_file_not_contains "$HWI_WORK/herdr.calls" 'tab rename '
+  assert_file_not_contains "$HWI_WORK/herdr.calls" 'agent rename '
   [ -n "$renamed" ] || fail 'control rename did not occur'
+}
+
+function test_scripts_1190_worktree_identity_revalidates_marker_before_ref_mutation() {
+  _bats_test_init 1190 'worktree identity requires its marker immediately before ref mutation'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local ready="$HWI_WORK/revalidate.ready" release="$HWI_WORK/revalidate.release" marker state
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  state="$(hwi_identity_state_path)"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 \
+    <<< 'Require live marker' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  rm "$marker"
+  : > "$release"
+  wait "$worker_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=marker-missing-before-rename '
+}
+
+function test_scripts_1191_worktree_identity_recovers_a_prepared_rename() {
+  _bats_test_init 1191 'worktree identity recovers a prepared rename before completing the workspace'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local common state
+  common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
+  state="$(hwi_identity_state_path)"
+  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
+repository_anchor=$(encode_value "$common")
+workspace=$(encode_value workspace-1)
+original_branch=$(encode_value "$HWI_BRANCH")
+branch=$(encode_value recover-prepared-rename)
+outcome=$(encode_value prepared)
+authorization=$(encode_value authorized)
+title=$(encode_value 'Recover prepared rename')
+slug=$(encode_value recover-prepared-rename)"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" recover-prepared-rename
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1192_worktree_identity_serializes_workspace_label_retries() {
+  _bats_test_init 1192 'worktree identity issues one workspace retry when concurrent workers observe workspace-failed'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  : > "$HWI_WORK/fail-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Serialize workspace retry'
+  assert_success
+  local state="$(hwi_identity_state_path)" ready="$HWI_WORK/lifecycle.ready" release="$HWI_WORK/lifecycle.release"
+  local attempt_ready="$HWI_WORK/lifecycle-attempt.ready"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-failed
+  rm "$HWI_WORK/fail-workspace-rename"
+
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event' &
+  local first_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 500 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_LIFECYCLE_ATTEMPT_READY="$attempt_ready" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Another event' &
+  local second_pid=$! attempt=0
+  while [[ ! -e "$attempt_ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$attempt_ready"
+  : > "$release"
+  wait "$first_pid"
+  wait "$second_pid"
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 2
+}
+
+function test_scripts_1193_worktree_identity_labels_after_revert_from_attribution_failure() {
+  _bats_test_init 1193 'worktree identity labels workspace-only after an agent reverts an attribution failure'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_git_proxy
+  : > "$HWI_WORK/fail-git-description"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Revert failed attribution'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" attribution_failed
+  git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
+  rm "$HWI_WORK/fail-git-description"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1194_worktree_identity_bounds_herdr_pane_reads() {
+  _bats_test_init 1194 'worktree identity turns a blocked Herdr pane read into retryable unresolved state'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  : > "$HWI_WORK/block-pane-get"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_HERDR_TIMEOUT=1 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Bound pane read'
+  assert_success
+  assert_file_exists "$HWI_WORK/pane-get.ready"
+  local state="$HWI_STATE/sessions/$(encode_key session-1).state"
+  assert_equal "$(read_state_field "$state" outcome)" unresolved
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=pane-unreachable '
+}
+
+function test_scripts_1195_worktree_identity_rejects_marker_owner_changes_before_ref_mutation() {
+  _bats_test_init 1195 'worktree identity rejects a changed marker immediately before ref mutation'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local ready="$HWI_WORK/revalidate.ready" release="$HWI_WORK/revalidate.release" marker state
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  state="$(hwi_identity_state_path)"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_REVALIDATE_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 \
+    <<< 'Require matching marker' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  printf '%s\n' another-owner > "$marker"
+  : > "$release"
+  wait "$worker_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(hwi_workspace_rename_count)" 0
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=marker-mismatched-before-rename '
+}
+
+function test_scripts_1196_worktree_identity_recovers_prepared_attribution_after_ref_mutation() {
+  _bats_test_init 1196 'worktree identity completes attribution when prepared HEAD already moved'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local common state marker branch=recover-prepared-attribution
+  common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
+  state="$(hwi_identity_state_path)"
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
+repository_anchor=$(encode_value "$common")
+workspace=$(encode_value workspace-1)
+original_branch=$(encode_value "$HWI_BRANCH")
+branch=$(encode_value "$branch")
+outcome=$(encode_value prepared)
+authorization=$(encode_value authorized)
+title=$(encode_value 'Recover prepared attribution')
+slug=$(encode_value recover-prepared-attribution)"
+  git -C "$HWI_CHECKOUT" branch -m "$branch"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_file_contains "$marker" "^Intentional rename by herdr-worktree-identity: $HWI_BRANCH -> $branch$"
+  assert_equal "$(hwi_branch_description "$branch")" "Intentional rename by herdr-worktree-identity: $HWI_BRANCH -> $branch"
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1197_worktree_identity_does_not_repeat_a_rename_after_workspace_failure() {
+  _bats_test_init 1197 'worktree identity preserves an agent revert after workspace failure'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  : > "$HWI_WORK/fail-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Preserve workspace failure revert'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-failed
+  git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
+  rm "$HWI_WORK/fail-workspace-rename"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(hwi_workspace_rename_count)" 2
+}
+
+function test_scripts_1198_worktree_identity_treats_a_prepared_revert_as_agent_owned() {
+  _bats_test_init 1198 'worktree identity does not repeat a prepared rename after an agent revert'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local common state candidate=prepared-agent-revert
+  common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
+  state="$(hwi_identity_state_path)"
+  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
+repository_anchor=$(encode_value "$common")
+workspace=$(encode_value workspace-1)
+original_branch=$(encode_value "$HWI_BRANCH")
+branch=$(encode_value "$candidate")
+outcome=$(encode_value prepared)
+authorization=$(encode_value authorized)
+title=$(encode_value 'Prepared agent revert')
+slug=$(encode_value prepared-agent-revert)"
+  git -C "$HWI_CHECKOUT" branch -m "$candidate"
+  git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(git -C "$HWI_CHECKOUT" reflog --format='%gs' "$HWI_BRANCH" | grep -c '^Branch: renamed ')" 2
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1199_worktree_identity_treats_a_prepared_branch_move_as_agent_owned() {
+  _bats_test_init 1199 'worktree identity labels after an agent moves a prepared candidate elsewhere'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local common state candidate=prepared-candidate-move
+  common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
+  state="$(hwi_identity_state_path)"
+  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
+repository_anchor=$(encode_value "$common")
+workspace=$(encode_value workspace-1)
+original_branch=$(encode_value "$HWI_BRANCH")
+branch=$(encode_value "$candidate")
+outcome=$(encode_value prepared)
+authorization=$(encode_value authorized)
+title=$(encode_value 'Prepared candidate move')
+slug=$(encode_value prepared-candidate-move)"
+  git -C "$HWI_CHECKOUT" branch -m "$candidate"
+  git -C "$HWI_CHECKOUT" branch -m agent-owned-after-prepare
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" agent-owned-after-prepare
+  assert_equal "$(read_state_field "$state" outcome)" workspace-only
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1200_worktree_identity_revalidates_after_prepared_state_persistence() {
+  _bats_test_init 1200 'worktree identity revalidates marker ownership after persisting prepared state'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local ready="$HWI_WORK/prepared.ready" release="$HWI_WORK/prepared.release" marker state
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  state="$(hwi_identity_state_path)"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_PREPARED_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_PREPARED_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Revalidate after prepare' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  rm "$marker"
+  : > "$release"
+  wait "$worker_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(hwi_workspace_rename_count)" 0
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=marker-missing-at-commit '
+}
+
+function test_scripts_1201_worktree_identity_reconciles_a_persist_failed_workspace_rename() {
+  _bats_test_init 1201 'worktree identity reconciles workspace success without repeating the external rename'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_mv_proxy
+  : > "$HWI_WORK/fail-terminal-state-write"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Reconcile workspace persistence'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-prepared
+  assert_equal "$(hwi_workspace_rename_count)" 1
+  rm "$HWI_WORK/fail-terminal-state-write"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1202_worktree_identity_rejects_marker_owner_changes_at_commit() {
+  _bats_test_init 1202 'worktree identity rejects changed marker ownership after persisting prepared state'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  local ready="$HWI_WORK/prepared.ready" release="$HWI_WORK/prepared.release" marker state
+  marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
+  state="$(hwi_identity_state_path)"
+  env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_TEST_PREPARED_READY="$ready" \
+    HERDR_WORKTREE_IDENTITY_TEST_PREPARED_RELEASE="$release" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Revalidate changed owner at commit' &
+  local worker_pid=$! attempt=0
+  while [[ ! -e "$ready" && "$attempt" -lt 3000 ]]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$ready"
+  printf '%s\n' another-owner > "$marker"
+  : > "$release"
+  wait "$worker_pid"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" "$HWI_BRANCH"
+  assert_equal "$(hwi_workspace_rename_count)" 0
+  assert_file_contains "${state%.state}.diagnostics.log" '^reason=marker-mismatched-at-commit '
+}
+
+function test_scripts_1203_worktree_identity_retries_a_nonmatching_prepared_workspace() {
+  _bats_test_init 1203 'worktree identity retries one workspace rename when reconciliation finds another label'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  hwi_write_mv_proxy
+  : > "$HWI_WORK/fail-terminal-state-write"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Retry nonmatching workspace'
+  assert_success
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" workspace-prepared
+  printf '%s' manual-label > "$HWI_WORK/workspace.label"
+  rm "$HWI_WORK/fail-terminal-state-write"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(cat "$HWI_WORK/workspace.label")" 'Retry nonmatching workspace'
+  assert_equal "$(hwi_workspace_rename_count)" 2
+}
+
+function test_scripts_1204_worktree_identity_reconciles_an_ambiguous_workspace_timeout() {
+  _bats_test_init 1204 'worktree identity reconciles a workspace rename committed before timeout'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  : > "$HWI_WORK/commit-then-block-workspace-rename"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_HERDR_TIMEOUT=1 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Reconcile timeout commit'
+  assert_success
+  assert_file_exists "$HWI_WORK/workspace-rename.ready"
+  local state="$(hwi_identity_state_path)"
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 1
+  rm "$HWI_WORK/commit-then-block-workspace-rename"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" complete
+  assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1205_worktree_identity_timeout_kills_term_ignoring_descendants() {
+  _bats_test_init 1205 'worktree identity timeout kills a Herdr process group with a TERM-ignoring descendant'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  : > "$HWI_WORK/block-pane-get-with-descendant"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_HERDR_TIMEOUT=1 \
+    bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Kill blocked descendants'
+  assert_success
+  assert_file_exists "$HWI_WORK/pane-child.pid"
+  local child_pid="$(cat "$HWI_WORK/pane-child.pid")" attempt=0
+  while kill -0 "$child_pid" 2>/dev/null && [ "$attempt" -lt 100 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  run kill -0 "$child_pid"
+  assert_failure
+  local state="$HWI_STATE/sessions/$(encode_key session-1).state"
+  assert_equal "$(read_state_field "$state" outcome)" unresolved
 }
 
 function test_scripts_1188_worktree_identity_declines_marker_and_retries_contention_and_workspace_failure() {
@@ -6800,7 +7260,7 @@ function test_scripts_258_herdr_child_descriptor_probe_passes_under_a_nes() {
   run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
   assert_success
   # Bashunit abbreviates long titles to the terminal width in Docker panes.
-  assert_output --partial "Passed: herdr-child detached watcher closes launcher desc"
+  assert_output --partial "All tests passed"
 }
 
 # Guards the local patch in the pinned runner itself ('Local patch vs upstream

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -925,7 +925,7 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
   # Pane and tab identity stay stable when Git state changes. Location metadata
   # remains available to integrations, but the sidebar renders identity only.
-  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace", "pane"\]\]$'
+  assert_file_contains "$config" '^rows = \[\["state_icon", "workspace"\], \["pane"\]\]$'
   run grep -E '\$git_ref|\$location_label|\$location_status' "$config"
   assert_failure
   # Sole owner of sidebar_min_width: the awk scope proves the key both carries
@@ -957,7 +957,7 @@ assert_herdr_sidebar_deployment_contract() {
   run grep -hEi 'state_icon|(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
     "$config" "${writer_files[@]}"
   assert_success
-  assert_file_contains "$config" 'rows = \[\["state_icon", "workspace", "pane"\]\]'
+  assert_file_contains "$config" 'rows = \[\["state_icon", "workspace"\], \["pane"\]\]'
   assert_file_contains "$config" '"state_icon"'
   # The engine builds the five codicon glyphs of the $git_ref grammar from
   # bash 3.2-safe octal printf sequences. Raw PUA glyphs are easily lost when

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -866,6 +866,27 @@ PY
   assert_success
 }
 
+function test_smoke_1063_worktree_identity_deploys_and_statusline_records_() {
+  _bats_test_init 1063 'worktree identity deploys and Claude statusline records its cwd'
+  local engine="$HOME/.local/bin/herdr-worktree-identity"
+  local library="$HOME/.local/lib/herdr-worktree-state.sh"
+  local hook="$HOME/.claude/hooks/statusline.sh"
+  local record_home="$BATS_TEST_TMPDIR/statusline-record-home"
+  local session='statusline-cwd-session'
+  local input
+
+  assert_file_executable "$engine"
+  assert_file_exists "$library"
+  assert_file_executable "$hook"
+  input="$(jq -nc --arg dir "$BATS_TEST_TMPDIR" --arg session "$session" \
+    '{workspace: {current_dir: $dir}, session_id: $session}')"
+
+  run env HOME="$record_home" HERDR_ENV=1 bash "$hook" <<< "$input"
+  assert_success
+  assert_file_contains "$record_home/.cache/herdr-worktree-identity/agent-cwd/$session" "^$BATS_TEST_TMPDIR$"
+  assert_file_not_exists "$record_home/.cache/herdr-task-sync/agent-cwd/$session"
+}
+
 function test_smoke_1055_pi_local_private_instructions_focused_tests_pass() {
   _bats_test_init 1055 'Pi local private instructions focused tests pass'
   run env PI_AGENTS_LOCAL_EXTENSION_PATH="$HOME/.pi/agent/extensions/agents-local.ts" \

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -881,9 +881,12 @@ function test_smoke_1063_worktree_identity_deploys_and_statusline_records_() {
   input="$(jq -nc --arg dir "$BATS_TEST_TMPDIR" --arg session "$session" \
     '{workspace: {current_dir: $dir}, session_id: $session}')"
 
-  run env HOME="$record_home" HERDR_ENV=1 bash "$hook" <<< "$input"
+  run env HOME="$record_home" HERDR_ENV=1 HERDR_WORKTREE_IDENTITY_STATE_LIBRARY="$library" bash "$hook" <<< "$input"
   assert_success
-  assert_file_contains "$record_home/.cache/herdr-worktree-identity/agent-cwd/$session" "^$BATS_TEST_TMPDIR$"
+  run find "$record_home/.cache/herdr-worktree-identity/agent-cwd" -type f
+  assert_success
+  local record="$output"
+  assert_file_contains "$record" "^$BATS_TEST_TMPDIR$"
   assert_file_not_exists "$record_home/.cache/herdr-task-sync/agent-cwd/$session"
 }
 

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -271,15 +271,18 @@ function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
 # ===========================================
 # private_settings.json.tmpl retirement contract
 # ===========================================
-function test_templates_0151_private_settings_omits_task_sync_hooks() {
-  _bats_test_init 151 'private_settings.json.tmpl omits task-sync hooks and keeps native Herdr state'
+function test_templates_0151_private_settings_registers_worktree_identity_prompt_hook() {
+  _bats_test_init 151 'private settings register the worktree identity prompt hook and omit task sync'
   BATS_TEST_TMPFILE="$(mktemp)"
   render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
-  run grep "herdr-task-sync-hook.sh" "$BATS_TEST_TMPFILE"
-  assert_failure
-  run grep -c "herdr-agent-state.sh" "$BATS_TEST_TMPFILE"
+  run jq -r '.hooks.UserPromptSubmit[]?.hooks[]?.command' "$BATS_TEST_TMPFILE"
   assert_success
-  assert_output "1"
+  assert_output --partial 'herdr-worktree-identity-hook.sh'
+  run jq -e '[.hooks.UserPromptSubmit[]?.hooks[]?.command] | any(contains("herdr-task-sync-hook.sh")) | not' "$BATS_TEST_TMPFILE"
+  assert_success
+  run jq -r '.hooks.SessionStart[]?.hooks[]?.command' "$BATS_TEST_TMPFILE"
+  assert_success
+  assert_output --partial 'herdr-agent-state.sh'
 }
 
 # ===========================================

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -1,0 +1,49 @@
+# Herdr worktree-identity harness. Load after helpers/common.
+
+HWI_STATE_LIBRARY="$SOURCE_ROOT/dot_local/lib/herdr-worktree-state.sh"
+export HWI_STATE_LIBRARY
+
+hwi_setup() {
+  HWI_WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/hwi.XXXXXX")"
+  HWI_STATE="$HWI_WORK/state"
+  HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE"
+  mkdir -p "$HWI_STATE"
+  export HWI_WORK HWI_STATE HERDR_WORKTREE_IDENTITY_STATE_DIR
+}
+
+# A separate Bash process holds a real claim until the caller releases it.
+# The ready marker is a causal barrier; the bounded loop below is only a hang
+# guard, never the assertion about contention.
+hwi_start_claim_holder() {
+  local lock="$1" attempt=0
+  HWI_HOLDER_READY="$HWI_WORK/claim-holder.ready"
+  HWI_HOLDER_RELEASE="$HWI_WORK/claim-holder.release"
+  HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" bash -c '
+    source "$1"
+    acquire_claim "$2" 1 || exit 1
+    printf "%s\\n" "$claim_owner_id" > "$3"
+    while [ ! -e "$4" ]; do sleep 0.01; done
+    release_claim "$2" "$claim_owner_id"
+  ' _ "$HWI_STATE_LIBRARY" "$lock" "$HWI_HOLDER_READY" "$HWI_HOLDER_RELEASE" &
+  HWI_HOLDER_PID=$!
+  while [[ ! -e "$HWI_HOLDER_READY" && "$attempt" -lt 3000 ]]; do
+    if ! kill -0 "$HWI_HOLDER_PID" 2>/dev/null; then
+      wait "$HWI_HOLDER_PID" 2>/dev/null || true
+      return 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  [[ -e "$HWI_HOLDER_READY" ]] || return 1
+}
+
+hwi_teardown() {
+  if [[ -n "${HWI_HOLDER_PID:-}" ]]; then
+    [[ -z "${HWI_HOLDER_RELEASE:-}" ]] || : > "$HWI_HOLDER_RELEASE" 2>/dev/null || true
+    kill "$HWI_HOLDER_PID" 2>/dev/null || true
+    wait "$HWI_HOLDER_PID" 2>/dev/null || true
+  fi
+  [[ -n "${HWI_WORK:-}" ]] && rm -rf "$HWI_WORK" || true
+  unset HWI_WORK HWI_STATE HWI_HOLDER_PID HWI_HOLDER_READY HWI_HOLDER_RELEASE
+  unset HERDR_WORKTREE_IDENTITY_STATE_DIR
+}

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -2,13 +2,93 @@
 
 HWI_STATE_LIBRARY="$SOURCE_ROOT/dot_local/lib/herdr-worktree-state.sh"
 export HWI_STATE_LIBRARY
+HWI_ENGINE="$SOURCE_ROOT/dot_local/bin/executable_herdr-worktree-identity"
+HWI_WORKTREE_SETUP_PLUGIN="$SOURCE_ROOT/private_dot_config/herdr/plugins/worktree-setup/setup.ts"
+export HWI_ENGINE HWI_WORKTREE_SETUP_PLUGIN
 
 hwi_setup() {
   HWI_WORK="$(mktemp -d "${BATS_TMPDIR:-/tmp}/hwi.XXXXXX")"
   HWI_STATE="$HWI_WORK/state"
+  HWI_STUB="$HWI_WORK/stub"
+  HWI_PANE_JSON="$HWI_WORK/pane.json"
+  HWI_SNAPSHOT_JSON="$HWI_WORK/snapshot.json"
+  HWI_COMMAND_PATH="$PATH"
   HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE"
-  mkdir -p "$HWI_STATE"
-  export HWI_WORK HWI_STATE HERDR_WORKTREE_IDENTITY_STATE_DIR
+  mkdir -p "$HWI_STATE" "$HWI_STUB"
+  export HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH
+  export HERDR_WORKTREE_IDENTITY_STATE_DIR
+  cat > "$HWI_STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = pane ] && [ "$2" = get ]; then
+  printf '%s\n' "$*" >> "$HWI_WORK/herdr.calls"
+  [ ! -e "$HWI_WORK/fail-pane-get" ] || exit 1
+  if [ -e "$HWI_WORK/block-pane-get" ]; then
+    : > "$HWI_WORK/pane-get.ready"
+    while [ ! -e "$HWI_WORK/pane-get.release" ]; do sleep 0.01; done
+  fi
+  cat "$HWI_PANE_JSON"
+  exit 0
+fi
+if [ "$1" = api ] && [ "$2" = snapshot ]; then
+  [ ! -e "$HWI_WORK/fail-snapshot" ] || exit 1
+  cat "$HWI_SNAPSHOT_JSON"
+  exit 0
+fi
+exit 1
+SH
+  chmod +x "$HWI_STUB/herdr"
+}
+
+hwi_write_pane() {
+  local pane="$1" agent="$2" session="$3" workspace="$4" cwd="$5"
+  jq -cn --arg pane "$pane" --arg agent "$agent" --arg session "$session" \
+    --arg workspace "$workspace" --arg cwd "$cwd" \
+    '{result:{pane:{pane_id:$pane,agent:$agent,agent_session:{value:$session},workspace_id:$workspace,cwd:$cwd}}}' \
+    > "$HWI_PANE_JSON"
+}
+
+hwi_write_snapshot_without_match() {
+  printf '%s\n' '{"result":{"snapshot":{"panes":[]}}}' > "$HWI_SNAPSHOT_JSON"
+}
+
+hwi_write_snapshot_from_pane() {
+  jq '{result:{snapshot:{panes:[.result.pane]}}}' "$HWI_PANE_JSON" > "$HWI_SNAPSHOT_JSON"
+}
+
+# Build a linked worktree and invoke the production plugin path that creates
+# the authorization marker. Tests must not synthesize that marker themselves.
+hwi_create_generated_worktree() {
+  local root="$HWI_WORK/repository" main="$HWI_WORK/repository/main"
+  HWI_MAIN="$main"
+  HWI_CHECKOUT="$root/generated"
+  HWI_BRANCH="worktree/quiet-stone-fd75"
+  HWI_PLUGIN_CONFIG="$HWI_WORK/plugin-config"
+  mkdir -p "$main" "$HWI_PLUGIN_CONFIG"
+  git -C "$main" init --quiet -b main
+  git -C "$main" config user.email test@example.com
+  git -C "$main" config user.name 'Test User'
+  printf '%s\n' tracked > "$main/tracked"
+  git -C "$main" add tracked
+  git -C "$main" commit --quiet -m initial
+  git -C "$main" remote add origin https://github.com/example/repository.git
+  git -C "$main" worktree add --quiet -b "$HWI_BRANCH" "$HWI_CHECKOUT"
+  cat > "$HWI_PLUGIN_CONFIG/config.toml" <<'TOML'
+[projects."github.com/example/repository"]
+fresh-base = false
+TOML
+  HERDR_PLUGIN_CONFIG_DIR="$HWI_PLUGIN_CONFIG" \
+    HERDR_PLUGIN_EVENT_JSON="{\"data\":{\"worktree\":{\"path\":\"$HWI_CHECKOUT\",\"branch\":\"$HWI_BRANCH\"}}}" \
+    bun "$HWI_WORKTREE_SETUP_PLUGIN" >/dev/null
+  export HWI_MAIN HWI_CHECKOUT HWI_BRANCH HWI_PLUGIN_CONFIG
+}
+
+hwi_identity_state_path() {
+  local root common
+  root="$(git -C "$HWI_CHECKOUT" rev-parse --show-toplevel)" || return 1
+  common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)" || return 1
+  printf '%s/repositories/%s/worktrees/%s.state' "$HWI_STATE" \
+    "$(printf '%s' "$common" | base64 | tr '/+' '_-' | tr -d '=\n')" \
+    "$(printf '%s' "$root" | base64 | tr '/+' '_-' | tr -d '=\n')"
 }
 
 # A separate Bash process holds a real claim until the caller releases it.
@@ -44,6 +124,7 @@ hwi_teardown() {
     wait "$HWI_HOLDER_PID" 2>/dev/null || true
   fi
   [[ -n "${HWI_WORK:-}" ]] && rm -rf "$HWI_WORK" || true
-  unset HWI_WORK HWI_STATE HWI_HOLDER_PID HWI_HOLDER_READY HWI_HOLDER_RELEASE
+  unset HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_MAIN
+  unset HWI_CHECKOUT HWI_BRANCH HWI_PLUGIN_CONFIG HWI_HOLDER_PID HWI_HOLDER_READY HWI_HOLDER_RELEASE
   unset HERDR_WORKTREE_IDENTITY_STATE_DIR
 }

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -13,9 +13,10 @@ hwi_setup() {
   HWI_PANE_JSON="$HWI_WORK/pane.json"
   HWI_SNAPSHOT_JSON="$HWI_WORK/snapshot.json"
   HWI_COMMAND_PATH="$PATH"
+  HWI_REAL_GIT="$(command -v git)"
   HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE"
   mkdir -p "$HWI_STATE" "$HWI_STUB"
-  export HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH
+  export HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT
   export HERDR_WORKTREE_IDENTITY_STATE_DIR
   cat > "$HWI_STUB/herdr" <<'SH'
 #!/usr/bin/env bash
@@ -91,6 +92,35 @@ hwi_identity_state_path() {
     "$(printf '%s' "$root" | base64 | tr '/+' '_-' | tr -d '=\n')"
 }
 
+hwi_branch_description() {
+  local branch="${1:-$(git -C "$HWI_CHECKOUT" branch --show-current)}"
+  git -C "$HWI_CHECKOUT" config --get "branch.$branch.description"
+}
+
+hwi_set_upstream() {
+  git -C "$HWI_MAIN" update-ref refs/remotes/origin/main HEAD
+  git -C "$HWI_CHECKOUT" branch --set-upstream-to=origin/main "$HWI_BRANCH"
+}
+
+hwi_add_remote_tracking_branch() {
+  git -C "$HWI_MAIN" update-ref "refs/remotes/origin/$1" HEAD
+}
+
+hwi_write_git_proxy() {
+  cat > "$HWI_STUB/git" <<'SH'
+#!/usr/bin/env bash
+args=" $* "
+if [ -e "$HWI_WORK/fail-git-branch-m" ] && [[ "$args" == *' branch -m '* ]]; then
+  exit 1
+fi
+if [ -e "$HWI_WORK/fail-git-description" ] && [[ "$args" == *' config '* ]] && [[ "$args" == *'.description '* ]]; then
+  exit 1
+fi
+exec "$HWI_REAL_GIT" "$@"
+SH
+  chmod +x "$HWI_STUB/git"
+}
+
 # A separate Bash process holds a real claim until the caller releases it.
 # The ready marker is a causal barrier; the bounded loop below is only a hang
 # guard, never the assertion about contention.
@@ -124,7 +154,7 @@ hwi_teardown() {
     wait "$HWI_HOLDER_PID" 2>/dev/null || true
   fi
   [[ -n "${HWI_WORK:-}" ]] && rm -rf "$HWI_WORK" || true
-  unset HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_MAIN
+  unset HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT HWI_MAIN
   unset HWI_CHECKOUT HWI_BRANCH HWI_PLUGIN_CONFIG HWI_HOLDER_PID HWI_HOLDER_READY HWI_HOLDER_RELEASE
   unset HERDR_WORKTREE_IDENTITY_STATE_DIR
 }

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -14,15 +14,22 @@ hwi_setup() {
   HWI_SNAPSHOT_JSON="$HWI_WORK/snapshot.json"
   HWI_COMMAND_PATH="$PATH"
   HWI_REAL_GIT="$(command -v git)"
+  HWI_REAL_MV="$(command -v mv)"
   HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE"
   mkdir -p "$HWI_STATE" "$HWI_STUB"
-  export HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT
+  export HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT HWI_REAL_MV
   export HERDR_WORKTREE_IDENTITY_STATE_DIR
   cat > "$HWI_STUB/herdr" <<'SH'
 #!/usr/bin/env bash
 if [ "$1" = pane ] && [ "$2" = get ]; then
   printf '%s\n' "$*" >> "$HWI_WORK/herdr.calls"
   [ ! -e "$HWI_WORK/fail-pane-get" ] || exit 1
+  if [ -e "$HWI_WORK/block-pane-get-with-descendant" ]; then
+    bash -c 'trap "" TERM; printf "%s\n" "$$" > "$HWI_WORK/pane-child.pid"; while :; do sleep 1; done' &
+    trap 'exit 0' TERM
+    : > "$HWI_WORK/pane-get.ready"
+    wait
+  fi
   if [ -e "$HWI_WORK/block-pane-get" ]; then
     : > "$HWI_WORK/pane-get.ready"
     while [ ! -e "$HWI_WORK/pane-get.release" ]; do sleep 0.01; done
@@ -39,6 +46,16 @@ if [ "$1" = workspace ] && [ "$2" = rename ]; then
   printf '%s\n' "$*" >> "$HWI_WORK/herdr.calls"
   [ ! -e "$HWI_WORK/fail-workspace-rename" ] || exit 1
   printf '%s' "$4" > "$HWI_WORK/workspace.label"
+  if [ -e "$HWI_WORK/commit-then-block-workspace-rename" ]; then
+    : > "$HWI_WORK/workspace-rename.ready"
+    while [ ! -e "$HWI_WORK/workspace-rename.release" ]; do sleep 0.01; done
+  fi
+  exit 0
+fi
+if [ "$1" = workspace ] && [ "$2" = get ]; then
+  label="$(cat "$HWI_WORK/workspace.label" 2>/dev/null)"
+  jq -cn --arg workspace "$3" --arg label "$label" \
+    '{result:{type:"workspace_info",workspace:{workspace_id:$workspace,label:$label}}}'
   exit 0
 fi
 exit 1
@@ -132,6 +149,17 @@ SH
   chmod +x "$HWI_STUB/git"
 }
 
+hwi_write_mv_proxy() {
+  cat > "$HWI_STUB/mv" <<'SH'
+#!/usr/bin/env bash
+if [ -e "$HWI_WORK/fail-terminal-state-write" ] && [ -e "$HWI_WORK/workspace.label" ] && [[ "${2:-}" == *.state ]]; then
+  exit 1
+fi
+exec "$HWI_REAL_MV" "$@"
+SH
+  chmod +x "$HWI_STUB/mv"
+}
+
 # A separate Bash process holds a real claim until the caller releases it.
 # The ready marker is a causal barrier; the bounded loop below is only a hang
 # guard, never the assertion about contention.
@@ -165,7 +193,7 @@ hwi_teardown() {
     wait "$HWI_HOLDER_PID" 2>/dev/null || true
   fi
   [[ -n "${HWI_WORK:-}" ]] && rm -rf "$HWI_WORK" || true
-  unset HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT HWI_MAIN
+  unset HWI_WORK HWI_STATE HWI_STUB HWI_PANE_JSON HWI_SNAPSHOT_JSON HWI_COMMAND_PATH HWI_REAL_GIT HWI_REAL_MV HWI_MAIN
   unset HWI_CHECKOUT HWI_BRANCH HWI_PLUGIN_CONFIG HWI_HOLDER_PID HWI_HOLDER_READY HWI_HOLDER_RELEASE
   unset HERDR_WORKTREE_IDENTITY_STATE_DIR
 }

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -35,6 +35,12 @@ if [ "$1" = api ] && [ "$2" = snapshot ]; then
   cat "$HWI_SNAPSHOT_JSON"
   exit 0
 fi
+if [ "$1" = workspace ] && [ "$2" = rename ]; then
+  printf '%s\n' "$*" >> "$HWI_WORK/herdr.calls"
+  [ ! -e "$HWI_WORK/fail-workspace-rename" ] || exit 1
+  printf '%s' "$4" > "$HWI_WORK/workspace.label"
+  exit 0
+fi
 exit 1
 SH
   chmod +x "$HWI_STUB/herdr"
@@ -95,6 +101,11 @@ hwi_identity_state_path() {
 hwi_branch_description() {
   local branch="${1:-$(git -C "$HWI_CHECKOUT" branch --show-current)}"
   git -C "$HWI_CHECKOUT" config --get "branch.$branch.description"
+}
+
+hwi_workspace_rename_count() {
+  [ -f "$HWI_WORK/herdr.calls" ] || { printf '0'; return 0; }
+  grep -c '^workspace rename ' "$HWI_WORK/herdr.calls" || true
 }
 
 hwi_set_upstream() {

--- a/tests/pi-herdr-worktree-identity.test.ts
+++ b/tests/pi-herdr-worktree-identity.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const extensionPath = join(import.meta.dir, "../home/dot_pi/agent/extensions/herdr-worktree-identity.ts");
+const { default: registerWorktreeIdentity } = await import(extensionPath);
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  for (const path of cleanupPaths.splice(0)) await rm(path, { recursive: true, force: true });
+  delete process.env.HERDR_ENV;
+  delete process.env.HERDR_WORKTREE_IDENTITY_ACTIVE;
+  delete process.env.HERDR_WORKTREE_IDENTITY_ENGINE;
+  delete process.env.HERDR_PANE_ID;
+  delete process.env.HERDR_WORKSPACE_ID;
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pi-worktree-identity-test-"));
+  cleanupPaths.push(root);
+  return root;
+}
+
+async function waitFor(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 3000; attempt += 1) {
+    if (await Bun.file(path).exists()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+async function stubEngine(root: string): Promise<string> {
+  const engine = join(root, "engine");
+  await writeFile(engine, `#!/usr/bin/env bash
+set -eu
+call="${root}/call-$$"
+mkdir "$call"
+printf '%s\\n' "$@" > "$call/argv"
+cat > "$call/stdin"
+: > "$call/ready"
+( while [ ! -e "${root}/release" ]; do sleep 0.01; done; : > "$call/released" ) &
+exit 0
+`);
+  await Bun.spawn(["chmod", "+x", engine]).exited;
+  return engine;
+}
+
+function register() {
+  const handlers = new Map<string, Function>();
+  registerWorktreeIdentity({ on: (event: string, handler: Function) => handlers.set(event, handler) } as never);
+  return handlers;
+}
+
+function context(hasUI = true) {
+  return { hasUI, sessionManager: { getSessionId: () => "session-pi" } };
+}
+
+describe("Pi worktree identity prompt capture", () => {
+  test("registers before_agent_start and hands off a stdin-only prompt while derivation remains pending", async () => {
+    const root = await temporaryRoot();
+    process.env.HERDR_ENV = "1";
+    process.env.HERDR_PANE_ID = "pane-pi";
+    process.env.HERDR_WORKSPACE_ID = "workspace-pi";
+    process.env.HERDR_WORKTREE_IDENTITY_ENGINE = await stubEngine(root);
+    const handlers = register();
+
+    const handler = handlers.get("before_agent_start");
+    expect(handler).toBeDefined();
+    await handler({ prompt: "Pi stdin-only sentinel" }, context());
+
+    const calls = (await readdir(root)).filter((entry) => entry.startsWith("call-"));
+    expect(calls).toHaveLength(1);
+    const call = join(root, calls[0]);
+    expect(await Bun.file(join(call, "stdin")).text()).toBe("Pi stdin-only sentinel");
+    expect(await Bun.file(join(call, "argv")).text()).toContain("pi");
+    expect(await Bun.file(join(call, "argv")).text()).not.toContain("Pi stdin-only sentinel");
+    await waitFor(join(call, "ready"));
+    expect(await Bun.file(join(call, "released")).exists()).toBe(false);
+    await writeFile(join(root, "release"), "");
+    await waitFor(join(call, "released"));
+  });
+
+  test("does not capture outside herdr, without session UI, or during naming re-entry", async () => {
+    const root = await temporaryRoot();
+    process.env.HERDR_WORKTREE_IDENTITY_ENGINE = await stubEngine(root);
+    const outside = register();
+    expect(outside.size).toBe(0);
+
+    process.env.HERDR_ENV = "1";
+    const headless = register();
+    await headless.get("before_agent_start")?.({ prompt: "headless" }, context(false));
+
+    process.env.HERDR_WORKTREE_IDENTITY_ACTIVE = "1";
+    const reentry = register();
+    expect(reentry.size).toBe(0);
+    expect((await readdir(root)).filter((entry) => entry.startsWith("call-")).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Generated Herdr worktrees now acquire human-readable task identities from the session's first prompt. The component derives a multi-word branch slug, performs one authorized branch rename with durable attribution, and labels the workspace while leaving pane, tab, and agent names under the existing alias system.

The implementation treats naming as a recoverable state machine rather than a best-effort hook. Marker changes, agent-owned branch moves, contention, interrupted writes, blocked Herdr calls, and process crashes either preserve the user's state or leave a diagnostic-backed retry path.

```mermaid
flowchart TB
  CC[Claude Code hook] --> ENG[herdr-worktree-identity]
  OC[OpenCode plugin] --> ENG
  PI[Pi extension] --> ENG
  CWD[Statusline cwd record] -.-> ENG
  MARK[Generated-worktree marker] -. authorizes .-> ENG
  ENG --> STATE[Atomic state and lifecycle claim]
  ENG --> REF[Branch rename and attribution]
  ENG --> WS[Workspace label]
  ALIAS[Alias system] -. solely owns pane, tab, and agent names .-> ENG
```

## Design

- Capture adapters return after a bounded foreground handoff; a detached worker owns model derivation and mutations.
- The generated-worktree marker remains the sole ref-mutation authorization boundary and is revalidated immediately before the rename.
- Atomic lifecycle claims serialize each worktree's complete transition. Transient contention and unavailable process identity fail closed without becoming terminal outcomes.
- Prepared, attribution-failed, workspace-prepared, and workspace-failed states reconcile external effects before retrying them.
- Herdr and model subprocesses run under bounded process-group supervision so timed-out descendants cannot survive the worker.
- Append-only diagnostics explain every declined or retryable path without influencing state transitions.

## Testing

- `make test-ubuntu`
- `tests/lib/bashunit tests/bashunit/scripts_test.sh --filter test_scripts_258`
- `make lint`
- `make test-issues`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-OpenCode-000000)
