### PR TITLE
fix(agents): scope verification by deployment risk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ Reference docs (read on demand):
 | Command | What it does |
 |---|---|
 | `make test-issues` | Strictly validate repository issues and run issue CLI tests |
-| `make test-ubuntu` | Full test in Docker |
+| `make test-ubuntu` | Full source render, disposable-home apply, and test suite in Docker |
 | `make test-docker` | Build + run full Docker test suite |
-| `make test-suite` | Post-apply suite in parallel, host-safe files only. It keeps `tests/bashunit/idempotent_test.sh` excluded as redundant defense behind that file's `MMS_DISPOSABLE_HOME` guard. Asserts against the **already-applied** `~/`, not this checkout — an unapplied edit under `home/` is not covered and still goes green |
-| `make test-templates` | Template tests in Docker; may rebuild images and take several minutes |
-| `make test-local` | `chezmoi diff` (dry-run, no changes) |
+| `make test-suite` | Post-apply suite against the already-applied `~/`; excludes `tests/bashunit/idempotent_test.sh` |
+| `make test-templates` | Focused source-render tests in Docker; included in `make test-ubuntu` |
+| `make test-local` | Diff this checkout's `home/` against the current home (dry-run, no changes) |
 | `make lint` | shellcheck |
 | `make shell-ubuntu` | Interactive shell in Ubuntu container |
 | `make build-docker` | Build Docker image only |
@@ -65,10 +65,10 @@ Edit the **source** in `home/` (e.g., `home/dot_tmux.conf`), not the live file i
 
 <important if="you edited a managed file and expect the change to take effect, or you ran chezmoi and got surprising results">
 
-**chezmoi reads its own clone, NOT this working checkout.** There are THREE copies of every managed file:
+**By default, chezmoi reads its own clone, NOT this working checkout.** `make test-local` is the deliberate exception: it passes `--source=./home` to compare this checkout. There are THREE copies of every managed file:
 
 1. **This repo checkout** (`~/Projects/my-mac-setup/home/...`) — where you edit and commit. `chezmoi` does **not** read it.
-2. **chezmoi source** (`~/.local/share/chezmoi/home/...`) — a **separate git clone** of the same repo. Every `chezmoi` command (`source-path`, `managed`, `diff`, `apply`) reads this, not copy 1.
+2. **chezmoi source** (`~/.local/share/chezmoi/home/...`) — a **separate git clone** of the same repo. Raw `chezmoi` commands without an explicit `--source` read this, not copy 1.
 3. **Live file** (`~/.config/...`, `~/.claude/...`) — what tools actually run. `chezmoi apply` deploys it from copy 2.
 
 Consequence: an edit in this checkout is **commit-ready but NOT live** — it hasn't reached copy 2 or 3. The path to live is commit here → sync into copy 2 (`git pull` there) → `chezmoi apply` (forbidden on host per the rule above, so the user runs it). Never assume your edit took effect in-session. Verify a file's chezmoi source with `chezmoi source-path ~/<live-path>` — it returns a path under `~/.local/share/chezmoi`, confirming the split.
@@ -92,7 +92,7 @@ Adding a managed config, step by step:
 2. `chezmoi add ~/.config/tool` — creates the source file in `home/`.
 3. Add a `.tmpl` suffix if the file needs OS branching or secrets; OS-specific files also need a rule in `home/.chezmoiignore`.
 4. Coverage passes the test-oracle gate first: state the oracle line (consumer, observable failure, oracle independent of this change) — when it cannot be completed, zero new tests is the correct outcome. When it can, extend the narrowest test that proves deployment behavior; use `tests/bashunit/smoke_test.sh` only for cross-component coverage.
-5. Verify: `make test-local` (diff only), then `make test-ubuntu`.
+5. A new managed path is deployment-sensitive; follow `docs/agent-verification.md`.
 
 `modify_` scripts (e.g., `modify_dot_claude.json`) read the existing file from stdin and output a modified version — don't treat them as regular templates.
 
@@ -118,7 +118,7 @@ Package the canonical content through three thin adapters:
 
 Use raw `include` with the explicit `.chezmoitemplates/<file>` path so literal Markdown and Go-template syntax remain data. Do not use `includeTemplate`, which executes the included content. Treat `$ARGUMENTS`, `$<digits>`, and unquoted `@path` as reserved OpenCode command syntax; a workflow that must preserve these sequences literally needs client-specific content instead.
 
-Keep `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` in `home/dot_zshenv.tmpl` so OpenCode cannot discover the Claude-only adapters. Do not set `OPENCODE_DISABLE_EXTERNAL_SKILLS`; OpenCode must discover shared `~/.agents/skills` natively. After deployment, restart each client from the managed zsh environment before checking discovery. Add the workflow name to the `explicit-only workflows keep manual invocation boundaries` case in `tests/bashunit/smoke_test.sh`, then run `make test-templates` and `make test-ubuntu`.
+Keep `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` in `home/dot_zshenv.tmpl` so OpenCode cannot discover the Claude-only adapters. Do not set `OPENCODE_DISABLE_EXTERNAL_SKILLS`; OpenCode must discover shared `~/.agents/skills` natively. After deployment, restart each client from the managed zsh environment before checking discovery. Add the workflow name to the `explicit-only workflows keep manual invocation boundaries` case in `tests/bashunit/smoke_test.sh`. These template and managed-path changes are deployment-sensitive; follow `docs/agent-verification.md`.
 
 </important>
 
@@ -149,12 +149,12 @@ Costly-to-reverse architecture decisions go to `docs/decisions/` as minimal Arch
 - Read `docs/solutions/design-patterns/semantic-regression-tests-over-source-shape.md`; it defines semantic regression tests, control fixtures, coverage ownership, and honest verification.
 - Assert command status before inspecting output. Pair rejection fixtures with a nearby valid control that reaches the intended success path.
 - Search existing coverage first and strengthen its best owner instead of duplicating the assertion. Put new coverage in the narrowest relevant suite; reserve `tests/bashunit/smoke_test.sh` for deployed cross-component behavior.
-- Run the smallest canonical `make` target that covers the change instead of reconstructing its component commands.
-- Run `make test-suite` for the parallel host-safe files, or `make test-ubuntu` for the full Docker suite including `tests/bashunit/idempotent_test.sh`.
-- `tests/bashunit/idempotent_test.sh` guards every real chezmoi command with `MMS_DISPOSABLE_HOME=1`. Direct workstation runs skip those commands; `make test-ubuntu` declares a disposable `$HOME` and runs them.
-- `make test-suite` reads the deployed `~/` and applies nothing, so it cannot see an edit under `home/` that has not been applied yet. For a change to a managed file, `make test-ubuntu` is the one that proves it — it applies the checkout first.
-- Treat skips, partial runs, and isolated passes as incomplete evidence. If a required suite stalls, record the exact boundary, isolate the case, create a repository issue, and report the suite as incomplete.
-- CI runs both ubuntu and macos jobs.
 - Use `chezmoi_test_init()` from `tests/helpers/common.bash` instead of raw `chezmoi init`.
+
+</important>
+
+<important if="you are selecting or running checks, reusing evidence after edits, deciding whether to skip a broad check, preparing to publish, or verifying merge readiness">
+
+- **Verification:** Read `docs/agent-verification.md` before selecting, running, reusing, or skipping checks. It defines risk classes, evidence validity, and publish and merge gates.
 
 </important>

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "  make test-templates   Run template tests in Docker (may rebuild images)"
 	@echo "  make test-pi-agents-local  Run focused Pi local-instructions extension tests"
 	@echo "  make test-pi-herdr-worktree-identity  Run focused Pi worktree-identity extension tests"
-	@echo "  make test-local       Run chezmoi diff on current machine (dry-run)"
+	@echo "  make test-local       Diff checkout source against current home (dry-run)"
 	@echo "  make test-docker      Build and run full Docker test suite"
 	@echo "  make lint             Run shellcheck on all scripts"
 	@echo "  make shell-ubuntu     Open interactive shell in Ubuntu container"
@@ -44,25 +44,11 @@ shell-ubuntu: build-docker
 test-local:
 	chezmoi diff --source=./home
 
-# The parallel post-apply suite keeps tests/bashunit/idempotent_test.sh excluded as
-# redundant defense behind that file's MMS_DISPOSABLE_HOME guard. The guard
-# makes direct host runs inert, but the exclusion keeps this host-safe target
-# from reaching the real apply commands at all. Use `make test-ubuntu` to run
-# the full suite against a disposable $$HOME.
-#
-# Second, sharper limit: the host-safe files assert against the deployed $$HOME,
-# and this target deliberately applies nothing. So it reports on whatever was
-# last applied to this machine, NOT on the working checkout -- an edit under
-# home/ that has not been applied is invisible here, and the run still goes
-# green. `make test-ubuntu` applies the checkout first, which is why it is the
-# answer for an unapplied edit. The echo below repeats this at the point of
-# use, because a caveat that lives only in this comment reaches nobody.
+# This host-safe target excludes tests/bashunit/idempotent_test.sh and applies
+# nothing. It reports on the already-applied $$HOME, not the working checkout.
 test-suite:
 	@echo "NOTE: tests/bashunit/idempotent_test.sh remains excluded behind its disposable-home guard."
-	@echo "      Use make test-ubuntu to run those real apply tests safely."
 	@echo "NOTE: asserts against the ALREADY-APPLIED ~/ , not this checkout."
-	@echo "      An edit under home/ is not covered until it is applied."
-	@echo "      To test an unapplied edit, use: make test-ubuntu"
 	tests/run-post-apply.sh host-safe
 
 test-docker: test-issues build-docker

--- a/docs/agent-verification.md
+++ b/docs/agent-verification.md
@@ -1,0 +1,34 @@
+# Agent Verification
+
+**Outcome:** collect the smallest evidence set that proves the affected behavior, then reuse each successful result while the state within its coverage remains unchanged.
+
+## Select Evidence
+
+Classify the changed paths before running checks. Deployment-sensitive classification takes precedence when a diff fits both rows.
+Run the smallest canonical target or documented test command that proves the affected behavior; do not reconstruct its component commands.
+
+| Risk class | Applies when | Required local evidence |
+|---|---|---|
+| Content-only managed file | An existing non-template managed file changes only in content | Applicable focused checks plus `make test-local`. Pull-request CI is the deployment backstop. |
+| Checkout logic | A narrow test exercises changed logic directly from the checkout and the diff does not alter deployment behavior | The narrowest canonical focused check. Add `make test-local` only when the diff also contains a managed file. |
+| Deployment-sensitive | A managed path is new, renamed, or removed; a `.tmpl`, `.chezmoiignore`, chezmoi run script under `home/.chezmoiscripts/`, or `.chezmoiexternal.toml` changes; or behavior depends on the deployed location | One successful `make test-ubuntu` verdict on the final deployment-relevant state before publishing. |
+
+`make test-suite` reads the already-applied `~/` and applies nothing. It is evidence for deployed state, not for an unapplied checkout edit. `tests/bashunit/idempotent_test.sh` runs real chezmoi commands only when `MMS_DISPOSABLE_HOME=1`; `make test-ubuntu` supplies that disposable home.
+
+A content-only managed-file verdict requires every existing canonical focused check whose coverage includes the change to pass. In `make test-local` output, confirm that the intended source content maps to the expected destination and that no path, template, or ignore behavior changed. When no focused test owns the content's semantics, report that missing local oracle and use the mandatory pull-request CI jobs for behavioral evidence; do not manufacture a source-shape test or upgrade a static content edit to deployment-sensitive solely because no focused test exists.
+
+## Keep The Loop Tight
+
+- Run checks after a coherent change batch.
+- Use a focused suite for intermediate feedback or failure diagnosis. When the required broader suite includes it, do not run both as success gates against the same unchanged state.
+- Reuse a passing result until files or generated state within its coverage change. Unrelated edits do not invalidate it.
+- Before publishing, run only applicable checks that lack valid evidence for their current covered state.
+
+## Finish With A Verdict
+
+- A failed or incomplete required local check blocks publication until resolved.
+- A diagnosed failed or interrupted attempt may be retried after its processes reach a terminal state.
+- A skipped, partial, or isolated run is not a pass for a required broader check.
+- When a required suite stalls, record the exact boundary, isolate the case, create a repository issue for unresolved behavior, and report the suite as incomplete.
+- When CI is the backstop, report the risk class, substitute evidence, and why the broader local check adds no assurance.
+- Both Ubuntu and macOS pull-request jobs must pass before merging.

--- a/docs/brainstorms/2026-09-04-risk-scoped-agent-test-cadence-requirements.md
+++ b/docs/brainstorms/2026-09-04-risk-scoped-agent-test-cadence-requirements.md
@@ -1,0 +1,91 @@
+---
+date: 2026-09-04
+topic: risk-scoped-agent-test-cadence
+---
+
+# Risk-Scoped Agent Test Cadence
+
+## Summary
+
+Repository guidance will select tests by deployment risk and prevent agents from rerunning successful checks while the state covered by those checks remains unchanged. Content-only managed-file changes will rely on focused local evidence plus pull-request CI, while deployment-sensitive changes retain one final local Docker gate before publishing.
+
+---
+
+## Problem Frame
+
+Agents currently interpret any edit under `home/` as requiring `make test-ubuntu`. Several individually reasonable instructions combine into an unconditional pre-push gate, so even changes whose behavior is exercised directly from the checkout trigger a full Docker build, disposable-home apply, and complete suite. Repeated runs add minutes of latency, consume a visible Herdr pane, and require supervision without adding evidence when the relevant files have not changed.
+
+---
+
+## Actors
+
+- A1. Coding agent: selects and runs checks while implementing and publishing a change.
+- A2. Pull-request CI: supplies the cross-platform deployment backstop after a branch is pushed.
+
+---
+
+## Requirements
+
+**Risk selection**
+
+- R1. The coding agent must classify the changed paths by deployment risk before selecting checks.
+- R2. A content-only edit to an existing non-template managed file must not require a local `make test-ubuntu` run when every applicable canonical focused check passes and `make test-local` confirms the intended destination mapping without path, template, or ignore changes. When no focused test owns the content semantics, the agent must report the missing local oracle and use pull-request CI as the behavioral backstop.
+- R3. Logic exercised directly from the checkout must use its narrowest canonical test rather than a full deployment suite unless the same diff also changes deployment behavior. `make test-local` applies only when that diff includes a managed file.
+- R4. Changes that can alter deployment behavior must retain a local `make test-ubuntu` gate before publishing. This class includes new, renamed, or removed managed paths; templates; ignore rules; chezmoi run scripts under `home/.chezmoiscripts/`; externals; and changes whose behavior depends on the deployed location. This classification takes precedence over the content-only class.
+
+**Cadence and evidence**
+
+- R5. During implementation, the coding agent must use focused checks after a coherent change batch when they provide intermediate feedback or diagnose a failure, not after each individual edit or immediately before an encompassing final suite on the same diff.
+- R6. A successful check must not be repeated while the files or generated state covered by that check remain unchanged.
+- R7. For a deployment-sensitive diff, the coding agent must obtain one successful `make test-ubuntu` verdict on the final deployment-relevant state before publishing and must not repeat that successful check while the state within its coverage remains unchanged. A diagnosed failed or interrupted attempt may be retried after its processes reach a terminal state.
+- R8. The coding agent must not run both a narrower suite and a broader suite containing the same coverage against the same unchanged diff unless the narrower result is needed to diagnose a failure.
+- R9. Before publishing, the coding agent must run only applicable checks without valid evidence for the current files and generated state within each check's coverage. Unrelated changes outside that coverage must not invalidate existing evidence.
+- R10. When skipping a broad check, the coding agent must report the selected risk class, the evidence used instead, and the reason the broader check adds no pre-push assurance.
+
+**CI boundary**
+
+- R11. Existing Ubuntu and macOS pull-request checks remain unchanged and mandatory as the deployment backstop for content-only changes.
+- R12. A failed or incomplete required local check remains blocking; this policy changes check selection and cadence, not how failures are treated.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R9, R10, R11.** Given a value-only edit to an existing non-template configuration file, when the agent prepares to publish, it runs applicable focused checks and `make test-local`, skips local `make test-ubuntu` with a stated reason, and relies on pull-request CI for full deployment coverage.
+- AE2. **Covers R1, R3, R5.** Given an executable managed script with a canonical test that reads the script from the checkout, when its logic changes, the agent runs that focused test after the coherent edit batch rather than running the full Docker suite after each edit.
+- AE3. **Covers R1, R4, R7.** Given a template or managed-path change, when the deployment-relevant state is ready to publish, the agent obtains one successful `make test-ubuntu` verdict and does not repeat it while the state covered by that check remains unchanged.
+- AE4. **Covers R6, R9.** Given a focused test that passed and no covered file changed afterward, when the agent reaches the pre-publish step, it reuses the existing result instead of rerunning the test.
+- AE5. **Covers R6, R7, R9.** Given a required check that passed and a later edit changes a file within that check's coverage, when the agent prepares to publish, the previous result is no longer valid and the agent reruns the check.
+- AE6. **Covers R8.** Given a broad suite that includes a narrower template suite, when the broad suite passes against the same diff, the agent does not run the narrower suite as an additional success gate.
+- AE7. **Covers R12.** Given a selected required check that fails or cannot reach a verdict, when the agent prepares to publish, it reports the incomplete evidence and does not reinterpret the new policy as permission to ignore the result.
+- AE8. **Covers R7, R12.** Given a required Docker attempt that fails or is interrupted, when its processes have reached a terminal state and the cause has been addressed, the agent may retry it to obtain the required successful verdict.
+- AE9. **Covers R6, R9.** Given a focused test that passed, when an unrelated documentation file outside that test's coverage changes, the focused result remains valid and is not rerun before publishing.
+
+---
+
+## Success Criteria
+
+- Content-only edits to existing non-template managed files no longer trigger local full Docker runs by default.
+- Deployment-sensitive changes still receive one local disposable-home verification before publishing.
+- Agents do not rerun successful checks when the diff relevant to those checks is unchanged.
+- Agent reports make the selected risk class and omitted checks auditable.
+- A downstream implementer can update the repository guidance without inventing additional policy decisions.
+
+---
+
+## Scope Boundaries
+
+- Do not add an automatic changed-path test selector in this iteration.
+- Do not add a new fast disposable-home test target in this iteration.
+- Do not restructure the test suites or change their coverage in this iteration.
+- Do not weaken, remove, or conditionally skip existing pull-request CI jobs.
+- Do not allow failed or incomplete required checks to become non-blocking.
+
+---
+
+## Key Decisions
+
+- Pull-request CI is an acceptable deployment backstop for content-only edits to existing non-template managed files.
+- The first iteration changes repository guidance and agent cadence only.
+- Deployment-sensitive changes require one successful full local Docker verdict on the final deployment-relevant state before publishing.
+- Check evidence is invalidated by changes within its coverage, not by unrelated edits or the passage from implementation to publishing.


### PR DESCRIPTION
## Summary

Agents now reserve the full Docker suite for changes that can alter deployment, reuse successful evidence while its covered state is unchanged, and rely on mandatory pull-request CI for content-only managed-file changes. This removes the blanket `home/` pre-push gate that made small edits pay for a full disposable-home apply.

`docs/agent-verification.md` owns the policy as a disclosed reference. `CLAUDE.md` keeps a short trigger pointer, while `Makefile` describes only what each target actually observes.

## Verification model

| Risk class | Local evidence |
|---|---|
| Content-only managed file | Applicable focused checks plus `make test-local`; CI supplies behavioral deployment evidence |
| Checkout-tested logic | Narrowest canonical focused check; `make test-local` only when managed files changed |
| Deployment-sensitive | One successful `make test-ubuntu` verdict on the final deployment-relevant state |

Successful checks remain valid across unrelated edits. Failed or incomplete required checks still block publication, and both Ubuntu and macOS jobs must pass before merge.

## Validation

- `make -n test-suite` confirms the revised target output and recipe shape.
- `git diff --check` passes for all tracked and newly added documents.
- Correctness and `writing-for-agents` audits completed with no remaining findings; requirements R1 through R12 remain represented.

## Post-Deploy Monitoring & Validation

No production monitoring is required because this changes repository guidance only. In the first fresh agent session after merge, confirm that a content-only managed-file edit skips local Docker with an explicit CI-backstop reason, while a template or managed-path change still selects one successful `make test-ubuntu` verdict before publishing. Revert the policy change if either risk class routes incorrectly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-GPT--5.6--sol-000000)
