### PR TITLE
fix(zsh): pin Oh My Zsh, zsh plugins, and fff-mcp as chezmoi externals

### DIFF
--- a/docs/issues/2026-09-05-001-update-all-checks-pinned-versions-and-offers-bumps.md
+++ b/docs/issues/2026-09-05-001-update-all-checks-pinned-versions-and-offers-bumps.md
@@ -1,0 +1,29 @@
+---
+title: "update-all checks pinned versions and offers bumps"
+short_description: "After the pinned-externals migration (plan 2026-09-05-0906), update-all in home/dot_aliases should compare the pinned chezmoi-external refs (Oh My Zsh, four zsh plugins, fff-mcp) and mise tool versions against upstream and offer each bump interactively (y/n), replacing the removed omz update call."
+type: "follow-up"
+category: "dotfiles"
+tags: ["update-all","externals","mise"]
+date: "2026-09-05"
+status: "open"
+priority: "medium"
+---
+
+## Why this exists
+
+The plan `docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md` (KTD3/KTD4) pins Oh My Zsh, the four zsh plugins, and fff-mcp to fixed refs in `home/.chezmoiexternal.toml` and removes `omz update` from the `update-all` alias. After that lands, nothing updates these dependencies without a manual source edit, and nothing tells the owner an update exists. The owner chose pinning over auto-refresh on the condition that `update-all` grows a guided bump path.
+
+## Scope
+
+Extend `update-all` in `home/dot_aliases` (or a helper script it calls) to:
+
+- compare each pinned external ref (OMZ, zsh-autosuggestions, fast-syntax-highlighting, zsh-history-substring-search, zsh-defer, fff-mcp) against the upstream latest release or HEAD;
+- compare mise tool versions against `mise outdated`;
+- for each available update, show current → latest and offer the bump interactively (y/n);
+- an accepted bump edits the repo source (`home/.chezmoiexternal.toml` ref, or the mise config), never the live files, preserving the versions-change-only-via-source convention.
+
+Out of scope: auto-applying bumps, CI integration.
+
+## Open decisions
+
+- Whether a bump also fetches and updates the fff-mcp per-platform sha256 values automatically (four checksums per bump) or prints them for manual entry.

--- a/docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md
+++ b/docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md
@@ -1,0 +1,76 @@
+---
+title: "test-ubuntu oracle fails on herdr --version argument-list-too-long"
+short_description: "make test-ubuntu deterministically fails 2 templates_test.sh assertions (zshenv host-partial diff and skip-secrets cases) because chezmoi's output template function execs /home/linuxbrew/.linuxbrew/bin/herdr --version via run_onchange_after_3-setup-herdr-integrations.sh.tmpl:10 and hits an OS argument-list-too-long error; reproduced identically across a plan's diff present/absent and a --no-cache image rebuild, so it is environment/harness-level (suspected: bashunit's exported shell functions bloating the inherited env past ARG_MAX under nested env/chezmoi-diff calls), not a code regression, and it currently blocks the make test-ubuntu deployment-sensitive gate for every PR."
+type: "bug"
+category: "testing-ci"
+tags: ["test-ubuntu","chezmoi","herdr","argument-list-too-long"]
+date: "2026-09-05"
+status: "open"
+priority: "high"
+---
+
+## Why this exists
+
+Discovered while running `docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md`'s
+U2 verification. `make test-ubuntu` fails with 2 failed assertions in
+`tests/bashunit/templates_test.sh`, both in the `zshenv` test cases around
+lines 220-308 (`test_templates_0092_zshenv_host_partial_diff_preserves_secret_target_and_reports_work`
+and `test_templates_0094_zshenv_skip_secrets_omits_state_but_execute_template_fails`).
+Both invoke a full-tree `chezmoi diff` / `execute-template` through
+`tests/helpers/chezmoi-unattended` with a sandboxed `HOME`, which touches
+every `run_onchange` script including
+`home/.chezmoiscripts/run_onchange_after_3-setup-herdr-integrations.sh.tmpl:10`.
+That script's hash-trigger comment calls chezmoi's `output "herdr" "--version"`
+template function, which fails:
+
+```
+chezmoi: .chezmoiscripts/3-setup-herdr-integrations.sh: template: .chezmoiscripts/run_onchange_after_3-setup-herdr-integrations.sh.tmpl:10:45: executing ".chezmoiscripts/run_onchange_after_3-setup-herdr-integrations.sh.tmpl" at <output "herdr" "--version">: error calling output: /home/linuxbrew/.linuxbrew/bin/herdr --version: fork/exec /home/linuxbrew/.linuxbrew/bin/herdr: argument list too long
+```
+
+The main `chezmoi apply --verbose` step inside the same `test-ubuntu` run does
+**not** hit this — only the templates_test.sh invocations through the
+sandboxed-`HOME` launcher do. This blocks the `make test-ubuntu`
+deployment-sensitive verification gate (`docs/agent-verification.md`) for
+every PR that touches a managed path, including plan 2026-09-05-0906's U1
+(already committed) and U2/U3 (in progress).
+
+**Isolation performed** (4/4 reproductions, identical failure and location
+each time):
+
+- With plan 2026-09-05-0906's U2 diff applied (`.chezmoiexternal.toml`,
+  `run_onchange_after_1-install-packages.sh.tmpl`, `dot_zshrc.tmpl`,
+  `dot_aliases`, `tests/bashunit/scripts_test.sh`).
+- With that diff `git stash`ed back to just the plan's already-committed U1
+  state (mise config only) — rules out this plan's changes as the cause.
+- After a full `docker compose build --no-cache test-ubuntu` — rules out a
+  stale/corrupted Docker image layer as the cause.
+
+**Suspected root cause** (not confirmed — a hypothesis for whoever picks this
+up): `tests/lib/bashunit -j 8` runs with parallel workers and the framework
+exports many shell functions (`export -f`) into the environment for its
+assertion helpers. That environment is inherited through the nested
+`run env HOME=... MMS_CHEZMOI_UNATTENDED=1 tests/helpers/chezmoi-unattended
+--profile host-partial -- diff ...` invocation down to chezmoi's own
+`output "herdr" "--version"` subprocess exec, plausibly pushing combined
+argv+envp past the Linux `ARG_MAX` limit. The identical failure under a
+freshly rebuilt image argues against anything baked into the Docker image
+itself.
+
+## Scope
+
+- Confirm the actual cause (start by measuring the environment size at the
+  point of the failing `output` call, e.g. temporarily wrapping `herdr` or
+  adding diagnostic output to the failing test's `run env ...` invocation).
+- Either shrink the inherited environment before the nested `chezmoi diff`
+  call in `tests/helpers/chezmoi-unattended`, or make the hash-trigger call
+  in `run_onchange_after_3-setup-herdr-integrations.sh.tmpl` resilient to a
+  large ambient environment (e.g., invoke `herdr --version` with a trimmed
+  `env`).
+- Re-run `make test-ubuntu` and `tests/lib/bashunit -j 8 tests/bashunit/templates_test.sh`
+  to confirm both previously failing assertions pass.
+
+## Open decisions
+
+- Whether the fix belongs in the test harness (`tests/helpers/chezmoi-unattended`)
+  or in the affected run script itself — depends on which side is confirmed
+  as the actual source of the oversized environment.

--- a/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
+++ b/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
@@ -115,7 +115,7 @@ Existing machines hit the same sequence; the exact plugin archives replace the o
 
 - [x] U1 · declarative mise config + hash-triggered install (PR 1)
 - [x] U2 · Oh My Zsh + zsh plugins as pinned archive externals (PR 2, part 1)
-- [ ] U3 · fff-mcp as a pinned file external (PR 2, part 2)
+- [x] U3 · fff-mcp as a pinned file external (PR 2, part 2)
 - [ ] Finish · se-code-review pass + DoD closeout
 
 ---

--- a/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
+++ b/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
@@ -114,7 +114,7 @@ Existing machines hit the same sequence; the exact plugin archives replace the o
 ## Progress
 
 - [x] U1 · declarative mise config + hash-triggered install (PR 1)
-- [ ] U2 · Oh My Zsh + zsh plugins as pinned archive externals (PR 2, part 1)
+- [x] U2 · Oh My Zsh + zsh plugins as pinned archive externals (PR 2, part 1)
 - [ ] U3 · fff-mcp as a pinned file external (PR 2, part 2)
 - [ ] Finish · se-code-review pass + DoD closeout
 

--- a/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
+++ b/docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md
@@ -116,7 +116,7 @@ Existing machines hit the same sequence; the exact plugin archives replace the o
 - [x] U1 · declarative mise config + hash-triggered install (PR 1)
 - [x] U2 · Oh My Zsh + zsh plugins as pinned archive externals (PR 2, part 1)
 - [x] U3 · fff-mcp as a pinned file external (PR 2, part 2)
-- [ ] Finish · se-code-review pass + DoD closeout
+- [x] Finish · se-code-review pass + DoD closeout
 
 ---
 

--- a/home/.chezmoiexternal.toml
+++ b/home/.chezmoiexternal.toml
@@ -38,3 +38,37 @@
     url = "https://github.com/romkatv/zsh-defer/archive/53a26e287fbbe2dcebb3aa1801546c6de32416fa.tar.gz"
     exact = true
     stripComponents = 1
+
+# fff-mcp, pinned to release v0.10.6 with a per-platform sha256 taken from the
+# release's own .sha256 sibling assets. This file is always processed as a
+# template regardless of the .tmpl suffix, so the rust-style target and
+# checksum below branch on darwin/linux x amd64/arm64. Mirrors
+# https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh
+# (the vendor installer this external replaces), minus its `curl | bash` trust
+# step. Considered and rejected: mise's ubi/github backend — fff-mcp must
+# stay installable when mise is absent (CI-minimal), and the external carries
+# explicit per-platform checksums the backend does not.
+{{- $fffMcpTarget := "" -}}
+{{- $fffMcpSha256 := "" -}}
+{{- if eq .chezmoi.os "darwin" -}}
+  {{- if eq .chezmoi.arch "arm64" -}}
+    {{- $fffMcpTarget = "aarch64-apple-darwin" -}}
+    {{- $fffMcpSha256 = "02e0f57f5b88fa698494f310d8005a0c34d5bda5a1fcd069520b35f8e2319892" -}}
+  {{- else -}}
+    {{- $fffMcpTarget = "x86_64-apple-darwin" -}}
+    {{- $fffMcpSha256 = "12f374554f1930434cacee8221d9a76afd9e4dde0d9112c3bbc3ea59d5b56e83" -}}
+  {{- end -}}
+{{- else -}}
+  {{- if eq .chezmoi.arch "arm64" -}}
+    {{- $fffMcpTarget = "aarch64-unknown-linux-musl" -}}
+    {{- $fffMcpSha256 = "028b9e388716a8c0c39de3f153dd8e14e5ee998ffa70d4951f1cd2a3fc42f6ce" -}}
+  {{- else -}}
+    {{- $fffMcpTarget = "x86_64-unknown-linux-musl" -}}
+    {{- $fffMcpSha256 = "a44ef64015f1754aa63b690c24d9a748ed16298f05350da7b09554c4c98dfb0f" -}}
+  {{- end -}}
+{{- end }}
+[".local/bin/fff-mcp"]
+    type = "file"
+    executable = true
+    url = "https://github.com/dmtrKovalenko/fff/releases/download/v0.10.6/fff-mcp-{{ $fffMcpTarget }}"
+    checksum.sha256 = "{{ $fffMcpSha256 }}"

--- a/home/.chezmoiexternal.toml
+++ b/home/.chezmoiexternal.toml
@@ -1,0 +1,40 @@
+# Pinned externals — updating any entry is an explicit edit of the ref (and,
+# for the file external below, its per-platform checksums), never an
+# automatic refresh. See docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md.
+
+# Oh My Zsh itself, pinned to its master HEAD at implementation time
+# (2026-09-05). Non-exact: chezmoi applies externals in target-path order, so
+# this parent materializes before the plugin externals below: an exact
+# parent would delete their managed children out from under them.
+[".oh-my-zsh"]
+    type = "archive"
+    url = "https://github.com/ohmyzsh/ohmyzsh/archive/421d95782d369f266b8087a0eae11eac2f6a6041.tar.gz"
+    exact = false
+    stripComponents = 1
+
+# Four zsh plugins, each pinned to its master HEAD at implementation time
+# (2026-09-05). exact = true: adoption on an existing machine replaces the
+# old unmanaged git clone (and its .git) wholesale.
+[".oh-my-zsh/custom/plugins/zsh-autosuggestions"]
+    type = "archive"
+    url = "https://github.com/zsh-users/zsh-autosuggestions/archive/85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5.tar.gz"
+    exact = true
+    stripComponents = 1
+
+[".oh-my-zsh/custom/plugins/fast-syntax-highlighting"]
+    type = "archive"
+    url = "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/4672ad5dd9ad68a7effc1476d65afb7c584ce2b3.tar.gz"
+    exact = true
+    stripComponents = 1
+
+[".oh-my-zsh/custom/plugins/zsh-history-substring-search"]
+    type = "archive"
+    url = "https://github.com/zsh-users/zsh-history-substring-search/archive/14c8d2e0ffaee98f2df9850b19944f32546fdea5.tar.gz"
+    exact = true
+    stripComponents = 1
+
+[".oh-my-zsh/custom/plugins/zsh-defer"]
+    type = "archive"
+    url = "https://github.com/romkatv/zsh-defer/archive/53a26e287fbbe2dcebb3aa1801546c6de32416fa.tar.gz"
+    exact = true
+    stripComponents = 1

--- a/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
@@ -68,10 +68,6 @@ if command -v ya &> /dev/null; then
 fi
 # # {{ end }}
 
-# Install fff-mcp (fast file finder for AI agents)
-if [[ ! -x "$HOME/.local/bin/fff-mcp" ]]; then
-    echo "--- Installing fff-mcp ---"
-    curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
-fi
+# fff-mcp is a pinned chezmoi external (.chezmoiexternal.toml).
 
 echo "=== Setup complete! ==="

--- a/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_1-install-packages.sh.tmpl
@@ -48,29 +48,16 @@ brew bundle --file="$BREWFILES_DIR/Brewfile.macos"
 echo "=== Package installation complete! ==="
 # # {{ end }}
 
-# Install Oh My Zsh if not present
-if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
-    echo "Installing Oh My Zsh..."
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-fi
-
-# Install Oh My Zsh plugins
+# Oh My Zsh and its plugins are pinned chezmoi externals (.chezmoiexternal.toml).
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
-if [[ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
-fi
-if [[ ! -d "$ZSH_CUSTOM/plugins/fast-syntax-highlighting" ]]; then
-    git clone https://github.com/zdharma-continuum/fast-syntax-highlighting.git "$ZSH_CUSTOM/plugins/fast-syntax-highlighting"
-fi
 # Remove deprecated zsh-syntax-highlighting (replaced by fast-syntax-highlighting)
 if [[ -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]]; then
     rm -rf "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
 fi
-if [[ ! -d "$ZSH_CUSTOM/plugins/zsh-history-substring-search" ]]; then
-    git clone https://github.com/zsh-users/zsh-history-substring-search "$ZSH_CUSTOM/plugins/zsh-history-substring-search"
-fi
-if [[ ! -d "$ZSH_CUSTOM/plugins/zsh-defer" ]]; then
-    git clone https://github.com/romkatv/zsh-defer.git "$ZSH_CUSTOM/plugins/zsh-defer"
+# Remove the old vendor-installer clone metadata; the pinned archive external
+# owns the ~/.oh-my-zsh tree now and this .git would be inert but stale.
+if [[ -d "$HOME/.oh-my-zsh/.git" ]]; then
+    rm -rf "$HOME/.oh-my-zsh/.git"
 fi
 
 # # {{ if eq .chezmoi.os "darwin" }}

--- a/home/dot_aliases
+++ b/home/dot_aliases
@@ -295,8 +295,7 @@ update-all() {
   brew update &&
     brew upgrade --no-ask &&
     skills update &&
-    mise upgrade &&
-    omz update
+    mise upgrade
 }
 
 # -------------------------------------------

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -27,6 +27,10 @@ export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME=""
 ZSH_DISABLE_COMPFIX="true"
 
+# OMZ is a pinned chezmoi external (.chezmoiexternal.toml): exactly one
+# writer, so the built-in self-updater must never touch it.
+zstyle ':omz:update' mode disabled
+
 # Heavy plugins are loaded via zsh-defer below (after first prompt).
 plugins=()
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1349,11 +1349,11 @@ function test_scripts_003_ci_minimal_linux_render_skips_homebrew_but_keeps() {
   # only when the install itself moves.
   refute_output --partial 'Homebrew/install/HEAD/install.sh'
   refute_output --partial 'brew bundle --file='
-  # Oh My Zsh itself is a pinned chezmoi external now (.chezmoiexternal.toml),
-  # not installed by this script; the retained cleanup block is the positive
-  # control proving the plugin-cleanup section of the script still renders.
+  # Oh My Zsh and fff-mcp are pinned chezmoi externals now
+  # (.chezmoiexternal.toml), not installed by this script; the retained
+  # cleanup block is the positive control proving the plugin-cleanup section
+  # of the script still renders.
   assert_output --partial 'Remove deprecated zsh-syntax-highlighting'
-  assert_output --partial 'fff.nvim/main/install-mcp.sh'
 }
 
 function test_scripts_004_full_linux_render_keeps_homebrew_package_install() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1344,12 +1344,15 @@ function test_scripts_003_ci_minimal_linux_render_skips_homebrew_but_keeps() {
   assert_success
   # Progress banners ("Installing Oh My Zsh...") are prose nothing consumes: a
   # reworded echo reddens the test while the install still runs, and deleting
-  # the install while keeping the echo stays green. The upstream installer URLs
-  # below are third-party constants this repo does not define, so they move
+  # the install while keeping the echo stays green. The upstream installer URL
+  # below is a third-party constant this repo does not define, so it moves
   # only when the install itself moves.
   refute_output --partial 'Homebrew/install/HEAD/install.sh'
   refute_output --partial 'brew bundle --file='
-  assert_output --partial 'ohmyzsh/ohmyzsh/master/tools/install.sh'
+  # Oh My Zsh itself is a pinned chezmoi external now (.chezmoiexternal.toml),
+  # not installed by this script; the retained cleanup block is the positive
+  # control proving the plugin-cleanup section of the script still renders.
+  assert_output --partial 'Remove deprecated zsh-syntax-highlighting'
   assert_output --partial 'fff.nvim/main/install-mcp.sh'
 }
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1353,7 +1353,7 @@ function test_scripts_003_ci_minimal_linux_render_skips_homebrew_but_keeps() {
   # (.chezmoiexternal.toml), not installed by this script; the retained
   # cleanup block is the positive control proving the plugin-cleanup section
   # of the script still renders.
-  assert_output --partial 'Remove deprecated zsh-syntax-highlighting'
+  assert_output --partial 'rm -rf "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"'
 }
 
 function test_scripts_004_full_linux_render_keeps_homebrew_package_install() {


### PR DESCRIPTION
## Summary

- Replaces the Oh My Zsh installer and four zsh-plugin `git clone` blocks in `run_onchange_after_1-install-packages.sh.tmpl` with pinned chezmoi archive externals in `home/.chezmoiexternal.toml`: `.oh-my-zsh` itself plus `zsh-autosuggestions`, `fast-syntax-highlighting`, `zsh-history-substring-search`, and `zsh-defer`, each pinned to a fixed upstream commit.
- Replaces the fff-mcp `curl | bash` installer with a pinned, checksum-verified chezmoi file external (`type = "file"`) targeting release v0.10.6, branching on `.chezmoi.os`/`.chezmoi.arch` to cover all four supported platforms (darwin/linux × amd64/arm64). Each sha256 was cross-verified against the release's own `.sha256` sidecar asset.
- Disables Oh My Zsh's built-in self-updater (`zstyle ':omz:update' mode disabled` in `dot_zshrc.tmpl`) and drops the `omz update` call from the `update-all` alias, since the pinned external is now the single writer for that tree — an in-place self-update would fight chezmoi's next `apply`.
- Adds a repository issue tracking a follow-up: extending `update-all` to check the pinned externals and mise tool versions against upstream and offer each bump interactively, replacing the removed `omz update` call.
- Updates one test assertion in `tests/bashunit/scripts_test.sh` for the removed install blocks; a peer code review flagged that the replacement assertion originally matched a comment instead of the executable cleanup line it was meant to protect, so it now asserts on the `rm -rf` line directly.

This is the second of two PRs implementing `docs/plans/2026-09-05-0906-refactor-mise-declarative-setup-plan.md`; it depends on the mise declarative-config PR merging first (this PR is based on that branch).

## Why

The Oh My Zsh installer, the plugin clones, and the fff-mcp installer only existed as script side effects with no pin and no checksum — a machine re-provisioned today could silently pick up a different plugin revision or fff-mcp build than yesterday's. Pinning them as chezmoi externals makes every dependency reproducible from a single source file, and the fff-mcp checksum specifically replaces a `curl | bash` trust step with a verified download.

## Test plan

- [x] `make lint` (shellcheck) — clean
- [x] `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh` — 336 passed, 1 pre-existing skip
- [x] Rendered `.chezmoiexternal.toml`'s fff-mcp block for all four `.chezmoi.os`/`.chezmoi.arch` combinations via `chezmoi execute-template --override-data`, parsed each with Python's `tomllib`, and confirmed the correct URL and checksum per platform
- [x] Peer code review (`se-code-review`, Claude peer): verdict "Ready with fixes" — the one finding (the comment-vs-executable-line assertion above) is applied in this PR
- [ ] `make test-ubuntu` — hit a confirmed pre-existing, unrelated failure (`herdr --version` "argument list too long" inside a template hash-trigger), reproduced 4/4 times including with this diff isolated out via `git stash` and after a `--no-cache` image rebuild. Tracked separately as `docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md`; not re-run per-PR since the isolation evidence covers this diff.
