### PR TITLE
fix(tests): isolate Herdr plugin registration

### DIFF
--- a/docs/solutions/test-failures/inherited-herdr-socket-contaminates-live-plugin-registry-2026-09-05.md
+++ b/docs/solutions/test-failures/inherited-herdr-socket-contaminates-live-plugin-registry-2026-09-05.md
@@ -1,0 +1,93 @@
+---
+title: Inherited Herdr socket contaminates the live plugin registry
+date: 2026-09-05
+category: test-failures
+module: herdr-command-palette
+problem_type: test_failure
+component: testing_framework
+severity: high
+symptoms:
+  - "A real Herdr CLI test registers a local plugin from an ephemeral worktree in the live server"
+  - "After the worktree is deleted, Herdr reports manifest unavailable and exposes no plugin actions"
+  - "Cmd+Shift+P reports custom command failed and plugin action not found"
+root_cause: test_isolation
+resolution_type: test_fix
+related_components:
+  - "tooling"
+  - "development_workflow"
+tags:
+  - herdr
+  - command-palette
+  - plugin-registry
+  - test-isolation
+  - socket-inheritance
+  - ephemeral-worktree
+  - bashunit
+---
+
+# Inherited Herdr socket contaminates the live plugin registry
+
+## Problem
+
+`tests/bashunit/palette_test.sh` changed `HOME` before running the real Herdr CLI, but a test launched inside Herdr still inherited `HERDR_SOCKET_PATH`. The explicit socket sent `herdr plugin link` to the live server, which persisted the command-palette path from the current test worktree. Herdr also supports other session and config-root overrides, so changing `HOME` alone is not a complete isolation boundary.
+
+When that worktree was removed, the registered manifest disappeared. Herdr kept the cached plugin entry for inspection but excluded its actions from resolution, so `seigi.command-palette.open` failed at keypress time.
+
+## Symptoms
+
+- `herdr plugin list --json` shows `seigi.command-palette` rooted in a deleted worktree with a `manifest unavailable` warning.
+- `herdr plugin action list --plugin seigi.command-palette` returns no actions.
+- `Cmd+Shift+P` shows `custom command failed` and `plugin action not found`.
+
+## What Didn't Work
+
+Changing only `HOME` does not isolate a socket-aware Herdr command:
+
+```bash
+env HOME="$home" herdr plugin link "$PALETTE_DIR" --enabled
+```
+
+`HERDR_SOCKET_PATH` takes precedence and routes the mutation to the running server. `herdr server reload-config` also cannot repair this state because it reloads `config.toml`, not plugin registration.
+
+## Solution
+
+Start the real CLI check with a clean environment and verify the persistent side effect in the disposable home:
+
+```bash
+run env -i HOME="$home" PATH="$PATH" \
+  herdr plugin link "$PALETTE_DIR" --enabled
+assert_success
+local link_json="$output"
+
+local registry="$home/.config/herdr/plugins.json"
+assert_file_exists "$registry"
+```
+
+The test parses `plugins.json` and requires `seigi.command-palette` to point at `$PALETTE_DIR`. It saves the first `run` output because the repository test DSL overwrites `$output` on every subsequent `run`.
+
+Repair an already contaminated live registry by replacing the same plugin ID with the stable managed path:
+
+```bash
+herdr plugin link ~/.config/herdr/plugins/command-palette --enabled
+```
+
+Relinking validates the new manifest before replacing the existing registration. An unlink-first window is unnecessary.
+
+## Why This Works
+
+The clean environment removes inherited socket, named-session, and config-root overrides. Herdr resolves its state from the disposable `HOME` and writes that home's `.config/herdr/plugins.json`. The test still exercises Herdr's real manifest parser and registry persistence, but it cannot reach the user's running server.
+
+The regression assertion observes the filesystem boundary rather than trusting successful CLI output. Before the fix, the command succeeded while the disposable registry remained empty and the live registry changed. After the fix, the focused test and all 62 command-palette tests passed, covering 228 assertions.
+
+## Prevention
+
+- Treat endpoint and config-root variables as part of test isolation. Changing `HOME` alone is insufficient when a CLI accepts explicit environment overrides.
+- For a real Herdr CLI test that needs no ambient state, use `env -i` and restore only required inputs such as `HOME` and `PATH`.
+- Assert the mutation in the disposable registry so a command routed to the wrong server cannot produce a false green.
+
+## Related Issues
+
+- [Semantic regression tests over source shape](../design-patterns/semantic-regression-tests-over-source-shape.md)
+- [Herdr git-status playground plan](../../plans/2026-08-25-001-feat-herdr-git-status-playground-plan.md)
+- [Task-sync tests measure only an unverified Herdr protocol fake](../../issues/2026-09-02-012-herdr-task-sync-tests-measure-only-an-unverified-herdr-protocol-fake.md)
+- [Palette dynamic plugin action source](../../issues/2026-08-18-008-palette-dynamic-plugin-action-source.md)

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1314,7 +1314,24 @@ function test_palette_063_herdr_loads_the_command_palette_manifest_and_actions()
   local home="$PALETTE_WORK/herdr-home"
   mkdir -p "$home"
 
-  run env HOME="$home" herdr plugin link "$PALETTE_DIR" --enabled
+  # A test launched inside Herdr inherits its live socket. Keep this real CLI
+  # validation confined to the disposable HOME instead of relinking the live plugin.
+  run env -u HERDR_SOCKET_PATH HOME="$home" herdr plugin link "$PALETTE_DIR" --enabled
+  assert_success
+  local link_json="$output"
+
+  local registry="$home/.config/herdr/plugins.json"
+  assert_file_exists "$registry"
+  run env PALETTE_REGISTRY="$registry" PALETTE_DIR="$PALETTE_DIR" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["PALETTE_REGISTRY"], encoding="utf-8") as handle:
+    plugins = json.load(handle)
+plugin = next((item for item in plugins if item["plugin_id"] == "seigi.command-palette"), None)
+assert plugin is not None, plugins
+assert plugin["plugin_root"] == os.environ["PALETTE_DIR"], plugin
+PY
   assert_success
 
   # assert_success above owns the real regression: herdr refusing a manifest
@@ -1324,7 +1341,7 @@ function test_palette_063_herdr_loads_the_command_palette_manifest_and_actions()
   # surfaces a dangling binding only at keypress time, so nothing else here
   # catches a renamed or deleted action. Asserting that the link report echoes
   # an id typed in the manifest it just read would prove nothing.
-  run env PALETTE_LINK_JSON="$output" \
+  run env PALETTE_LINK_JSON="$link_json" \
     HERDR_CONFIG="$SOURCE_ROOT/private_dot_config/herdr/config.toml" python3 - <<'PY'
 import json
 import os

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1314,9 +1314,9 @@ function test_palette_063_herdr_loads_the_command_palette_manifest_and_actions()
   local home="$PALETTE_WORK/herdr-home"
   mkdir -p "$home"
 
-  # A test launched inside Herdr inherits its live socket. Keep this real CLI
-  # validation confined to the disposable HOME instead of relinking the live plugin.
-  run env -u HERDR_SOCKET_PATH HOME="$home" herdr plugin link "$PALETTE_DIR" --enabled
+  # Keep this real CLI validation independent of inherited Herdr session and
+  # config overrides, which can otherwise relink the live plugin.
+  run env -i HOME="$home" PATH="$PATH" herdr plugin link "$PALETTE_DIR" --enabled
   assert_success
   local link_json="$output"
 


### PR DESCRIPTION
Palette tests now validate Herdr manifests in a clean environment, so inherited session or config overrides cannot replace global plugin registration with ephemeral worktree paths. The regression assertion confirms the real CLI persists the command-palette plugin in its disposable `HOME` while preserving action/keybinding consistency coverage.

The accompanying learning documents the causal chain from test leakage to `plugin action not found`, the live repair command, and the isolation rule for future Herdr CLI tests.

Verified with `tests/lib/bashunit -j 8 tests/bashunit/palette_test.sh --no-color` (62 tests, 228 assertions).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
