### PR TITLE
fix(herdr): retry first OpenCode session publication

### DIFF
--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -14,6 +14,8 @@ TITLE_MAX_LEN=48
 BRANCH_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_BRANCH_CLAIM_ATTEMPTS:-3}"
 FIRST_PROMPT_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_FIRST_PROMPT_CLAIM_ATTEMPTS:-3}"
 LIFECYCLE_CLAIM_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_LIFECYCLE_CLAIM_ATTEMPTS:-260}"
+PANE_SESSION_RETRY_ATTEMPTS="${HERDR_WORKTREE_IDENTITY_PANE_SESSION_RETRY_ATTEMPTS:-20}"
+PANE_SESSION_RETRY_DELAY="${HERDR_WORKTREE_IDENTITY_PANE_SESSION_RETRY_DELAY:-0.05}"
 ENGINE_TIMEOUT="${HERDR_WORKTREE_IDENTITY_TIMEOUT:-30}"
 HERDR_RPC_TIMEOUT="${HERDR_WORKTREE_IDENTITY_HERDR_TIMEOUT:-5}"
 PI_MODEL="${HERDR_WORKTREE_IDENTITY_PI_MODEL:-openai-codex/gpt-5.4-mini}"
@@ -356,7 +358,7 @@ pane_fields() {
     | if ($pane | type) != "object" then error("missing pane") else
         [($pane.pane_id // ""), ($pane.agent // ""), ($pane.agent_session.value // ""),
          ($pane.workspace_id // ""), ($pane.foreground_cwd // $pane.cwd // "")]
-        | map(if type == "string" then . else "" end) | @tsv
+        | map(if type == "string" then . else "" end) | join("\u001f")
       end
   ' 2>/dev/null
 }
@@ -626,7 +628,7 @@ label_workspace() {
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-malformed "pane=$expected_pane workspace=$workspace" || true
     return 1
   }
-  IFS=$'\t' read -r final_pane final_agent final_session final_workspace _ <<< "$fields"
+  IFS=$'\037' read -r final_pane final_agent final_session final_workspace _ <<< "$fields"
   if [ "$final_pane" != "$expected_pane" ] || [ "$final_agent" != "$agent" ] || \
     [ "$final_session" != "$session" ] || [ "$final_workspace" != "$workspace" ]; then
     write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
@@ -906,7 +908,7 @@ process_worktree() {
 
 worker() {
   local prompt="$1" payload fields resolved_pane pane_agent pane_session pane_workspace pane_cwd cwd root common status
-  local first_prompt
+  local first_prompt pane_session_retry=0
   if ! first_prompt="$(recorded_first_prompt "$prompt")"; then
     record_unresolved first-prompt-unavailable "agent=$agent session=$session"
     return 0
@@ -920,26 +922,36 @@ worker() {
     record_unresolved jq-unavailable "pane=${pane:-missing}"
     return 0
   }
-  payload="$(resolve_pane_payload)"
-  status=$?
-  if [ "$status" -eq 2 ]; then
-    record_unresolved pane-unreachable "pane=${pane:-missing} session=$session"
-    return 0
-  fi
-  if [ "$status" -ne 0 ]; then
-    record_unresolved pane-unresolved "pane=missing session=$session"
-    return 0
-  fi
-  fields="$(printf '%s' "$payload" | pane_fields)" || {
-    record_unresolved pane-malformed "pane=${pane:-missing} session=$session"
-    return 0
-  }
-  IFS=$'\t' read -r resolved_pane pane_agent pane_session pane_workspace pane_cwd <<< "$fields"
-  if { [ -n "$pane" ] && [ "$resolved_pane" != "$pane" ]; } || \
-    [ "$pane_agent" != "$agent" ] || [ "$pane_session" != "$session" ]; then
+  while :; do
+    payload="$(resolve_pane_payload)"
+    status=$?
+    if [ "$status" -eq 2 ]; then
+      record_unresolved pane-unreachable "pane=${pane:-missing} session=$session"
+      return 0
+    fi
+    if [ "$status" -ne 0 ]; then
+      record_unresolved pane-unresolved "pane=missing session=$session"
+      return 0
+    fi
+    fields="$(printf '%s' "$payload" | pane_fields)" || {
+      record_unresolved pane-malformed "pane=${pane:-missing} session=$session"
+      return 0
+    }
+    IFS=$'\037' read -r resolved_pane pane_agent pane_session pane_workspace pane_cwd <<< "$fields"
+    if { [ -z "$pane" ] || [ "$resolved_pane" = "$pane" ]; } && \
+      [ "$pane_agent" = "$agent" ] && [ "$pane_session" = "$session" ]; then
+      break
+    fi
+    if [ "$agent" = opencode ] && [ -n "$pane" ] && [ "$resolved_pane" = "$pane" ] && \
+      [ "$pane_agent" = "$agent" ] && [ -z "$pane_session" ] && \
+      [ "$pane_session_retry" -lt "$PANE_SESSION_RETRY_ATTEMPTS" ]; then
+      pane_session_retry=$((pane_session_retry + 1))
+      sleep "$PANE_SESSION_RETRY_DELAY"
+      continue
+    fi
     record_unresolved pane-mismatched "pane=${resolved_pane:-missing} agent=$pane_agent session=$pane_session"
     return 0
-  fi
+  done
   [ -n "$workspace" ] || workspace="$pane_workspace"
   cwd="$(reported_cwd)"
   [ -n "$cwd" ] || cwd="$pane_cwd"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -263,6 +263,21 @@ function test_scripts_1139_worktree_identity_keeps_unresolved_events_retryable_a
   assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" retry-later
 }
 
+function test_scripts_1206_worktree_identity_waits_for_the_first_opencode_session_publication() {
+  _bats_test_init 1206 'worktree identity waits for the first opencode session publication'
+  hwi_setup
+  hwi_create_generated_worktree
+  hwi_delay_pane_session_publication pane-1 opencode session-1 workspace-1 "$HWI_CHECKOUT"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    HERDR_WORKTREE_IDENTITY_PANE_SESSION_RETRY_DELAY=0 \
+    bash "$HWI_ENGINE" --worker --agent opencode --session session-1 --pane pane-1 --workspace workspace-1 \
+    <<< 'Rename on first OpenCode prompt'
+  assert_success
+  assert_file_exists "$HWI_WORK/pane-session-published"
+  assert_equal "$(git -C "$HWI_CHECKOUT" branch --show-current)" rename-on-first-opencode-prompt
+}
+
 function test_scripts_1140_worktree_identity_declines_primary_checkouts_and_unmatched_sessions() {
   _bats_test_init 1140 'worktree identity declines primary checkouts and records unmatched sessions as unresolved'
   hwi_setup

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -24,6 +24,13 @@ hwi_setup() {
 if [ "$1" = pane ] && [ "$2" = get ]; then
   printf '%s\n' "$*" >> "$HWI_WORK/herdr.calls"
   [ ! -e "$HWI_WORK/fail-pane-get" ] || exit 1
+  if [ -e "$HWI_WORK/delay-pane-session-publication" ] && [ ! -e "$HWI_WORK/pane-session-published" ]; then
+    payload="$(cat "$HWI_PANE_JSON")"
+    cp "$HWI_WORK/published-pane.json" "$HWI_PANE_JSON"
+    : > "$HWI_WORK/pane-session-published"
+    printf '%s\n' "$payload"
+    exit 0
+  fi
   if [ -e "$HWI_WORK/block-pane-get-with-descendant" ]; then
     bash -c 'trap "" TERM; printf "%s\n" "$$" > "$HWI_WORK/pane-child.pid"; while :; do sleep 1; done' &
     trap 'exit 0' TERM
@@ -69,6 +76,18 @@ hwi_write_pane() {
     --arg workspace "$workspace" --arg cwd "$cwd" \
     '{result:{pane:{pane_id:$pane,agent:$agent,agent_session:{value:$session},workspace_id:$workspace,cwd:$cwd}}}' \
     > "$HWI_PANE_JSON"
+}
+
+hwi_delay_pane_session_publication() {
+  local pane="$1" agent="$2" session="$3" workspace="$4" cwd="$5"
+  jq -cn --arg pane "$pane" --arg agent "$agent" --arg workspace "$workspace" --arg cwd "$cwd" \
+    '{result:{pane:{pane_id:$pane,agent:$agent,workspace_id:$workspace,cwd:$cwd}}}' \
+    > "$HWI_PANE_JSON"
+  jq -cn --arg pane "$pane" --arg agent "$agent" --arg session "$session" \
+    --arg workspace "$workspace" --arg cwd "$cwd" \
+    '{result:{pane:{pane_id:$pane,agent:$agent,agent_session:{value:$session},workspace_id:$workspace,cwd:$cwd}}}' \
+    > "$HWI_WORK/published-pane.json"
+  : > "$HWI_WORK/delay-pane-session-publication"
 }
 
 hwi_write_snapshot_without_match() {


### PR DESCRIPTION
## Summary

Generated OpenCode worktrees now receive first-prompt names when Herdr publishes the pane session after the chat hook fires. The identity worker retries only while the same OpenCode process occupies the expected pane, and pane parsing preserves empty fields without shifting workspace or cwd values.

A delayed-publication fixture reproduces the ordering race and verifies the resulting Git branch at the real worktree boundary.

## Testing

- `tests/lib/bashunit test tests/bashunit/scripts_test.sh --filter worktree_identity --no-color` (41 tests, 269 assertions)
- `make lint`
- `make test-ubuntu` (exit 0; expected macOS-only case skipped on Linux)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-OpenCode-000000)
