### PR TITLE
fix(tests): isolate parallel bashunit workers

### DIFF
--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -3004,7 +3004,7 @@ function test_scripts_037_herdr_child_detached_delivery_retries_temporary() {
   assert_file_exists "$CHILD_STUB/parent-blocked-observed"
   assert_file_not_exists "$CHILD_STUB/successful-prompts.log"
   printf 'working\n' > "$CHILD_STUB/parent-status"
-  child_wait_for_log 'event=settled-11'
+  child_wait_for_log 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   assert_success
   assert_output 1
@@ -3016,13 +3016,7 @@ function test_scripts_037_herdr_child_detached_delivery_retries_temporary() {
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
   printf 'idle 11\n' > "$CHILD_STUB/child-state"
-  child_wait_for_log 'event=settled-11'
-  attempt=0
-  while [ ! -s "$CHILD_STUB/successful-prompts.log" ] && [ "$attempt" -lt 500 ]; do
-    attempt=$((attempt + 1))
-    sleep 0.01
-  done
-  assert_file_exists "$CHILD_STUB/successful-prompts.log"
+  child_wait_for_log 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   assert_success
   assert_output 1
@@ -3059,7 +3053,7 @@ function test_scripts_039_herdr_child_transient_pane_reads_never_become_ch() {
   : > "$CHILD_STUB/pane-transient-after-settlement"
   printf 'idle 11\n' > "$CHILD_STUB/child-state"
   child_wait_for_file "$CHILD_STUB/pane-get-transient-observed"
-  child_wait_for_log 'event=settled-11'
+  child_wait_for_log 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   run grep -q 'event=child-gone' "$CHILD_STUB/calls.log"
   assert_failure
   run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
@@ -7449,6 +7443,16 @@ function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
   run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
   assert_success
   assert_output --partial "Assertions: 1 passed, 1 total"
+}
+
+function test_scripts_2841_test_dsl_isolates_parallel_tests_with_the_same_historical_number() {
+  _bats_test_init 2841 'test DSL isolates parallel tests with the same historical number'
+  local probe_file="$BATS_TEST_DIRNAME/bashunit/test_dsl_parallel_isolation_probe_test.sh"
+  assert_file_exists "$probe_file"
+
+  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
+  assert_success
+  assert_output --partial "Tests:      2 passed, 2 total"
 }
 
 # watcher orphan self-termination (docs/solutions/design-patterns/outliving-processes-hang-the-suite.md)

--- a/tests/bashunit/test-dsl.bash
+++ b/tests/bashunit/test-dsl.bash
@@ -461,7 +461,9 @@ _bats_test_init() {
   BATS_TEST_DESCRIPTION="$2"
   BATS_TEST_NAME="$2"
   bashunit::set_test_title "$2"
-  BATS_TEST_TMPDIR="$_BATS_FILE_TMPROOT/test-$1"
+  # Historical Bats numbers can repeat after suites are merged. Bashunit's
+  # runtime identity is unique per test, including under parallel execution.
+  BATS_TEST_TMPDIR="$_BATS_FILE_TMPROOT/$BASHUNIT_CURRENT_TEST_ID"
   mkdir -p "$BATS_TEST_TMPDIR"
   export BATS_TEST_NUMBER BATS_TEST_DESCRIPTION BATS_TEST_NAME BATS_TEST_TMPDIR
   # -E: inherit the ERR trap into helper functions (bats runs tests with

--- a/tests/bashunit/test_dsl_parallel_isolation_probe_test.sh
+++ b/tests/bashunit/test_dsl_parallel_isolation_probe_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# post-apply: excluded
+# Dedicated two-test fixture for the test DSL's parallel temp-directory
+# isolation. Converted historical test numbers are metadata, not unique IDs.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+assert_parallel_tmpdirs_differ() {
+  local own="$1" other="$2" attempt=0
+  printf '%s\n' "$BATS_TEST_TMPDIR" > "$_BATS_FILE_TMPROOT/$own"
+  while [ ! -f "$_BATS_FILE_TMPROOT/$other" ] && [ "$attempt" -lt 500 ]; do
+    attempt=$((attempt + 1))
+    sleep 0.01
+  done
+  assert_file_exists "$_BATS_FILE_TMPROOT/$other"
+  run test "$(< "$_BATS_FILE_TMPROOT/$own")" != "$(< "$_BATS_FILE_TMPROOT/$other")"
+  assert_success
+}
+
+function test_parallel_tmpdir_isolation_first() {
+  _bats_test_init 1 'parallel temp directory isolation first probe'
+  assert_parallel_tmpdirs_differ first second
+}
+
+function test_parallel_tmpdir_isolation_second() {
+  _bats_test_init 1 'parallel temp directory isolation second probe'
+  assert_parallel_tmpdirs_differ second first
+}
+
+function set_up_before_script() { :; }
+function tear_down_after_script() { _bats_file_cleanup; }
+function tear_down() { _bats_run_teardown; }


### PR DESCRIPTION
## Summary

Parallel bashunit workers no longer share output capture files when historical Bats test numbers repeat. Herdr delivery tests now wait for successful prompt transport rather than invocation, eliminating the second macOS race recorded in [Actions job 101264433445](https://github.com/Seigiard/my-mac-setup/actions/runs/33950570872/job/101264433445).

The test DSL keys each temporary directory by bashunit's per-test runtime identity instead of manually assigned metadata. A dedicated parallel probe intentionally gives 2 tests the same historical number and requires distinct runtime directories, covering all 20 duplicate-number pairs currently present in `scripts_test.sh` without renumbering them individually.

## Verification

- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh` (336 passed, 1 expected platform skip)
- Repeated focused runs: 20 capture-collision iterations and 10 iterations each for detached retry, transient delivery, and the new isolation probe
- `make lint`
- `bash -n tests/bashunit/test-dsl.bash tests/bashunit/scripts_test.sh tests/bashunit/test_dsl_parallel_isolation_probe_test.sh`
- `shellcheck --severity=warning tests/bashunit/test_dsl_parallel_isolation_probe_test.sh`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
