### PR TITLE
fix(tests): batch oversized chezmoi diff arguments

### DIFF
--- a/docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md
+++ b/docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md
@@ -1,12 +1,13 @@
 ---
 title: "test-ubuntu oracle fails on herdr --version argument-list-too-long"
-short_description: "make test-ubuntu deterministically fails 2 templates_test.sh assertions (zshenv host-partial diff and skip-secrets cases) because chezmoi's output template function execs /home/linuxbrew/.linuxbrew/bin/herdr --version via run_onchange_after_3-setup-herdr-integrations.sh.tmpl:10 and hits an OS argument-list-too-long error; reproduced identically across a plan's diff present/absent and a --no-cache image rebuild, so it is environment/harness-level (suspected: bashunit's exported shell functions bloating the inherited env past ARG_MAX under nested env/chezmoi-diff calls), not a code regression, and it currently blocks the make test-ubuntu deployment-sensitive gate for every PR."
+short_description: "Host-partial full-tree diffs flattened 464,434 bytes of explicit targets into chezmoi's single CHEZMOI_ARGS environment entry, exceeding Linux MAX_ARG_STRLEN before template subprocesses could start; bounded diff batching now preserves every filtered target below the limit, and make test-ubuntu passes."
 type: "bug"
 category: "testing-ci"
 tags: ["test-ubuntu","chezmoi","herdr","argument-list-too-long"]
 date: "2026-09-05"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-09-05"
 ---
 
 ## Why this exists
@@ -74,3 +75,7 @@ itself.
 - Whether the fix belongs in the test harness (`tests/helpers/chezmoi-unattended`)
   or in the affected run script itself — depends on which side is confirmed
   as the actual source of the oversized environment.
+
+## Resolution
+
+Confirmed CHEZMOI_ARGS, not bashunit function exports, as the oversized environment entry. Batched host-partial diff targets below 96 KiB per chezmoi invocation, added behavioral coverage for Linux's per-string exec limit and complete target delivery, and verified the focused suites plus make test-ubuntu.

--- a/tests/bashunit/chezmoi_unattended_test.sh
+++ b/tests/bashunit/chezmoi_unattended_test.sh
@@ -29,6 +29,16 @@ for arg in "$@"; do
       printf '%s\0' "$HOME/.zshenv" "$HOME/.claude.json"
       exit 0
     fi
+    if [ -n "${FAKE_MANAGED_TARGET_COUNT:-}" ]; then
+      managed_index=1
+      while [ "$managed_index" -le "$FAKE_MANAGED_TARGET_COUNT" ]; do
+        managed_target="$HOME/.config/generated-target-$managed_index-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        printf '%s\0' "$managed_target"
+        printf '%s\0' "$managed_target" >> "$FAKE_STATE/managed-targets"
+        managed_index=$((managed_index + 1))
+      done
+      exit 0
+    fi
     printf '%s\0' \
       "$HOME/.zshenv" \
       "$HOME/.claude.json" \
@@ -40,10 +50,28 @@ break"
   fi
 done
 
+serialized_args="$0"
+for arg in "$@"; do
+  serialized_args="$serialized_args $arg"
+done
+if [ -n "${FAKE_MAX_CHEZMOI_ARGS_BYTES:-}" ] &&
+   [ "${#serialized_args}" -gt "$FAKE_MAX_CHEZMOI_ARGS_BYTES" ]; then
+  printf 'simulated CHEZMOI_ARGS limit exceeded: %s bytes\n' "${#serialized_args}" >&2
+  exit 88
+fi
+
 printf 'final\n' >> "$FAKE_STATE/invocations"
 printf '%s' "$PATH" > "$FAKE_STATE/path"
 printf '%s' "${MMS_CHEZMOI_UNATTENDED_PROFILE:-}" > "$FAKE_STATE/profile"
 printf '%s\0' "$@" > "$FAKE_STATE/argv"
+printf '%s\n' "${#serialized_args}" >> "$FAKE_STATE/serialized-args-sizes"
+for arg in "$@"; do
+  case "$arg" in
+    "$HOME/.config/generated-target-"*)
+      printf '%s\0' "$arg" >> "$FAKE_STATE/received-targets"
+      ;;
+  esac
+done
 neighbor
 cat > "$FAKE_STATE/stdin"
 printf '%s' "${FAKE_STDOUT:-}"
@@ -329,6 +357,32 @@ function test_chezmoi_unattended_010_diff_omits_exact_inventory_destinations() {
     '/tmp/source tree' "$HOME/.zshenv.backup" \
     "$HOME/.config/ordinary target" "$HOME/.config/line
 break"
+}
+
+function test_chezmoi_unattended_0101_large_host_diff_stays_below_linux_exec_string_limit() {
+  _bats_test_init 101 'large host diff keeps CHEZMOI_ARGS below the Linux exec string limit'
+  local target_count=2000 final_invocations=0 invocation serialized_size
+  local linux_max_env_string_bytes=$((128 * 1024))
+  local chezmoi_args_name_and_nul_bytes=14
+  local max_chezmoi_args_bytes=$((linux_max_env_string_bytes - chezmoi_args_name_and_nul_bytes))
+
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    FAKE_MANAGED_TARGET_COUNT="$target_count" \
+    FAKE_MAX_CHEZMOI_ARGS_BYTES="$max_chezmoi_args_bytes" \
+    run "$LAUNCHER" --profile host-partial -- diff --source '/tmp/source tree'
+  assert_success
+
+  while IFS= read -r invocation; do
+    [ "$invocation" = final ] && final_invocations=$((final_invocations + 1))
+  done < "$FAKE_STATE/invocations"
+  assert_equal "$((final_invocations > 1))" 1
+
+  run cmp "$FAKE_STATE/managed-targets" "$FAKE_STATE/received-targets"
+  assert_success
+
+  while IFS= read -r serialized_size; do
+    assert_equal "$((serialized_size <= max_chezmoi_args_bytes))" 1
+  done < "$FAKE_STATE/serialized-args-sizes"
 }
 
 function test_chezmoi_unattended_011_malformed_inventory_fails_closed() {

--- a/tests/helpers/chezmoi-unattended
+++ b/tests/helpers/chezmoi-unattended
@@ -12,6 +12,11 @@ fail() {
   exit 2
 }
 
+set_argument_byte_count() {
+  local LC_ALL=C
+  argument_byte_count=${#1}
+}
+
 if [ "${MMS_CHEZMOI_UNATTENDED:-}" != "1" ]; then
   fail "MMS_CHEZMOI_UNATTENDED must equal 1"
 fi
@@ -187,6 +192,18 @@ for passthrough_arg in "$@"; do
 done
 
 if [ "$profile" = "host-partial" ] && [ "$command_name" = "diff" ]; then
+  # Chezmoi flattens argv into CHEZMOI_ARGS. Stay below Linux's 128 KiB
+  # per-string exec limit with enough headroom for the variable name and NUL.
+  max_chezmoi_args_bytes=$((96 * 1024))
+  diff_batch_args=()
+  set_argument_byte_count "$chezmoi_bin"
+  diff_batch_base_bytes=$argument_byte_count
+  for diff_arg in "${chezmoi_args[@]}"; do
+    set_argument_byte_count "$diff_arg"
+    diff_batch_base_bytes=$((diff_batch_base_bytes + argument_byte_count + 1))
+  done
+  diff_batch_bytes=$diff_batch_base_bytes
+
   managed_file="${TMPDIR:-/tmp}/chezmoi-unattended-managed.$$.$RANDOM"
   trap 'rm -f "$managed_file"' EXIT
   managed_args=(--no-tty --no-pager --skip-secrets managed)
@@ -213,7 +230,19 @@ if [ "$profile" = "host-partial" ] && [ "$command_name" = "diff" ]; then
       inventory_index=$((inventory_index + 1))
     done
     if [ "$omit_target" -eq 0 ]; then
-      chezmoi_args+=("$managed_target")
+      set_argument_byte_count "$managed_target"
+      target_bytes=$((argument_byte_count + 1))
+      if [ "$((diff_batch_bytes + target_bytes))" -gt "$max_chezmoi_args_bytes" ]; then
+        [ "${#diff_batch_args[@]}" -gt 0 ] || \
+          fail "managed target is too long to invoke safely: $managed_target"
+        "$chezmoi_bin" "${chezmoi_args[@]}" "${diff_batch_args[@]}" </dev/null
+        diff_rc=$?
+        [ "$diff_rc" -eq 0 ] || exit "$diff_rc"
+        diff_batch_args=()
+        diff_batch_bytes=$diff_batch_base_bytes
+      fi
+      diff_batch_args+=("$managed_target")
+      diff_batch_bytes=$((diff_batch_bytes + target_bytes))
       included_target_count=$((included_target_count + 1))
     fi
   done < "$managed_file"
@@ -221,6 +250,7 @@ if [ "$profile" = "host-partial" ] && [ "$command_name" = "diff" ]; then
   trap - EXIT
   [ "$included_target_count" -gt 0 ] || \
     fail "no non-sensitive managed targets remain after host-partial filtering"
+  chezmoi_args+=("${diff_batch_args[@]}")
 
   inventory_index=0
   while [ "$inventory_index" -lt "${#inventory_sources[@]}" ]; do


### PR DESCRIPTION
## Summary

Host-partial chezmoi diffs no longer fail Linux template rendering with `herdr --version: argument list too long`.

Chezmoi flattened every explicit diff target into one 464,434-byte `CHEZMOI_ARGS` environment entry, exceeding Linux's per-string exec limit before template subprocesses could start. The unattended launcher now sends the same filtered target set through bounded 96 KiB batches, stops on the first failed batch, and preserves `exec` for the final invocation.

## Testing

- Added a behavioral launcher test that enforces Linux's independent 128 KiB string boundary and compares the complete ordered target stream across batches.
- Passed all 14 `chezmoi_unattended_test.sh` cases and ShellCheck.
- Passed `make test-ubuntu` on the exact final tree, including the 31 template tests and full post-apply suite.

Repository issue: `docs/issues/2026-09-05-002-test-ubuntu-oracle-fails-on-herdr-version-argument-list-too-long.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-GPT_5.6_Sol-000000)
