### PR TITLE
fix(ci): refresh Homebrew before full installs

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -273,6 +273,12 @@ jobs:
             echo "no Brewfile change; the minimal install stands"
           fi
 
+      # Hosted macOS images can carry Homebrew metadata older than a formula's
+      # minimum version required by the managed configuration.
+      - name: Refresh Homebrew metadata for the full install
+        if: env.MMS_CI_MINIMAL == ''
+        run: brew update
+
       - name: Install chezmoi
         run: brew install chezmoi
 


### PR DESCRIPTION
## Summary

Full macOS Brewfile verification now refreshes Homebrew metadata before installing packages. This prevents stale hosted-runner metadata from installing Herdr 0.7.5 and rejecting managed plugins that require Herdr 0.8.x, while minimal push and PR runs still skip the update.

## Verification

- `make lint`
- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/test-dotfiles.yml")'`
- `git diff --check`
- [Full workflow dispatch](https://github.com/Seigiard/my-mac-setup/actions/runs/33847984427): Homebrew refresh and the formerly failing macOS `chezmoi apply` passed. The existing post-apply suite later hit the unchanged 12/20-minute job limits, as it also does on `main`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/GPT_5.6_sol-000000)
