### PR TITLE
fix(herdr): forward Claude effort selection

### DIFF
--- a/docs/issues/2026-09-04-005-herdr-child-rejects-claude-effort-selection.md
+++ b/docs/issues/2026-09-04-005-herdr-child-rejects-claude-effort-selection.md
@@ -5,8 +5,9 @@ type: "bug"
 category: "herdr"
 tags: ["ask-in-herdr","claude","model-selection"]
 date: "2026-09-04"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-04"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ Allow managed Claude children to receive supported native effort levels through 
 ## Open decisions
 
 Whether herdr-child should maintain a per-agent effort capability matrix or pass through effort whenever the installed client advertises native support.
+
+## Resolution
+
+herdr-child now forwards --effort to Claude's native CLI, keeps OpenCode fail-closed, and documents and tests the corrected mapping.

--- a/home/dot_local/lib/herdr-child-launch.sh
+++ b/home/dot_local/lib/herdr-child-launch.sh
@@ -78,7 +78,7 @@ start_child() {
   if [ "$kind" = pi ] && [ "$posture" = ro ]; then
     fail_usage 'pi does not support read-only posture: its return channel requires bash (R10)'
   fi
-  if [ -n "$effort" ] && [ "$kind" != pi ]; then fail_usage "--effort is not supported for $kind"; fi
+  if [ -n "$effort" ] && [ "$kind" = opencode ]; then fail_usage "--effort is not supported for $kind"; fi
   if [ "$skills_count" -gt 0 ] && [ "$kind" = opencode ]; then fail_usage '--skills is not supported for opencode'; fi
   if [ -n "$configured_agent" ] && [ "$kind" != opencode ]; then fail_usage "--agent is not supported for $kind"; fi
 
@@ -274,6 +274,7 @@ except Exception: raise SystemExit(1)')" || {
   case "$kind" in
     claude)
       [ -z "$model" ] || native_args+=(--model "$model")
+      [ -z "$effort" ] || native_args+=(--effort "$effort")
       local skill
       set +u
       for skill in "${skills[@]}"; do native_args+=(--add-dir "$skill"); done

--- a/home/dot_local/lib/herdr-child-runtime.sh
+++ b/home/dot_local/lib/herdr-child-runtime.sh
@@ -17,7 +17,7 @@ Start options:
   --posture <ro|rw>       Child tool posture (default: ro)
   --cwd <dir>             Child working directory (default: current directory)
   --model <model>         Native model selector
-  --effort <level>        Pi thinking level
+  --effort <level>        Claude effort or Pi thinking level
   --skills <dir>          Skill directory; repeatable
   --agent <name>          Opencode configured agent
   --prompt <text>         Initial task

--- a/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
+++ b/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
@@ -21,7 +21,7 @@ bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh <agent> "<question>" [flags]
 |---|---|
 | `--rw` | Give the child a read-write posture. The default is read-only. |
 | `--model M` | Override the model. |
-| `--effort L` | Set pi's reasoning effort. The default is `medium`. |
+| `--effort L` | Set Claude effort or Pi thinking level. Pi defaults to `medium`. |
 | `--cwd DIR` | Set the child working directory. |
 | `--skills DIR` | Add a claude or pi skill directory. Repeat the flag for multiple directories. |
 | `--agent NAME` | Select a configured opencode agent. |
@@ -34,7 +34,7 @@ If the caller supplies no model, opencode uses `openai/gpt-5.5` and pi uses `ope
 
 | Agent | Read-only posture | Extra options |
 |---|---|---|
-| `claude` | Denies `Edit`, `Write`, `NotebookEdit`, and `AskUserQuestion`. Keeps Bash for the return channel. | `--skills` maps to `--add-dir`. |
+| `claude` | Denies `Edit`, `Write`, `NotebookEdit`, and `AskUserQuestion`. Keeps Bash for the return channel. | `--effort` is native; `--skills` maps to `--add-dir`. |
 | `opencode` | Denies `edit` and `question` through the child process environment. Keeps Bash for the return channel. | `--agent` selects a configured agent. |
 | `pi` | Refused. Pi cannot keep the callback shell while withholding its write-capable shell. | Under `--rw`, excludes `ask_user`; `--skills` maps to `--skill`. |
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -3818,13 +3818,13 @@ function test_scripts_058_herdr_child_markers_round_trip_documented_shape() {
   done
 }
 
-function test_scripts_060_herdr_child_maps_claude_postures_and_skill_direc() {
-  _bats_test_init 60 'herdr-child maps claude postures and skill directories'
+function test_scripts_060_herdr_child_maps_claude_postures_effort_and_skill_direc() {
+  _bats_test_init 60 'herdr-child maps claude postures, effort, and skill directories'
   child_stub_herdr
-  run child_start --kind claude --skills A --skills B --wait
+  run child_start --kind claude --effort high --skills A --skills B --wait
   assert_success
   assert_output "{\"agent\":\"$(child_started_name)\",\"pane\":\"wT:p9\"}"
-  assert_file_contains "$CHILD_STUB/calls.log" 'agent start.*--add-dir A --add-dir B.*--disallowed-tools Edit Write NotebookEdit AskUserQuestion'
+  assert_file_contains "$CHILD_STUB/calls.log" 'agent start.*--effort high --add-dir A --add-dir B.*--disallowed-tools Edit Write NotebookEdit AskUserQuestion'
 
   : > "$CHILD_STUB/calls.log"
   run child_start --kind claude --posture rw --wait
@@ -3866,9 +3866,9 @@ function test_scripts_062_herdr_child_maps_pi_model_effort_skills_and_ques() {
 function test_scripts_063_herdr_child_rejects_native_options_that_the_sele() {
   _bats_test_init 63 'herdr-child rejects native options that the selected kind cannot map'
   child_stub_herdr
-  run child_start --kind claude --effort high --wait
+  run child_start --kind opencode --effort high --wait
   assert_failure 2
-  assert_output --partial "--effort is not supported for claude"
+  assert_output --partial "--effort is not supported for opencode"
   run child_start --kind pi --posture rw --agent reviewer --wait
   assert_failure 2
   assert_output --partial "--agent is not supported for pi"


### PR DESCRIPTION
## Summary

Claude peers launched through `herdr-child` can now honor an explicit `--effort` selection. The launcher forwards the value to Claude's native CLI while keeping OpenCode combinations fail-closed, and the managed help and `ask-in-herdr` contract now describe the same behavior.

Regression coverage verifies the Claude mapping and preserves rejection for unsupported agent-option combinations. The repository issue is closed with the implemented resolution.

## Verification

- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh --no-color` (295 passed, 1 platform skip)
- `make lint`
- `make test-local`
- `make test-issues` (56 passed)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
