### PR TITLE
fix(context): make compact handoff command copyable

### DIFF
--- a/home/private_dot_claude/hooks/executable_context-threshold.sh
+++ b/home/private_dot_claude/hooks/executable_context-threshold.sh
@@ -307,7 +307,9 @@ fi
 if [ "$level" = hard ]; then
   message="Context limit reached: $detail.$note Compact now, editing the goal as you like:
 $command_line"
-  reason="Stopped at the context limit: $detail. Run $command_line to carry the current goal through compaction, or send another prompt to continue anyway."
+  reason="Stopped at the context limit: $detail. Run this command to carry the current goal through compaction:
+$command_line
+Or send another prompt to continue anyway."
   context_usage_spend "$session_id" hard "$dimensions" "$turns" "$goal" "$goal_status" > /dev/null 2>&1 || true
   [ -z "$warn_dimensions" ] ||
     context_usage_spend "$session_id" warn "$warn_dimensions" "$turns" > /dev/null 2>&1 || true

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -9645,6 +9645,7 @@ function test_scripts_2823_context_threshold_hard_crossing_carries_halt_and_mess
   assert_success
   assert_output --partial '/compact handoff:'
   assert_output --partial '305 turns since the last compaction'
+  assert_output --partial $'Run this command to carry the current goal through compaction:\n/compact handoff:'
   run jq -r '.systemMessage' <<< "$response"
   assert_success
   assert_output --partial '305 turns since the last compaction'


### PR DESCRIPTION
## Summary

Claude context-limit stops now show the suggested `/compact handoff:...` command on its own line in the stop reason. That makes the generated handoff command easy to find and copy from the halt message instead of being embedded in a long sentence.

## Validation

- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh --filter context_threshold`
- `git diff --check`
- `make test-local`
