### PR TITLE
fix(ci): stop charging unrelated PRs a full Homebrew install

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -108,6 +108,14 @@ jobs:
           # SHAs from the event payload, read through the environment rather
           # than interpolated into the script.
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          # On `pull_request`, actions/checkout leaves HEAD at the merge of the
+          # PR head with the current main, while BASE_SHA is the base recorded
+          # for the PR. Diffing to HEAD therefore also reports every Brewfile
+          # commit merged into main after that base, and forces the full
+          # install on unrelated PRs until the base pointer advances. Name the
+          # PR's own head instead. `github.sha` covers `push`, where it is the
+          # pushed commit and already equals HEAD.
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           install_full() {
             echo "MMS_CI_MINIMAL=" >> "$GITHUB_ENV"
@@ -125,13 +133,20 @@ jobs:
             exit 0
           fi
 
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            install_full "base commit $BASE_SHA is not in this checkout"
+          if [ -z "$HEAD_SHA" ]; then
+            install_full "no head commit for this event"
             exit 0
           fi
 
-          if ! changed=$(git diff --name-only "${BASE_SHA}...HEAD"); then
-            install_full "could not diff against $BASE_SHA"
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              install_full "commit $sha is not in this checkout"
+              exit 0
+            fi
+          done
+
+          if ! changed=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}"); then
+            install_full "could not diff ${BASE_SHA}...${HEAD_SHA}"
             exit 0
           fi
 
@@ -246,6 +261,14 @@ jobs:
           # SHAs from the event payload, read through the environment rather
           # than interpolated into the script.
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          # On `pull_request`, actions/checkout leaves HEAD at the merge of the
+          # PR head with the current main, while BASE_SHA is the base recorded
+          # for the PR. Diffing to HEAD therefore also reports every Brewfile
+          # commit merged into main after that base, and forces the full
+          # install on unrelated PRs until the base pointer advances. Name the
+          # PR's own head instead. `github.sha` covers `push`, where it is the
+          # pushed commit and already equals HEAD.
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           install_full() {
             echo "MMS_CI_MINIMAL=" >> "$GITHUB_ENV"
@@ -263,13 +286,20 @@ jobs:
             exit 0
           fi
 
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            install_full "base commit $BASE_SHA is not in this checkout"
+          if [ -z "$HEAD_SHA" ]; then
+            install_full "no head commit for this event"
             exit 0
           fi
 
-          if ! changed=$(git diff --name-only "${BASE_SHA}...HEAD"); then
-            install_full "could not diff against $BASE_SHA"
+          for sha in "$BASE_SHA" "$HEAD_SHA"; do
+            if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              install_full "commit $sha is not in this checkout"
+              exit 0
+            fi
+          done
+
+          if ! changed=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}"); then
+            install_full "could not diff ${BASE_SHA}...${HEAD_SHA}"
             exit 0
           fi
 

--- a/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
+++ b/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
@@ -1,6 +1,6 @@
 ---
 title: "macOS scripts_test.sh flakes under -j 8 across unrelated cases"
-short_description: "Three of four test-macos jobs on one branch failed tests/bashunit/scripts_test.sh on trees that differ only in unrelated files, in two distinct cases and with two distinct symptoms — another case's JSON in place of the expected output, and a temp file that does not exist yet — so the suite's parallel execution is the suspect rather than the herdr behavior under test."
+short_description: "Four of five test-macos jobs on one branch failed tests/bashunit/scripts_test.sh on trees that differ only in unrelated files, in two distinct cases and with two distinct symptoms — another case's JSON in place of the expected output, and a temp file that does not exist yet — while test-ubuntu passed every time, so the suite's parallel execution on macOS is the suspect rather than the herdr behavior under test."
 type: "bug"
 category: "testing-ci"
 tags: ["flaky-test","parallel-execution","herdr","macos"]
@@ -11,7 +11,7 @@ priority: "high"
 
 ## Why this exists
 
-`tests/bashunit/scripts_test.sh` runs in the post-apply suite under `tests/lib/bashunit -j 8`. On branch `ci/brewfile-gate-head-sha` its `test-macos` job went red in three of four runs, in two unrelated cases, on trees that differ only in files neither case reads.
+`tests/bashunit/scripts_test.sh` runs in the post-apply suite under `tests/lib/bashunit -j 8`. On branch `ci/brewfile-gate-head-sha` its `test-macos` job went red in four of five runs, in two unrelated cases, on trees that differ only in files neither case reads. The `test-ubuntu` job passed every time.
 
 | Run | Result | Case | Symptom |
 |---|---|---|---|
@@ -19,12 +19,13 @@ priority: "high"
 | 33947165694 | fail | same case | same symptom |
 | 33947609695 | pass | — | tree byte-identical to run 33946767926 |
 | 33948544900 | fail | `herdr-child detached delivery retries temporary parent blockage and prompt transport failure` | `scripts_test.sh:2989` — `grep` exited 2 on `$TMPDIR/.../successful-prompts.log`: "No such file or directory" |
+| 33948914983 | fail | pane-label case again | same JSON-substitution symptom, third occurrence |
 
 Two symptoms, one setting. A case reading another case's stdout points at shared output capture; a missing temp file points at a wait that returns before a background writer has created it. Both are properties of how the suite runs in parallel, not of the herdr behavior under test.
 
 Evidence that the branch's own diff is not the cause. The passing run carried a tree byte-identical to the first failing run. `git diff refs/pull/170/merge origin/main` reported only that pull request's own files: a CI workflow step, `tests/test_ci_workflow.py`, an issue record, and a Brewfile comment. None is read by either failing case. The same `scripts_test.sh` passed on `main` run 33945570715 (commit `457c1e7`) and in pull request #168.
 
-Impact: a required macOS job goes red on unrelated pull requests and merging waits on a re-run. At three failures in four runs, re-running is not a workaround.
+Impact: a required macOS job goes red on unrelated pull requests and merging waits on a re-run. At four failures in five runs, re-running is not a workaround; it is what merging currently depends on.
 
 ## Scope
 

--- a/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
+++ b/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
@@ -1,0 +1,31 @@
+---
+title: "Pane-label after-script test captures another test's output under -j 8"
+short_description: "The bashunit test 'herdr pane-label after script still fails a sweep that never converges' failed two of three test-macos jobs on identical trees, with a JSON MCP-server document in place of the expected sweep message, so parallel output capture rather than pane-label logic is the suspect."
+type: "bug"
+category: "testing-ci"
+tags: ["flaky-test","parallel-execution","herdr","macos"]
+date: "2026-09-05"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+`tests/bashunit/scripts_test.sh` runs the case `herdr pane-label after script still fails a sweep that never converges`, whose assertion is `assert_output --partial "strict pane-label sweep did not converge"`. In two consecutive `test-macos` jobs the captured output was instead a JSON document listing MCP server entries (`fff`, `executor`, `jina`, `tavily-mcp`) — output that belongs to a different case in the suite. The pane-label expectation never appeared, so the failure says nothing about sweep convergence.
+
+Evidence that the tree is not the cause. Runs on branch `ci/brewfile-gate-head-sha`: 33946767926 failed, 33947165694 failed, 33947609695 passed. The passing run carried a tree byte-identical to the first failing run. The same case passed on `main` run 33945570715 (commit `457c1e7`) and in pull request #168. `git diff refs/pull/170/merge origin/main` reported only that pull request's own three files, none of which touch pane-label code or the post-apply suite.
+
+The suite runs under `tests/lib/bashunit -j 8`. Output-capture crosstalk between parallel workers explains both the wrong payload and the run-to-run variation; a defect in the pane-label sweep would not substitute another case's stdout.
+
+Impact: a required macOS job goes red on unrelated pull requests, and merging waits on a re-run. Two failures in three runs is frequent enough that re-running is not a workaround.
+
+## Scope
+
+- Determine how another case's stdout reaches this case's `assert_output` under `-j 8` — shared capture path, shared temporary file, or a leaked file descriptor from a backgrounded child.
+- Make the capture deterministic for this case, and for any sibling that shares the same mechanism.
+- Keep the case's protected behavior intact: a strict sweep that never converges must still fail, still report `strict pane-label sweep did not converge`, and still disable the plugin.
+- Related but distinct, and out of scope here: `2026-09-02-013` (palette herdr-stub tests bounded by a wall-clock timeout under `-j 8`) and `2026-09-02-009` (a single `test-ubuntu` flake in the herdr-child watcher barrier).
+
+## Open decisions
+
+- Whether the fix belongs in the shared bashunit capture helper or in this case's own harness. Deciding needs the mechanism first.

--- a/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
+++ b/docs/issues/2026-09-05-001-pane-label-after-script-test-captures-another-test-s-output-under-j-8.md
@@ -1,31 +1,39 @@
 ---
-title: "Pane-label after-script test captures another test's output under -j 8"
-short_description: "The bashunit test 'herdr pane-label after script still fails a sweep that never converges' failed two of three test-macos jobs on identical trees, with a JSON MCP-server document in place of the expected sweep message, so parallel output capture rather than pane-label logic is the suspect."
+title: "macOS scripts_test.sh flakes under -j 8 across unrelated cases"
+short_description: "Three of four test-macos jobs on one branch failed tests/bashunit/scripts_test.sh on trees that differ only in unrelated files, in two distinct cases and with two distinct symptoms — another case's JSON in place of the expected output, and a temp file that does not exist yet — so the suite's parallel execution is the suspect rather than the herdr behavior under test."
 type: "bug"
 category: "testing-ci"
 tags: ["flaky-test","parallel-execution","herdr","macos"]
 date: "2026-09-05"
 status: "open"
-priority: "medium"
+priority: "high"
 ---
 
 ## Why this exists
 
-`tests/bashunit/scripts_test.sh` runs the case `herdr pane-label after script still fails a sweep that never converges`, whose assertion is `assert_output --partial "strict pane-label sweep did not converge"`. In two consecutive `test-macos` jobs the captured output was instead a JSON document listing MCP server entries (`fff`, `executor`, `jina`, `tavily-mcp`) — output that belongs to a different case in the suite. The pane-label expectation never appeared, so the failure says nothing about sweep convergence.
+`tests/bashunit/scripts_test.sh` runs in the post-apply suite under `tests/lib/bashunit -j 8`. On branch `ci/brewfile-gate-head-sha` its `test-macos` job went red in three of four runs, in two unrelated cases, on trees that differ only in files neither case reads.
 
-Evidence that the tree is not the cause. Runs on branch `ci/brewfile-gate-head-sha`: 33946767926 failed, 33947165694 failed, 33947609695 passed. The passing run carried a tree byte-identical to the first failing run. The same case passed on `main` run 33945570715 (commit `457c1e7`) and in pull request #168. `git diff refs/pull/170/merge origin/main` reported only that pull request's own three files, none of which touch pane-label code or the post-apply suite.
+| Run | Result | Case | Symptom |
+|---|---|---|---|
+| 33946767926 | fail | `herdr pane-label after script still fails a sweep that never converges` | `assert_output --partial "strict pane-label sweep did not converge"` saw a JSON document of MCP server entries (`fff`, `executor`, `jina`, `tavily-mcp`) — output belonging to a different case |
+| 33947165694 | fail | same case | same symptom |
+| 33947609695 | pass | — | tree byte-identical to run 33946767926 |
+| 33948544900 | fail | `herdr-child detached delivery retries temporary parent blockage and prompt transport failure` | `scripts_test.sh:2989` — `grep` exited 2 on `$TMPDIR/.../successful-prompts.log`: "No such file or directory" |
 
-The suite runs under `tests/lib/bashunit -j 8`. Output-capture crosstalk between parallel workers explains both the wrong payload and the run-to-run variation; a defect in the pane-label sweep would not substitute another case's stdout.
+Two symptoms, one setting. A case reading another case's stdout points at shared output capture; a missing temp file points at a wait that returns before a background writer has created it. Both are properties of how the suite runs in parallel, not of the herdr behavior under test.
 
-Impact: a required macOS job goes red on unrelated pull requests, and merging waits on a re-run. Two failures in three runs is frequent enough that re-running is not a workaround.
+Evidence that the branch's own diff is not the cause. The passing run carried a tree byte-identical to the first failing run. `git diff refs/pull/170/merge origin/main` reported only that pull request's own files: a CI workflow step, `tests/test_ci_workflow.py`, an issue record, and a Brewfile comment. None is read by either failing case. The same `scripts_test.sh` passed on `main` run 33945570715 (commit `457c1e7`) and in pull request #168.
+
+Impact: a required macOS job goes red on unrelated pull requests and merging waits on a re-run. At three failures in four runs, re-running is not a workaround.
 
 ## Scope
 
-- Determine how another case's stdout reaches this case's `assert_output` under `-j 8` — shared capture path, shared temporary file, or a leaked file descriptor from a backgrounded child.
-- Make the capture deterministic for this case, and for any sibling that shares the same mechanism.
-- Keep the case's protected behavior intact: a strict sweep that never converges must still fail, still report `strict pane-label sweep did not converge`, and still disable the plugin.
-- Related but distinct, and out of scope here: `2026-09-02-013` (palette herdr-stub tests bounded by a wall-clock timeout under `-j 8`) and `2026-09-02-009` (a single `test-ubuntu` flake in the herdr-child watcher barrier).
+- Identify the mechanism behind each symptom: how one case's stdout reaches another case's `assert_output`, and why the herdr-child case proceeds before `successful-prompts.log` exists.
+- Determine whether both share one root cause in the suite's parallel harness or need separate fixes.
+- Make both cases deterministic at `-j 8` without weakening what they protect: the strict sweep must still fail and report `strict pane-label sweep did not converge`, and the detached-delivery case must still prove the retry after parent blockage.
+- Check the rest of `scripts_test.sh` for the same pattern once the mechanism is known, rather than patching only the two observed cases.
+- Related but distinct, and out of scope here: `2026-09-02-013` (palette herdr-stub tests bounded by a wall-clock timeout at `-j 8`) and `2026-09-02-009` (a single `test-ubuntu` flake in the herdr-child watcher barrier). If the mechanism found here explains either, fold them in then.
 
 ## Open decisions
 
-- Whether the fix belongs in the shared bashunit capture helper or in this case's own harness. Deciding needs the mechanism first.
+- Whether the fix belongs in the shared bashunit capture and wait helpers or in each case's own harness. Deciding needs the mechanism first.

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -1,6 +1,4 @@
 {{- /* CI-minimal render guard. See docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md */ -}}
-{{- /* CI gate probe: this line is reverted by the next commit. It renders to      */ -}}
-{{- /* nothing, so only the file's diff status changes.                                */ -}}
 {{- /*                                                                                                */ -}}
 {{- /* $full selects the whole file. It is true on every host and in every                            */ -}}
 {{- /* environment that does not set MMS_CI_MINIMAL before `chezmoi init`;                            */ -}}

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -1,4 +1,6 @@
 {{- /* CI-minimal render guard. See docs/plans/2026-08-20-2217-perf-ci-minimal-brew-install-plan.md */ -}}
+{{- /* CI gate probe: this line is reverted by the next commit. It renders to      */ -}}
+{{- /* nothing, so only the file's diff status changes.                                */ -}}
 {{- /*                                                                                                */ -}}
 {{- /* $full selects the whole file. It is true on every host and in every                            */ -}}
 {{- /* environment that does not set MMS_CI_MINIMAL before `chezmoi init`;                            */ -}}

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+import os
 import re
+import subprocess
+import tempfile
+import textwrap
 import unittest
 
 
@@ -172,6 +176,147 @@ class TestDotfilesWorkflow(unittest.TestCase):
                 self.assertTrue(
                     any(save_key.startswith(prefix) for prefix in prefixes),
                     "no restore-keys prefix can find the key the save step writes: %s" % save_key,
+                )
+
+    def gate_script(self, text, job_name):
+        """The shell body of the Brewfile-diff gate, ready to execute."""
+        step = self.named_step_block(
+            self.job_block(text, job_name),
+            "Install the full Brewfiles when the diff touches one",
+        )
+        match = re.search(r"^        run: \|\n(?P<body>(?:^ {10}.*\n|^\n)+)", step, re.MULTILINE)
+        self.assertIsNotNone(match, "gate step must declare a literal run: block")
+        return textwrap.dedent(match.group("body"))
+
+    def git_environment(self, home):
+        """A git environment that cannot read the developer's own config."""
+        environment = dict(os.environ)
+        environment.update(
+            HOME=str(home),
+            GIT_CONFIG_GLOBAL=os.devnull,
+            GIT_CONFIG_SYSTEM=os.devnull,
+            GIT_AUTHOR_NAME="Gate Test",
+            GIT_AUTHOR_EMAIL="gate@example.com",
+            GIT_COMMITTER_NAME="Gate Test",
+            GIT_COMMITTER_EMAIL="gate@example.com",
+        )
+        return environment
+
+    def build_pull_request_checkout(self, root, pr_touches_brewfile):
+        """A checkout shaped like actions/checkout on a `pull_request` event:
+        HEAD is the merge of the PR head with a main tip that has moved on.
+        Main's newer commit edits a Brewfile; the PR's own commit edits one
+        only when asked. Returns (base_sha, head_sha)."""
+        repository = root / "repo"
+        repository.mkdir()
+        brewfile = repository / "home" / "private_dot_config" / "brewfiles"
+        brewfile.mkdir(parents=True)
+        environment = self.git_environment(root)
+
+        def git(*arguments):
+            return subprocess.run(
+                ("git",) + arguments,
+                cwd=repository,
+                env=environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+        def commit(path, contents, message):
+            path.write_text(contents, encoding="utf-8")
+            git("add", "-A")
+            git("commit", "-q", "-m", message)
+            return git("rev-parse", "HEAD")
+
+        git("init", "-q")
+        base = commit(brewfile / "Brewfile", 'brew "git"\n', "base")
+        git("branch", "feature")
+        main_tip = commit(brewfile / "Brewfile", 'brew "git"\nbrew "imagemagick"\n', "main edits a Brewfile")
+
+        git("checkout", "-q", "feature")
+        if pr_touches_brewfile:
+            # A different file under brewfiles/ than main edited, so the merge
+            # stays clean and the fixture tests the gate, not conflict handling.
+            head = commit(
+                brewfile / "Brewfile.macos", 'cask "ghostty"\n', "the PR edits a Brewfile"
+            )
+        else:
+            head = commit(repository / "README.md", "unrelated\n", "the PR edits nothing under brewfiles")
+
+        # The merge commit actions/checkout leaves in the working tree.
+        git("checkout", "-q", "--detach", main_tip)
+        git("merge", "-q", "--no-ff", "-m", "merge", head)
+        return repository, base, head
+
+    def run_gate(self, script, repository, event_name, base_sha, head_sha):
+        """The gate's decision: (selects_full_install, stdout)."""
+        github_env = repository.parent / "github_env"
+        github_env.write_text("", encoding="utf-8")
+        environment = self.git_environment(repository.parent)
+        environment.update(
+            GITHUB_EVENT_NAME=event_name,
+            GITHUB_ENV=str(github_env),
+            BASE_SHA=base_sha,
+            HEAD_SHA=head_sha,
+        )
+        result = subprocess.run(
+            ["bash", "-e", "-c", script],
+            cwd=repository,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "gate script failed: %s%s" % (result.stdout, result.stderr),
+        )
+        return "MMS_CI_MINIMAL=" in github_env.read_text(encoding="utf-8"), result.stdout
+
+    def test_gate_reads_the_pull_request_head_not_the_merge_commit(self):
+        # On a `pull_request` run, HEAD is the merge of the PR head with the
+        # current main, so a Brewfile commit merged into main after the PR's
+        # recorded base sits inside a diff that ends at HEAD. That charged
+        # every unrelated PR a full Brewfile install (~4.5 min per job) until
+        # the base pointer advanced. The oracle is the synthetic history below,
+        # not the workflow text: only the PR's own commits may decide this.
+        text = self.workflow_text()
+        for job_name in ("test-ubuntu", "test-macos"):
+            with self.subTest(job=job_name):
+                script = self.gate_script(text, job_name)
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    repository, base, head = self.build_pull_request_checkout(
+                        root, pr_touches_brewfile=False
+                    )
+                    full, output = self.run_gate(
+                        script, repository, "pull_request", base, head
+                    )
+                self.assertFalse(
+                    full,
+                    "a PR that touches no Brewfile must keep the minimal "
+                    "install even when main has since edited one: %s" % output,
+                )
+
+    def test_gate_still_selects_the_full_install_for_a_brewfile_pull_request(self):
+        # Control for the test above: the narrowed diff must not cost a
+        # Brewfile-editing PR its only pre-merge install proof.
+        text = self.workflow_text()
+        for job_name in ("test-ubuntu", "test-macos"):
+            with self.subTest(job=job_name):
+                script = self.gate_script(text, job_name)
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    repository, base, head = self.build_pull_request_checkout(
+                        root, pr_touches_brewfile=True
+                    )
+                    full, output = self.run_gate(
+                        script, repository, "pull_request", base, head
+                    )
+                self.assertTrue(
+                    full,
+                    "a PR that edits a Brewfile must install the full set: %s" % output,
                 )
 
     def test_every_job_declares_a_timeout(self):


### PR DESCRIPTION
A pull request that changes no Brewfile no longer pays for a full Homebrew install. The workflow's Brewfile gate decided from `${BASE_SHA}...HEAD`, but on a `pull_request` event `HEAD` is the merge of the PR head with current `main`, while `BASE_SHA` is the base recorded for the PR and never follows `main`. Any Brewfile commit merged into `main` after that base therefore read as the PR's own change. The gate now diffs `${BASE_SHA}...${HEAD_SHA}`, so only the PR's commits decide; a PR that does edit a Brewfile still installs the full set.

Two runs of PR #168, with no change to the PR between them, straddle the moment `fix(brewfile): declare ImageMagick runtime delegates on macOS` reached `main`:

| Run | Gate verdict | `Apply dotfiles`, macOS job |
|---|---|---|
| before that commit reached `main` | minimal install | — (run cancelled) |
| after it reached `main` | full install | 310 s: 191 s of casks, 92 s of formulas |
| an ordinary minimal run, for scale | minimal install | 31 s |

Fail-open behavior is unchanged: an empty or unresolvable SHA on either side still installs everything, because a needless full install costs minutes while a wrong minimal install drops the only pre-merge proof a Brewfile edit gets. The `push` path is untouched — there `github.sha` is the pushed commit and already equals `HEAD`.

Validation: `make test-issues` (58 Python tests) and `make lint` pass. Two new tests execute the gate's shell body against a synthetic checkout shaped like a `pull_request` merge commit whose `main` side edits a Brewfile, and they were confirmed to fail against the pre-fix `...HEAD` line. GitHub evaluates the `${{ }}` expressions, which cannot run locally, so the live proof is this PR's own run: the branch starts deliberately from a commit that predates the ImageMagick Brewfile change, which is the exact condition that used to force the full install.
