### PR TITLE
fix(herdr): show worktrees in command palette picker

### DIFF
--- a/home/private_dot_config/herdr/command-palette/commands.toml
+++ b/home/private_dot_config/herdr/command-palette/commands.toml
@@ -66,13 +66,12 @@ placeholder = "worktree/my-feature"
 [[commands]]
 group = "Worktrees"
 title = "Open worktree"
-description = "Open and focus an existing worktree by branch name"
-type = "form"
+description = "Choose and focus an existing worktree"
+type = "select"
+options_command = "git -C {target_cwd_q} worktree list --porcelain | awk '/^worktree / { path = substr($0, 10) } index($0, \"branch refs/heads/\") == 1 { branch = substr($0, 19); printf \"%s\\t%s\\t%s\\n\", branch, branch, path }'"
 run_type = "shell"
 pause = false
 command = "root=$(git -C {target_cwd_q} worktree list --porcelain | head -n 1 | cut -d ' ' -f 2-); if [ -z \"$root\" ]; then printf '%s\\n' 'Not inside a Git repository.' >&2; exit 1; fi; exec \"$HERDR_BIN_PATH\" worktree open --cwd \"$root\" --branch {value_q} --focus"
-prompt = "Existing worktree branch"
-placeholder = "feature/my-feature"
 
 [[commands]]
 group = "Worktrees"

--- a/home/private_dot_config/herdr/plugins/command-palette/README.md
+++ b/home/private_dot_config/herdr/plugins/command-palette/README.md
@@ -162,6 +162,19 @@ value = "seigiard/my-mac-setup"
 description = "dotfiles"
 ```
 
+Use `options_command` when the choices must be loaded at invocation time. Each
+non-empty output line is `value<TAB>label<TAB>description`; a line without tabs
+uses the same text for its value and label. Dynamic choices are appended after
+any static `[[options]]`. The command receives the palette environment and
+placeholders, runs from `{target_cwd}`, and fails after 10 seconds.
+
+```toml
+name = "Open branch"
+type = "select"
+options_command = "git -C {target_cwd_q} branch --format='%(refname:short)'"
+command = "git -C {target_cwd_q} switch {value_q}"
+```
+
 For `select`/`form`, either place the nested runnable command fields at the top
 level, or use an explicit `run` table:
 

--- a/home/private_dot_config/herdr/plugins/command-palette/palette.py
+++ b/home/private_dot_config/herdr/plugins/command-palette/palette.py
@@ -292,7 +292,7 @@ def interactive_child_raw(raw: dict[str, Any]) -> dict[str, Any]:
     run = raw.get("run")
     if isinstance(run, dict):
         return dict(run)
-    child = {key: value for key, value in raw.items() if key not in {"options", "form", "prompt", "placeholder"}}
+    child = {key: value for key, value in raw.items() if key not in {"options", "options_command", "form", "prompt", "placeholder"}}
     child["type"] = raw.get("run_type") or "shell"
     return child
 
@@ -365,8 +365,14 @@ def validate_command_raw(raw: dict[str, Any], title: str, source: str) -> tuple[
             raise ValueError(f"command '{title}' ({source}) has unsupported interactive run type '{run_kind}'")
         if kind == "select":
             options = raw.get("options")
-            if not isinstance(options, list) or not any(isinstance(option, dict) and option.get("label") for option in options):
-                raise ValueError(f"command '{title}' ({source}) select commands need at least one labeled option")
+            has_static = isinstance(options, list) and any(isinstance(option, dict) and option.get("label") for option in options)
+            options_command = raw.get("options_command")
+            has_dynamic = isinstance(options_command, str) and options_command.strip() != ""
+            if not has_static and not has_dynamic:
+                raise ValueError(
+                    f"command '{title}' ({source}) select commands need at least one labeled option "
+                    "or an options_command"
+                )
     validate_value_quoting(raw, title, source, kind)
     return kind, shortcuts
 
@@ -1295,10 +1301,55 @@ def pick_workspace(herdr: str) -> tuple[int, str, bool]:
     return 0, "", False
 
 
-def command_choices(command: Command) -> list[Choice]:
+OPTIONS_COMMAND_TIMEOUT = 10
+
+
+def dynamic_choices(command: Command, variables: dict[str, str]) -> list[Choice]:
+    """Run a select command's `options_command` and read its rows.
+
+    The rows are tab-separated `value<TAB>label<TAB>description`; a row with no
+    tab is its own label and value. A failing command raises instead of showing
+    an empty list, because "no options" and "the lister is broken" are different
+    problems and only one of them is the user's to fix.
+    """
+    options_command = command.raw.get("options_command")
+    if not isinstance(options_command, str) or not options_command.strip():
+        return []
+    script = str(expand(options_command, variables))
+    try:
+        result = subprocess.run(
+            script,
+            shell=True,
+            text=True,
+            capture_output=True,
+            env=command_environment(variables),
+            cwd=variables.get("target_cwd") or None,
+            timeout=OPTIONS_COMMAND_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"{command.title}: options_command timed out after {OPTIONS_COMMAND_TIMEOUT}s") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise ValueError(f"{command.title}: options_command failed ({result.returncode}). {detail}".rstrip())
+
+    choices: list[Choice] = []
+    for line in (result.stdout or "").splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        value = fields[0].strip()
+        label = fields[1].strip() if len(fields) > 1 and fields[1].strip() else value
+        description = fields[2].strip() if len(fields) > 2 else ""
+        if not value:
+            continue
+        choices.append(Choice(label=label, value=value, description=description, heading=""))
+    return choices
+
+
+def command_choices(command: Command, variables: dict[str, str] | None = None) -> list[Choice]:
     options = command.raw.get("options")
     if not isinstance(options, list):
-        return []
+        return list(dynamic_choices(command, variables)) if variables is not None else []
     choices: list[Choice] = []
     for option in options:
         if not isinstance(option, dict):
@@ -1313,6 +1364,8 @@ def command_choices(command: Command) -> list[Choice]:
                 heading=str(option.get("heading") or ""),
             )
         )
+    if variables is not None:
+        choices.extend(dynamic_choices(command, variables))
     return choices
 
 
@@ -1458,10 +1511,10 @@ def choice_picker_curses_loop(stdscr: Any, command: Command, choices: list[Choic
             selected = 0
 
 
-def pick_choice(command: Command) -> str | None:
+def pick_choice(command: Command, variables: dict[str, str] | None = None) -> str | None:
     import curses
 
-    choices = command_choices(command)
+    choices = command_choices(command, variables)
     try:
         return curses.wrapper(choice_picker_curses_loop, command, choices)
     except KeyboardInterrupt:
@@ -1787,7 +1840,7 @@ def run_command(command: Command, config_path: Path) -> tuple[int, str, bool]:
     pause = bool(raw.get("pause", False))
 
     if command.kind == "select":
-        value = pick_choice(command)
+        value = pick_choice(command, variables)
         if value is None:
             return 0, "", False
         child_raw = interactive_run_raw(command)

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1477,6 +1477,41 @@ function test_palette_065_worktree_commands_refuse_a_target_outside_a_repo() {
   done
 }
 
+function test_palette_066_open_worktree_lists_existing_checkouts() {
+  _bats_test_init 66 'Open worktree lists existing branches and checkout paths'
+  local fixture="$PALETTE_WORK/worktree choices"
+  local primary="$fixture/repo" linked="$fixture/linked"
+  mkdir -p "$primary"
+
+  run git init -q -b main "$primary"
+  assert_success
+  run git -C "$primary" -c user.email=t@example.com -c user.name=T \
+    commit -q --allow-empty -m init
+  assert_success
+  run git -C "$primary" worktree add -q -b fixture/linked "$linked"
+  assert_success
+
+  run env HERDR_TARGET_CWD="$linked" HERDR_COMMAND_PALETTE_CONFIG="$REAL_COMMANDS" \
+    EXPECTED_PRIMARY="$(git -C "$primary" rev-parse --show-toplevel)" \
+    EXPECTED_LINKED="$(git -C "$linked" rev-parse --show-toplevel)" python3 - <<'PY'
+import os
+
+import palette_boot
+
+palette = palette_boot.palette()
+config_path, commands = palette.load_commands()
+command = next(c for c in commands if c.title == "Open worktree")
+choices = palette.command_choices(command, palette.context_vars(config_path))
+actual = [(choice.value, choice.label, choice.description) for choice in choices]
+expected = [
+    ("main", "main", os.environ["EXPECTED_PRIMARY"]),
+    ("fixture/linked", "fixture/linked", os.environ["EXPECTED_LINKED"]),
+]
+assert actual == expected, actual
+PY
+  assert_success
+}
+
 function set_up_before_script() {
   :
 }


### PR DESCRIPTION
## Summary

`Open worktree` now presents the existing branches and checkout paths in a compact picker instead of asking users to type a branch name. Dynamic select options are loaded at invocation time, so the list reflects the repository where the palette was opened.

The dynamic option command has a bounded runtime and reports command failures rather than presenting a misleading empty list.

## Test plan

- `tests/lib/bashunit -j 8 tests/bashunit/palette_test.sh` (62 passed)
- `make test-local` (exit 0)
- `python3 -m py_compile home/private_dot_config/herdr/plugins/command-palette/palette.py`
- `python3 home/private_dot_config/herdr/plugins/command-palette/palette.py --validate home/private_dot_config/herdr/command-palette/commands.toml`
- `git diff --check`

Local `make lint` remains red because it traverses an unrelated nested `.claude/worktrees/...` checkout and reports its existing warnings; none are in this PR's files.
