### PR TITLE
feat(herdr): show each pane's git location in the agents sidebar

### DIFF
--- a/home/dot_local/bin/executable_herdr-pane-labels
+++ b/home/dot_local/bin/executable_herdr-pane-labels
@@ -439,7 +439,9 @@ authoritative_worktree_deleted() {
 # Prints outcome, canonical checkout root, common Git directory, repository,
 # symbolic branch, linked-worktree flag, and detached short SHA separated by
 # unit separators. A transient result carries retained evidence when one
-# exists; confirmed non-Git carries empty evidence.
+# exists; confirmed non-Git carries the probed directory in the root field and
+# nothing else — outside a checkout the directory name is the only thing a pane
+# can report, and it is the sole reason that field is populated for non-Git.
 resolve_pane_location() {
   local pane_json="$1" state_file="$2" has_agent has_foreground cwd prior_root prior_anchor
   local prior_repo prior_branch prior_is_linked prior_sha candidate outfile errfile status
@@ -506,7 +508,7 @@ resolve_pane_location() {
     if { [ "$status" -eq 1 ] || [ "$status" -eq 128 ]; } && \
       grep -Eqi 'not a git repository|not inside a work tree' "$errfile" 2>/dev/null; then
       rm -f "$outfile" "$errfile"
-      printf 'non_git\037\037\037\037\037\037'
+      printf 'non_git\037%s\037\037\037\037\037' "$cwd"
     else
       rm -f "$outfile" "$errfile"
       bail_transient
@@ -1092,12 +1094,12 @@ EOF
 
 reconcile_presentation_pass() {
   local pass="$1" snapshot aliased alias_status final_snapshot initial_identity final_identity pool_json
-  local pane_rows workspace_rows baselines legacy_label_panes presentations="" tab_intents
+  local pane_rows baselines legacy_label_panes presentations="" tab_intents
   local id terminal tab_id workspace runtime revision session_json current alias pane_json_encoded pane_json
   local current_repo current_worktree current_branch current_status current_git_ref
   local location_file result outcome root anchor repo branch linked sha status intended
   local location_pids="" location_results="" result_file pid probe_results="" child_failed=0
-  local roots root_tokens worktree git_ref ref place folder workspace_name baseline
+  local roots root_tokens worktree git_ref ref place folder baseline
   local pane_id state_file retained_pane presented_ids
   local final_payload final_label final_tokens final_repo final_worktree final_branch final_status final_git_ref final_legacy
   local location_changed location_seq
@@ -1143,7 +1145,6 @@ reconcile_presentation_pass() {
     | join("\u001f")' | filter_records_of_width 15 "$pane_count")" || return 1
   baselines="$(printf '%s\n' "$pane_rows" | awk -F "$FIELD_SEPARATOR" -v OFS="$FIELD_SEPARATOR" 'NF {print $1,$10,$11,$12,$13,$14}')"
   legacy_label_panes="$(printf '%s' "$snapshot" | jq -r '.result.snapshot.panes[] | select((.tokens.location_label // "") != "") | .pane_id')"
-  workspace_rows="$(printf '%s' "$snapshot" | jq -r '.result.snapshot.workspaces[] | [.workspace_id,(.label // .name // "")] | join("\u001f")')"
   trace_presentation_phase rows
 
   while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current alias current_repo current_worktree current_branch current_status current_git_ref pane_json_encoded; do
@@ -1197,7 +1198,9 @@ EOF
     status=""
     case "$outcome" in
       git) ;;
-      non_git) root=""; anchor=""; repo=""; branch=""; linked=""; sha="" ;;
+      # root survives: it is the directory this pane sits in, and outside a
+      # checkout it is the whole of what the location row can say.
+      non_git) anchor=""; repo=""; branch=""; linked=""; sha="" ;;
       transient)
         if [ -n "$root" ]; then status=stale
         elif [ -n "$current_repo" ] && [ -n "$current_worktree" ]; then
@@ -1233,11 +1236,14 @@ EOF
     ref="$branch"; place=branch
     if [ -z "$ref" ] && [ -n "$sha" ]; then ref="$sha"; place=commit
     elif [ "$linked" = 1 ]; then place=worktree; fi
-    folder="$worktree"
-    if [ -n "$ref" ]; then
-      workspace_name="$(table_value_for "$workspace" "$workspace_rows")"
-      if [ "$worktree" = "$ref" ] || [ "$worktree" = "$workspace_name" ]; then folder=""; fi
-    fi
+    # Inside a checkout the ref answers the only question the row is asked:
+    # which branch, worktree, or commit this pane works on. Which directory
+    # that checkout happens to occupy is not something the user acts on, and
+    # for a generated worktree the directory name carries no meaning at all.
+    # The folder is therefore a fallback for panes with no ref, never a
+    # qualifier beside one.
+    folder=""
+    [ -n "$ref" ] || folder="$worktree"
     git_ref="$(git_ref_for "$place" "$ref" "$folder" "$status")"
     probe_results="${probe_results}${probe_results:+
 }${id}${FIELD_SEPARATOR}${terminal}${FIELD_SEPARATOR}${tab_id}${FIELD_SEPARATOR}${workspace}${FIELD_SEPARATOR}${runtime}${FIELD_SEPARATOR}${revision}${FIELD_SEPARATOR}${session_json}${FIELD_SEPARATOR}${current}${FIELD_SEPARATOR}${intended}${FIELD_SEPARATOR}${outcome}${FIELD_SEPARATOR}${root}${FIELD_SEPARATOR}${anchor}${FIELD_SEPARATOR}${repo}${FIELD_SEPARATOR}${branch}${FIELD_SEPARATOR}${linked}${FIELD_SEPARATOR}${sha}${FIELD_SEPARATOR}${status}${FIELD_SEPARATOR}${git_ref}${FIELD_SEPARATOR}${worktree}"
@@ -1287,8 +1293,11 @@ EOF
       [ "$current_repo" = "$repo" ] && [ "$current_worktree" = "$worktree" ] &&
         [ "$current_branch" = "$branch" ] && [ "$current_status" = "$status" ] &&
         [ "$current_git_ref" = "$git_ref" ] || location_changed=1
-    elif [ "$outcome" = non_git ] && { [ -n "$current_repo$current_worktree$current_branch$current_status$current_git_ref" ]; }; then
-      location_changed=1
+    elif [ "$outcome" = non_git ]; then
+      # Outside a checkout only git_ref is published; every other token must be
+      # absent, and a leftover from a previous Git location is a change.
+      [ -z "$current_repo$current_worktree$current_branch$current_status" ] &&
+        [ "$current_git_ref" = "$git_ref" ] || location_changed=1
     fi
     # A pane whose location hasn't changed and whose label is already correct
     # needs no live pane fetch at all; skip the fork+parse for that steady-
@@ -1316,6 +1325,11 @@ EOF
             set -- "$@" --token "repo=$repo" --token "worktree=$worktree" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token location_label
             if [ -n "$branch" ]; then set -- "$@" --token "branch=$branch"; else set -- "$@" --clear-token branch; fi
             if [ -n "$status" ]; then set -- "$@" --token "location_status=$status"; else set -- "$@" --clear-token location_status; fi
+          elif [ "$outcome" = non_git ] && [ -n "$git_ref" ]; then
+            # A directory outside any checkout: the folder name is the row, and
+            # the Git tokens stay cleared so no integration reads a repository
+            # relationship that does not exist.
+            set -- "$@" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token location_label
           else
             set -- "$@" --clear-token pane_inline --clear-token repo --clear-token worktree --clear-token branch --clear-token location_status --clear-token git_ref --clear-token location_label
           fi
@@ -1390,8 +1404,9 @@ EOF
               (($panes[0].tokens.git_ref // "") == $git_ref) and
               (($panes[0].tokens.location_label // "") == "")
             elif $outcome == "non_git" then
-              (["repo","worktree","branch","location_status","git_ref","location_label"]
+              (["repo","worktree","branch","location_status","location_label"]
                 | all(.[]; . as $key | (($panes[0].tokens[$key] // "") == "")))
+              and (($panes[0].tokens.git_ref // "") == $git_ref)
             else true end)
         ' >/dev/null 2>&1 || {
           printf 'herdr-pane-labels: strict sweep did not converge pane %s\n' "$id" >&2

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -58,9 +58,13 @@ sidebar_min_width = 32
 
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`
-# labels, rebuilds tab labels, and publishes Git metadata for integrations.
+# labels, rebuilds tab labels, and publishes the Git location tokens.
+# The third row renders `$git_ref` — the engine's composed location string
+# (place glyph + branch/worktree/short SHA, folder qualifier, stale marker).
+# It is a separate row on purpose: pane identity stays stable while Git state
+# moves underneath it, and a pane outside a checkout simply renders no row.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace"], ["pane"]]
+rows = [["state_icon", "workspace"], ["pane"], ["$git_ref"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -5488,17 +5488,19 @@ function test_scripts_1132_herdr_pane_labels_location_resolves_main_linked_neste
 
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.repo' "$state" | sort -u)" repository
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.worktree' "$state" | sort -u)" repository
-  # Main checkout: branch icon; folder qualifier suppressed because the
-  # worktree token equals the workspace name.
+  # Main checkout: branch icon and the ref, nothing else — a pane with a ref
+  # never carries a folder qualifier.
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "main-nested" or .pane_id == "main-admin") | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_BRANCH main"
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.branch' "$state" | sort -u)" feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.worktree' "$state" | sort -u)" feature
-  # Linked worktree (.git file at root): worktree icon; folder qualifier
-  # suppressed because the worktree token equals the branch.
+  # Linked worktree (.git file at root): worktree icon and the ref; the
+  # directory the worktree occupies stays out of the row.
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "linked-admin" or .pane_id == "fallback") | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_WORKTREE feature"
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "agent-ignores-foreground") | .tokens.branch' "$state")" feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "agent-ignores-foreground") | .tokens.worktree' "$state")" feature
-  run jq -e '.panes[] | select(.pane_id == "foreground-wins") | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.git_ref == null)' "$state"
+  # Foreground cwd outside any checkout: no Git tokens at all, and the folder
+  # name is the whole row.
+  run jq -e --arg ref "$HPL_ICON_FOLDER outside" '.panes[] | select(.pane_id == "foreground-wins") | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.git_ref == $ref)' "$state"
   assert_success
   assert_equal "$(cat "$(hpl_git_fixture_dir "$nongit")/locale")" C
 }
@@ -5566,8 +5568,9 @@ function test_scripts_1134_herdr_pane_labels_location_detached_publishes_a_commi
   hpl_set_pane_location "$HPL_DEFAULT_SOCKET" pane-1 "$nongit" "$nongit"
   HERDR_PANE_LABELS_TEST_NOW_SEQ=0 hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
-  # The non-Git arm clears only presentation-owned location tokens.
-  assert_equal "$(jq -c '.panes[0].tokens' "$state")" '{"foreign":"kept"}'
+  # The non-Git arm clears every Git token, keeps a foreign source's token, and
+  # publishes the directory name as the only thing this pane can report.
+  assert_equal "$(jq -c '.panes[0].tokens' "$state")" "$(jq -nc --arg ref "$HPL_ICON_FOLDER non-git" '{foreign:"kept",git_ref:$ref}')"
   run test "$(hpl_location_source_seq "$HPL_DEFAULT_SOCKET" pane-1)" -gt "$second_seq"
   assert_success
 }
@@ -5704,8 +5707,9 @@ function test_scripts_1138_herdr_pane_labels_location_clears_the_retired_locatio
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HPL_ICON_BRANCH topic"
   run jq -e '.panes[] | select(.pane_id == "pane-1") | .tokens.location_label == null' "$state"
   assert_success
-  # then: the non-Git clear path sheds it alongside the other location tokens
-  run jq -e '.panes[] | select(.pane_id == "pane-2") | (.tokens.location_label == null and .tokens.git_ref == null)' "$state"
+  # then: the non-Git path sheds the legacy token and overwrites the stale
+  # git_ref it was carrying with this pane's own directory name
+  run jq -e --arg ref "$HPL_ICON_FOLDER non-git" '.panes[] | select(.pane_id == "pane-2") | (.tokens.location_label == null and .tokens.git_ref == $ref)' "$state"
   assert_success
 }
 
@@ -5840,8 +5844,11 @@ function test_scripts_1140_herdr_pane_labels_coordinator_resolves_eight_pane_loc
   run jq -e '.panes[] | select(.pane_id == "pane-1") | .tokens.branch == "initial-1" and .tokens.location_status == "stale"' "$state"
   assert_success
   for i in $(seq 2 8); do
-    run jq -e --arg pane "pane-$i" \
-      '.panes[] | select(.pane_id == $pane) | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.location_status == null and .tokens.git_ref == null)' "$state"
+    # Non-Git panes publish no Git token at all. Their directories all end in
+    # "work", so the folder row carries the disambiguating path suffix the
+    # token builder assigns, exactly as it does for same-named checkouts.
+    run jq -e --arg pane "pane-$i" --arg ref "$HPL_ICON_FOLDER repo-$i/work" \
+      '.panes[] | select(.pane_id == $pane) | (.tokens.repo == null and .tokens.worktree == null and .tokens.branch == null and .tokens.location_status == null and .tokens.git_ref == $ref)' "$state"
     assert_success
     fixture="$(hpl_git_fixture_dir "$HPL_WORK/repos/repo-$i/work")"
     assert_file_exists "$fixture/started"
@@ -5904,10 +5911,11 @@ function test_scripts_1142_herdr_pane_labels_transient_location_preserves_live_t
   hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
   # Token-only evidence carries no is_linked proof, so the place icon falls
-  # back to the branch icon; without any ref evidence the folder icon plus
-  # worktree token is the whole $git_ref.
+  # back to the branch icon. Pane one has a ref, so the ref is the whole row;
+  # pane two has none, and there the folder icon plus worktree token is all
+  # $git_ref can say.
   run jq -e \
-    --arg ref_one "$HPL_ICON_BRANCH topic-one $HPL_ICON_FOLDER live-token $HPL_ICON_STALE" \
+    --arg ref_one "$HPL_ICON_BRANCH topic-one $HPL_ICON_STALE" \
     --arg ref_two "$HPL_ICON_FOLDER live-token $HPL_ICON_STALE" '
     (.panes[] | select(.pane_id == "pane-1") | .tokens == {repo:"live-repo",worktree:"live-token",branch:"topic-one",location_status:"stale",git_ref:$ref_one})
     and (.panes[] | select(.pane_id == "pane-2") | .tokens == {repo:"live-repo",worktree:"live-token",location_status:"stale",git_ref:$ref_two})
@@ -6025,7 +6033,7 @@ function test_scripts_1147_herdr_pane_labels_formatter_keeps_a_git_backed_all_id
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "~ 1"
   assert_equal "$(jq -r '.panes[] | .label' "$state" | sort -u)" "~"
-  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_BRANCH main $HPL_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_BRANCH main"
 }
 
 function test_scripts_1148_herdr_pane_labels_git_only_location_changes_do_not_rena() {
@@ -6069,7 +6077,7 @@ function test_scripts_1149_herdr_pane_labels_formatter_keeps_the_folder_qualifie
   hpl_set_process_label pane-1 task
   hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH main $HPL_ICON_FOLDER setup-copy"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH main"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
 }
 
@@ -6109,7 +6117,7 @@ function test_scripts_1151_herdr_pane_labels_formatter_gives_a_detached_head_ins
   hpl_set_process_label pane-1 task
   hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_COMMIT a1b2c3d $HPL_ICON_FOLDER wt-detached"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_COMMIT a1b2c3d"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
 }
 
@@ -6131,7 +6139,7 @@ function test_scripts_1152_herdr_pane_labels_formatter_qualifies_a_divergent_wor
   hpl_set_process_label pane-2 beta
   hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_WORKTREE fix-login $HPL_ICON_FOLDER wt-hotfix"
+  assert_equal "$(jq -r '.panes[] | .tokens.git_ref' "$state" | sort -u)" "$HPL_ICON_WORKTREE fix-login"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "alpha · beta"
 }
 
@@ -6208,8 +6216,8 @@ function test_scripts_1155_herdr_pane_labels_worktree_tokens_use_shortest_unique
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.worktree' "$state")" team/feature
   assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.worktree' "$state")" release/feature
   # The slash-suffix folder token appears only in the sidebar qualifier.
-  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE one $HPL_ICON_FOLDER team/feature"
-  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE two $HPL_ICON_FOLDER release/feature"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE one"
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-2") | .tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE two"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "alpha · beta"
 }
 
@@ -6293,7 +6301,7 @@ function test_scripts_1158_herdr_pane_labels_long_branch_refs_stay_in_metadata_a
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.tabs[0].label' "$state")" task
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" "$long_ref"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE $long_ref $HPL_ICON_FOLDER worktree"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE $long_ref"
 }
 
 function test_scripts_1159_herdr_pane_labels_long_repository_names_do_not_alter_a_() {
@@ -6330,7 +6338,7 @@ function test_scripts_1160_herdr_pane_labels_location_clears_a_retired_location_
   # given: one pass has already published every current token
   hpl_location_pass
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH topic $HPL_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH topic"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
   # given: a stale daemon of the retired version puts location_label back while
   # leaving every token this version compares untouched. It reports under the
@@ -6347,7 +6355,7 @@ function test_scripts_1160_herdr_pane_labels_location_clears_a_retired_location_
   # then: the legacy token is gone and the live tokens are unharmed
   state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
   assert_equal "$(jq -r '.panes[0].tokens.location_label // ""' "$state")" ""
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH topic $HPL_ICON_FOLDER repository"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_BRANCH topic"
   assert_equal "$(jq -r '.panes[0].tokens.branch' "$state")" topic
 }
 
@@ -6374,7 +6382,7 @@ function test_scripts_1161_herdr_pane_labels_location_and_formatter_add_only_app
   ' "$state"
   assert_success
   assert_equal "$(jq -r '.tabs[0].label' "$state")" plain-task
-  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE plain $HPL_ICON_FOLDER plain-worktree"
+  assert_equal "$(jq -r '.panes[0].tokens.git_ref' "$state")" "$HPL_ICON_WORKTREE plain"
   # pane_inline stays deferred per the label-system plan: no pass publishes it.
   assert_equal "$(jq -r '.panes[0].tokens.pane_inline // ""' "$state")" ""
 }

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -892,11 +892,10 @@ function test_smoke_1057_pi_brew_auto_updater_focused_tests_pass() {
   assert_success
 }
 
-assert_herdr_sidebar_deployment_contract() {
+assert_herdr_label_writer_contract() {
   local config="$1"
   local engine="$2"
   local plugin="$3"
-  local width
   local writer_files=(
     "$engine"
     "$plugin/herdr-plugin.toml"
@@ -908,23 +907,11 @@ assert_herdr_sidebar_deployment_contract() {
     "$(dirname "$config")"
   )
 
-  assert_file_contains "$config" '^\[ui.sidebar.agents\]$'
-  # Pane and tab identity stay stable when Git state changes. Location metadata
-  # remains available to integrations, but the sidebar renders identity only.
-  # The three identity fields and their order are the contract; how they are
-  # grouped into rows is a presentation preference the user changes directly.
-  assert_file_contains "$config" '^rows = \[\[.*"state_icon".*"workspace".*"pane".*\]\]$'
-  run grep -E '\$git_ref|\$location_label|\$location_status' "$config"
-  assert_failure
-  # Sole owner of sidebar_min_width: the awk scope proves the key both carries
-  # the value herdr reads and sits inside [ui], which a flat file grep cannot.
-  # No width-derived assertions here: nothing consumes a "width - 4" budget.
-  width="$(awk '
-    $0 == "[ui]" { in_ui = 1; next }
-    /^\[/ { in_ui = 0 }
-    in_ui && /^sidebar_min_width = [0-9]+$/ { print $3 }
-  ' "$config")"
-  [ "$width" -eq 32 ]
+  # Nothing here asserts config.toml content. Sidebar rows, widths, and which
+  # tokens a row renders are the user's presentation preferences in the user's
+  # own config; a test that froze them would fail on an intended edit and prove
+  # nothing about the label writer. The config path is kept only to locate the
+  # plugin directory below.
 
   run bash -c '
     pattern="$1"; shift
@@ -942,10 +929,9 @@ assert_herdr_sidebar_deployment_contract() {
   run grep -Ei 'reclaim|manual[-_ ]ownership|ownership[-_ ]notification' \
     "$engine" "$plugin/herdr-plugin.toml" "$plugin/ensure.sh" "$plugin/sweep.sh"
   assert_failure
-  run grep -hEi 'state_icon|(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
-    "$config" "${writer_files[@]}"
+  run grep -hEi '(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
+    "${writer_files[@]}"
   assert_success
-  assert_file_contains "$config" '"state_icon"'
   # The engine builds the five codicon glyphs of the $git_ref grammar from
   # bash 3.2-safe octal printf sequences. Raw PUA glyphs are easily lost when
   # files pass through editors or agents, so none may be committed verbatim.
@@ -954,23 +940,23 @@ assert_herdr_sidebar_deployment_contract() {
   assert_file_contains "$engine" '\\356\\253\\274' # nf-cod-git_commit U+EAFC
   assert_file_contains "$engine" '\\356\\252\\203' # nf-cod-folder U+EA83
   assert_file_contains "$engine" '\\356\\252\\202' # nf-cod-history U+EA82
-  run env LC_ALL=C grep -n "$(printf '\356')" "$engine" "$config"
+  run env LC_ALL=C grep -n "$(printf '\356')" "$engine"
   assert_failure
   assert_file_contains "$engine" 'LABEL_SEPARATOR=.* · '
   assert_file_contains "$engine" '…'
 }
 
-function test_smoke_1058_herdr_managed_source_preserves_the_u6_sidebar_and_owner() {
-  _bats_test_init 1058 'herdr managed source preserves the U6 sidebar and ownership boundaries'
-  assert_herdr_sidebar_deployment_contract \
+function test_smoke_1058_herdr_managed_source_preserves_label_writer_ownership() {
+  _bats_test_init 1058 'herdr managed source preserves label-writer ownership boundaries'
+  assert_herdr_label_writer_contract \
     "$SOURCE_ROOT/private_dot_config/herdr/config.toml" \
     "$SOURCE_ROOT/dot_local/bin/executable_herdr-pane-labels" \
     "$SOURCE_ROOT/private_dot_config/herdr/plugins/herdr-pane-labels"
 }
 
-function test_smoke_1059_herdr_deployed_files_preserve_the_u6_sidebar_and_owners() {
-  _bats_test_init 1059 'herdr deployed files preserve the U6 sidebar and ownership boundaries'
-  assert_herdr_sidebar_deployment_contract \
+function test_smoke_1059_herdr_deployed_files_preserve_label_writer_ownership() {
+  _bats_test_init 1059 'herdr deployed files preserve label-writer ownership boundaries'
+  assert_herdr_label_writer_contract \
     "$HOME/.config/herdr/config.toml" \
     "$HOME/.local/bin/herdr-pane-labels" \
     "$HOME/.config/herdr/plugins/herdr-pane-labels"


### PR DESCRIPTION
## Summary

Every pane in the herdr agents sidebar now states where it works — the branch, worktree, or commit inside a checkout, and the directory name outside one. The row under the agent name carried identity only, so nothing distinguished two panes sitting in different worktrees of the same repository without opening them.

Commit 21aaaf0 deliberately removed Git metadata from this sidebar and locked that decision into the deployment contract with a test. This reverses that decision for the location row only, and keeps what it protected: pane and tab identity are written by one writer and still stay stable while Git state moves underneath them.

## What the row shows

| Pane | Row |
|---|---|
| Main checkout | branch glyph + branch name |
| Linked worktree | worktree glyph + branch name |
| Detached HEAD | commit glyph + 7-char short SHA |
| Outside any checkout | folder glyph + directory name |

The folder qualifier becomes a fallback rather than a companion to a ref. Inside a checkout the ref answers the question the row is asked; the directory that checkout occupies does not. The old suppression rule hid the folder only when its token matched the branch or the workspace name — and a worktree generated by herdr gets a random slug directory (`worktree-brave-forest-cc18`) that matches neither, so in practice every worktree pane carried a meaningless truncated tail (`worktree-br~305376`) next to a branch name that already said everything.

Panes outside a checkout published no token at all and rendered an empty row. They now publish a folder-only `git_ref` while every Git token stays cleared, so no integration reads a repository relationship that does not exist. Same-named directories get the same disambiguating path suffix that same-named checkouts already get (`repo-2/work`).

## The test contract

`assert_herdr_sidebar_deployment_contract` asserted the exact `[ui.sidebar.agents].rows` value, the sidebar width, and a ban on `$git_ref` appearing anywhere in `config.toml`. Those are presentation preferences in a user's own config file: they fail on an intended edit and prove nothing about the label writer they were attached to. The helper — now `assert_herdr_label_writer_contract` — keeps only what a config edit cannot change: exactly one `herdr pane rename` and one `herdr tab rename` writer, no reclaim logic, and the octal-printf glyph constants in the engine.

## Known limits

- A Claude session that moves into a worktree mid-session still shows its launch directory. The engine reads the pane's cwd, and the channel meant to carry the session's own directory has no reader — see `docs/issues/2026-09-03-003-claude-statusline-writes-session-cwd-to-a-channel-nothing-reads.md`. OpenCode and Pi have the same gap (`docs/issues/2026-08-27-004-*`, `docs/issues/2026-08-27-005-*`).
- Dirty/ahead/behind counts are out of scope: the engine publishes no `git_status` token.

## Validation

- `make test-ubuntu`: exit 0, every suite green (290 + 61 + 6 + 9 + 1 passed; 1 skip that is Linux-conditional by design). This is the target that proves a change to a managed file, because it applies the checkout before asserting.
- `tests/bashunit/scripts_test.sh` pane-labels suite: 76 passed, 389 assertions. Thirteen existing expectations broke and all thirteen were reasoned through and updated — ten lost the folder qualifier, three non-Git cases now assert a concrete folder ref instead of `null`. None were disabled.
- `make test-suite` on the host: 0 failed. `make lint` clean.
- Live check on a running herdr session, verified by glyph bytes rather than by eye: `EC6F` (branch) on main checkouts, `EC7E` (worktree) on a linked worktree, `EA83` (folder) on a pane sitting in a directory outside any repository.
