### PR TITLE
feat(herdr): show branch and status for every space in the sidebar

### DIFF
--- a/home/dot_local/bin/executable_herdr-pane-labels
+++ b/home/dot_local/bin/executable_herdr-pane-labels
@@ -38,6 +38,14 @@ ICON_BRANCH="$(printf '\356\261\257')"   # nf-cod-git_branch U+EC6F
 ICON_WORKTREE="$(printf '\356\261\276')" # nf-cod-worktree U+EC7E
 ICON_COMMIT="$(printf '\356\253\274')"   # nf-cod-git_commit U+EAFC
 ICON_FOLDER="$(printf '\356\252\203')"   # nf-cod-folder U+EA83
+# The status vocabulary this repo used before 21aaaf0 removed it, restored
+# unchanged so a reader who learned it once still reads it the same way.
+ICON_PULL="$(printf '\342\207\243')"   # U+21E3 downwards dashed arrow
+ICON_PUSH="$(printf '\342\207\241')"   # U+21E1 upwards dashed arrow
+ICON_CONFLICT='~'
+ICON_STAGED='+'
+ICON_UNSTAGED='!'
+ICON_UNTRACKED='?'
 ICON_STALE="$(printf '\356\252\202')"    # nf-cod-history U+EA82
 # Worktree-token width math (text_length's `wc -m`, text_prefix's `cut -c`)
 # must count codepoints: under a non-UTF-8 locale both count bytes, so a cap
@@ -55,8 +63,14 @@ case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
     ;;
 esac
 FIELD_SEPARATOR=$'\037'
+STATUS_SEPARATOR=$'\036'
 WORKTREE_TOKEN_MAX_LEN=18
 LOCATION_GIT_BUDGET="${HERDR_PANE_LABELS_GIT_BUDGET:-0.075}"
+# The space probe scans the working tree, which the scan-free rev-parse budget
+# above is not calibrated for. Measured at or under 10 ms warm on this repo and
+# its main checkout; the budget is an order of magnitude above that so a cold
+# or large tree degrades to "no counts" instead of to wrong ones.
+SPACE_STATUS_BUDGET="${HERDR_PANE_LABELS_STATUS_BUDGET:-0.5}"
 # Seconds between two sweeps of the daemon. Five keeps a finished command
 # visible for at most one glance without hammering the herdr socket.
 SWEEP_INTERVAL="${HERDR_PANE_LABELS_SWEEP_INTERVAL:-5}"
@@ -384,11 +398,15 @@ admin_checkout_for_path() {
 }
 
 run_budgeted_command() {
-  local outfile="$1" errfile="$2"
-  shift 2
+  run_budgeted_command_within "$LOCATION_GIT_BUDGET" "$@"
+}
+
+run_budgeted_command_within() {
+  local budget="$1" outfile="$2" errfile="$3"
+  shift 3
   "$@" </dev/null >"$outfile" 2>"$errfile" &
   local command_pid=$!
-  ( sleep "$LOCATION_GIT_BUDGET"; kill -9 "$command_pid" ) >/dev/null 2>&1 &
+  ( sleep "$budget"; kill -9 "$command_pid" ) >/dev/null 2>&1 &
   local watchdog=$! status=0
   wait "$command_pid" || status=$?
   kill "$watchdog" >/dev/null 2>&1 || true
@@ -772,6 +790,136 @@ git_ref_for() {
   printf '%s' "$label"
 }
 
+# Counts are volatile where identity is stable, so they get their own probe,
+# their own budget and their own outcome: a status timeout must never make a
+# space's branch lie. `fresh` carries the count bundle (empty when clean),
+# `stale` means the probe did not answer in budget, `absent` means there is
+# nothing to count.
+resolve_checkout_status() {
+  local root="$1" outfile errfile status counts pull push conflicts staged unstaged untracked
+  [ -n "$root" ] || { printf 'absent\037'; return 0; }
+  command -v git >/dev/null 2>&1 || { printf 'stale\037'; return 0; }
+  outfile="$(mktemp "$(namespace_dir)/.git-status.XXXXXX" 2>/dev/null)" || {
+    printf 'stale\037'
+    return 0
+  }
+  errfile="$outfile.err"
+  # One call answers both halves: the changed paths and, as `# branch.ab`, the
+  # ahead/behind pair. Two probes would cost a second process launch.
+  #
+  # `--untracked-files=all` is what makes the count mean the same thing on
+  # every machine: without it `status.showUntrackedFiles` can hide untracked
+  # paths entirely, or collapse a new directory to a single entry while
+  # tracked edits still count one per file.
+  if run_budgeted_command_within "$SPACE_STATUS_BUDGET" "$outfile" "$errfile" \
+    env LC_ALL=C git -C "$root" --no-optional-locks status --porcelain=v2 --branch \
+    --untracked-files=all; then
+    status=0
+  else
+    status=$?
+  fi
+  if [ "$status" -ne 0 ]; then
+    rm -f "$outfile" "$errfile"
+    printf 'stale\037'
+    return 0
+  fi
+  # Parse every category in one pass. For ordinary and renamed records, X is
+  # the staged state and Y is the unstaged state. A partially staged path
+  # intentionally increments both; unmerged paths get their own count only.
+  counts="$(awk '
+    /^# branch\.ab / { push = substr($3, 2) + 0; pull = substr($4, 2) + 0; next }
+    $1 == "u" { conflicts++; next }
+    $1 == "?" { untracked++; next }
+    $1 == "1" || $1 == "2" {
+      if (substr($2, 1, 1) != ".") staged++
+      if (substr($2, 2, 1) != ".") unstaged++
+    }
+    END { print pull + 0, push + 0, conflicts + 0, staged + 0, unstaged + 0, untracked + 0 }
+  ' "$outfile" 2>/dev/null)"
+  rm -f "$outfile" "$errfile"
+  IFS=' ' read -r pull push conflicts staged unstaged untracked <<EOF
+$counts
+EOF
+  printf 'fresh\037%s' "$(git_status_counts_for "$pull" "$push" "$conflicts" "$staged" "$unstaged" "$untracked")"
+}
+
+# Six independent values behind one separator, so an all-zero status stays
+# wholly empty and a caller can still join only the parts it wants.
+git_status_counts_for() {
+  local pull="$1" push="$2" conflicts="$3" staged="$4" unstaged="$5" untracked="$6"
+  local git_pull="" git_push="" git_conflicts="" git_staged="" git_unstaged="" git_untracked=""
+  case "$pull" in '' | *[!0-9]*) pull=0 ;; esac
+  case "$push" in '' | *[!0-9]*) push=0 ;; esac
+  case "$conflicts" in '' | *[!0-9]*) conflicts=0 ;; esac
+  case "$staged" in '' | *[!0-9]*) staged=0 ;; esac
+  case "$unstaged" in '' | *[!0-9]*) unstaged=0 ;; esac
+  case "$untracked" in '' | *[!0-9]*) untracked=0 ;; esac
+  [ "$pull" -eq 0 ] || git_pull="$ICON_PULL$pull"
+  [ "$push" -eq 0 ] || git_push="$ICON_PUSH$push"
+  [ "$conflicts" -eq 0 ] || git_conflicts="$ICON_CONFLICT$conflicts"
+  [ "$staged" -eq 0 ] || git_staged="$ICON_STAGED$staged"
+  [ "$unstaged" -eq 0 ] || git_unstaged="$ICON_UNSTAGED$unstaged"
+  [ "$untracked" -eq 0 ] || git_untracked="$ICON_UNTRACKED$untracked"
+  [ -n "$git_pull$git_push$git_conflicts$git_staged$git_unstaged$git_untracked" ] || return 0
+  printf '%s\036%s\036%s\036%s\036%s\036%s' \
+    "$git_pull" "$git_push" "$git_conflicts" "$git_staged" "$git_unstaged" "$git_untracked"
+}
+
+# The space row renders one string, so the bundle joins on a single space in a
+# fixed order and empty positions simply disappear.
+status_line_for() {
+  local status="$1" pull push conflicts staged unstaged untracked line="" value
+  IFS="$STATUS_SEPARATOR" read -r pull push conflicts staged unstaged untracked <<EOF
+$status
+EOF
+  for value in "$pull" "$push" "$conflicts" "$staged" "$unstaged" "$untracked"; do
+    [ -n "$value" ] || continue
+    if [ -z "$line" ]; then line="$value"; else line="$line $value"; fi
+  done
+  printf '%s' "$line"
+}
+
+# Spaces routinely share a checkout, so the probe runs once per distinct root
+# rather than once per space, and distinct roots run concurrently: several slow
+# checkouts cost one status budget rather than one budget each.
+build_root_statuses() {
+  local roots="$1" table="" root result_file status_pid
+  local status_pids="" status_results="" status_child_failed=0
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    result_file="$(umask 077; mktemp "$(namespace_dir)/.status-result.XXXXXX" 2>/dev/null)" || {
+      status_child_failed=1
+      break
+    }
+    (
+      printf '%s%s' "$root" "$FIELD_SEPARATOR"
+      resolve_checkout_status "$root"
+    ) > "$result_file" &
+    status_pids="${status_pids}${status_pids:+
+}$!"
+    status_results="${status_results}${status_results:+
+}$result_file"
+  done <<EOF
+$roots
+EOF
+  while IFS= read -r status_pid; do
+    [ -n "$status_pid" ] || continue
+    wait "$status_pid" 2>/dev/null || status_child_failed=1
+  done <<EOF
+$status_pids
+EOF
+  while IFS= read -r result_file; do
+    [ -n "$result_file" ] || continue
+    [ "$status_child_failed" -eq 1 ] || table="${table}${table:+
+}$(cat "$result_file" 2>/dev/null)"
+    rm -f "$result_file"
+  done <<EOF
+$status_results
+EOF
+  [ "$status_child_failed" -eq 0 ] || return 1
+  printf '%s' "$table"
+}
+
 snapshot_is_complete() {
   jq -e '
     def safe_string:
@@ -816,6 +964,8 @@ snapshot_is_complete() {
         (.label | safe_string))
       and all($s.workspaces[];
         (.workspace_id | nonempty_string) and
+        (((.tokens // {}) | type) == "object") and
+        ((.tokens // {}) | all([.branch, .git_status][]; optional_safe_string)) and
         ((has("label") | not) or (.label | optional_safe_string)) and
         ((has("name") | not) or (.name | optional_safe_string)))
       and all($s.agents[];
@@ -1095,6 +1245,9 @@ EOF
 reconcile_presentation_pass() {
   local pass="$1" snapshot aliased alias_status final_snapshot initial_identity final_identity pool_json
   local pane_rows baselines legacy_label_panes presentations="" tab_intents workspace_origins
+  local workspace_tokens space_rows space_roots root_statuses space_row status_row
+  local space_id space_current_branch space_current_status space_root space_branch
+  local status_outcome status_counts space_status
   local id terminal tab_id workspace runtime revision session_json current alias pane_json_encoded pane_json
   local current_repo current_worktree current_branch current_status current_git_ref current_space_origin
   local location_file result outcome root anchor repo branch linked sha status intended
@@ -1150,6 +1303,10 @@ reconcile_presentation_pass() {
   # that parent as worktree.repo_name, so no Git probe is needed. A workspace
   # whose own label already is the repository name (the main checkout) would
   # only repeat itself, so it publishes nothing.
+  workspace_tokens="$(printf '%s' "$snapshot" | jq -r '
+    .result.snapshot.workspaces[]
+    | [.workspace_id, ((.tokens.branch) // ""), ((.tokens.git_status) // "")]
+    | join("\u001f")')" || return 1
   workspace_origins="$(printf '%s' "$snapshot" | jq -r '
     .result.snapshot.workspaces[]
     | (.label // .name // "") as $label
@@ -1374,6 +1531,58 @@ EOF
     fi
   done <<EOF
 $presentations
+EOF
+
+  # Space rows read workspace metadata. herdr fills its builtin `branch` token
+  # only for a repository's primary checkout — a space on a linked worktree
+  # renders that row empty (herdrdev/herdr#2952, open against 0.8.0 and still
+  # reproducing on 0.8.2), and no builtin can be forced from outside. This pass
+  # already resolved every pane's checkout, so it reports the branch and the
+  # counts for each space itself, and the rows read `$branch` / `$git_status`.
+  space_rows="$(printf '%s\n' "$presentations" | LC_ALL=C sort -t "$FIELD_SEPARATOR" -k1,1 |
+    awk -F "$FIELD_SEPARATOR" -v OFS="$FIELD_SEPARATOR" '
+      NF >= 19 && $10 == "git" && $11 != "" && !($4 in seen) {
+        seen[$4] = 1
+        print $4, $11, ($14 != "" ? $14 : $16)
+      }')"
+  space_roots="$(printf '%s\n' "$space_rows" | awk -F "$FIELD_SEPARATOR" 'NF { print $2 }' | LC_ALL=C sort -u)"
+  root_statuses=""
+  if [ -n "$space_roots" ]; then
+    root_statuses="$(build_root_statuses "$space_roots")" || return 1
+  fi
+  while IFS="$FIELD_SEPARATOR" read -r space_id space_current_branch space_current_status; do
+    [ -n "$space_id" ] || continue
+    space_row="$(table_row_for "$space_id" "$space_rows")"
+    IFS="$FIELD_SEPARATOR" read -r space_root space_branch <<EOF
+$space_row
+EOF
+    if [ -n "$space_root" ]; then
+      status_row="$(table_row_for "$space_root" "$root_statuses")"
+      IFS="$FIELD_SEPARATOR" read -r status_outcome status_counts <<EOF
+$status_row
+EOF
+      case "$status_outcome" in
+        fresh) space_status="$(status_line_for "$status_counts")" ;;
+        # A probe that ran out of budget must not erase a count the user is
+        # looking at; it keeps what is published until the next pass answers.
+        *) space_status="$space_current_status" ;;
+      esac
+    else
+      space_branch=""
+      space_status=""
+    fi
+    [ "$space_current_branch" != "$space_branch" ] || [ "$space_current_status" != "$space_status" ] ||
+      continue
+    presentation_generation_valid "$pass" || return 2
+    set -- herdr workspace report-metadata "$space_id" --source "$LOCATION_SOURCE_ID" --seq "$pass"
+    if [ -n "$space_branch" ]; then set -- "$@" --token "branch=$space_branch"; else set -- "$@" --clear-token branch; fi
+    if [ -n "$space_status" ]; then set -- "$@" --token "git_status=$space_status"; else set -- "$@" --clear-token git_status; fi
+    "$@" >/dev/null 2>&1 || {
+      [ "$STRICT_SWEEP" != 1 ] || return 1
+      continue
+    }
+  done <<EOF
+$workspace_tokens
 EOF
 
   while IFS="$FIELD_SEPARATOR" read -r tab_id workspace current intended; do

--- a/home/dot_local/bin/executable_herdr-pane-labels
+++ b/home/dot_local/bin/executable_herdr-pane-labels
@@ -781,7 +781,7 @@ snapshot_is_complete() {
     def safe_tokens:
       ((.tokens // {}) | type) == "object" and
       ((.tokens // {}) |
-        all([.repo,.worktree,.branch,.location_status,.git_ref,.location_label][];
+        all([.repo,.worktree,.branch,.location_status,.git_ref,.space_origin,.location_label][];
           optional_safe_string));
     def finite_number: type == "number" and (tostring | test("nan|infinite"; "i") | not);
     def optional_session:
@@ -1094,14 +1094,15 @@ EOF
 
 reconcile_presentation_pass() {
   local pass="$1" snapshot aliased alias_status final_snapshot initial_identity final_identity pool_json
-  local pane_rows baselines legacy_label_panes presentations="" tab_intents
+  local pane_rows baselines legacy_label_panes presentations="" tab_intents workspace_origins
   local id terminal tab_id workspace runtime revision session_json current alias pane_json_encoded pane_json
-  local current_repo current_worktree current_branch current_status current_git_ref
+  local current_repo current_worktree current_branch current_status current_git_ref current_space_origin
   local location_file result outcome root anchor repo branch linked sha status intended
   local location_pids="" location_results="" result_file pid probe_results="" child_failed=0
   local roots root_tokens worktree git_ref ref place folder baseline
   local pane_id state_file retained_pane presented_ids
-  local final_payload final_label final_tokens final_repo final_worktree final_branch final_status final_git_ref final_legacy
+  local final_payload final_label final_tokens final_repo final_worktree final_branch final_status final_git_ref final_space_origin final_legacy
+  local space_origin
   local location_changed location_seq
   local pane_count active_tab_count
   command -v jq >/dev/null 2>&1 || return 1
@@ -1141,13 +1142,24 @@ reconcile_presentation_pass() {
     | [$p.pane_id,$p.terminal_id,$p.tab_id,$p.workspace_id,($p.agent // ""),
        ($p.revision|tostring),(($p.agent_session // null)|tojson),($p.label // ""),($a.name // ""),
        ($p.tokens.repo // ""),($p.tokens.worktree // ""),($p.tokens.branch // ""),
-       ($p.tokens.location_status // ""),($p.tokens.git_ref // ""),($p|@base64)]
-    | join("\u001f")' | filter_records_of_width 15 "$pane_count")" || return 1
-  baselines="$(printf '%s\n' "$pane_rows" | awk -F "$FIELD_SEPARATOR" -v OFS="$FIELD_SEPARATOR" 'NF {print $1,$10,$11,$12,$13,$14}')"
+       ($p.tokens.location_status // ""),($p.tokens.git_ref // ""),
+       ($p.tokens.space_origin // ""),($p|@base64)]
+    | join("\u001f")' | filter_records_of_width 16 "$pane_count")" || return 1
+  baselines="$(printf '%s\n' "$pane_rows" | awk -F "$FIELD_SEPARATOR" -v OFS="$FIELD_SEPARATOR" 'NF {print $1,$10,$11,$12,$13,$14,$15}')"
+  # A worktree workspace names the space it was cut from. herdr already reports
+  # that parent as worktree.repo_name, so no Git probe is needed. A workspace
+  # whose own label already is the repository name (the main checkout) would
+  # only repeat itself, so it publishes nothing.
+  workspace_origins="$(printf '%s' "$snapshot" | jq -r '
+    .result.snapshot.workspaces[]
+    | (.label // .name // "") as $label
+    | ((.worktree.repo_name) // "") as $origin
+    | [.workspace_id, (if $origin == "" or $origin == $label then "" else $origin end)]
+    | join("\u001f")')" || return 1
   legacy_label_panes="$(printf '%s' "$snapshot" | jq -r '.result.snapshot.panes[] | select((.tokens.location_label // "") != "") | .pane_id')"
   trace_presentation_phase rows
 
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current alias current_repo current_worktree current_branch current_status current_git_ref pane_json_encoded; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current alias current_repo current_worktree current_branch current_status current_git_ref current_space_origin pane_json_encoded; do
     [ -n "$id" ] || continue
     pane_json="$(printf '%s' "$pane_json_encoded" | base64 -d 2>/dev/null)" || return 1
     location_file="$(location_state_file "$id")"
@@ -1188,7 +1200,7 @@ EOF
   [ "$child_failed" -eq 0 ] || return 1
   trace_presentation_phase locations
 
-  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current alias current_repo current_worktree current_branch current_status current_git_ref pane_json_encoded; do
+  while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current alias current_repo current_worktree current_branch current_status current_git_ref current_space_origin pane_json_encoded; do
     [ -n "$id" ] || continue
     result="${probe_results%%$'\n'*}"; [ -n "$result" ] || return 1
     if [ "$probe_results" = "$result" ]; then probe_results=""; else probe_results="${probe_results#*$'\n'}"; fi
@@ -1282,10 +1294,16 @@ EOF
   while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current intended outcome root anchor repo branch linked sha status git_ref worktree; do
     [ -n "$id" ] || continue
     baseline="$(table_row_for "$id" "$baselines")"
-    IFS="$FIELD_SEPARATOR" read -r current_repo current_worktree current_branch current_status current_git_ref <<EOF
+    IFS="$FIELD_SEPARATOR" read -r current_repo current_worktree current_branch current_status current_git_ref current_space_origin <<EOF
 $baseline
 EOF
+    # The origin is a property of the pane's workspace, not of its Git probe,
+    # so it is looked up here rather than carried through the location record.
+    # herdr renders its own separator between row tokens, so the value is the
+    # bare name.
+    space_origin="$(table_value_for "$workspace" "$workspace_origins")"
     location_changed=0
+    [ "$current_space_origin" = "$space_origin" ] || location_changed=1
     if { [ -n "$repo" ] && [ -n "$worktree" ]; } || [ "$outcome" = non_git ]; then
       ! list_contains_line "$id" "$legacy_label_panes" || location_changed=1
     fi
@@ -1312,15 +1330,17 @@ EOF
         continue
       }
       if [ "$location_changed" -eq 1 ]; then
-        final_tokens="$(printf '%s' "$final_payload" | jq -r '.result.pane.tokens | [(.repo//""),(.worktree//""),(.branch//""),(.location_status//""),(.git_ref//""),(.location_label//"")] | join("\u001f")')"
-        IFS="$FIELD_SEPARATOR" read -r final_repo final_worktree final_branch final_status final_git_ref final_legacy <<EOF
+        final_tokens="$(printf '%s' "$final_payload" | jq -r '.result.pane.tokens | [(.repo//""),(.worktree//""),(.branch//""),(.location_status//""),(.git_ref//""),(.space_origin//""),(.location_label//"")] | join("\u001f")')"
+        IFS="$FIELD_SEPARATOR" read -r final_repo final_worktree final_branch final_status final_git_ref final_space_origin final_legacy <<EOF
 $final_tokens
 EOF
         if [ "$final_repo" != "$repo" ] || [ "$final_worktree" != "$worktree" ] || [ "$final_branch" != "$branch" ] ||
-          [ "$final_status" != "$status" ] || [ "$final_git_ref" != "$git_ref" ] || [ -n "$final_legacy" ]; then
+          [ "$final_status" != "$status" ] || [ "$final_git_ref" != "$git_ref" ] ||
+          [ "$final_space_origin" != "$space_origin" ] || [ -n "$final_legacy" ]; then
           presentation_generation_valid "$pass" || return 2
           location_seq="$pass"
           set -- herdr pane report-metadata "$id" --source "$LOCATION_SOURCE_ID" --seq "$location_seq"
+          if [ -n "$space_origin" ]; then set -- "$@" --token "space_origin=$space_origin"; else set -- "$@" --clear-token space_origin; fi
           if [ -n "$repo" ] && [ -n "$worktree" ]; then
             set -- "$@" --token "repo=$repo" --token "worktree=$worktree" --token "git_ref=$git_ref" --clear-token pane_inline --clear-token location_label
             if [ -n "$branch" ]; then set -- "$@" --token "branch=$branch"; else set -- "$@" --clear-token branch; fi
@@ -1390,12 +1410,15 @@ EOF
     }
     while IFS="$FIELD_SEPARATOR" read -r id terminal tab_id workspace runtime revision session_json current intended outcome root anchor repo branch linked sha status git_ref worktree; do
       [ -n "$id" ] || continue
+      space_origin="$(table_value_for "$workspace" "$workspace_origins")"
       printf '%s' "$final_snapshot" | jq -e \
         --arg id "$id" --arg terminal "$terminal" --arg intended "$intended" \
         --arg outcome "$outcome" --arg repo "$repo" --arg worktree "$worktree" \
-        --arg branch "$branch" --arg status "$status" --arg git_ref "$git_ref" '
+        --arg branch "$branch" --arg status "$status" --arg git_ref "$git_ref" \
+        --arg space_origin "$space_origin" '
           [.result.snapshot.panes[] | select(.pane_id == $id and .terminal_id == $terminal)] as $panes
           | ($panes | length) == 1 and ($panes[0].label == $intended)
+            and (($panes[0].tokens.space_origin // "") == $space_origin)
             and (if ($repo != "" and $worktree != "") then
               (($panes[0].tokens.repo // "") == $repo) and
               (($panes[0].tokens.worktree // "") == $worktree) and

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -59,21 +59,25 @@ sidebar_min_width = 32
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`
 # labels, rebuilds tab labels, and publishes the Git location tokens.
-# The third row is the pane's location. `$space_origin` names the space a
-# worktree space was cut from; `$git_ref` carries the engine's composed
-# location string (place glyph + branch/worktree/short SHA, folder qualifier
-# when there is no ref, stale marker). herdr supplies the separator, so the
-# pair reads "my-mac-setup <sep> <worktree-glyph> branch" and a worktree pane
-# is distinguishable from a plain checkout at a glance. A space whose label
-# already is the repository name publishes no origin, so the main checkout
-# does not repeat what the first row said.
-# Location stays its own row on purpose: pane identity stays stable while Git
-# state moves underneath it, and a pane outside a checkout still names the
-# folder it sits in. It sits above the pane name because where a pane works
-# is what the eye looks for when scanning the sidebar; the allocator-owned
-# alias is the last line.
+# The second row pairs the pane's allocator-owned alias with `$space_origin`,
+# the space a worktree space was cut from, so an agent reads
+# "cc:olive-heron <sep> my-mac-setup". A space whose label already is the
+# repository name publishes no origin and the alias stands alone. The branch
+# itself lives in the space rows below, so it is not repeated here.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace"], ["$space_origin", "$git_ref"], ["pane"]]
+rows = [["state_icon", "workspace"], ["pane", "$space_origin"]]
+
+# Space rows read `$branch` and `$git_status` from workspace metadata, which
+# herdr-pane-labels publishes, rather than herdr's same-named built-ins. The
+# built-ins render only for a repository's primary checkout: a space on a
+# linked worktree leaves that row empty (herdrdev/herdr#2952, open against
+# 0.8.0 and still reproducing on 0.8.2), which is every worktree space here.
+# Custom tokens have no such gap, so every space shows its branch, and the
+# counts read ⇣pull ⇡push ~conflicts +staged !unstaged ?untracked with empty
+# positions omitted.
+[ui.sidebar.spaces]
+row_gap = 0
+rows = [["state_icon", "workspace"], ["$branch", "$git_status"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -59,12 +59,21 @@ sidebar_min_width = 32
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`
 # labels, rebuilds tab labels, and publishes the Git location tokens.
-# The third row renders `$git_ref` — the engine's composed location string
-# (place glyph + branch/worktree/short SHA, folder qualifier, stale marker).
-# It is a separate row on purpose: pane identity stays stable while Git state
-# moves underneath it, and a pane outside a checkout simply renders no row.
+# The third row is the pane's location. `$space_origin` names the space a
+# worktree space was cut from; `$git_ref` carries the engine's composed
+# location string (place glyph + branch/worktree/short SHA, folder qualifier
+# when there is no ref, stale marker). herdr supplies the separator, so the
+# pair reads "my-mac-setup <sep> <worktree-glyph> branch" and a worktree pane
+# is distinguishable from a plain checkout at a glance. A space whose label
+# already is the repository name publishes no origin, so the main checkout
+# does not repeat what the first row said.
+# Location stays its own row on purpose: pane identity stays stable while Git
+# state moves underneath it, and a pane outside a checkout still names the
+# folder it sits in. It sits above the pane name because where a pane works
+# is what the eye looks for when scanning the sidebar; the allocator-owned
+# alias is the last line.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace"], ["pane"], ["$git_ref"]]
+rows = [["state_icon", "workspace"], ["$space_origin", "$git_ref"], ["pane"]]
 
 # Native agent-status toasts are off: the herdr-focus-notify plugin sends its
 # own clickable notification (with `herdr agent focus` on click), and the two

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -64,8 +64,14 @@ sidebar_min_width = 32
 # above its own alias. A space whose label already is the repository name
 # publishes no origin and the label stands alone. The branch itself lives in
 # the space rows below, so it is not repeated here.
+# herdr dims an agent's secondary row by default while space rows keep the
+# theme's ordinary foreground, so the same text read fainter here than two
+# panels up. `dim = false` restores the contextual color instead of naming
+# one: inline token styles accept only strict #RGB/#RRGGBB (the binary rejects
+# anything else with "sidebar token fg must be #RGB or #RRGGBB"), and a hex
+# value would survive a theme switch as the wrong color.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace", "$space_origin"], ["pane"]]
+rows = [["state_icon", "workspace", "$space_origin"], [{ token = "pane", dim = false }]]
 
 # Space rows read `$branch` and `$git_status` from workspace metadata, which
 # herdr-pane-labels publishes, rather than herdr's same-named built-ins. The

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -59,13 +59,13 @@ sidebar_min_width = 32
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`
 # labels, rebuilds tab labels, and publishes the Git location tokens.
-# The second row pairs the pane's allocator-owned alias with `$space_origin`,
-# the space a worktree space was cut from, so an agent reads
-# "cc:olive-heron <sep> my-mac-setup". A space whose label already is the
-# repository name publishes no origin and the alias stands alone. The branch
-# itself lives in the space rows below, so it is not repeated here.
+# The first row pairs the space with `$space_origin`, the space a worktree
+# space was cut from, so an agent reads "Git Branch Sidebar <sep> my-mac-setup"
+# above its own alias. A space whose label already is the repository name
+# publishes no origin and the label stands alone. The branch itself lives in
+# the space rows below, so it is not repeated here.
 [ui.sidebar.agents]
-rows = [["state_icon", "workspace"], ["pane", "$space_origin"]]
+rows = [["state_icon", "workspace", "$space_origin"], ["pane"]]
 
 # Space rows read `$branch` and `$git_status` from workspace metadata, which
 # herdr-pane-labels publishes, rather than herdr's same-named built-ins. The

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6143,6 +6143,40 @@ function test_scripts_1152_herdr_pane_labels_formatter_qualifies_a_divergent_wor
   assert_equal "$(jq -r '.tabs[0].label' "$state")" "alpha · beta"
 }
 
+function test_scripts_1206_herdr_pane_labels_names_the_space_a_worktree_space_ca() {
+  _bats_test_init 1206 'herdr-pane-labels names the space a worktree space came from, and only when it adds something'
+  command -v jq >/dev/null || skip "jq not available"
+  hpl_setup
+  # given: a worktree space labelled by its task, a worktree space whose label
+  # already is the repository name, and a space herdr reports no worktree for
+  local work="$HPL_WORK/work" state
+  mkdir -p "$work"
+  hpl_git_fixture "$work" "" 1 ready 'fatal: not a git repository'
+  hpl_set_pane "$HPL_DEFAULT_SOCKET" "$(hpl_process_pane_json pane-1 tab-1 "$work")"
+  hpl_set_pane "$HPL_DEFAULT_SOCKET" "$(hpl_process_pane_json pane-2 tab-2 "$work" | jq -c '.workspace_id = "ws-2"')"
+  hpl_set_pane "$HPL_DEFAULT_SOCKET" "$(hpl_process_pane_json pane-3 tab-3 "$work" | jq -c '.workspace_id = "ws-3"')"
+  hpl_set_tab "$HPL_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hpl_set_tab "$HPL_DEFAULT_SOCKET" '{"tab_id":"tab-2","workspace_id":"ws-2","label":""}'
+  hpl_set_tab "$HPL_DEFAULT_SOCKET" '{"tab_id":"tab-3","workspace_id":"ws-3","label":""}'
+  hpl_set_workspace "$HPL_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"Task Name","worktree":{"repo_name":"repository","is_linked_worktree":true}}'
+  hpl_set_workspace "$HPL_DEFAULT_SOCKET" '{"workspace_id":"ws-2","label":"repository","worktree":{"repo_name":"repository","is_linked_worktree":false}}'
+  hpl_set_workspace "$HPL_DEFAULT_SOCKET" '{"workspace_id":"ws-3","label":"IronVault"}'
+  hpl_set_process_label pane-1 one
+  hpl_set_process_label pane-2 two
+  hpl_set_process_label pane-3 three
+
+  # when: one location/presentation pass runs
+  hpl_location_pass
+  state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
+
+  # then: only the space whose label differs from its repository names the parent
+  assert_equal "$(jq -r '.panes[] | select(.pane_id == "pane-1") | .tokens.space_origin' "$state")" repository
+  run jq -e '.panes[] | select(.pane_id == "pane-2") | .tokens.space_origin == null' "$state"
+  assert_success
+  run jq -e '.panes[] | select(.pane_id == "pane-3") | .tokens.space_origin == null' "$state"
+  assert_success
+}
+
 function test_scripts_1153_herdr_pane_labels_formatter_keeps_mixed_git_identities_() {
   _bats_test_init 1153 'herdr-pane-labels formatter keeps mixed Git identities out of tabs and repairs external labels'
   command -v jq >/dev/null || skip "jq not available"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6177,6 +6177,49 @@ function test_scripts_1206_herdr_pane_labels_names_the_space_a_worktree_space_ca
   assert_success
 }
 
+function test_scripts_1207_herdr_pane_labels_reports_branch_and_counts_as_space_() {
+  _bats_test_init 1207 'herdr-pane-labels reports branch and status counts as space metadata, and clears them off a non-Git space'
+  command -v jq >/dev/null || skip "jq not available"
+  hpl_setup
+  # given: a worktree checkout whose status carries every category, and a
+  # second space whose pane sits outside any checkout
+  local root="$HPL_WORK/wt" common="$HPL_WORK/repository/.git" outside="$HPL_WORK/outside" state
+  mkdir -p "$root" "$common" "$outside"
+  hpl_mark_linked_worktree "$root" "$common/worktrees/wt"
+  hpl_git_location_fixture "$root" "$root" "$common" refs/heads/feature
+  hpl_git_status_fixture "$root" '# branch.oid abc
+# branch.head feature
+# branch.upstream origin/feature
+# branch.ab +2 -1
+1 M. N... 100644 100644 100644 aaa bbb staged-only.txt
+1 .M N... 100644 100644 100644 aaa bbb unstaged-only.txt
+1 MM N... 100644 100644 100644 aaa bbb both.txt
+u UU N... 100644 100644 100644 100644 aaa bbb ccc conflicted.txt
+? untracked.txt'
+  hpl_git_fixture "$outside" "" 1 ready 'fatal: not a git repository'
+  hpl_set_pane "$HPL_DEFAULT_SOCKET" "$(hpl_process_pane_json pane-1 tab-1 "$root")"
+  hpl_set_pane "$HPL_DEFAULT_SOCKET" "$(hpl_process_pane_json pane-2 tab-2 "$outside" | jq -c '.workspace_id = "ws-2"')"
+  hpl_set_tab "$HPL_DEFAULT_SOCKET" '{"tab_id":"tab-1","workspace_id":"ws-1","label":""}'
+  hpl_set_tab "$HPL_DEFAULT_SOCKET" '{"tab_id":"tab-2","workspace_id":"ws-2","label":""}'
+  hpl_set_workspace "$HPL_DEFAULT_SOCKET" '{"workspace_id":"ws-1","label":"Task Name"}'
+  hpl_set_workspace "$HPL_DEFAULT_SOCKET" '{"workspace_id":"ws-2","label":"Elsewhere","tokens":{"branch":"stale","git_status":"stale"}}'
+  hpl_set_process_label pane-1 one
+  hpl_set_process_label pane-2 two
+
+  # when: one location/presentation pass runs
+  hpl_location_pass
+  state="$(hpl_socket_state "$HPL_DEFAULT_SOCKET")"
+
+  # then: the worktree space carries its branch and one count per category,
+  # ordered pull, push, conflicts, staged, unstaged, untracked
+  assert_equal "$(jq -r '.workspaces[] | select(.workspace_id == "ws-1") | .tokens.branch' "$state")" feature
+  assert_equal "$(jq -r '.workspaces[] | select(.workspace_id == "ws-1") | .tokens.git_status' "$state")" \
+    "${HPL_ICON_PULL}1 ${HPL_ICON_PUSH}2 ~1 +2 !2 ?1"
+  # then: the space with no checkout sheds the tokens it was carrying
+  run jq -e '.workspaces[] | select(.workspace_id == "ws-2") | (.tokens // {}) == {}' "$state"
+  assert_success
+}
+
 function test_scripts_1153_herdr_pane_labels_formatter_keeps_mixed_git_identities_() {
   _bats_test_init 1153 'herdr-pane-labels formatter keeps mixed Git identities out of tabs and repairs external labels'
   command -v jq >/dev/null || skip "jq not available"

--- a/tests/helpers/herdr_pane_labels.bash
+++ b/tests/helpers/herdr_pane_labels.bash
@@ -31,6 +31,8 @@ HPL_ICON_COMMIT="$(hpl_icon COMMIT)"     # nf-cod-git_commit U+EAFC
 # shellcheck disable=SC2034
 HPL_ICON_FOLDER="$(hpl_icon FOLDER)"     # nf-cod-folder U+EA83
 # shellcheck disable=SC2034
+HPL_ICON_PULL="$(hpl_icon PULL)"         # U+21E3 downwards dashed arrow
+HPL_ICON_PUSH="$(hpl_icon PUSH)"         # U+21E1 upwards dashed arrow
 HPL_ICON_STALE="$(hpl_icon STALE)"       # nf-cod-history U+EA82
 
 hpl_teardown() {
@@ -310,6 +312,31 @@ elif [ "$1" = "tab" ] && [ "$2" = "rename" ]; then
   result=$?
   hpl_fixture_state_unlock "$dir"
   [ "$result" -eq 0 ] || exit "$result"
+elif [ "$1" = "workspace" ] && [ "$2" = "report-metadata" ]; then
+  [ ! -f "$HPL_WORK/fail-workspace-report" ] || exit 1
+  shift 2
+  source_id= workspace_id= report_seq= tokens='{}' clear_tokens='[]'
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --source) source_id="$2"; shift 2 ;;
+      --seq) report_seq="$2"; shift 2 ;;
+      --token) tokens="$(jq -c --arg pair "$2" '. + {($pair | split("=")[0]): ($pair | split("=")[1:] | join("="))}' <<< "$tokens")"; shift 2 ;;
+      --clear-token) clear_tokens="$(jq -c --arg name "$2" '. + [$name]' <<< "$clear_tokens")"; shift 2 ;;
+      --*) shift 2 ;;
+      *) workspace_id="$1"; shift ;;
+    esac
+  done
+  [ -n "$source_id" ] && [ -n "$workspace_id" ] || exit 2
+  tmp="$state.tmp.$$"
+  hpl_fixture_state_lock "$dir" || exit 1
+  jq --arg ws "$workspace_id" --argjson tokens "$tokens" --argjson clears "$clear_tokens" '
+      .workspaces |= map(if .workspace_id == $ws then
+        .tokens = ((reduce $clears[] as $key ((.tokens // {}); del(.[$key]))) + $tokens)
+        | if (.tokens | length) == 0 then del(.tokens) else . end
+      else . end)' "$state" > "$tmp" && mv "$tmp" "$state"
+  result=$?
+  hpl_fixture_state_unlock "$dir"
+  [ "$result" -eq 0 ] || exit "$result"
 elif [ "$1" = "pane" ] && [ "$2" = "report-metadata" ]; then
   [ ! -f "$HPL_WORK/fail-pane-report" ] || exit 1
   [ ! -f "$HPL_WORK/drop-pane-report" ] || exit 0
@@ -390,6 +417,7 @@ if [ -d "$fixture" ]; then
   out="$fixture/stdout"
   case "$command_args" in
     *"--short=7"*) [ ! -f "$fixture/stdout.short" ] || out="$fixture/stdout.short" ;;
+    *"--porcelain=v2"*) [ ! -f "$fixture/stdout.status" ] || out="$fixture/stdout.status" ;;
   esac
   cat "$out"
   exit "$(cat "$fixture/status")"
@@ -828,6 +856,15 @@ hpl_process_pane_json() {
     --arg mode "$foreground_mode" '
       {pane_id:$id,tab_id:$tab,workspace_id:"ws-1",terminal_id:("term-" + $id),agent:null,label:"",tokens:{},cwd:$cwd}
       | if $mode == "absent" then . else .foreground_cwd = $fg end'
+}
+
+# Attaches a `status --porcelain=v2` body to the fixture already registered for
+# this cwd, so one fixture answers both the identity probe and the status probe.
+hpl_git_status_fixture() {
+  local fixture
+  fixture="$(hpl_git_fixture_dir "$1")"
+  [ -n "$fixture" ] || return 1
+  printf '%s\n' "$2" > "$fixture/stdout.status"
 }
 
 hpl_set_process_label() {


### PR DESCRIPTION
## Summary

Every space in the sidebar now names the branch it works on, and every agent row names the repository its worktree came from. Before this, a space created for a task showed only the task name — "Git Branch Sidebar" — while the branch row stayed empty, and nothing anywhere said which repository that worktree belongs to.

The empty branch row is an upstream gap: herdr's builtin `branch` space-row token renders only for a repository's primary checkout, and a space on a linked worktree leaves it blank (herdrdev/herdr#2952, open against 0.8.0 and still reproducing on 0.8.2). Since every task space here is a linked worktree, the builtin was blank exactly where it mattered. Custom metadata tokens have no such gap, so the pass publishes them itself.

## What the sidebar shows now

```
● my-mac-setup
  main
  ├ ● Git Branch Sidebar
  │   sidebar-space-origin  !4
  └ ● Test Run Overuse
      test-run-overuse  !2 ?1
● homelab
  main
```

Space rows read `$branch` and `$git_status`; agent rows pair the pane's alias with `$space_origin`. Counts read `⇣pull ⇡push ~conflicts +staged !unstaged ?untracked`, empty positions omitted — the vocabulary this repo used before commit 21aaaf0 removed it, restored unchanged so a reader who learned it once still reads it the same way.

## Two published token sets

**`space_origin`** (agent rows) names the space a worktree space was cut from. herdr already reports the parent as `workspaces[].worktree.repo_name`, so no Git probe is involved. A space whose label already is the repository name publishes nothing, so the main checkout does not repeat itself.

**`branch` + `git_status`** (space rows) come from the pass's own probe. The status probe is the one 21aaaf0 removed, restored in substance:

- One `status --porcelain=v2 --branch --untracked-files=all` answers the changed paths and the `# branch.ab` pair together, instead of two process launches. `--untracked-files=all` is what makes the count mean the same thing on every machine, since `status.showUntrackedFiles` can otherwise hide untracked paths or collapse a new directory to one entry.
- It runs under its own budget (0.5 s, measured at or under 10 ms warm on this repo and on the main checkout), separate from the 75 ms scan-free identity budget. A probe that exceeds it keeps the counts already published rather than erasing or guessing them.
- Distinct checkout roots are probed concurrently, so several worktrees cost one budget rather than one each.

## Validation

- New test 1207: a worktree space with one path in every status category publishes its branch and `⇣1 ⇡2 ~1 +2 !2 ?1`, and a space whose pane sits outside any checkout sheds the tokens it was carrying. Expected values come from the fixture's own `--porcelain=v2` body.
- New test 1206: the origin token appears only when it adds something — a task-labelled worktree space publishes the repository name, while a space whose label already is that name, and a space with no worktree record, publish nothing.
- Both were mutation-checked: dropping the conflict count made 1207 fail on the missing `~1`; dropping the label-equals-repo condition made 1206 fail. The engine was restored from a copy each time.
- `tests/bashunit/scripts_test.sh` pane-labels suite: 78 passed, 395 assertions. `make lint` clean.
- Live on a running herdr session: two worktree spaces show their branches with real counts (`!4`, `!2 ?1`), three primary checkouts show `main` clean, and a non-Git space shows nothing.
- `make test-ubuntu` was not run for this change at the author's direction; the ubuntu CI job covers it.
