### PR TITLE
fix(context): announce context growth by token load, not window share

### DIFF
--- a/home/dot_local/lib/context-usage.sh
+++ b/home/dot_local/lib/context-usage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Context growth measurement shared by the Claude Code statusline and the
-# context-threshold Stop hook. One owner for both growth numbers: window
-# fullness and turns since the last compaction (R1).
+# context-threshold Stop hook. One owner for both growth numbers: the context
+# load in tokens and turns since the last compaction (R1).
 #
 # Sourcing this file must have no effect beyond defining these functions and
 # their defaults — no output, no shell-option or trap changes, no redefinition
@@ -19,15 +19,33 @@
 # must not abort here. Every path built from it is guarded at use.
 CONTEXT_USAGE_STATE_DIR="${CONTEXT_USAGE_STATE_DIR:-${HOME:-}/.cache/context-usage}"
 
-# Percentage points added to raw window occupancy to stand in for the system
-# prompt, which Claude Code does not report (R2). Empirical; one definition
-# serves the bar and the announcement alike.
-CONTEXT_USAGE_ALLOWANCE_PCT="${CONTEXT_USAGE_ALLOWANCE_PCT:-20}"
+# Tokens added to the occupancy Claude Code reports, standing in for the
+# system prompt, which it does not report (R2). Absolute rather than a share
+# of the window: the system prompt is a fixed cost, so a percentage grew it
+# with the window -- 40k tokens against 200k, 200k against 1M.
+#
+# The bar is its only consumer. The announcement compares thresholds against
+# the number Claude Code itself reports, so an operator setting a threshold
+# writes the same figure the client shows rather than one shifted by an
+# allowance they cannot see.
+CONTEXT_USAGE_ALLOWANCE_TOKENS="${CONTEXT_USAGE_ALLOWANCE_TOKENS:-40000}"
+case "$CONTEXT_USAGE_ALLOWANCE_TOKENS" in
+  '' | *[!0-9]*) CONTEXT_USAGE_ALLOWANCE_TOKENS=40000 ;;
+esac
 
-# Thresholds (R5). Turn counts come from the U1 re-derivation of the local
-# session-length distribution under the rule this library evaluates.
-CONTEXT_USAGE_FULLNESS_WARN_PCT="${CONTEXT_USAGE_FULLNESS_WARN_PCT:-70}"
-CONTEXT_USAGE_FULLNESS_HARD_PCT="${CONTEXT_USAGE_FULLNESS_HARD_PCT:-85}"
+# Thresholds (R5). The context dimension counts tokens, not a share of the
+# window: what degrades a session is the amount of context it carries, and
+# that amount does not change when the same work runs against a 1M window
+# instead of a 200k one. A share of the window put the announcement at 650k
+# tokens on a 1M model, long past the point the operator wanted it.
+#
+# Against a 200k window the hard threshold lands at 95%, too late to act on;
+# the warning at 75% and the turn count still cover that case, which is why
+# there is no second, window-relative ceiling here. Turn counts come from the
+# U1 re-derivation of the local session-length distribution under the rule
+# this library evaluates.
+CONTEXT_USAGE_TOKENS_WARN="${CONTEXT_USAGE_TOKENS_WARN:-150000}"
+CONTEXT_USAGE_TOKENS_HARD="${CONTEXT_USAGE_TOKENS_HARD:-190000}"
 CONTEXT_USAGE_TURNS_WARN="${CONTEXT_USAGE_TURNS_WARN:-150}"
 CONTEXT_USAGE_TURNS_HARD="${CONTEXT_USAGE_TURNS_HARD:-300}"
 
@@ -57,11 +75,11 @@ case "$CONTEXT_USAGE_EXTRACTION_BUDGET_BYTES" in
   '' | *[!0-9]* | 0) CONTEXT_USAGE_EXTRACTION_BUDGET_BYTES=120000 ;;
 esac
 
-# A rendered fullness number is trusted only while it can still describe the
+# A published token count is trusted only while it can still describe the
 # current turn (KTD3). The statusline renders many times per turn, so an older
 # file means rendering stopped — a resumed session before its first render, or
-# a turn that outran the UI. Fullness then reports unavailable and turn count
-# carries the decision alone.
+# a turn that outran the UI. The context dimension then reports unavailable and
+# turn count carries the decision alone.
 CONTEXT_USAGE_MAX_AGE_SECONDS="${CONTEXT_USAGE_MAX_AGE_SECONDS:-300}"
 
 # Hard-threshold repeat cadence (R25, KTD12). The gap halves for every step of
@@ -69,7 +87,7 @@ CONTEXT_USAGE_MAX_AGE_SECONDS="${CONTEXT_USAGE_MAX_AGE_SECONDS:-300}"
 # current distance rather than from a stored counter, so a resume or a fork
 # cannot carry a stale cadence.
 CONTEXT_USAGE_REPEAT_FIRST_GAP="${CONTEXT_USAGE_REPEAT_FIRST_GAP:-8}"
-CONTEXT_USAGE_FULLNESS_REPEAT_STEP="${CONTEXT_USAGE_FULLNESS_REPEAT_STEP:-3}"
+CONTEXT_USAGE_TOKENS_REPEAT_STEP="${CONTEXT_USAGE_TOKENS_REPEAT_STEP:-10000}"
 CONTEXT_USAGE_TURNS_REPEAT_STEP="${CONTEXT_USAGE_TURNS_REPEAT_STEP:-25}"
 
 context_usage_encode_key() {
@@ -163,22 +181,27 @@ window_size=$window
 written_at=$now"
 }
 
-# Raw occupancy plus the system-prompt allowance, capped at 100. The bar and
-# the announcement both come through here so they cannot disagree (R1, R2).
+# The operator's bar: occupancy plus the allowance, as a share of the window,
+# capped at 100. Presentation only -- the announcement decides on the tokens
+# themselves. Both come through this library so they cannot disagree about
+# either input (R1, R2); this is the only place a percentage is formed.
 context_usage_fullness_pct() {
   local current="$1" window="$2" pct
   case "$current" in '' | *[!0-9]*) return 1 ;; esac
   case "$window" in '' | *[!0-9]* | 0) return 1 ;; esac
-  pct=$((current * 100 / window + CONTEXT_USAGE_ALLOWANCE_PCT))
+  pct=$(((current + CONTEXT_USAGE_ALLOWANCE_TOKENS) * 100 / window))
   [ "$pct" -gt 100 ] && pct=100
   printf '%s' "$pct"
 }
 
 # --- the hook's side -------------------------------------------------------
 
-# Print the session's fullness percentage, or return 1 for "unavailable".
-# Unavailable never degrades to a guess and never silences turn count (KTD3).
-context_usage_read_fullness() {
+# Print the session's context load in tokens as Claude Code reported it, or
+# return 1 for "unavailable". Unavailable never degrades to a guess and never
+# silences turn count (KTD3). `window_size` is validated but not used: a record
+# missing it is a partial write, and trusting the rest of such a record is how
+# a wrong number reaches the announcement.
+context_usage_read_tokens() {
   local session="$1" now="${2:-}" file current window written age
   file="$(context_usage_usage_file "$session")" || return 1
   current="$(context_usage_number_field "$file" current_tokens)" || return 1
@@ -189,7 +212,7 @@ context_usage_read_fullness() {
   age=$((now - written))
   [ "$age" -ge 0 ] || return 1
   [ "$age" -le "$CONTEXT_USAGE_MAX_AGE_SECONDS" ] || return 1
-  context_usage_fullness_pct "$current" "$window"
+  printf '%s' "$current"
 }
 
 # Assistant entries in the main transcript after the last compaction boundary
@@ -228,20 +251,20 @@ context_usage_repeat_gap() {
 # Decide what, if anything, to announce this turn. Read-only: spending the
 # budget is a separate call so the announcement file keeps one writer.
 #
-# Usage: context_usage_evaluate <session> <fullness|""> <turns>
+# Usage: context_usage_evaluate <session> <tokens|""> <turns>
 # Prints `level=<warn|hard>` and `dimensions=<comma list>` and returns 0 when
 # there is something to announce; returns 1 when there is not.
 context_usage_evaluate() {
-  local session="$1" fullness="$2" turns="$3"
+  local session="$1" tokens="$2" turns="$3"
   local file hard="" warn="" last gap
   file="$(context_usage_announce_file "$session")" || return 1
   case "$turns" in '' | *[!0-9]*) turns=0 ;; esac
 
   # Hard level first: it outranks warn and, per R22, consumes the warn budget
   # for the same dimension rather than producing a second message.
-  if [ -n "$fullness" ] && [ "$fullness" -ge "$CONTEXT_USAGE_FULLNESS_HARD_PCT" ]; then
+  if [ -n "$tokens" ] && [ "$tokens" -ge "$CONTEXT_USAGE_TOKENS_HARD" ]; then
     gap="$(context_usage_repeat_gap \
-      "$((fullness - CONTEXT_USAGE_FULLNESS_HARD_PCT))" "$CONTEXT_USAGE_FULLNESS_REPEAT_STEP")"
+      "$((tokens - CONTEXT_USAGE_TOKENS_HARD))" "$CONTEXT_USAGE_TOKENS_REPEAT_STEP")"
     if last="$(context_usage_number_field "$file" hard_fullness_turn)"; then
       if [ "$((turns - last))" -ge "$gap" ]; then
         hard="fullness"
@@ -263,7 +286,7 @@ context_usage_evaluate() {
   fi
   # Warn level: once per session per dimension (R9), and one dimension having
   # spent its budget never suppresses the other (R10).
-  if [ -n "$fullness" ] && [ "$fullness" -ge "$CONTEXT_USAGE_FULLNESS_WARN_PCT" ] &&
+  if [ -n "$tokens" ] && [ "$tokens" -ge "$CONTEXT_USAGE_TOKENS_WARN" ] &&
     ! context_usage_field "$file" warn_fullness_spent > /dev/null; then
     warn="fullness"
   fi

--- a/home/private_dot_claude/hooks/executable_context-threshold.sh
+++ b/home/private_dot_claude/hooks/executable_context-threshold.sh
@@ -3,9 +3,9 @@
 # hard threshold.
 #
 # Auto-compact is off in this setup, so a session that reaches the context
-# limit loses the conversation. Two independent signs are watched: how full
-# the window is, and how many turns have accumulated since the last
-# compaction. Either one is enough to act on.
+# limit loses the conversation. Two independent signs are watched: how many
+# tokens of context the session carries, and how many turns have accumulated
+# since the last compaction. Either one is enough to act on.
 #
 # The announcement is addressed to the operator, not the model.
 # `systemMessage` renders in the operator's UI and never enters model
@@ -233,9 +233,9 @@ transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty' 2>/dev/nul
 # must not lose the other dimension even if that ever changes.
 turns=$(context_usage_turn_count "$transcript") || turns=0
 case "$turns" in '' | *[!0-9]*) turns=0 ;; esac
-fullness=$(context_usage_read_fullness "$session_id") || fullness=""
+tokens=$(context_usage_read_tokens "$session_id") || tokens=""
 
-crossing=$(context_usage_evaluate "$session_id" "$fullness" "$turns") || exit 0
+crossing=$(context_usage_evaluate "$session_id" "$tokens" "$turns") || exit 0
 level=$(printf '%s' "$crossing" | sed -n 's/^level=//p')
 dimensions=$(printf '%s' "$crossing" | sed -n 's/^dimensions=//p')
 warn_dimensions=$(printf '%s' "$crossing" | sed -n 's/^warn_dimensions=//p')
@@ -268,14 +268,21 @@ if context_threshold_crossed_at turns "$dimensions"; then
 elif context_threshold_crossed_at turns "$warn_dimensions"; then
   detail="$turns turns since the last compaction (warn at $CONTEXT_USAGE_TURNS_WARN)"
 fi
+# Thousands, because the operator's own threshold is stated that way and the
+# exact token is never the point. Truncated rather than rounded: a message
+# saying 150k must mean the threshold was reached, not approached.
+context_threshold_thousands() {
+  printf '%sk' "$(($1 / 1000))"
+}
+
 if context_threshold_crossed_at fullness "$dimensions"; then
   if [ "$level" = hard ]; then
-    detail="${detail:+$detail and }context window ${fullness}% full (limit $CONTEXT_USAGE_FULLNESS_HARD_PCT%)"
+    detail="${detail:+$detail and }context at $(context_threshold_thousands "$tokens") tokens (limit $(context_threshold_thousands "$CONTEXT_USAGE_TOKENS_HARD"))"
   else
-    detail="${detail:+$detail and }context window ${fullness}% full (warn at $CONTEXT_USAGE_FULLNESS_WARN_PCT%)"
+    detail="${detail:+$detail and }context at $(context_threshold_thousands "$tokens") tokens (warn at $(context_threshold_thousands "$CONTEXT_USAGE_TOKENS_WARN"))"
   fi
 elif context_threshold_crossed_at fullness "$warn_dimensions"; then
-  detail="${detail:+$detail and }context window ${fullness}% full (warn at $CONTEXT_USAGE_FULLNESS_WARN_PCT%)"
+  detail="${detail:+$detail and }context at $(context_threshold_thousands "$tokens") tokens (warn at $(context_threshold_thousands "$CONTEXT_USAGE_TOKENS_WARN"))"
 fi
 
 # The goal is extracted once per session and reused by every later

--- a/home/private_dot_claude/hooks/executable_statusline.sh
+++ b/home/private_dot_claude/hooks/executable_statusline.sh
@@ -84,10 +84,13 @@ usage=$(echo "$input" | jq '.context_window.current_usage')
 if [ "$usage" != "null" ]; then
     current=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
     size=$(echo "$input" | jq '.context_window.context_window_size')
-    raw_pct=$((current * 100 / size))
-    adjusted_pct=$((raw_pct + ${CONTEXT_USAGE_ALLOWANCE_PCT:-0}))
-    [ "$adjusted_pct" -gt 100 ] && adjusted_pct=100
-    CONTEXT_PCT="$adjusted_pct"
+    # The library owns the allowance and the cap, so the bar has no arithmetic
+    # of its own beyond the fallback an unsourced library leaves it with.
+    if command -v context_usage_fullness_pct > /dev/null 2>&1; then
+        CONTEXT_PCT="$(context_usage_fullness_pct "$current" "$size")"
+    else
+        CONTEXT_PCT=$((current * 100 / size))
+    fi
     # Claude Code hands these counts to the status line and to nothing else, so
     # publishing them is the only way the Stop hook can see fullness at all.
     # A failed write costs the hook one dimension and the bar nothing.

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -8788,8 +8788,8 @@ TS
 # Coverage owner for the two growth numbers the context-threshold hook and the
 # statusline both read. The oracles are outside this library: transcript
 # fixtures use Claude Code's own entry shape (`type`, `compactMetadata`), and
-# the fullness percentage is compared against the statusline's existing
-# arithmetic rather than against a number restated from the library.
+# the token count is the one Claude Code publishes through the statusline
+# payload rather than a number restated from the library.
 
 context_usage_lib() {
   printf '%s' "$SOURCE_ROOT/dot_local/lib/context-usage.sh"
@@ -8870,20 +8870,26 @@ function test_scripts_2802_context_usage_turn_count_ignores_non_assistant_entrie
   assert_output '0'
 }
 
-function test_scripts_2803_context_usage_fullness_adds_the_allowance_and_caps() {
-  _bats_test_init 2803 'context-usage fullness adds the system-prompt allowance and caps at 100'
+function test_scripts_2803_context_usage_reports_tokens_and_the_bar_adds_the_allowance() {
+  _bats_test_init 2803 'context-usage reports published tokens and the bar adds the allowance'
   local state="$BATS_TEST_TMPDIR/state"
 
-  # R2. The expected value comes from the test's own inputs -- a raw occupancy
-  # and an allowance both named here -- not from the library's default, so this
-  # asserts the relationship rather than restating the constant.
-  run env CONTEXT_USAGE_STATE_DIR="$state" CONTEXT_USAGE_ALLOWANCE_PCT=17 bash -c '
+  # R2. The hook decides on the number Claude Code published, unshifted: what
+  # the statusline wrote is what comes back, so an operator's threshold means
+  # the same figure their client shows them. The allowance belongs to the bar
+  # alone, and the percentage below comes from this test's own inputs -- an
+  # occupancy, a window and an allowance all named here -- not from the
+  # library's defaults.
+  run env CONTEXT_USAGE_STATE_DIR="$state" CONTEXT_USAGE_ALLOWANCE_TOKENS=170000 bash -c '
     . "$1"
     context_usage_write_usage sess-bar 372000 1000000 "$(date +%s)" || exit 1
-    context_usage_read_fullness sess-bar
+    context_usage_read_tokens sess-bar
+    printf "\n"
+    context_usage_fullness_pct 372000 1000000
   ' _ "$(context_usage_lib)"
   assert_success
-  assert_output '54'
+  assert_line --index 0 '372000'
+  assert_line --index 1 '54'
 
   # The cap holds: a nearly full window plus any allowance never exceeds 100.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
@@ -8893,8 +8899,8 @@ function test_scripts_2803_context_usage_fullness_adds_the_allowance_and_caps() 
   assert_output '100'
 }
 
-function test_scripts_2804_context_usage_fullness_degrades_to_unavailable() {
-  _bats_test_init 2804 'context-usage fullness degrades to unavailable and leaves turns computable'
+function test_scripts_2804_context_usage_tokens_degrade_to_unavailable() {
+  _bats_test_init 2804 'context-usage token reading degrades to unavailable and leaves turns computable'
   local state="$BATS_TEST_TMPDIR/state" transcript="$BATS_TEST_TMPDIR/t.jsonl"
   context_usage_fixture_transcript "$transcript" assistant assistant assistant
 
@@ -8902,7 +8908,7 @@ function test_scripts_2804_context_usage_fullness_degrades_to_unavailable() {
   # zero, and none of them stops the turn count from being computed.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
     . "$1"
-    context_usage_read_fullness never-rendered && exit 9
+    context_usage_read_tokens never-rendered && exit 9
     context_usage_turn_count "$2"
   ' _ "$(context_usage_lib)" "$transcript"
   assert_success
@@ -8913,7 +8919,7 @@ function test_scripts_2804_context_usage_fullness_degrades_to_unavailable() {
     file="$(context_usage_usage_file truncated)"
     mkdir -p "$(dirname "$file")"
     printf "current_tokens=400000\n" > "$file"
-    context_usage_read_fullness truncated && exit 9
+    context_usage_read_tokens truncated && exit 9
     context_usage_turn_count "$2"
   ' _ "$(context_usage_lib)" "$transcript"
   assert_success
@@ -8923,18 +8929,18 @@ function test_scripts_2804_context_usage_fullness_degrades_to_unavailable() {
     . "$1"
     now="$(date +%s)"
     context_usage_write_usage stale 400000 1000000 "$((now - 4000))" || exit 1
-    context_usage_read_fullness stale "$now" && exit 9
-    context_usage_read_fullness stale "$((now - 3999))"
+    context_usage_read_tokens stale "$now" && exit 9
+    context_usage_read_tokens stale "$((now - 3999))"
   ' _ "$(context_usage_lib)"
   assert_success
-  assert_output '60'
+  assert_output '400000'
 
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
     . "$1"
     file="$(context_usage_usage_file unreadable)"
     mkdir -p "$(dirname "$file")"
     printf "current_tokens=x\nwindow_size=0\nwritten_at=abc\n" > "$file"
-    context_usage_read_fullness unreadable && exit 9
+    context_usage_read_tokens unreadable && exit 9
     exit 0
   ' _ "$(context_usage_lib)"
   assert_success
@@ -8946,12 +8952,13 @@ function test_scripts_2805_context_usage_warning_budgets_are_per_dimension_and_s
 
   # Both dimensions crossing warn in one call is one crossing naming both
   # (R22), and spending it silences that level (AE4, R9).
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
+  run env CONTEXT_USAGE_STATE_DIR="$state" \
+    CONTEXT_USAGE_TOKENS_WARN=100000 CONTEXT_USAGE_TOKENS_HARD=200000 bash -c '
     . "$1"
-    context_usage_evaluate both 72 160
+    context_usage_evaluate both 120000 160
     context_usage_spend both warn fullness,turns 160 "finish the unit" ok
-    context_usage_evaluate both 72 161 && exit 9
-    context_usage_evaluate both 99 400 > /dev/null || exit 9
+    context_usage_evaluate both 120000 161 && exit 9
+    context_usage_evaluate both 250000 400 > /dev/null || exit 9
     exit 0
   ' _ "$(context_usage_lib)"
   assert_success
@@ -8959,11 +8966,12 @@ function test_scripts_2805_context_usage_warning_budgets_are_per_dimension_and_s
   assert_line --index 1 'dimensions=fullness,turns'
 
   # R10: a spent fullness budget never suppresses the turn-count dimension.
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
+  run env CONTEXT_USAGE_STATE_DIR="$state" \
+    CONTEXT_USAGE_TOKENS_WARN=100000 CONTEXT_USAGE_TOKENS_HARD=200000 bash -c '
     . "$1"
     context_usage_spend split warn fullness 40 "finish the unit" ok
-    context_usage_evaluate split 72 40 && exit 9
-    context_usage_evaluate split 72 160
+    context_usage_evaluate split 120000 40 && exit 9
+    context_usage_evaluate split 120000 160
   ' _ "$(context_usage_lib)"
   assert_success
   assert_line --index 0 'level=warn'
@@ -9108,23 +9116,24 @@ function test_scripts_2810_context_usage_state_files_have_one_writer_each() {
   # KTD10. Both files are replaced whole by rename. Sharing one would let the
   # statusline's next render erase a budget the hook had just spent -- a bug
   # invisible to any test that stages the file by hand.
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
+  run env CONTEXT_USAGE_STATE_DIR="$state" \
+    CONTEXT_USAGE_TOKENS_WARN=100000 CONTEXT_USAGE_TOKENS_HARD=200000 bash -c '
     . "$1"
     now="$(date +%s)"
     context_usage_spend writers warn fullness,turns 160 "keep both writers apart" ok
     context_usage_write_usage writers 700000 1000000 "$now" || exit 1
-    context_usage_evaluate writers 90 161 > /dev/null
+    context_usage_evaluate writers 250000 161 > /dev/null
     hard_only=$?
     context_usage_goal writers
-    context_usage_read_fullness writers "$now"
+    context_usage_read_tokens writers "$now"
     printf "\n"
-    context_usage_evaluate writers 72 161 && exit 9
+    context_usage_evaluate writers 120000 161 && exit 9
     [ "$hard_only" -eq 0 ] || exit 9
     exit 0
   ' _ "$(context_usage_lib)"
   assert_success
   assert_line --index 0 'keep both writers apart'
-  assert_line --index 1 '90'
+  assert_line --index 1 '700000'
 
   # And the reverse: publishing usage again leaves the announcement file alone.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
@@ -9141,13 +9150,14 @@ function test_scripts_2811_context_usage_clear_rearms_every_budget() {
   local state="$BATS_TEST_TMPDIR/state"
 
   # R11: compaction hands the session back able to announce again.
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
+  run env CONTEXT_USAGE_STATE_DIR="$state" \
+    CONTEXT_USAGE_TOKENS_WARN=100000 bash -c '
     . "$1"
     context_usage_spend rearm warn fullness,turns 160 "before compaction" ok
-    context_usage_evaluate rearm 72 161 && exit 9
+    context_usage_evaluate rearm 120000 161 && exit 9
     context_usage_clear rearm || exit 1
     context_usage_goal_status rearm && exit 9
-    context_usage_evaluate rearm 72 161
+    context_usage_evaluate rearm 120000 161
   ' _ "$(context_usage_lib)"
   assert_success
   assert_line --index 0 'level=warn'
@@ -9160,18 +9170,18 @@ function test_scripts_2812_context_usage_thresholds_are_environment_tunable() {
 
   # KTD11, R5: all four thresholds and the allowance move without a code edit.
   run env CONTEXT_USAGE_STATE_DIR="$state" \
-    CONTEXT_USAGE_ALLOWANCE_PCT=0 \
-    CONTEXT_USAGE_FULLNESS_WARN_PCT=10 \
-    CONTEXT_USAGE_FULLNESS_HARD_PCT=12 \
+    CONTEXT_USAGE_ALLOWANCE_TOKENS=0 \
+    CONTEXT_USAGE_TOKENS_WARN=110000 \
+    CONTEXT_USAGE_TOKENS_HARD=130000 \
     CONTEXT_USAGE_TURNS_WARN=2 \
     CONTEXT_USAGE_TURNS_HARD=4 \
     bash -c '
       . "$1"
       context_usage_fullness_pct 130000 1000000
       printf "\n"
-      context_usage_evaluate tuned 11 1
+      context_usage_evaluate tuned 120000 1
       context_usage_spend tuned warn fullness 1
-      context_usage_evaluate tuned 13 1
+      context_usage_evaluate tuned 130000 1
     ' _ "$(context_usage_lib)"
   assert_success
   assert_line --index 0 '13'
@@ -9193,8 +9203,8 @@ context_usage_statusline_payload() {
         context_window_size: $window}}'
 }
 
-function test_scripts_2813_statusline_bar_and_library_report_the_same_fullness() {
-  _bats_test_init 2813 'statusline bar and the usage library report the same fullness'
+function test_scripts_2813_statusline_bar_and_library_describe_the_same_load() {
+  _bats_test_init 2813 'statusline bar and the usage library describe the same load'
   local statusline="$SOURCE_ROOT/private_dot_claude/hooks/executable_statusline.sh"
   local library home="$BATS_TEST_TMPDIR/home" state="$BATS_TEST_TMPDIR/state"
   local reported with_allowance without_allowance
@@ -9202,26 +9212,27 @@ function test_scripts_2813_statusline_bar_and_library_report_the_same_fullness()
   mkdir -p "$home"
 
   # AE8, R1. The oracle is agreement between the two consumers, not a number
-  # restated from either. Render the bar once with the allowance the library
-  # owns, then render it again with the allowance forced off and a raw
-  # occupancy already equal to what the library reported. Identical bars mean
-  # the operator's bar and the announcement describe the same percentage.
+  # restated from either. The bar and the hook now speak different units, so
+  # what must agree is the load underneath them: the hook reads back exactly
+  # the occupancy the payload carried, and the bar drawn with the allowance the
+  # library owns equals the bar drawn with that allowance folded into the
+  # occupancy instead. A bar that applied its own allowance would fail this.
   run env HOME="$home" HERDR_ENV= CONTEXT_USAGE_LIBRARY="$library" \
-    CONTEXT_USAGE_STATE_DIR="$state" bash "$statusline" \
+    CONTEXT_USAGE_STATE_DIR="$state" CONTEXT_USAGE_ALLOWANCE_TOKENS=40000 bash "$statusline" \
     <<< "$(context_usage_statusline_payload agree 372000 1000000)"
   assert_success
   with_allowance="$output"
 
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_read_fullness agree
+    . "$1"; context_usage_read_tokens agree
   ' _ "$library"
   assert_success
   reported="$output"
-  assert_equal "$reported" '57'
+  assert_equal "$reported" '372000'
 
   run env HOME="$home" HERDR_ENV= CONTEXT_USAGE_LIBRARY="$library" \
-    CONTEXT_USAGE_STATE_DIR="$state" CONTEXT_USAGE_ALLOWANCE_PCT=0 bash "$statusline" \
-    <<< "$(context_usage_statusline_payload mirror "${reported}0000" 1000000)"
+    CONTEXT_USAGE_STATE_DIR="$state" CONTEXT_USAGE_ALLOWANCE_TOKENS=0 bash "$statusline" \
+    <<< "$(context_usage_statusline_payload mirror "$((reported + 40000))" 1000000)"
   assert_success
   without_allowance="$output"
   assert_equal "$with_allowance" "$without_allowance"
@@ -9273,7 +9284,7 @@ function test_scripts_2814_statusline_renders_when_publishing_is_impossible() {
   assert_success
   refute_output ''
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_read_fullness nolib
+    . "$1"; context_usage_read_tokens nolib
   ' _ "$library"
   assert_failure
 
@@ -9285,7 +9296,7 @@ function test_scripts_2814_statusline_renders_when_publishing_is_impossible() {
   assert_success
   assert_output --partial '░░░░░░░░░░'
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_read_fullness empty
+    . "$1"; context_usage_read_tokens empty
   ' _ "$library"
   assert_failure
 }
@@ -9530,32 +9541,34 @@ function test_scripts_2820_context_threshold_names_the_dimension_that_crossed() 
   context_threshold_transcript "$short" 12
   mkdir -p "$BATS_TEST_TMPDIR/home"
 
-  # AE1. A long session on a nearly empty window announces on turn count, and
-  # the message says so rather than reporting a percentage nobody is worried
-  # about. This is the common case on this machine.
+  # AE1. A long session carrying little context announces on turn count, and
+  # the message says so rather than reporting a load nobody is worried about.
+  # This is the common case on this machine.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
     . "$1"; context_usage_write_usage long-session 130000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
-  run context_threshold_run long-session "$long"
+  run context_threshold_run long-session "$long" CONTEXT_USAGE_TOKENS_WARN=140000
   assert_success
   run jq -r '.systemMessage' <<< "$output"
   assert_success
   assert_output --partial '160 turns since the last compaction'
-  refute_output --partial 'context window'
+  refute_output --partial 'context at'
   assert_output --partial '/compact handoff:'
 
   # AE2. The mirror case: a short session that pulled in several large files
-  # announces on fullness.
+  # announces on the context dimension. The window here is 1M and 160k fills
+  # 16% of it, which is the point -- the load is what the operator is told
+  # about, not the share of a window that happens to be large.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_write_usage short-session 600000 1000000 "$(date +%s)"
+    . "$1"; context_usage_write_usage short-session 160000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
-  run context_threshold_run short-session "$short"
+  run context_threshold_run short-session "$short" CONTEXT_USAGE_TOKENS_WARN=120000
   assert_success
   run jq -r '.systemMessage' <<< "$output"
   assert_success
-  assert_output --partial 'context window 80% full'
+  assert_output --partial 'context at 160k tokens (warn at 120k)'
   refute_output --partial 'turns since the last compaction'
 }
 
@@ -9661,16 +9674,16 @@ function test_scripts_2824_context_threshold_sends_one_message_per_turn() {
   # R22. Two dimensions crossing in one turn is one message carrying one
   # command, not two announcements the operator has to reconcile.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_write_usage combined 600000 1000000 "$(date +%s)"
+    . "$1"; context_usage_write_usage combined 170000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
   local response
-  run context_threshold_run combined "$both"
+  run context_threshold_run combined "$both" CONTEXT_USAGE_TOKENS_WARN=120000
   assert_success
   response="$output"
   run jq -r '.systemMessage' <<< "$response"
   assert_success
-  assert_output --partial '160 turns since the last compaction (warn at 150) and context window 80% full'
+  assert_output --partial '160 turns since the last compaction (warn at 150) and context at 170k tokens (warn at 120k)'
   run jq -r '[.systemMessage | scan("/compact handoff:")] | length' <<< "$response"
   assert_success
   assert_output '1'
@@ -9694,14 +9707,14 @@ function test_scripts_2825_context_threshold_warns_once_but_keeps_halting() {
 
   # R10. The spent turn-count budget does not suppress fullness.
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
-    . "$1"; context_usage_write_usage repeat 600000 1000000 "$(date +%s)"
+    . "$1"; context_usage_write_usage repeat 170000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
-  run context_threshold_run repeat "$warn_level"
+  run context_threshold_run repeat "$warn_level" CONTEXT_USAGE_TOKENS_WARN=120000
   assert_success
   run jq -r '.systemMessage' <<< "$output"
   assert_success
-  assert_output --partial 'context window 80% full'
+  assert_output --partial 'context at 170k tokens (warn at 120k)'
   refute_output --partial 'turns since the last compaction'
 
   # AE12, R25. Held above the hard threshold the session is told again, and
@@ -10009,7 +10022,7 @@ function test_scripts_2834_handoff_injector_rearms_the_announcement_budgets() {
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
     . "$1"
     context_usage_spend rearmed warn fullness,turns 160 "before compaction" ok
-    context_usage_evaluate rearmed 72 161 && exit 9
+    context_usage_evaluate rearmed 160000 161 && exit 9
     exit 0
   ' _ "$library"
   assert_success
@@ -10021,7 +10034,7 @@ function test_scripts_2834_handoff_injector_rearms_the_announcement_budgets() {
   run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '
     . "$1"
     context_usage_goal_status rearmed && exit 9
-    context_usage_evaluate rearmed 72 161
+    context_usage_evaluate rearmed 160000 161
   ' _ "$library"
   assert_success
   assert_line --index 0 'level=warn'
@@ -10031,7 +10044,7 @@ function test_scripts_2834_handoff_injector_rearms_the_announcement_budgets() {
 # --- review follow-ups -----------------------------------------------------
 
 function test_scripts_2835_context_threshold_keeps_dimensions_independent_under_damage() {
-  _bats_test_init 2835 'context threshold keeps the fullness dimension when the transcript will not parse'
+  _bats_test_init 2835 'context threshold keeps the context dimension when the transcript will not parse'
   local damaged="$BATS_TEST_TMPDIR/damaged.jsonl" library
   library="$(context_usage_lib)"
   mkdir -p "$BATS_TEST_TMPDIR/home"
@@ -10055,7 +10068,7 @@ function test_scripts_2835_context_threshold_keeps_dimensions_independent_under_
   assert_success
   run jq -r '.systemMessage' <<< "$response"
   assert_success
-  assert_output --partial 'context window'
+  assert_output --partial 'context at 900k tokens'
   refute_output --partial 'turns since the last compaction'
 }
 
@@ -10073,18 +10086,18 @@ function test_scripts_2836_context_threshold_reports_both_levels_in_one_message(
     . "$1"; context_usage_write_usage mixed 700000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
-  run context_threshold_run mixed "$long"
+  run context_threshold_run mixed "$long" CONTEXT_USAGE_TOKENS_HARD=200000
   assert_success
   local response="$output"
   run jq -r '.systemMessage' <<< "$response"
   assert_success
   assert_output --partial '160 turns since the last compaction (warn at 150)'
-  assert_output --partial 'context window 90% full (limit 85%)'
+  assert_output --partial 'context at 700k tokens (limit 200k)'
   run jq -e '.continue == false' <<< "$response"
   assert_success
 
   # Both budgets are spent, so the next turn at the same levels says nothing.
-  run context_threshold_run mixed "$long"
+  run context_threshold_run mixed "$long" CONTEXT_USAGE_TOKENS_HARD=200000
   assert_success
   assert_output ''
 }
@@ -10131,7 +10144,7 @@ function test_scripts_2838_context_threshold_fails_open_when_it_cannot_remember(
 }
 
 function test_scripts_2839_handoff_injector_drops_the_emptied_window_reading() {
-  _bats_test_init 2839 'handoff injector drops the fullness reading for the window compaction emptied'
+  _bats_test_init 2839 'handoff injector drops the token reading for the window compaction emptied'
   local library state="$BATS_TEST_TMPDIR/state"
   library="$(context_usage_lib)"
   mkdir -p "$BATS_TEST_TMPDIR/home"
@@ -10143,13 +10156,13 @@ function test_scripts_2839_handoff_injector_drops_the_emptied_window_reading() {
     . "$1"; context_usage_write_usage emptied 900000 1000000 "$(date +%s)"
   ' _ "$library"
   assert_success
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_fullness emptied' _ "$library"
+  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_tokens emptied' _ "$library"
   assert_success
-  assert_output '100'
+  assert_output '900000'
 
   run handoff_session_start_run emptied compact
   assert_success
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_fullness emptied' _ "$library"
+  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_tokens emptied' _ "$library"
   assert_failure
 
   # A start that is not a compaction leaves the reading alone.
@@ -10159,9 +10172,9 @@ function test_scripts_2839_handoff_injector_drops_the_emptied_window_reading() {
   assert_success
   run handoff_session_start_run kept startup
   assert_success
-  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_fullness kept' _ "$library"
+  run env CONTEXT_USAGE_STATE_DIR="$state" bash -c '. "$1"; context_usage_read_tokens kept' _ "$library"
   assert_success
-  assert_output '100'
+  assert_output '900000'
 }
 
 function test_scripts_2840_handoff_pre_compact_never_resurrects_an_older_goal() {


### PR DESCRIPTION
## Summary

The context-growth warning now fires at the same token load on every model, instead of at a share of the context window that let a 1M-window session run to roughly 650k tokens before saying anything — the runaway this hook exists to catch.

Thresholds are absolute: 150k tokens to warn, 190k to halt. The announcement reads `context at 155k tokens (warn at 150k)`. The system-prompt allowance moves to tokens for the same reason a percentage failed — 20 points of a 1M window is an impossible 200k — and now belongs to the status-line bar alone. The hook compares against the count Claude Code itself publishes, so a threshold an operator sets means the figure their client shows them rather than one shifted by an allowance they cannot see.

## Threshold names changed

An existing override under an old name stops applying, silently:

| Removed | Replacement |
|---|---|
| `CONTEXT_USAGE_FULLNESS_WARN_PCT` | `CONTEXT_USAGE_TOKENS_WARN` |
| `CONTEXT_USAGE_FULLNESS_HARD_PCT` | `CONTEXT_USAGE_TOKENS_HARD` |
| `CONTEXT_USAGE_FULLNESS_REPEAT_STEP` | `CONTEXT_USAGE_TOKENS_REPEAT_STEP` |
| `CONTEXT_USAGE_ALLOWANCE_PCT` | `CONTEXT_USAGE_ALLOWANCE_TOKENS` |

## Why no window-relative ceiling

Against a 200k window the halt now lands at 95%, too late to act on. The warning at 75% and the turn-count dimension, which never depended on window size, still cover that case. A second window-relative threshold would add a scale to reason about without adding protection.

## Validation

`tests/bashunit/scripts_test.sh`: 337 passed, 1 skipped, 0 failed. `make lint` clean. `make test-local` exit 0, with the three managed files mapping to `~/.local/lib/context-usage.sh`, `~/.claude/hooks/context-threshold.sh` and `~/.claude/hooks/statusline.sh`, and no path, template, or ignore behavior changed.

Exercised end to end against the real hook and status line: 140k tokens on a 1M window stays silent, 155k warns, 195k halts with `continue: false`, and 155k on a 200k window produces that same warning rather than a different one.
