### PR TITLE
fix(agents): keep one-shot checks in Bash after timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@ Reference docs (read on demand):
 
 </important>
 
+<important if="you are about to run make test-local">
+
+- Run `make test-local` as a one-shot command in the current Bash tool with enough transport time to reach its own terminal verdict; never run it in a Herdr pane.
+- Invoke only the canonical target. Do not reconstruct its chezmoi command or add ad hoc flags.
+- If the target stalls or transport expires, determine the previous process's state and diagnose the stall before retrying.
+
+</important>
+
 <important if="you are about to run make test-templates, make test-ubuntu, make test-docker, or make build-docker">
 
 - Treat these targets as long-running Docker workloads, including cached runs. Read `~/.claude/shared/long-running-work.md` before launch.

--- a/docs/issues/2026-09-04-005-herdr-child-rejects-claude-effort-selection.md
+++ b/docs/issues/2026-09-04-005-herdr-child-rejects-claude-effort-selection.md
@@ -1,0 +1,22 @@
+---
+title: "herdr-child rejects Claude effort selection"
+short_description: "ask-in-herdr forwards --effort to herdr-child, but herdr-child rejects it for Claude even though the installed Claude CLI supports low, medium, high, xhigh, and max effort levels."
+type: "bug"
+category: "herdr"
+tags: ["ask-in-herdr","claude","model-selection"]
+date: "2026-09-04"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+A requested Claude Sonnet review at medium effort failed before launch with 'herdr-child: --effort is not supported for claude'. The ask-in-herdr script accepts --effort and forwards it, while 'claude --help' confirms native --effort support. Callers must currently bypass the managed child transport to honor an explicit Claude effort request.
+
+## Scope
+
+Allow managed Claude children to receive supported native effort levels through herdr-child and ask-in-herdr. Keep invalid kind or level combinations fail-closed. Update the skill contract and focused coverage so documented flags match accepted behavior.
+
+## Open decisions
+
+Whether herdr-child should maintain a per-agent effort capability matrix or pass through effort whenever the installed client advertises native support.

--- a/home/private_dot_claude/CLAUDE.md
+++ b/home/private_dot_claude/CLAUDE.md
@@ -28,7 +28,7 @@ Ask the user when:
 - Multiple interpretations with 2x+ effort difference
 - Missing critical info (file, error, context)
 - User's design seems flawed
-- Script timeout (>2min), sudo needed, or any blocker
+- Process state remains indeterminate after timeout or stall diagnosis, sudo is needed, or another blocker requires a user decision
 
 ### Multi-step tasks
 
@@ -109,6 +109,13 @@ Pick one (more recent / more tested), state why in one line, and flag the other 
 
 **Long-running work**
 
+<important if="a one-shot command may exceed the tool's default timeout, or a prior one-shot invocation timed out">
+
+- Size the tool transport timeout to the command's expected runtime before launch; elapsed time does not determine whether work is long-running.
+- If transport expires, determine whether the previous process is still running or has terminated before waiting, retrying, or escalating.
+
+</important>
+
 <important if="you are about to start, background, or wait on a long-running process — build, test run, dev server, migration, background agent, remote job">
 
 - Read `~/.claude/shared/long-running-work.md` before launching. It carries the supervision contract: completion and progress signals, launch-path verification, observation cadence and the mechanism behind it, stall diagnosis, chosen vs imposed deadlines, ownership of the wait, and escalation when the state cannot be determined.
@@ -116,14 +123,12 @@ Pick one (more recent / more tested), state why in one line, and flag the other 
 
 </important>
 
-<important if="you are about to start a long-running or observable process — dev server, test watcher, log tail, build — and HERDR_ENV=1 is set">
+<important if="you are deciding where to run a command or process and HERDR_ENV=1 is set">
 
-- You are inside herdr, a terminal multiplexer. The user watches panes, not your background processes.
-- Load the `herdr` skill, then run the process in a sibling pane of the current tab. The pane stays visible to the user and survives your session.
-- Do not start it as a background Bash process — the user cannot see those.
-- Read the process output through the herdr CLI (the skill documents it), not by re-running the command in your own shell.
-- Short one-shot commands (a single test run, lint, typecheck) stay in your own Bash tool. Do not create panes for them.
-- If HERDR_ENV is not set, this block does not apply; use normal background processes.
+- The user observes long-running work through visible panes.
+- Classify work by its execution model before launch. Run long-running or observable work such as a dev server, test watcher, log tail, or build in a sibling pane after loading the `herdr` skill; the pane stays visible and survives your session.
+- Keep one-shot checks such as a single test run, lint, or typecheck in the current Bash tool. A Bash transport timeout does not change their placement.
+- Read pane output through the herdr CLI and keep the original invocation as the source of truth.
 
 </important>
 


### PR DESCRIPTION
## Summary

One-shot checks now stay in the current Bash tool when they outlast its default transport timeout. Process placement follows the execution model instead of elapsed time, while indeterminate process state remains the point for escalation.

`make test-local` has an explicit repository-level execution contract. The separate inability to request Claude effort through `ask-in-herdr` is recorded as owned follow-up work rather than folded into the timeout rules.

## Validation

- `make test-local` completed and rendered the intended `.claude/CLAUDE.md` changes.
- `make test-issues` passed all 50 tests.
- `python3 scripts/issues validate` passed.
- Claude Sonnet at medium effort reviewed the instructions with `writing-for-agents`; confirmed findings were resolved.
