### PR TITLE
feat(skills): persist manifest choices

### DIFF
--- a/docs/agent-setup-inventory.md
+++ b/docs/agent-setup-inventory.md
@@ -25,9 +25,15 @@ selected upstream skill name.
 
 Use `skills add <source> [skill...]`, `skills remove <source> <skill...>`,
 `skills update [skill...]`, or `skills sync`. `sync` installs every manifest
-entry and reports unmanaged or obsolete lock entries with explicit `skills
-remove` commands. It never removes drift automatically. Restart Claude Code,
-OpenCode, and Pi after installation or discovery configuration changes.
+entry and reports unmanaged or obsolete lock entries with explicit commands to
+remove them or preserve them through `skills add`. Before a managed `add` or
+`remove`, the wrapper requires a clean chezmoi source branch, pulls it with
+`--ff-only`, and refreshes the live manifest. After the local operation, it
+captures the manifest with `chezmoi add`, commits only that file, and pushes the
+commit. Removing one skill from a wildcard source is rejected because the
+manifest cannot represent "all except this skill". `sync` never removes drift
+automatically. Restart Claude Code, OpenCode, and Pi after installation or
+discovery configuration changes.
 Successful upstream CLI output is hidden by default; use `skills --verbose
 <command>` to restore it. Failed commands always replay the captured diagnostics.
 

--- a/home/dot_local/bin/executable_skills
+++ b/home/dot_local/bin/executable_skills
@@ -168,6 +168,142 @@ run_update() {
   run_npx update --global "$@"
 }
 
+managed_manifest() {
+  [ -z "${SKILLS_MANIFEST+x}" ]
+}
+
+prepare_managed_manifest() {
+  local dirty upstream ahead temporary
+  managed_manifest || return 0
+  command -v chezmoi >/dev/null 2>&1 || { fail 'chezmoi is required for managed skill changes'; return 1; }
+  dirty="$(chezmoi git -- status --porcelain)" || { fail 'could not inspect chezmoi source repository'; return 1; }
+  [ -z "$dirty" ] || { fail 'chezmoi source repository has uncommitted changes'; return 1; }
+  upstream="$(chezmoi git -- rev-parse --abbrev-ref --symbolic-full-name '@{u}')" || {
+    fail 'chezmoi source branch has no upstream'; return 1
+  }
+  chezmoi git -- pull --ff-only || { fail 'could not fast-forward chezmoi source repository'; return 1; }
+  ahead="$(chezmoi git -- rev-list --count "$upstream..HEAD")" || {
+    fail 'could not inspect unpushed chezmoi commits'; return 1
+  }
+  [ "$ahead" = 0 ] || { fail 'chezmoi source branch has unpushed commits'; return 1; }
+  mkdir -p "$(dirname "$MANIFEST")" || return 1
+  temporary="$(mktemp "$(dirname "$MANIFEST")/.skills-manifest.XXXXXX")" || return 1
+  if [ -e "$MANIFEST" ]; then
+    cp -p "$MANIFEST" "$temporary" || { rm -f "$temporary"; return 1; }
+  fi
+  if ! chezmoi cat "$MANIFEST" > "$temporary"; then
+    rm -f "$temporary"
+    fail 'could not render managed skills manifest'
+    return 1
+  fi
+  mv "$temporary" "$MANIFEST" || { rm -f "$temporary"; return 1; }
+}
+
+update_manifest_skills() {
+  local action="$1" source="$2"
+  shift 2
+  python3 - "$MANIFEST" "$action" "$source" "$@" <<'PY'
+import os
+import sys
+import tempfile
+
+manifest, action, source, *skills = sys.argv[1:]
+
+
+def write_atomic(path, content):
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    try:
+        mode = os.stat(path).st_mode
+    except FileNotFoundError:
+        mode = None
+    descriptor, temporary = tempfile.mkstemp(prefix=".skills-manifest.", dir=directory, text=True)
+    try:
+        if mode is not None:
+            os.chmod(temporary, mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+try:
+    with open(manifest, encoding="utf-8") as stream:
+        previous = stream.read()
+except FileNotFoundError:
+    previous = ""
+lines = previous.splitlines()
+
+found = False
+for index, line in enumerate(lines):
+    body, separator, comment = line.partition("#")
+    fields = body.split()
+    if not fields or fields[0] != source:
+        continue
+    found = True
+    current = fields[1:]
+    if action == "add":
+        if "*" in skills:
+            current = ["*"]
+        elif "*" not in current:
+            for skill in skills:
+                if skill not in current:
+                    current.append(skill)
+    else:
+        current = [skill for skill in current if skill not in skills]
+        if not current:
+            del lines[index]
+            break
+    leading = body[:len(body) - len(body.lstrip())]
+    trailing = body[len(body.rstrip()):]
+    updated = leading + " ".join([source] + current) + trailing
+    if separator:
+        updated += separator + comment
+    lines[index] = updated
+    break
+
+if not found and action == "add":
+    lines.append(" ".join([source] + skills))
+
+content = "\n".join(lines) + "\n"
+if content != previous:
+    write_atomic(manifest, content)
+PY
+}
+
+publish_managed_manifest() {
+  local action="$1" source_manifest message
+  shift
+  managed_manifest || return 0
+  chezmoi add "$MANIFEST" || { fail 'could not capture skills manifest in chezmoi source'; return 1; }
+  source_manifest="$(chezmoi source-path "$MANIFEST")" || {
+    fail 'could not resolve chezmoi source manifest'; return 1
+  }
+  chezmoi git -- add -- "$source_manifest" || { fail 'could not stage chezmoi skills manifest'; return 1; }
+  if ! chezmoi git -- diff --cached --quiet -- "$source_manifest"; then
+    message="chore(skills): $action $*"
+    chezmoi git -- commit -m "$message" -- "$source_manifest" || {
+      fail 'could not commit chezmoi skills manifest'; return 1
+    }
+  fi
+  chezmoi git -- push || {
+    fail 'skills manifest is committed locally but could not be pushed'; return 1
+  }
+}
+
+manifest_source_uses_wildcard() {
+  local entry
+  for entry in "${MANIFEST_SKILLS[@]:-}"; do
+    [ "$entry" != "$1:*" ] || return 0
+  done
+  return 1
+}
+
 parse_manifest() {
   local line source skill count had_noglob=0
   MANIFEST_SOURCES=()
@@ -287,7 +423,10 @@ report_drift() {
       [ "${entry#*:}" != '*' ] || wildcard=1
       [ "${entry#*:}" != "$name" ] || desired=1
     done
-    [ "$desired" -eq 1 ] || [ "$wildcard" -eq 1 ] || printf 'drift: skills remove %s %s\n' "$source" "$name"
+    if [ "$desired" -eq 0 ] && [ "$wildcard" -eq 0 ]; then
+      printf 'drift: skills remove %s %s\n' "$source" "$name"
+      printf 'keep:  skills add %s %s\n' "$source" "$name"
+    fi
   done < <(lock_records)
 }
 
@@ -352,8 +491,10 @@ add() {
   local skill
   for skill in "$@"; do [ "$skill" = '*' ] || valid_skill "$skill" || { fail "invalid skill: $skill"; return 1; }; done
   validate_live_lock || return 1
+  prepare_managed_manifest || return 1
   run_add "$source" "$@" || return "$?"
-  grep -Fqx "$source $*" "$MANIFEST" 2>/dev/null || printf 'warning: add diverges from managed manifest\n' >&2
+  update_manifest_skills add "$source" "$@" || { fail "could not save skills in manifest: $MANIFEST"; return 1; }
+  publish_managed_manifest add "$@"
 }
 
 remove() {
@@ -367,8 +508,15 @@ remove() {
     owner="$(lock_source_for_skill "$skill")"
     [ "$owner" = "$source" ] || { fail "lock does not own $skill as $source"; return 1; }
   done
+  prepare_managed_manifest || return 1
+  parse_manifest || return 1
+  manifest_source_uses_wildcard "$source" && {
+    fail "cannot persist removal from wildcard manifest source: $source"
+    return 1
+  }
   run_remove "$@" || return "$?"
-  printf 'warning: remove diverges from managed manifest\n' >&2
+  update_manifest_skills remove "$source" "$@" || { fail "could not update skills manifest: $MANIFEST"; return 1; }
+  publish_managed_manifest remove "$@"
 }
 
 update() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -8033,11 +8033,105 @@ function test_scripts_272_skills_add_is_global_isolated_and_preserves_cwd() {
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
     XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/config" XDG_DATA_HOME="$BATS_TEST_TMPDIR/data" \
     XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" XDG_CACHE_HOME="$BATS_TEST_TMPDIR/cache" \
+    SKILLS_MANIFEST="$BATS_TEST_TMPDIR/manifest" \
     bash "$SKILLS_WRAPPER" add owner/repo named-skill
   assert_success
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^PWD=.*/tmp$'
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '^ARGS=<--yes><skills@latest><add><owner/repo><--skill><named-skill><--global><--agent><claude-code><--agent><opencode><--agent><pi><--yes>$'
   assert_equal "$PWD" "$original"
+
+  rm -f "$BATS_TEST_TMPDIR/tmp/npx.log"
+  run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" add owner/repo named-skill
+  assert_failure
+  assert_output --partial 'chezmoi is required for managed skill changes'
+  assert_file_not_exists "$BATS_TEST_TMPDIR/tmp/npx.log"
+}
+
+function test_scripts_2720_skills_add_saves_the_skill_in_the_manifest() {
+  _bats_test_init 2720 'skills add saves a successfully installed skill in the managed manifest'
+  local stub manifest
+  stub="$(skills_stub_npx)"
+  manifest="$BATS_TEST_TMPDIR/manifest"
+  printf '%s\n' 'other/repo other-skill' 'owner/repo existing-skill' > "$manifest"
+
+  run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    SKILLS_MANIFEST="$manifest" bash "$SKILLS_WRAPPER" add owner/repo named-skill
+  assert_success
+  assert_file_contains "$manifest" '^owner/repo existing-skill named-skill$'
+
+  run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    SKILLS_MANIFEST="$manifest" bash "$SKILLS_WRAPPER" add owner/repo named-skill
+  assert_success
+  run grep -o 'named-skill' "$manifest"
+  assert_success
+  assert_output 'named-skill'
+}
+
+function test_scripts_27202_skills_add_publishes_the_managed_manifest_through_chezmoi() {
+  _bats_test_init 27202 'skills add pulls, captures, commits, and pushes the managed manifest through chezmoi'
+  local stub home source_manifest manifest
+  stub="$(skills_stub_npx)"
+  home="$BATS_TEST_TMPDIR/home"
+  manifest="$home/.config/agent-skills/manifest"
+  source_manifest="$home/source/home/private_dot_config/agent-skills/manifest"
+  mkdir -p "$(dirname "$manifest")" "$(dirname "$source_manifest")" "$BATS_TEST_TMPDIR/tmp"
+  printf '%s\n' 'owner/repo existing-skill' > "$manifest"
+  cp "$manifest" "$source_manifest"
+  cat > "$stub/chezmoi" <<'SH'
+#!/usr/bin/env bash
+printf '<%s>' "$@" >> "$TMPDIR/chezmoi.log"
+printf '\n' >> "$TMPDIR/chezmoi.log"
+if [ "$1" = git ]; then
+  shift 2
+  case "$1" in
+    status) [ "${CHEZMOI_DIRTY:-0}" = 0 ] || printf '%s\n' ' M unrelated-file' ;;
+    rev-parse) printf '%s\n' origin/main ;;
+    pull) exit 0 ;;
+    rev-list) printf '%s\n' 0 ;;
+    diff) exit 1 ;;
+    add|commit|push) exit 0 ;;
+  esac
+elif [ "$1" = cat ]; then
+  cat "$HOME/source/home/private_dot_config/agent-skills/manifest"
+elif [ "$1" = add ]; then
+  cp "$2" "$HOME/source/home/private_dot_config/agent-skills/manifest"
+elif [ "$1" = source-path ]; then
+  printf '%s\n' "$HOME/source/home/private_dot_config/agent-skills/manifest"
+fi
+SH
+  chmod +x "$stub/chezmoi"
+
+  run env PATH="$stub:/usr/bin:/bin" HOME="$home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" add owner/repo named-skill
+  assert_success
+  assert_file_contains "$source_manifest" '^owner/repo existing-skill named-skill$'
+  assert_file_contains "$BATS_TEST_TMPDIR/tmp/chezmoi.log" '^<git><--><pull><--ff-only>$'
+  assert_file_contains "$BATS_TEST_TMPDIR/tmp/chezmoi.log" '^<add>.*/\.config/agent-skills/manifest>$'
+  run cat "$BATS_TEST_TMPDIR/tmp/chezmoi.log"
+  assert_success
+  assert_output --partial '<git><--><commit><-m><chore(skills): add named-skill><-->'
+  assert_file_contains "$BATS_TEST_TMPDIR/tmp/chezmoi.log" '^<git><--><push>$'
+
+  mkdir -p "$home/.local/state/skills"
+  printf '%s\n' '{"version":3,"skills":{"named-skill":{"source":"owner/repo"}}}' \
+    > "$home/.local/state/skills/.skill-lock.json"
+  run env PATH="$stub:/usr/bin:/bin" HOME="$home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    bash "$SKILLS_WRAPPER" remove owner/repo named-skill
+  assert_success
+  run cat "$source_manifest"
+  assert_success
+  assert_output 'owner/repo existing-skill'
+  run cat "$BATS_TEST_TMPDIR/tmp/chezmoi.log"
+  assert_success
+  assert_output --partial '<git><--><commit><-m><chore(skills): remove named-skill><-->'
+
+  rm -f "$BATS_TEST_TMPDIR/tmp/npx.log"
+  run env PATH="$stub:/usr/bin:/bin" HOME="$home" TMPDIR="$BATS_TEST_TMPDIR/tmp" CHEZMOI_DIRTY=1 \
+    bash "$SKILLS_WRAPPER" add owner/repo another-skill
+  assert_failure
+  assert_output --partial 'chezmoi source repository has uncommitted changes'
+  assert_file_not_exists "$BATS_TEST_TMPDIR/tmp/npx.log"
 }
 
 function test_scripts_2721_skills_hides_success_output_but_preserves_verbose_and_failure_diagnostics() {
@@ -8052,8 +8146,10 @@ for arg in "$@"; do [ "$arg" != fail ] || exit 7; done
 SH
   chmod +x "$stub/npx"
   mkdir -p "$BATS_TEST_TMPDIR/home/.local/state/skills"
+  mkdir -p "$BATS_TEST_TMPDIR/home/.config/agent-skills"
   printf '%s\n' '{"version":3,"skills":{"fail":{"source":"owner/repo"}}}' \
     > "$BATS_TEST_TMPDIR/home/.local/state/skills/.skill-lock.json"
+  printf '%s\n' 'owner/repo fail' > "$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest"
 
   run --separate-stderr env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
     bash "$SKILLS_WRAPPER" update
@@ -8083,10 +8179,12 @@ SH
   assert_stderr --partial 'upstream stderr'
 
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
     bash "$SKILLS_WRAPPER" add owner/repo fail
   assert_failure 7
 
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
+    SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
     bash "$SKILLS_WRAPPER" remove owner/repo fail
   assert_failure 7
 
@@ -8256,12 +8354,17 @@ function test_scripts_273_skills_dispatch_validates_inert_argv_and_uses_global_r
   printf '%s\n' '{"version":3,"skills":{"owned":{"source":"owner/repo"}}}' > "$lock"
 
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
-    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" bash "$SKILLS_WRAPPER" add owner/repo
+    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
+    bash "$SKILLS_WRAPPER" add owner/repo
   assert_success
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '<add><owner/repo><--skill><\*><--global>'
 
+  mkdir -p "$BATS_TEST_TMPDIR/home/.config/agent-skills"
+  printf '%s\n' 'owner/repo owned' > "$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest"
+
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
-    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" bash "$SKILLS_WRAPPER" remove owner/repo owned
+    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
+    bash "$SKILLS_WRAPPER" remove owner/repo owned
   assert_success
   assert_file_contains "$BATS_TEST_TMPDIR/tmp/npx.log" '<remove><--global><owned><--yes>$'
 
@@ -8330,12 +8433,17 @@ function test_scripts_276_skills_remove_uses_explicit_and_default_xdg_locks_iden
   mkdir -p "$(dirname "$state_lock")" "$(dirname "$fallback_lock")"
   printf '%s\n' '{"version":3,"skills":{"owned":{"source":"owner/repo"}}}' > "$state_lock"
   printf '%s\n' '{"version":3,"skills":{"owned":{"source":"owner/repo"}}}' > "$fallback_lock"
+  mkdir -p "$BATS_TEST_TMPDIR/home/.config/agent-skills"
+  printf '%s\n' 'owner/repo owned' > "$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest"
 
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
-    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" bash "$SKILLS_WRAPPER" remove owner/repo owned
+    XDG_STATE_HOME="$BATS_TEST_TMPDIR/state" SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
+    bash "$SKILLS_WRAPPER" remove owner/repo owned
   assert_success
+  printf '%s\n' 'owner/repo owned' > "$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest"
   run env PATH="$stub:/usr/bin:/bin" HOME="$BATS_TEST_TMPDIR/home" TMPDIR="$BATS_TEST_TMPDIR/tmp" \
-    XDG_STATE_HOME= bash "$SKILLS_WRAPPER" remove owner/repo owned
+    XDG_STATE_HOME= SKILLS_MANIFEST="$BATS_TEST_TMPDIR/home/.config/agent-skills/manifest" \
+    bash "$SKILLS_WRAPPER" remove owner/repo owned
   assert_success
   run grep -c '<remove><--global><owned><--yes>' "$BATS_TEST_TMPDIR/tmp/npx.log"
   assert_output '2'
@@ -8436,8 +8544,8 @@ function test_scripts_2781_skills_sync_default_file_limit_accepts_large_document
   assert_output --partial 'canonical tree file exceeds 2097152 bytes'
 }
 
-function test_scripts_279_skills_sync_reports_installs_and_named_drift_but_not_wildcard_drift() {
-  _bats_test_init 279 'skills sync reports installs and non-wildcard drift without removing it'
+function test_scripts_279_skills_sync_offers_to_remove_or_save_named_drift_but_not_wildcard_drift() {
+  _bats_test_init 279 'skills sync offers remove and add commands for non-wildcard drift'
   local stub manifest lock canonical skill
   stub="$(skills_stub_npx)"
   manifest="$BATS_TEST_TMPDIR/manifest"
@@ -8458,7 +8566,9 @@ function test_scripts_279_skills_sync_reports_installs_and_named_drift_but_not_w
   assert_output --partial 'Installing skills from EveryInc/compound-engineering-plugin: *'
   assert_output --partial 'Installing skills from owner/repo: desired'
   assert_output --partial 'drift: skills remove owner/repo stale'
+  assert_output --partial 'keep:  skills add owner/repo stale'
   assert_output --partial 'drift: skills remove gone/repo orphan'
+  assert_output --partial 'keep:  skills add gone/repo orphan'
   refute_output --partial 'ce-code-review'
 }
 


### PR DESCRIPTION
## Summary

Locally installed skills can now be adopted instead of only removed: `skills sync` prints both recovery commands, and managed `skills add` or `skills remove` persists the choice through chezmoi and pushes it to origin.

The wrapper requires a clean tracking branch, pulls with `--ff-only`, and refuses to push over uncommitted or unpushed source-repository work. Removing one skill from a wildcard source remains blocked because the manifest cannot represent exclusions.

## Validation

- `tests/lib/bashunit tests/bashunit/scripts_test.sh --filter skills_` (19 tests, 104 assertions)
- `make lint`
- `bash -n home/dot_local/bin/executable_skills`
- `git diff --check`
- `make test-local`

## Post-Deploy Monitoring & Validation

- Owner: Andrew Borisenko
- Window: first managed `skills add` and `skills remove` after deployment
- Healthy: one manifest-only commit reaches origin and the live manifest matches the chezmoi source
- Failure: the wrapper exits non-zero, reports dirty/diverged source state, or leaves a local commit after a push failure
- Mitigation: inspect `chezmoi git -- status` and `chezmoi git -- log @{u}..HEAD` before retrying
