### PR TITLE
test: make the bashunit suites fail when guarded behavior breaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local test-agents-local-opencode test-pi-herdr-worktree-identity test-agent-hooks-core test-agent-hooks-opencode test-agent-hooks-pi lint clean build-docker shell-ubuntu
+.PHONY: help test-issues test-ubuntu test-local test-suite test-docker test-templates test-pi-agents-local test-agents-local-opencode test-pi-brew-auto-update test-pi-herdr-worktree-identity test-agent-hooks-core test-agent-hooks-opencode test-agent-hooks-pi lint clean build-docker shell-ubuntu
 
 help:
 	@echo "Chezmoi Dotfiles - Available commands:"
@@ -9,6 +9,7 @@ help:
 	@echo "  make test-templates   Run template tests in Docker (may rebuild images)"
 	@echo "  make test-pi-agents-local  Run focused Pi local-instructions extension tests"
 	@echo "  make test-agents-local-opencode  Run focused opencode local-instructions plugin tests"
+	@echo "  make test-pi-brew-auto-update  Run focused Pi brew auto-update extension tests"
 	@echo "  make test-pi-herdr-worktree-identity  Run focused Pi worktree-identity extension tests"
 	@echo "  make test-agent-hooks-core  Run focused agent-hooks dispatch core tests"
 	@echo "  make test-agent-hooks-opencode  Run focused agent-hooks opencode adapter tests"
@@ -41,6 +42,10 @@ test-pi-agents-local:
 
 test-agents-local-opencode:
 	bun test tests/agents-local-opencode-plugin.test.ts
+
+# Checkout-side runner for the suite; smoke test 1056 owns the deployed run.
+test-pi-brew-auto-update:
+	bun test tests/pi-brew-auto-update.test.ts
 
 test-pi-herdr-worktree-identity:
 	bun test tests/pi-herdr-worktree-identity.test.ts

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -300,7 +300,7 @@ test derives its inventory; sequential probe run skips; suite green.
 
 ## Progress
 
-- [ ] P1 · stall-proof chezmoi_unattended test 009
+- [x] P1 · stall-proof chezmoi_unattended test 009
 - [ ] P2 · launcher guard + failure-propagation coverage
 - [x] P3 · smart_close.py behavior tests
 - [ ] P4 · palette ranking onto fixtures + scroll consolidation

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -312,7 +312,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [ ] P10 · herdr-integrations present-leg
 - [ ] P11 · re-home checkout colony in smoke_test.sh
 - [x] P12 · Brewfile full-render controls
-- [ ] P13 · rework smoke grep zone
+- [x] P13 · rework smoke grep zone
 - [ ] P14 · visible skips instead of return 0
 - [ ] P15 · deduplicate and unfreeze
 - [x] P16 · small-suite fixes

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -310,7 +310,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P8 · remove source-shape greps in scripts_test.sh
 - [x] P9 · split multi-scenario tests
 - [x] P10 · herdr-integrations present-leg
-- [ ] P11 · re-home checkout colony in smoke_test.sh
+- [x] P11 · re-home checkout colony in smoke_test.sh
 - [x] P12 · Brewfile full-render controls
 - [x] P13 · rework smoke grep zone
 - [x] P14 · visible skips instead of return 0

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -306,7 +306,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P4 · palette ranking onto fixtures + scroll consolidation
 - [x] P5 · untested palette run paths
 - [x] P6 · morning-cleanup destructive legs
-- [ ] P7 · herdr-child stub calibration visibility
+- [x] P7 · herdr-child stub calibration visibility
 - [x] P8 · remove source-shape greps in scripts_test.sh
 - [x] P9 · split multi-scenario tests
 - [x] P10 · herdr-integrations present-leg

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -311,7 +311,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [ ] P9 · split multi-scenario tests
 - [ ] P10 · herdr-integrations present-leg
 - [ ] P11 · re-home checkout colony in smoke_test.sh
-- [ ] P12 · Brewfile full-render controls
+- [x] P12 · Brewfile full-render controls
 - [ ] P13 · rework smoke grep zone
 - [ ] P14 · visible skips instead of return 0
 - [ ] P15 · deduplicate and unfreeze

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -305,7 +305,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P3 · smart_close.py behavior tests
 - [x] P4 · palette ranking onto fixtures + scroll consolidation
 - [ ] P5 · untested palette run paths
-- [ ] P6 · morning-cleanup destructive legs
+- [x] P6 · morning-cleanup destructive legs
 - [ ] P7 · herdr-child stub calibration visibility
 - [ ] P8 · remove source-shape greps in scripts_test.sh
 - [ ] P9 · split multi-scenario tests

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -301,7 +301,7 @@ test derives its inventory; sequential probe run skips; suite green.
 ## Progress
 
 - [x] P1 · stall-proof chezmoi_unattended test 009
-- [ ] P2 · launcher guard + failure-propagation coverage
+- [x] P2 · launcher guard + failure-propagation coverage
 - [x] P3 · smart_close.py behavior tests
 - [x] P4 · palette ranking onto fixtures + scroll consolidation
 - [ ] P5 · untested palette run paths

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -304,7 +304,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P2 · launcher guard + failure-propagation coverage
 - [x] P3 · smart_close.py behavior tests
 - [x] P4 · palette ranking onto fixtures + scroll consolidation
-- [ ] P5 · untested palette run paths
+- [x] P5 · untested palette run paths
 - [x] P6 · morning-cleanup destructive legs
 - [ ] P7 · herdr-child stub calibration visibility
 - [ ] P8 · remove source-shape greps in scripts_test.sh

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -303,7 +303,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P1 · stall-proof chezmoi_unattended test 009
 - [ ] P2 · launcher guard + failure-propagation coverage
 - [x] P3 · smart_close.py behavior tests
-- [ ] P4 · palette ranking onto fixtures + scroll consolidation
+- [x] P4 · palette ranking onto fixtures + scroll consolidation
 - [ ] P5 · untested palette run paths
 - [ ] P6 · morning-cleanup destructive legs
 - [ ] P7 · herdr-child stub calibration visibility

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -307,7 +307,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P5 · untested palette run paths
 - [x] P6 · morning-cleanup destructive legs
 - [ ] P7 · herdr-child stub calibration visibility
-- [ ] P8 · remove source-shape greps in scripts_test.sh
+- [x] P8 · remove source-shape greps in scripts_test.sh
 - [ ] P9 · split multi-scenario tests
 - [ ] P10 · herdr-integrations present-leg
 - [ ] P11 · re-home checkout colony in smoke_test.sh

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -302,7 +302,7 @@ test derives its inventory; sequential probe run skips; suite green.
 
 - [ ] P1 · stall-proof chezmoi_unattended test 009
 - [ ] P2 · launcher guard + failure-propagation coverage
-- [ ] P3 · smart_close.py behavior tests
+- [x] P3 · smart_close.py behavior tests
 - [ ] P4 · palette ranking onto fixtures + scroll consolidation
 - [ ] P5 · untested palette run paths
 - [ ] P6 · morning-cleanup destructive legs

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -314,5 +314,5 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P12 · Brewfile full-render controls
 - [x] P13 · rework smoke grep zone
 - [x] P14 · visible skips instead of return 0
-- [ ] P15 · deduplicate and unfreeze
+- [x] P15 · deduplicate and unfreeze
 - [x] P16 · small-suite fixes

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -308,7 +308,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [x] P6 · morning-cleanup destructive legs
 - [ ] P7 · herdr-child stub calibration visibility
 - [x] P8 · remove source-shape greps in scripts_test.sh
-- [ ] P9 · split multi-scenario tests
+- [x] P9 · split multi-scenario tests
 - [ ] P10 · herdr-integrations present-leg
 - [ ] P11 · re-home checkout colony in smoke_test.sh
 - [x] P12 · Brewfile full-render controls

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -313,6 +313,6 @@ test derives its inventory; sequential probe run skips; suite green.
 - [ ] P11 · re-home checkout colony in smoke_test.sh
 - [x] P12 · Brewfile full-render controls
 - [x] P13 · rework smoke grep zone
-- [ ] P14 · visible skips instead of return 0
+- [x] P14 · visible skips instead of return 0
 - [ ] P15 · deduplicate and unfreeze
 - [x] P16 · small-suite fixes

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -315,4 +315,4 @@ test derives its inventory; sequential probe run skips; suite green.
 - [ ] P13 · rework smoke grep zone
 - [ ] P14 · visible skips instead of return 0
 - [ ] P15 · deduplicate and unfreeze
-- [ ] P16 · small-suite fixes
+- [x] P16 · small-suite fixes

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -1,0 +1,318 @@
+# Test quality fixes
+
+Source: six-agent audit of `tests/bashunit/` (2026-09-07) using two review skills
+(analyzing-test-effectiveness, testing-skill) with cross-checked partitions. This plan
+carries every accepted finding. Each item is one commit; the repository works after each.
+
+Verification baseline for every item: `make lint` and the touched suite via
+`tests/lib/bashunit -j 8 tests/bashunit/<file>_test.sh`. Items touching templates or
+deployment behavior additionally note their own checks.
+
+## Items
+
+### P1 · Stall-proof `chezmoi_unattended_test.sh` test 009
+
+Observed once live: the fake chezmoi's signal mode loops `while :; do sleep 1; done`
+unbounded, and the test has no failure-path cleanup, so a failed assertion between
+launch and `kill` hangs the whole suite (documented class:
+`docs/solutions/design-patterns/outliving-processes-hang-the-suite.md`).
+Fix: cap the fake's wait loop (exit 143 after a bounded number of iterations), kill the
+backgrounded launcher from `tear_down`/trap, and replace the fixed ~1s pid-file poll
+with a state-aware longer bound (latent-flake class:
+`docs/solutions/.../idle-machine-wall-clock-bounds-are-latent-flakes.md`).
+
+Oracle: consumer = suite runner; observable failure = suite hangs indefinitely after an
+assertion failure inside test 009; oracle = existing test 009 assertions still pass and
+a bounded run terminates — no new test, only fixture hardening.
+
+Done when: full `chezmoi_unattended_test.sh` passes twice in a row within its runtime
+budget; the fake's loop has a hard bound; teardown kills the launcher.
+
+### P2 · Launcher guard and failure-propagation coverage
+
+`tests/helpers/chezmoi-unattended` fail-closed branches with zero coverage:
+unknown option before `--` (:44), missing `--` delimiter (:49), empty command after
+`--` (:54), the exactly-five-fixture-identities inventory rule (:141-142),
+single-target-too-long (:236-237). Plus: test 0071 (:282-306) asserts only failure with
+no message fragment — add `assert_output --partial` on the launcher's non-terminal-stdin
+message. Plus: extend the fake chezmoi so `managed` can fail and a mid-batch diff can
+fail, then assert the launcher exits with the child's status (:215-217, :238-242).
+
+Oracle: consumer = CI invoking the launcher; observable failure = a guard silently
+passes a malformed invocation through to a real `chezmoi apply`, or a failing batch
+diff reads as green; oracle = filesystem markers written by the fake
+(`assert_final_not_reached`) plus the launcher's exit status and stderr message —
+independent of this patch's edits to the test file.
+
+Done when: each listed branch has a rejection test with a message fragment and a nearby
+valid control; failure-propagation tests pass; suite green.
+
+### P3 · Behavior tests for `smart_close.py`
+
+The only coverage today is `py_compile`. Cover the three decision branches (close pane
+when tab has >1 panes; else close tab when workspace has >1 tabs; else refuse + notify)
+and the error-notify path, using the existing `stub_herdr` pattern
+(`palette_test.sh:784-807`).
+
+Oracle: consumer = herdr keybinding invoking `smart_close.py` on Cmd-W; observable
+failure = the last tab of a workspace gets closed (data loss) or close requests go to
+the wrong object; oracle = argv recorded by the stubbed `herdr` binary — the stub log
+is independent of `smart_close.py`'s source.
+
+Done when: four behavioral tests pass; a hand-inverted branch (mutation check during
+development, not committed) flips at least one test red.
+
+### P4 · Palette ranking block onto fixtures
+
+Tests 016-025 pin titles/shortcuts copied from mutable production `commands.toml`
+(same-patch-oracle hazard the file itself documents at `palette_test.sh:487-493`).
+Replace with: fixture-backed mechanism tests (pattern of 026/029/030) for shortcut-tier
+vs title-tier, prefix match, case folding; one self-maintaining inventory test that
+reads every `shortcuts` declaration from the deployed `commands.toml` and asserts each
+ranks its own command first; one new fixture pinning exact-shortcut-beats-prefix-shortcut
+(`palette.py:620-645`). Drop the count-of-1 assertions at :389 and :412. Also:
+consolidate scroll tests 034-037 into one test with four assertions (one subprocess
+run), and fix the stale "58 tests" comment at :25.
+
+Oracle: consumer = palette user typing a query; observable failure = a shortcut stops
+ranking its command first; oracle = ranking output over test-owned fixtures (mechanism)
+and the config-derived relationship "each declared shortcut ranks its own command
+first" (two independent sides: config declaration vs ranker output).
+
+Done when: mechanism tests run on fixtures only; inventory test derives expectations
+from `commands.toml` at runtime; suite green.
+
+### P5 · Untested palette run paths
+
+Cover: `plugin_action` kind (`palette.py:1947-1956`), plain `shell` kind including the
+runtime `append_value` quoting (`palette.py:1962-1963` — inject a hostile value, assert
+inertness like the existing `PWNED` marker test at :1431-1478), and `pane_run` with
+`HERDR_TARGET_PANE_ID` unset (`palette.py:1888-1890`).
+
+Oracle: consumer = palette executing a selected command; observable failure = injected
+shell metacharacters execute, or a run path crashes/targets the wrong pane; oracle =
+stub argv logs and a marker file that must NOT exist after a hostile append value.
+
+Done when: three run paths have behavioral tests; hostile-value test uses a
+would-be-created marker as its negative oracle; suite green.
+
+### P6 · morning-cleanup destructive legs
+
+`home/dot_local/bin/executable_morning-cleanup.sh` trash purge (`rm -rf` by ctime,
+:28-33) and platform worktree/branch cleanup (`git worktree remove`, `git branch -d` of
+merged branches, :51-76) have zero tests. Add an age-threshold env knob to the script
+(shipped default stays the control), then: a stale entry the purge must remove, a fresh
+entry it must keep; a git fixture (bare origin, merged-clean worktree, unmerged branch,
+dirty worktree) proving merged-clean is removed and unmerged/dirty survive.
+
+Oracle: consumer = the user's morning launchd run; observable failure = an unmerged
+branch or dirty worktree is deleted, or stale trash accumulates forever; oracle = the
+filesystem/git state after running the real script against a fixture repo — git itself
+(`git branch --list`, `git worktree list`) judges the outcome, independent of the
+script's source.
+
+Done when: purge and git-cleanup legs each have remove-and-survive test pairs in
+`scripts_test.sh` (or a new focused file if `scripts_test.sh` sectioning demands);
+suite green.
+
+### P7 · herdr-child stub calibration visibility
+
+The large herdr fake (`scripts_test.sh:2064-2548`) has no CI-reachable tether to the
+real binary; the only calibration (test 1209) double-skips in Docker. Fix: extend the
+1209 pattern to compare stub vs real result-envelope key sets for
+`agent list`/`agent get`/`pane get` at the boundary the scripts consume, when a real
+herdr is available; in the disposable-home gate convert the silent skip to a
+`mms_disposable_home_verdict`-style hard fail (pattern of `test_scripts_100`,
+:4910-4921) OR document why herdr cannot be installed there and keep a visible skip.
+
+Oracle: consumer = ~200 herdr-child/pane-labels tests trusting the stub; observable
+failure = upstream herdr renames a field and deployed watchers break while the suite
+stays green; oracle = the real herdr binary's JSON output — the independent side the
+stub is compared against.
+
+Done when: calibration covers the three envelopes; its skip is visible or converted to
+a hard fail in the environment that controls its deps; suite green on this host with
+real herdr present.
+
+### P8 · Remove source-shape greps in `scripts_test.sh`
+
+Delete the source-text greps in `test_scripts_1119` (:5559-5562) and the source-absence
+grep tail of `test_scripts_1057` (:1825-1826) — their behavioral halves already own
+those contracts. Fold `test_scripts_1001` (:1291-1304, `declare -F` existence checks)
+into the behavioral tests 1002/1003 or delete it.
+
+Oracle: deletion-only; the remaining behavioral assertions in the same tests are the
+coverage owners. No new tests.
+
+Done when: greps gone, behavioral halves intact, suite green.
+
+### P9 · Split multi-scenario tests
+
+Tests 033 (:2935), 036 (:3065), 037 (:3097), 040 (:3167), 068 (:4365), 069 (:4387) in
+`scripts_test.sh` pack 2-3 scenarios with mid-test `teardown; setup`; a leg-1 failure
+silently retires legs 2-3. Split each into one function per scenario, preserving every
+assertion.
+
+Oracle: refactor of test structure only; assertion set before == after (verify by
+diffing assertion lines). No new tests.
+
+Done when: each scenario is its own named test; total assertion count unchanged; suite
+green.
+
+### P10 · herdr-integrations present-leg
+
+`test_scripts_093` (:4788-4797) tests only the herdr-absent skip path. Add the
+herdr-present leg: stub `herdr` on PATH, assert the refresh commands it receives (same
+pattern as neighboring cutover tests).
+
+Oracle: consumer = chezmoi apply refreshing agent-state integrations; observable
+failure = the refresh silently stops issuing commands when herdr is present; oracle =
+argv recorded by the stub binary.
+
+Done when: present-leg test passes; absent-leg untouched; suite green.
+
+### P11 · Re-home the checkout colony in `smoke_test.sh`
+
+(a) Focus-notify behavior tests 033-035 (:638-722) run the checkout `notify.py`; point
+them at the deployed copy `$HOME/.config/herdr/plugins/herdr-focus-notify/notify.py`
+(gate on `is_macos` like siblings), or run both with deployed as the primary.
+(b) Move tests 007/008 (:198-260, checkout script under fake herdr/uname) into
+`scripts_test.sh`.
+(c) `smoke_test.sh` test 1057 (:902-906) is the sole runner of
+`tests/pi-brew-auto-update.test.ts` and runs it against the checkout: add a direct bun
+Makefile target for the source suite (pattern of `Makefile:40-55` siblings) and make
+1057 parameterize on the deployed path like 1055/1065/1068-1070, or drop it if the
+deployed run is added elsewhere.
+
+Oracle (a): consumer = herdr executing the deployed plugin; observable failure = a
+chezmoi ignore rule drops `notify.py` from deployment while checkout tests stay green;
+oracle = executing the deployed file itself. (b)(c) are re-homing; existing oracles move
+with the tests.
+
+Done when: deployed focus-notify is executed by tests on macOS; 007/008 live in
+`scripts_test.sh`; the bun suite has a checkout runner independent of smoke; both
+suites green.
+
+### P12 · Brewfile full-render controls
+
+`templates_test.sh` tests 021/022 (:594-633) assert the full render but never pin
+`gitleaks`, `node`, `bun` — the entries asserted only in the minimal render. A template
+edit wrapping them in the `ci_minimal` guard passes everything while real hosts stop
+installing a security scanner. Add the three `assert_line` controls to the full-render
+test, mirroring the symmetric-pinning comment at :605-608.
+
+Oracle: consumer = a real host's `brew bundle`; observable failure = `gitleaks`/`node`/
+`bun` silently leave the install set; oracle = the rendered Brewfile produced by real
+chezmoi — the render is the independent side (two-sided mode matrix already exists).
+
+Done when: full render pins all entries the minimal render refutes/asserts
+asymmetrically; both mode renders green.
+
+### P13 · Rework the smoke grep zone (1052, 1058, 1061, 1062, label-writer helper)
+
+(a) Test 1052 (:766-787): drop the SKILL.md prose greps and the `--name`
+source-absence greps; if the reap/verify/reply flow matters, keep at most the one
+command string agents copy verbatim, or replace with a behavioral check through the
+herdr-child fakes.
+(b) Tests 1061/1062 (:1102-1154): keep the `include ... | sha256sum` hash-input
+contract but derive the include list from the templates themselves (technique of
+`templates_test.sh` test 027, :705-724) instead of a hand-copied six-entry inventory;
+drop the internal-function-name greps (`^hpl_cutover_rollback()` etc.).
+(c) `assert_herdr_label_writer_contract` (:996-1048): remove the word-ban greps
+(:1030-1035, :1098) and the `icon|glyph|nerd font` keyword grep; keep the
+single-writer `herdr pane rename` count and the octal-glyph literals with their
+negative control.
+(d) Drop test 1058 (:1050-1056), keeping 1059 as the deployed owner — the engine's
+behavior is owned by ~40 `scripts_test.sh` tests.
+
+Oracle: mostly deletion of shape assertions whose behavioral owners exist and are
+named; the derived-include change compares two independent sides (template's own
+include lines vs plugin directory listing) with no hand copy.
+
+Done when: no doc-prose greps, no absence-greps, no function-name greps remain in the
+zone; derived include check catches a deliberately dropped include (verified during
+development); suite green.
+
+### P14 · Visible skips instead of silent `return 0`
+
+`smoke_test.sh:165` (test 004 chezmoi-membership half) and :671 (test 032 deployed-
+manifest half) drop assertions via `command_exists || return 0` / `is_macos ||
+return 0`, invisible to skip-identity comparison. Convert to `skip "<reason>"` or split
+each into two tests so the lost half is visible.
+
+Oracle: honesty fix; existing assertions unchanged.
+
+Done when: a reduced-environment run reports these as skips, not passes; suite green.
+
+### P15 · Deduplicate and unfreeze
+
+(a) Registration dedup: `herdr-agent-state.sh` SessionStart asserted 4×. Keep one
+deployed owner (fold test 1054's tail into 1064 or vice versa); in `templates_test.sh`
+keep 0154's registration conjunction OR the per-test asserts — not both: per the
+cross-review, drop 0154 (its three facts are each owned by 0151/0152) and keep
+0151/0152's unique `source-path` resolution checks.
+(b) Remove `templates_test.sh` 0095 (:311-333, owned by `chezmoi_unattended_test.sh`
+test 002) and the third block of 0094 (:300-309, repeats 0092's diff).
+(c) Drop pure-absence test 1053 (`smoke_test.sh:789-795`); keep 1054's paired
+absence+positive as the single retirement owner; trim the duplicate retirement asserts
+in 1063/0151 where they have no positive pairing.
+(d) Unfreeze preferences: test 017 (:384-397) theme names → referential-integrity
+assertion (settings-named theme resolves to a deployed theme file); test 024 (:530)
+`include Alabaster.conf` pin → drop or convert to "references a theme file that
+exists".
+(e) Upgrade test 1056 (:896-900) to run the Pi extension's focused bun suite against
+the deployed path via env override (pattern of 1065/1068-1070).
+(f) Add unrendered-`{{` guards to `templates_test.sh` 0151/0152 renders (pattern of
+:90, :207-208).
+
+Oracle: (a)-(c) deletion with named surviving owners; (d) the referential check
+compares two independent sides (settings value vs deployed file tree); (e) the bun
+suite is the oracle, pointed at the deployed artifact; (f) rendered output free of
+template syntax, judged by real chezmoi render.
+
+Done when: each retired assertion has a named surviving owner in the plan-item commit
+message; suite green.
+
+### P16 · Small-suite fixes
+
+(a) `herdr_pane_labels_descriptor_probe_test.sh`: dead bats-style `teardown` hook —
+add `function tear_down() { _bats_run_teardown; }` and
+`function tear_down_after_script() { _bats_file_cleanup; }` (siblings' pattern), or
+delete the dead hook with a comment explaining deferred cleanup; add the one-line
+header naming `test_scripts_1103` as its driver.
+(b) `platform_test.sh`: add a positive cross-platform control (e.g. `.zshenv` present)
+to the refute-only Linux leg of test 001; derive the expected macOS-only set from
+`.chezmoiignore`'s darwin block instead of the hand-copied list (reconciling the
+001/002 asymmetry: `Library`, `kitty`); add a case for the Linux-only section
+(`.chezmoiscripts/linux` filtered on macOS).
+(c) `test_dsl_parallel_isolation_probe_test.sh`: skip with a message when not running
+under its parallel driver, so a direct sequential invocation reports a skip instead of
+a 5-second stall and false red.
+(d) `idempotent_test.sh:298`: widen the YAML matcher to tolerate quoted values
+(`MMS_DISPOSABLE_HOME: '1'`).
+
+Oracle (b): two independent sides — `.chezmoiignore`'s own darwin block vs `chezmoi
+managed` evaluation; a newly added darwin-only path is caught without editing the test.
+(a)(c)(d) are fixture/matcher fixes with existing oracles.
+
+Done when: probe cleanup runs (verify tmp root removed after a nested run); platform
+test derives its inventory; sequential probe run skips; suite green.
+
+## Progress
+
+- [ ] P1 · stall-proof chezmoi_unattended test 009
+- [ ] P2 · launcher guard + failure-propagation coverage
+- [ ] P3 · smart_close.py behavior tests
+- [ ] P4 · palette ranking onto fixtures + scroll consolidation
+- [ ] P5 · untested palette run paths
+- [ ] P6 · morning-cleanup destructive legs
+- [ ] P7 · herdr-child stub calibration visibility
+- [ ] P8 · remove source-shape greps in scripts_test.sh
+- [ ] P9 · split multi-scenario tests
+- [ ] P10 · herdr-integrations present-leg
+- [ ] P11 · re-home checkout colony in smoke_test.sh
+- [ ] P12 · Brewfile full-render controls
+- [ ] P13 · rework smoke grep zone
+- [ ] P14 · visible skips instead of return 0
+- [ ] P15 · deduplicate and unfreeze
+- [ ] P16 · small-suite fixes

--- a/docs/plans/2026-09-07-test-quality-fixes.md
+++ b/docs/plans/2026-09-07-test-quality-fixes.md
@@ -309,7 +309,7 @@ test derives its inventory; sequential probe run skips; suite green.
 - [ ] P7 · herdr-child stub calibration visibility
 - [x] P8 · remove source-shape greps in scripts_test.sh
 - [x] P9 · split multi-scenario tests
-- [ ] P10 · herdr-integrations present-leg
+- [x] P10 · herdr-integrations present-leg
 - [ ] P11 · re-home checkout colony in smoke_test.sh
 - [x] P12 · Brewfile full-render controls
 - [x] P13 · rework smoke grep zone

--- a/home/dot_local/bin/executable_morning-cleanup.sh
+++ b/home/dot_local/bin/executable_morning-cleanup.sh
@@ -9,6 +9,7 @@ STATE_DIR="$HOME/.local/state/morning-cleanup"
 STAMP="$STATE_DIR/last-run"
 LOG="$STATE_DIR/cleanup.log"
 TRASH="$HOME/.scratchpad"
+TRASH_MAX_AGE_DAYS="${MORNING_CLEANUP_TRASH_MAX_AGE_DAYS:-2}"
 PLATFORM="$HOME/Projects/platform"
 today=$(date +%Y-%m-%d)
 
@@ -22,15 +23,25 @@ wt_count=0
 br_count=0
 trash_count=0
 
-# 0) Purge trash entries older than 2 days. ctime is keyed to the moment the
-# entry was moved into the trash (rename updates it), not its original mtime,
-# so fresh moves keep a two-day undo window.
+# 0) Purge trash entries older than the age threshold (default 2 days; ctime
+# cannot be backdated, so tests lower MORNING_CLEANUP_TRASH_MAX_AGE_DAYS
+# instead of aging fixtures). ctime is keyed to the moment the entry was moved
+# into the trash (rename updates it), not its original mtime, so fresh moves
+# keep an undo window. A threshold of 0 purges regardless of age — find's
+# day-granularity rounding would otherwise keep sub-day entries at -ctime +0.
+trash_candidates() {
+  if [[ "$TRASH_MAX_AGE_DAYS" == 0 ]]; then
+    find "$TRASH" -mindepth 1 -maxdepth 1 2>/dev/null
+  else
+    find "$TRASH" -mindepth 1 -maxdepth 1 -ctime "+$TRASH_MAX_AGE_DAYS" 2>/dev/null
+  fi
+}
 while IFS= read -r entry; do
   if rm -rf "$entry"; then
     log "purged trash: $entry"
     trash_count=$((trash_count + 1))
   fi
-done < <(find "$TRASH" -mindepth 1 -maxdepth 1 -ctime +2 2>/dev/null)
+done < <(trash_candidates)
 
 # 1) .omc runtime state in project checkouts. Files touched in the last 12h
 # can belong to a live OMC run — leave those dirs alone.

--- a/tests/bashunit/chezmoi_unattended_test.sh
+++ b/tests/bashunit/chezmoi_unattended_test.sh
@@ -25,6 +25,15 @@ fi
 for arg in "$@"; do
   if [ "$arg" = "managed" ]; then
     printf 'managed\n' >> "$FAKE_STATE/invocations"
+    if [ -n "${FAKE_MANAGED_EXIT_STATUS:-}" ]; then
+      exit "$FAKE_MANAGED_EXIT_STATUS"
+    fi
+    if [ "${FAKE_MANAGED_OVERSIZED_TARGET:-}" = "1" ]; then
+      # 98304 bytes = the launcher's 96 KiB batch budget; with the $HOME
+      # prefix this single target can never fit in an empty batch.
+      printf '%s\0' "$HOME/.config/oversized-$(head -c 98304 /dev/zero | tr '\0' x)"
+      exit 0
+    fi
     if [ "${FAKE_MANAGED_ONLY_OMITTED:-}" = "1" ]; then
       printf '%s\0' "$HOME/.zshenv" "$HOME/.claude.json"
       exit 0
@@ -301,8 +310,6 @@ env["MMS_CHEZMOI_UNATTENDED"] = "1"
 result = subprocess.run(
     [sys.argv[2], "--profile", "host-partial", "--finite-stdin", "--", "verify"],
     stdin=slave,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
     env=env,
 )
 os.close(master)
@@ -310,6 +317,7 @@ os.close(slave)
 sys.exit(result.returncode)
 ' "$TEST_PATH" "$LAUNCHER"
   assert_failure
+  assert_output --partial '--finite-stdin requires non-terminal stdin'
   assert_final_not_reached
 }
 
@@ -423,6 +431,114 @@ function test_chezmoi_unattended_012_empty_filtered_target_set_fails_closed() {
   assert_failure
   assert_output --partial 'no non-sensitive managed targets remain'
   assert_final_not_reached
+}
+
+function test_chezmoi_unattended_013_rejects_malformed_launcher_invocations() {
+  _bats_test_init 13 'rejects malformed launcher invocations before final execution'
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$LAUNCHER" --profile host-partial --bogus -- verify
+  assert_failure
+  assert_output --partial 'unknown launcher option before --: --bogus'
+  assert_final_not_reached
+
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$LAUNCHER" --profile host-partial
+  assert_failure
+  assert_output --partial 'launcher options must end with --'
+  assert_final_not_reached
+
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$LAUNCHER" --profile host-partial --
+  assert_failure
+  assert_output --partial 'a chezmoi command is required after --'
+  assert_final_not_reached
+
+  run_host verify
+  assert_success
+  assert_file_exists "$FAKE_STATE/argv"
+}
+
+function test_chezmoi_unattended_014_inventory_requires_exactly_five_fixture_identities() {
+  _bats_test_init 14 'inventory requires exactly five distinct fixture identities'
+  local copied="$BATS_TEST_TMPDIR/copied"
+  mkdir -p "$copied"
+  cp "$LAUNCHER" "$copied/chezmoi-unattended"
+  chmod +x "$copied/chezmoi-unattended"
+
+  # Well-formed row, four distinct identities: only the count gate can reject.
+  printf 'home/dot_a.tmpl\t~/.a\tsecret-template\tomit\tMMS_CHEZMOI_FIXTURE_A,MMS_CHEZMOI_FIXTURE_B,MMS_CHEZMOI_FIXTURE_C,MMS_CHEZMOI_FIXTURE_D\n' \
+    > "$copied/chezmoi-unattended-targets.tsv"
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$copied/chezmoi-unattended" --profile host-partial -- verify
+  assert_failure
+  assert_output --partial 'inventory must register exactly five distinct fixture identities'
+  assert_final_not_reached
+
+  # Six distinct identities: "exactly five" also rejects an over-count.
+  printf 'home/dot_a.tmpl\t~/.a\tsecret-template\tomit\tMMS_CHEZMOI_FIXTURE_A,MMS_CHEZMOI_FIXTURE_B,MMS_CHEZMOI_FIXTURE_C,MMS_CHEZMOI_FIXTURE_D,MMS_CHEZMOI_FIXTURE_E,MMS_CHEZMOI_FIXTURE_F\n' \
+    > "$copied/chezmoi-unattended-targets.tsv"
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$copied/chezmoi-unattended" --profile host-partial -- verify
+  assert_failure
+  assert_output --partial 'inventory must register exactly five distinct fixture identities'
+  assert_final_not_reached
+
+  printf 'home/dot_a.tmpl\t~/.a\tsecret-template\tomit\tMMS_CHEZMOI_FIXTURE_A,MMS_CHEZMOI_FIXTURE_B,MMS_CHEZMOI_FIXTURE_C,MMS_CHEZMOI_FIXTURE_D,MMS_CHEZMOI_FIXTURE_E\n' \
+    > "$copied/chezmoi-unattended-targets.tsv"
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    run "$copied/chezmoi-unattended" --profile host-partial -- verify
+  assert_success
+  assert_file_exists "$FAKE_STATE/argv"
+}
+
+function test_chezmoi_unattended_015_single_oversized_managed_target_fails_closed() {
+  _bats_test_init 15 'host diff fails closed on a single oversized managed target'
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 FAKE_MANAGED_OVERSIZED_TARGET=1 \
+    run "$LAUNCHER" --profile host-partial -- diff --source /tmp/source
+  assert_failure
+  assert_output --partial 'managed target is too long to invoke safely'
+  assert_final_not_reached
+
+  # Control: the default managed targets fit one batch and pass the same gate.
+  run_host diff --source /tmp/source
+  assert_success
+  assert_file_exists "$FAKE_STATE/argv"
+}
+
+function test_chezmoi_unattended_016_managed_failure_propagates_child_status() {
+  _bats_test_init 16 'host diff propagates the managed child status without a final invocation'
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 FAKE_MANAGED_EXIT_STATUS=41 \
+    run "$LAUNCHER" --profile host-partial -- diff --source /tmp/source
+  assert_failure 41
+  assert_final_not_reached
+
+  run_host diff --source /tmp/source
+  assert_success
+  assert_file_exists "$FAKE_STATE/argv"
+}
+
+function test_chezmoi_unattended_017_mid_batch_diff_failure_propagates_and_stops() {
+  _bats_test_init 17 'mid-batch diff failure propagates the child status and stops batching'
+  # 2000 targets need several batches (test 0101 proves >1 final invocation);
+  # every final invocation exits 53, so the first batch must end the launcher.
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 \
+    FAKE_MANAGED_TARGET_COUNT=2000 FAKE_EXIT_STATUS=53 \
+    run "$LAUNCHER" --profile host-partial -- diff --source /tmp/source
+  assert_failure 53
+
+  local final_invocations=0 invocation
+  while IFS= read -r invocation; do
+    [ "$invocation" = final ] && final_invocations=$((final_invocations + 1))
+  done < "$FAKE_STATE/invocations"
+  assert_equal "$final_invocations" 1
+
+  rm -f "$FAKE_STATE/invocations" "$FAKE_STATE/managed-targets" \
+    "$FAKE_STATE/received-targets"
+  PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 FAKE_MANAGED_TARGET_COUNT=2000 \
+    run "$LAUNCHER" --profile host-partial -- diff --source /tmp/source
+  assert_success
+  run cmp "$FAKE_STATE/managed-targets" "$FAKE_STATE/received-targets"
+  assert_success
 }
 
 teardown() {

--- a/tests/bashunit/chezmoi_unattended_test.sh
+++ b/tests/bashunit/chezmoi_unattended_test.sh
@@ -79,7 +79,15 @@ printf '%s' "${FAKE_STDERR:-}" >&2
 if [ -n "${FAKE_SIGNAL_MODE:-}" ]; then
   printf '%s' "$$" > "$FAKE_STATE/pid"
   trap 'printf term > "$FAKE_STATE/signal"; exit 143' TERM
-  while :; do sleep 1; done
+  # Bounded wait: an undelivered TERM must fail this fake (exit 143, same
+  # status as the trap but without the signal marker) instead of hanging the
+  # suite forever.
+  signal_wait_iterations=0
+  while [ "$signal_wait_iterations" -lt 30 ]; do
+    sleep 1
+    signal_wait_iterations=$((signal_wait_iterations + 1))
+  done
+  exit 143
 fi
 exit "${FAKE_EXIT_STATUS:-0}"
 FAKE_CHEZMOI
@@ -323,16 +331,23 @@ function test_chezmoi_unattended_009_exec_propagates_signals_to_the_child() {
   PATH="$TEST_PATH" MMS_CHEZMOI_UNATTENDED=1 FAKE_SIGNAL_MODE=1 \
     "$LAUNCHER" --profile host-partial -- verify \
     > "$BATS_TEST_TMPDIR/signal.out" 2>&1 &
-  local launcher_pid=$! attempts=0 rc
-  while [ ! -f "$FAKE_STATE/pid" ] && [ "$attempts" -lt 100 ]; do
-    sleep 0.01
-    attempts=$((attempts + 1))
+  # Global, not local: teardown must still see the pid when an assertion below
+  # exits the body mid-test, or the backgrounded fake outlives the test
+  # (docs/solutions/design-patterns/outliving-processes-hang-the-suite.md).
+  SIGNAL_LAUNCHER_PID=$!
+  local rc deadline=$((SECONDS + 10))
+  # Elapsed-time hang guard with a fast poll: the pid file lands in
+  # milliseconds when healthy, but a loaded machine gets a real budget
+  # (docs/solutions/design-patterns/idle-machine-wall-clock-bounds-are-latent-flakes.md).
+  while [ ! -f "$FAKE_STATE/pid" ] && [ "$SECONDS" -lt "$deadline" ]; do
+    sleep 0.05
   done
   assert_file_exists "$FAKE_STATE/pid"
-  assert_equal "$(< "$FAKE_STATE/pid")" "$launcher_pid"
-  kill -TERM "$launcher_pid"
+  assert_equal "$(< "$FAKE_STATE/pid")" "$SIGNAL_LAUNCHER_PID"
+  kill -TERM "$SIGNAL_LAUNCHER_PID"
   rc=0
-  wait "$launcher_pid" || rc=$?
+  wait "$SIGNAL_LAUNCHER_PID" || rc=$?
+  SIGNAL_LAUNCHER_PID=""
   assert_equal "$rc" 143
   assert_equal "$(< "$FAKE_STATE/signal")" term
 }
@@ -408,6 +423,18 @@ function test_chezmoi_unattended_012_empty_filtered_target_set_fails_closed() {
   assert_failure
   assert_output --partial 'no non-sensitive managed targets remain'
   assert_final_not_reached
+}
+
+teardown() {
+  # Failure-path cleanup for test 009: an assertion exiting the body between
+  # launch and kill must not orphan the backgrounded launcher (the fake execs
+  # in its place, so killing this pid kills the fake too). Green path clears
+  # the variable after reaping, making this a no-op.
+  if [ -n "${SIGNAL_LAUNCHER_PID:-}" ]; then
+    kill -TERM "$SIGNAL_LAUNCHER_PID" 2>/dev/null || true
+    wait "$SIGNAL_LAUNCHER_PID" 2>/dev/null || true
+    SIGNAL_LAUNCHER_PID=""
+  fi
 }
 
 function set_up_before_script() {

--- a/tests/bashunit/herdr_pane_labels_descriptor_probe_test.sh
+++ b/tests/bashunit/herdr_pane_labels_descriptor_probe_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # post-apply: excluded
+# Inner half of a two-part probe: test_scripts_1103 in scripts_test.sh drives
+# this file under a nested tests/lib/bashunit invocation and owns its oracle.
 source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
 _bats_file_init "${BASH_SOURCE[0]}"
 
@@ -32,3 +34,7 @@ function test_herdr_pane_labels_descriptor_001_herdr_pane_labels_descriptor_chil
   run test -s "$HPL_DESCRIPTOR_PID_FILE"
   assert_success
 }
+
+function tear_down() { _bats_run_teardown; }
+
+function tear_down_after_script() { _bats_file_cleanup; }

--- a/tests/bashunit/idempotent_test.sh
+++ b/tests/bashunit/idempotent_test.sh
@@ -295,7 +295,7 @@ function test_idempotent_013_guard_the_misconfigured_message_names_the_marker() 
   if [[ -d "$repo_root/.github" ]]; then
     while IFS= read -r rel; do
       assert_file_exists "$repo_root/$rel"
-      grep -qE 'MMS_DISPOSABLE_HOME[=:][[:space:]]*"?1"?' "$repo_root/$rel" || \
+      grep -qE "MMS_DISPOSABLE_HOME[=:][[:space:]]*[\"']?1[\"']?" "$repo_root/$rel" || \
         fail "$rel is named as a site that declares MMS_DISPOSABLE_HOME=1, but does not set it"
     done <<< "$named"
   fi

--- a/tests/bashunit/morning_cleanup_test.sh
+++ b/tests/bashunit/morning_cleanup_test.sh
@@ -69,6 +69,10 @@ function test_morning_cleanup_001_purge_removes_entries_past_the_age_threshold()
   _bats_test_init 1 'trash purge removes entries past the age threshold'
   # ctime cannot be backdated (touch -t rewrites it to now), so staleness is
   # simulated by lowering the threshold to 0 instead of aging the entry.
+  # Honest limit: this exercises the purge machinery, not the production
+  # `-ctime +N` comparison itself -- no fixture can age past a day-granular
+  # threshold, so a wrong sign or unit there is only caught by test 002
+  # refusing to over-delete, never by a positive aged-removal proof.
   mkdir -p "$FAKE_HOME/.scratchpad/stale-entry"
   printf 'x' > "$FAKE_HOME/.scratchpad/stale-entry/file"
   printf 'y' > "$FAKE_HOME/.scratchpad/stale-file"

--- a/tests/bashunit/morning_cleanup_test.sh
+++ b/tests/bashunit/morning_cleanup_test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# post-apply: 25 host-safe
+# morning-cleanup destructive legs (trash purge, platform worktree/branch
+# cleanup), run against the SOURCE script under a disposable $HOME — both
+# roots the script touches derive from $HOME, so the override isolates them.
+# Oracle: resulting filesystem state and git's own reports (worktree list,
+# branch --list); no assertion inspects the script's source.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+load 'helpers/common'
+
+setup() {
+  SCRIPT="$SOURCE_ROOT/dot_local/bin/executable_morning-cleanup.sh"
+  FAKE_HOME="$BATS_TEST_TMPDIR/mc-home"
+  mkdir -p "$FAKE_HOME"
+  # Resolved path: git prints worktrees resolved, and the script compares the
+  # main checkout by string equality against $HOME-derived paths.
+  FAKE_HOME="$(cd "$FAKE_HOME" && pwd -P)"
+}
+
+# Extra VAR=VALUE arguments are forwarded into the script's environment.
+run_cleanup() {
+  run env HOME="$FAKE_HOME" MORNING_CLEANUP_NO_NOTIFY=1 "$@" bash "$SCRIPT"
+}
+
+# Fixture git must not read the invoking user's real ~/.gitconfig (gpg
+# signing, hooks templates would break commits in CI-less environments).
+fgit() {
+  env HOME="$FAKE_HOME" GIT_CONFIG_NOSYSTEM=1 git "$@"
+}
+
+# Bare origin + platform clone-equivalent checkout on main, three worktrees:
+# merged-clean (tip == origin/main, clean), unmerged (commit ahead of
+# origin/main), dirty-merged (tip == origin/main, untracked file).
+build_platform_fixture() {
+  PLATFORM="$FAKE_HOME/Projects/platform"
+  ORIGIN="$FAKE_HOME/origin.git"
+  WT_MERGED="$FAKE_HOME/Projects/platform-wt-merged"
+  WT_UNMERGED="$FAKE_HOME/Projects/platform-wt-unmerged"
+  WT_DIRTY="$FAKE_HOME/Projects/platform-wt-dirty"
+
+  mkdir -p "$FAKE_HOME/Projects"
+  fgit init -q "$PLATFORM"
+  fgit -C "$PLATFORM" config user.name "Morning Cleanup Test"
+  fgit -C "$PLATFORM" config user.email mc@example.invalid
+  fgit -C "$PLATFORM" config commit.gpgsign false
+  fgit -C "$PLATFORM" checkout -q -b main
+  printf 'base\n' > "$PLATFORM/base.txt"
+  fgit -C "$PLATFORM" add base.txt
+  fgit -C "$PLATFORM" commit -q -m 'base commit'
+  fgit init -q --bare "$ORIGIN"
+  fgit -C "$PLATFORM" remote add origin "$ORIGIN"
+  fgit -C "$PLATFORM" push -q origin main
+  # The script's own fetch tolerates failure; the fixture must guarantee
+  # refs/remotes/origin/main exists regardless.
+  fgit -C "$PLATFORM" fetch -q origin
+
+  fgit -C "$PLATFORM" worktree add -q -b merged-clean "$WT_MERGED"
+  fgit -C "$PLATFORM" worktree add -q -b unmerged "$WT_UNMERGED"
+  printf 'ahead\n' > "$WT_UNMERGED/ahead.txt"
+  fgit -C "$WT_UNMERGED" add ahead.txt
+  fgit -C "$WT_UNMERGED" commit -q -m 'unmerged commit'
+  fgit -C "$PLATFORM" worktree add -q -b dirty-merged "$WT_DIRTY"
+  printf 'dirt\n' > "$WT_DIRTY/untracked.txt"
+}
+
+function test_morning_cleanup_001_purge_removes_entries_past_the_age_threshold() {
+  _bats_test_init 1 'trash purge removes entries past the age threshold'
+  # ctime cannot be backdated (touch -t rewrites it to now), so staleness is
+  # simulated by lowering the threshold to 0 instead of aging the entry.
+  mkdir -p "$FAKE_HOME/.scratchpad/stale-entry"
+  printf 'x' > "$FAKE_HOME/.scratchpad/stale-entry/file"
+  printf 'y' > "$FAKE_HOME/.scratchpad/stale-file"
+
+  run_cleanup MORNING_CLEANUP_TRASH_MAX_AGE_DAYS=0
+  assert_success
+  assert_dir_not_exists "$FAKE_HOME/.scratchpad/stale-entry"
+  assert_file_not_exists "$FAKE_HOME/.scratchpad/stale-file"
+  # -mindepth 1 contract: the trash root itself survives the purge.
+  assert_dir_exists "$FAKE_HOME/.scratchpad"
+  # Completion proof for the keep-control below: the same stamp shows the
+  # default-threshold run also reached the end, not that it crashed early.
+  assert_file_exists "$FAKE_HOME/.local/state/morning-cleanup/last-run"
+}
+
+function test_morning_cleanup_002_default_threshold_keeps_a_fresh_entry() {
+  _bats_test_init 2 'default age threshold keeps a fresh trash entry (purge control)'
+  mkdir -p "$FAKE_HOME/.scratchpad/fresh-entry"
+  printf 'x' > "$FAKE_HOME/.scratchpad/fresh-entry/file"
+
+  run_cleanup
+  assert_success
+  assert_file_exists "$FAKE_HOME/.local/state/morning-cleanup/last-run"
+  assert_dir_exists "$FAKE_HOME/.scratchpad/fresh-entry"
+  assert_file_exists "$FAKE_HOME/.scratchpad/fresh-entry/file"
+}
+
+function test_morning_cleanup_003_git_cleanup_removes_only_merged_clean() {
+  _bats_test_init 3 'git cleanup removes only the merged-clean worktree and branch'
+  build_platform_fixture
+
+  run_cleanup
+  assert_success
+
+  run fgit -C "$PLATFORM" worktree list --porcelain
+  assert_success
+  # Positive control first: degenerate output cannot satisfy the refute.
+  assert_output --partial "worktree $WT_UNMERGED"
+  assert_output --partial "worktree $WT_DIRTY"
+  refute_output --partial "worktree $WT_MERGED"
+  assert_dir_not_exists "$WT_MERGED"
+  assert_dir_exists "$WT_UNMERGED"
+  assert_dir_exists "$WT_DIRTY"
+  assert_file_exists "$WT_DIRTY/untracked.txt"
+
+  run fgit -C "$PLATFORM" branch --list
+  assert_success
+  assert_output --partial "main"
+  assert_output --partial "unmerged"
+  assert_output --partial "dirty-merged"
+  refute_output --partial "merged-clean"
+
+  # The main checkout itself is never a cleanup candidate.
+  assert_dir_exists "$PLATFORM"
+  assert_file_exists "$PLATFORM/base.txt"
+}
+
+function set_up_before_script() {
+  :
+}
+
+function tear_down_after_script() {
+  _bats_file_cleanup
+}
+
+function tear_down() { _bats_run_teardown; }

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1535,6 +1535,112 @@ PY
   assert_success
 }
 
+# ===========================================
+# smart_close -- Cmd-W closes pane, then tab, never the workspace
+# ===========================================
+
+# A `herdr` for smart_close.py that logs its argv and answers the two JSON
+# queries the script makes. TABS_JSON is the `tabs` array verbatim; the
+# sentinel `unreachable` makes `pane current` fail so the error path runs.
+# oracle: the argv log the stub writes -- independent of smart_close.py.
+smart_close_stub_herdr() {
+  local dir="$1" tabs_json="$2"
+  mkdir -p "$dir"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'LOG=%s/herdr.log\n' "$dir"
+    printf 'TABS=%s\n' "$(printf '%q' "$tabs_json")"
+  } > "$dir/herdr"
+  cat >> "$dir/herdr" <<'SH'
+printf '%s\n' "$*" >> "$LOG"
+case "$1 $2" in
+  "pane current")
+    [ "$TABS" = "unreachable" ] && exit 1
+    printf '{"result":{"pane":{"pane_id":"w1:p1","tab_id":"w1:t1","workspace_id":"w1"}}}\n' ;;
+  "tab list") printf '{"result":{"tabs":%s}}\n' "$TABS" ;;
+  "pane close") : ;;
+  "tab close") : ;;
+  "notification show") : ;;
+  *) exit 2 ;;
+esac
+exit 0
+SH
+  chmod +x "$dir/herdr"
+}
+
+run_smart_close() {
+  env HERDR_BIN_PATH="$1/herdr" python3 "$PALETTE_DIR/smart_close.py"
+}
+
+function test_palette_067_smart_close_closes_the_focused_pane_when_the_tab() {
+  _bats_test_init 67 'smart close closes the focused pane when the tab has more than one'
+  smart_close_stub_herdr "$PALETTE_WORK/sc-panes" \
+    '[{"tab_id":"w1:t1","pane_count":2},{"tab_id":"w1:t2","pane_count":1}]'
+  run run_smart_close "$PALETTE_WORK/sc-panes"
+  assert_success
+
+  run cat "$PALETTE_WORK/sc-panes/herdr.log"
+  assert_success
+  assert_line "pane close w1:p1"
+  refute_output --partial "tab close"
+  refute_output --partial "notification show"
+}
+
+function test_palette_068_smart_close_closes_the_tab_when_it_holds_the_last() {
+  _bats_test_init 68 'smart close closes the tab when it holds the last pane but tabs remain'
+  smart_close_stub_herdr "$PALETTE_WORK/sc-tabs" \
+    '[{"tab_id":"w1:t1","pane_count":1},{"tab_id":"w1:t2","pane_count":1}]'
+  run run_smart_close "$PALETTE_WORK/sc-tabs"
+  assert_success
+
+  run cat "$PALETTE_WORK/sc-tabs/herdr.log"
+  assert_success
+  assert_line "tab close w1:t1"
+  refute_output --partial "pane close"
+  refute_output --partial "notification show"
+}
+
+# Tests 067/068 are the valid controls proving the stub reaches the close
+# paths; here the same stub must record no close at all.
+function test_palette_069_smart_close_refuses_the_last_tab_and_notifies() {
+  _bats_test_init 69 'smart close refuses to close the last tab and notifies instead'
+  smart_close_stub_herdr "$PALETTE_WORK/sc-last" \
+    '[{"tab_id":"w1:t1","pane_count":1}]'
+  run run_smart_close "$PALETTE_WORK/sc-last"
+  assert_success
+
+  run cat "$PALETTE_WORK/sc-last/herdr.log"
+  assert_success
+  refute_output --partial "pane close"
+  refute_output --partial "tab close"
+  assert_output --partial "notification show Keeping last tab"
+}
+
+function test_palette_070_smart_close_reports_a_failing_or_garbled_herdr() {
+  _bats_test_init 70 'smart close reports a failing or garbled herdr and closes nothing'
+  # A `pane current` that fails outright.
+  smart_close_stub_herdr "$PALETTE_WORK/sc-broken" 'unreachable'
+  run run_smart_close "$PALETTE_WORK/sc-broken"
+  assert_failure
+
+  run cat "$PALETTE_WORK/sc-broken/herdr.log"
+  assert_success
+  refute_output --partial "pane close"
+  refute_output --partial "tab close"
+  assert_output --partial "notification show Smart close failed"
+
+  # A `tab list` answering garbage instead of JSON.
+  smart_close_stub_herdr "$PALETTE_WORK/sc-garbled" 'garbage'
+  run run_smart_close "$PALETTE_WORK/sc-garbled"
+  assert_failure
+
+  run cat "$PALETTE_WORK/sc-garbled/herdr.log"
+  assert_success
+  refute_output --partial "pane close"
+  refute_output --partial "tab close"
+  assert_output --partial "notification show Smart close failed"
+}
+
 function set_up_before_script() {
   PALETTE_FILE_PYCACHE="$(mktemp -d "${BATS_TMPDIR:-/tmp}/palette-pycache.XXXXXX")"
   export PALETTE_FILE_PYCACHE

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -20,8 +20,8 @@ REAL_COMMANDS="$SOURCE_ROOT/private_dot_config/herdr/command-palette/commands.to
 
 setup() {
   # No `command_exists python3 || skip` here. python3 is a declared requirement
-  # (README.md, Requirements), so its absence must fail rather than silence all
-  # 58 tests in this file from inside setup(). Deliberate exception to the
+  # (README.md, Requirements), so its absence must fail rather than silence
+  # every test in this file from inside setup(). Deliberate exception to the
   # skip-on-missing-tool convention; the first test below names the cause.
   export PALETTE_PY="$PALETTE_DIR/palette.py"
   export PALETTE_OPEN_PY="$PALETTE_DIR/open.py"
@@ -360,104 +360,130 @@ rank_real() {
   rank_in "$REAL_COMMANDS" "$1"
 }
 
-function test_palette_016_r1_lg_ranks_lazygit_in_popup_first() {
-  _bats_test_init 16 'R1: lg ranks Lazygit in popup first'
-  run rank_real lg
+# The title-tier match sits first in the file, so file order alone cannot
+# produce the expected ranking -- only a working shortcut tier can. "Popup git"
+# contains no `l`, so a dead shortcut tier cannot be rescued by a fuzzy title
+# hit either: "lg viewer" would take index 0 instead.
+function test_palette_016_r10_the_shortcut_tier_outranks_the_title_tier() {
+  _bats_test_init 16 'R10: the shortcut tier outranks the title tier'
+  cat > "$PALETTE_WORK/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "lg viewer"
+type = "shell"
+command = "true"
+
+[[commands]]
+group = "Fixture"
+title = "Popup git"
+type = "shell"
+command = "true"
+shortcuts = ["lg"]
+TOML
+
+  run rank_in "$PALETTE_WORK/commands.toml" lg
   assert_success
-  assert_line --index 0 "Lazygit in popup"
+  assert_line --index 0 "Popup git"
+  assert_line --index 1 "lg viewer"
 }
 
-function test_palette_017_r1_ws_ranks_switch_workspace_first() {
-  _bats_test_init 17 'R1: ws ranks Switch workspace first'
-  run rank_real ws
+# The title shares no fuzzy subsequence with the query, so only the shortcut
+# prefix can produce this hit -- an empty result is the regression.
+function test_palette_017_r10_a_half_typed_shortcut_still_matches_by_prefi() {
+  _bats_test_init 17 'R10: a half-typed shortcut still matches by prefix'
+  cat > "$PALETTE_WORK/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Ship the crate"
+type = "shell"
+command = "true"
+shortcuts = ["deploy"]
+TOML
+
+  run rank_in "$PALETTE_WORK/commands.toml" dep
   assert_success
-  assert_line --index 0 "Switch workspace"
+  assert_line --index 0 "Ship the crate"
 }
 
-function test_palette_018_r1_edit_ranks_edit_command_palette_config_first() {
-  _bats_test_init 18 'R1: edit ranks Edit command palette config first'
-  run rank_real edit
+function test_palette_018_r1_r10_shortcut_and_title_matching_both_fold_cas() {
+  _bats_test_init 18 'R1+R10: shortcut and title matching both fold case'
+  cat > "$PALETTE_WORK/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Popup git"
+type = "shell"
+command = "true"
+shortcuts = ["lg"]
+
+[[commands]]
+group = "Fixture"
+title = "Deploy the widget"
+type = "shell"
+command = "true"
+TOML
+
+  # Shortcut tier: without case folding "LG" hits no shortcut, and the title
+  # tier would then rank "Deploy the widget" (l...g subsequence) at index 0.
+  run rank_in "$PALETTE_WORK/commands.toml" LG
   assert_success
-  assert_line --index 0 "Edit command palette config"
+  assert_line --index 0 "Popup git"
+
+  # Title tier: fzf defaults to smart case, so an uppercase query turns
+  # matching case-sensitive unless the ranker passes -i.
+  run rank_in "$PALETTE_WORK/commands.toml" WIDGET
+  assert_success
+  assert_line --index 0 "Deploy the widget"
 }
 
-function test_palette_019_r1_zed_ranks_open_in_zed_first_and_returns_only() {
-  _bats_test_init 19 'R1: zed ranks Open in Zed first, and returns only it'
-  run rank_real zed
+# shortcut_rank gives an exact shortcut 0 and a prefix hit 1; file order breaks
+# ties only within a rank. The prefix owner sits first in the file, so ordering
+# alone cannot mask an inverted or flattened tier.
+function test_palette_019_r10_an_exact_shortcut_outranks_a_prefix_shortcut() {
+  _bats_test_init 19 'R10: an exact shortcut outranks a command whose shortcut it merely prefixes'
+  cat > "$PALETTE_WORK/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Prefix owner"
+type = "shell"
+command = "true"
+shortcuts = ["lgx"]
+
+[[commands]]
+group = "Fixture"
+title = "Exact owner"
+type = "shell"
+command = "true"
+shortcuts = ["lg"]
+TOML
+
+  run rank_in "$PALETTE_WORK/commands.toml" lg
   assert_success
-  assert_line --index 0 "Open in Zed"
-  assert_equal "${#lines[@]}" 1
+  assert_line --index 0 "Exact owner"
+  assert_line --index 1 "Prefix owner"
 }
 
-function test_palette_020_r1_main_ranks_merge_main_branch_first() {
-  _bats_test_init 20 'R1: main ranks Merge main branch first'
-  run rank_real main
+# Replaces the pinned-title tests that copied shortcuts and titles out of
+# commands.toml -- editing the config rewrote those expectations in the same
+# patch. Here the two sides stay independent: the operator's `shortcuts`
+# declarations, read from the deployed config at run time, against what the
+# ranker actually puts first. A new, renamed, or reassigned shortcut is
+# covered the moment it lands, including the Cyrillic ЙЦУКЕН-layout entries.
+function test_palette_020_r10_every_shortcut_declared_in_commands_toml_ran() {
+  _bats_test_init 20 'R10: every shortcut declared in commands.toml ranks its own command first'
+  run env HERDR_COMMAND_PALETTE_CONFIG="$REAL_COMMANDS" python3 - <<'PY'
+import palette_boot
+
+palette = palette_boot.palette()
+_, commands = palette.load_commands()
+declared = [(shortcut, command) for command in commands for shortcut in command.shortcuts]
+assert declared, "commands.toml declares no shortcuts; the shortcut tier has no production coverage"
+for shortcut, command in declared:
+    top = palette.ranked(shortcut, commands, palette.DEFAULT_LIMIT)
+    assert top and top[0] is command, (shortcut, command.title, [c.title for c in top])
+print(f"checked {len(declared)} shortcuts")
+PY
   assert_success
-  assert_line --index 0 "Merge main branch"
-}
-
-function test_palette_021_r1_lazy_ranks_lazygit_in_popup_first() {
-  _bats_test_init 21 'R1: lazy ranks Lazygit in popup first'
-  run rank_real lazy
-  assert_success
-  assert_line --index 0 "Lazygit in popup"
-}
-
-function test_palette_022_r10_the_cyrillic_shortcuts_rank_their_command_fi() {
-  _bats_test_init 22 'R10: the Cyrillic shortcuts rank their command first'
-  run rank_real "дп"
-  assert_success
-  assert_line --index 0 "Lazygit in popup"
-  # No title contains Cyrillic, so the fzf tier adds nothing.
-  assert_equal "${#lines[@]}" 1
-
-  run rank_real "дфян"
-  assert_success
-  assert_line --index 0 "Lazygit in popup"
-
-  run rank_real "цы"
-  assert_success
-  assert_line --index 0 "Switch workspace"
-
-  run rank_real "яув"
-  assert_success
-  assert_line --index 0 "Open in Zed"
-
-  run rank_real "увше"
-  assert_success
-  assert_line --index 0 "Edit command palette config"
-}
-
-# fzf defaults to smart case, so an uppercase letter would switch the title tier
-# to case-sensitive matching while the shortcut tier keeps case-folding.
-function test_palette_023_r1_the_title_tier_is_case_insensitive() {
-  _bats_test_init 23 'R1: the title tier is case-insensitive'
-  local upper lower
-  for lower in main config workspace lazy; do
-    upper="$(printf '%s' "$lower" | tr '[:lower:]' '[:upper:]')"
-    run rank_real "$lower"
-    assert_success
-    lower_out="$output"
-
-    run rank_real "$upper"
-    assert_success
-    assert_equal "$output" "$lower_out"
-    refute_output ""
-  done
-}
-
-function test_palette_024_r10_a_half_typed_shortcut_still_matches_by_prefi() {
-  _bats_test_init 24 'R10: a half-typed shortcut still matches by prefix'
-  run rank_real "дфя"
-  assert_success
-  assert_line --index 0 "Lazygit in popup"
-}
-
-function test_palette_025_r10_shortcut_matching_is_case_insensitive() {
-  _bats_test_init 25 'R10: shortcut matching is case-insensitive'
-  run rank_real "LG"
-  assert_success
-  assert_line --index 0 "Lazygit in popup"
+  assert_output --partial "checked"
 }
 
 function test_palette_026_r10_a_decoy_title_cannot_displace_a_shortcut_hit() {
@@ -742,36 +768,28 @@ print("flat_last_visible", int(start <= 40 < start + max_visible))
 PY
 }
 
-function test_palette_034_r3_every_command_is_reachable_at_40_commands_in() {
-  _bats_test_init 34 'R3: every command is reachable at 40 commands in 8 groups'
+# One test, one subprocess: scroll_fixture prints every probe in a single run,
+# so splitting these assertions across tests only repeated that run.
+function test_palette_034_r3_scrolling_keeps_every_command_reachable_and_o() {
+  _bats_test_init 34 'R3: scrolling keeps every command reachable and off the description line'
   run scroll_fixture
   assert_success
+
+  # Every command reachable at 40 commands in 8 groups.
   assert_line "visible 40"
   assert_line "reachable 40"
-}
 
-function test_palette_035_r3_the_last_drawn_row_never_reaches_the_descript() {
-  _bats_test_init 35 'R3: the last drawn row never reaches the description line'
-  run scroll_fixture
-  assert_success
+  # The last drawn row never reaches the description line.
   local lowest detail
   lowest="$(printf '%s\n' "$output" | awk '/^lowest_drawn /{print $2}')"
   detail="$(printf '%s\n' "$output" | awk '/^detail_y /{print $2}')"
   [ "$lowest" -lt "$detail" ]
-}
 
-function test_palette_036_r3_ten_commands_still_render_unscrolled() {
-  _bats_test_init 36 'R3: ten commands still render unscrolled'
-  run scroll_fixture
-  assert_success
+  # Ten commands still render unscrolled.
   assert_line "ten_start 0"
   assert_line "ten_fits 1"
-}
 
-function test_palette_037_r3_a_single_group_with_no_extra_headers_still_sc() {
-  _bats_test_init 37 'R3: a single group with no extra headers still scrolls'
-  run scroll_fixture
-  assert_success
+  # A single group with no extra headers still scrolls to the last command.
   assert_line "flat_last_visible 1"
 }
 

--- a/tests/bashunit/palette_test.sh
+++ b/tests/bashunit/palette_test.sh
@@ -1659,6 +1659,160 @@ function test_palette_070_smart_close_reports_a_failing_or_garbled_herdr() {
   assert_output --partial "notification show Smart close failed"
 }
 
+# ===========================================
+# run paths -- plugin_action, plain shell append, pane_run precondition
+# ===========================================
+
+# Run the command with the given title from $dir/commands.toml against the
+# argv-logging stub from palette_worktree_stub. One argument per line in the
+# log is what makes quoting and flag boundaries observable.
+run_palette_title() {
+  local dir="$1" title="$2"
+  env HERDR_BIN_PATH="$dir/bin/herdr" HERDR_TARGET_CWD="$dir" \
+    HERDR_COMMAND_PALETTE_CONFIG="$dir/commands.toml" \
+    PALETTE_COMMAND_TITLE="$title" python3 - <<'PY'
+import os
+
+import palette_boot
+
+palette = palette_boot.palette()
+config_path, commands = palette.load_commands()
+command = next(c for c in commands if c.title == os.environ["PALETTE_COMMAND_TITLE"])
+code, output, _ = palette.run_command(command, config_path)
+print(f"code={code}")
+print(output)
+PY
+}
+
+function test_palette_071_plugin_action_hands_herdr_the_action_id() {
+  _bats_test_init 71 'plugin_action hands herdr the action id, adding --plugin only when configured'
+  local fixture="$PALETTE_WORK/plugin-action"
+  mkdir -p "$fixture"
+  palette_worktree_stub "$fixture"
+  cat > "$fixture/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Bare action"
+type = "plugin_action"
+action = "toggle_thing"
+
+[[commands]]
+group = "Fixture"
+title = "Scoped action"
+type = "plugin_action"
+action = "toggle_thing"
+plugin = "seigi.other"
+TOML
+
+  run run_palette_title "$fixture" "Bare action"
+  assert_success
+  assert_line "code=0"
+
+  run cat "$fixture/herdr.log"
+  assert_success
+  assert_line --index 0 "plugin"
+  assert_line --index 1 "action"
+  assert_line --index 2 "invoke"
+  assert_line --index 3 "toggle_thing"
+  # The scoped run below is the positive control proving the stub log would
+  # show --plugin if the palette sent it.
+  refute_output --partial -- "--plugin"
+
+  : > "$fixture/herdr.log"
+  run run_palette_title "$fixture" "Scoped action"
+  assert_success
+  assert_line "code=0"
+
+  run cat "$fixture/herdr.log"
+  assert_success
+  assert_line --index 3 "toggle_thing"
+  assert_line --index 4 -- "--plugin"
+  assert_line --index 5 "seigi.other"
+}
+
+function test_palette_072_a_shell_command_appends_the_value_as_one_inert_ar() {
+  _bats_test_init 72 'a shell command appends the form value as one inert argument'
+  local work="$PALETTE_WORK/shell-append"
+  mkdir -p "$work"
+  cat > "$work/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Echo it"
+type = "shell"
+command = "printf '%s\n'"
+TOML
+
+  # If append_value's runtime quoting broke, bash would run the text after the
+  # semicolon and create the marker instead of printing the string.
+  local hostile="a b; touch $work/PWNED #"
+  run env HERDR_TARGET_CWD="$work" HERDR_COMMAND_PALETTE_CONFIG="$work/commands.toml" \
+    PALETTE_COMMAND_VALUE="$hostile" python3 - <<'PY'
+import os
+
+import palette_boot
+
+palette = palette_boot.palette()
+config_path, commands = palette.load_commands()
+command = next(c for c in commands if c.title == "Echo it")
+variables = palette.variables_with_value(
+    palette.context_vars(config_path), os.environ["PALETTE_COMMAND_VALUE"]
+)
+code, output, _ = palette.run_command_with_variables(
+    command, config_path, variables, os.environ.get("HERDR_BIN_PATH", "herdr")
+)
+print(f"code={code}")
+print(output)
+PY
+  assert_success
+  assert_line "code=0"
+  # Positive control for the marker refutation below: the hostile text came
+  # back verbatim on one line, so it reached printf as a single argument.
+  assert_line "$hostile"
+
+  # oracle: only the injected `touch` can create this marker, so its absence
+  # is the observable proof that the appended value stayed inert.
+  if [[ -e "$work/PWNED" ]]; then
+    fail "the appended value ran a command"
+  fi
+}
+
+function test_palette_073_pane_run_without_a_target_pane_is_refused_before() {
+  _bats_test_init 73 'pane_run without a target pane refuses with guidance and never reaches herdr'
+  local dir="$PALETTE_WORK/no-target-pane"
+  stub_herdr "$dir" 'null'
+  cat > "$dir/commands.toml" <<'TOML'
+[[commands]]
+group = "Fixture"
+title = "Edit in place"
+type = "pane_run"
+command = "vi /tmp/x"
+TOML
+
+  # test_palette_039 is the paired positive control: the same stub with
+  # HERDR_TARGET_PANE_ID set reaches `pane run` and writes the log.
+  run env -u HERDR_TARGET_PANE_ID HERDR_BIN_PATH="$dir/herdr" HERDR_TARGET_CWD="$dir" \
+    HERDR_COMMAND_PALETTE_CONFIG="$dir/commands.toml" python3 - <<'PY'
+import palette_boot
+
+palette = palette_boot.palette()
+config_path, commands = palette.load_commands()
+command = next(c for c in commands if c.kind == "pane_run")
+try:
+    palette.run_command(command, config_path)
+except ValueError as exc:
+    print(f"refused: {exc}")
+else:
+    raise SystemExit("pane_run ran without a target pane")
+PY
+  assert_success
+  assert_output --partial "refused:"
+  assert_output --partial "No target pane found"
+
+  # oracle: the stub logs every invocation, so a missing log proves herdr was
+  # never called on the refusal path.
+  [ ! -e "$dir/herdr.log" ]
+}
+
 function set_up_before_script() {
   PALETTE_FILE_PYCACHE="$(mktemp -d "${BATS_TMPDIR:-/tmp}/palette-pycache.XXXXXX")"
   export PALETTE_FILE_PYCACHE

--- a/tests/bashunit/platform_test.sh
+++ b/tests/bashunit/platform_test.sh
@@ -17,17 +17,43 @@ setup() {
 # .chezmoiignore platform filtering
 # ===========================================
 
+# Entries of one platform block in home/.chezmoiignore: the lines between the
+# given template guard and its {{ end }}, minus comments, blanks, and the
+# '/**' content globs (the bare directory entry already names the target).
+# Deriving the list at runtime keeps two independent sides — the ignore file's
+# own claim vs chezmoi's managed evaluation — so a newly added platform-only
+# path is covered without editing this test.
+chezmoiignore_block_entries() {
+  local guard="$1"
+  awk -v guard="$guard" '
+    index($0, guard) { in_block = 1; next }
+    /\{\{ end \}\}/ { in_block = 0 }
+    in_block { sub(/[[:space:]]+$/, ""); print }
+  ' "$SOURCE_ROOT/.chezmoiignore" | grep -v -e '^#' -e '^$' -e '/\*\*$'
+}
+
+darwin_only_entries() {
+  chezmoiignore_block_entries '{{ if ne .chezmoi.os "darwin" }}'
+}
+
+linux_only_entries() {
+  chezmoiignore_block_entries '{{ if ne .chezmoi.os "linux" }}'
+}
+
 function test_platform_001_chezmoiignore_filters_macos_files_on_linux() {
   _bats_test_init 1 'chezmoiignore filters macOS files on Linux'
   is_linux || skip "Only relevant on Linux"
   run chezmoi_host_partial managed --source "$SOURCE_ROOT"
   assert_success
-  refute_output --partial ".hammerspoon"
-  refute_output --partial "Library"
-  refute_output --partial ".config/ghostty"
-  refute_output --partial ".config/kitty"
-  refute_output --partial ".config/karabiner"
-  refute_output --partial ".config/zed"
+  # Positive cross-platform control: degenerate or empty managed output
+  # cannot satisfy the refutes below by accident.
+  assert_output --partial ".zshenv"
+  local entries entry
+  entries="$(darwin_only_entries)"
+  [ -n "$entries" ] || fail "no entries derived from the darwin block of .chezmoiignore"
+  while IFS= read -r entry; do
+    refute_output --partial "$entry"
+  done <<< "$entries"
 }
 
 function test_platform_002_chezmoiignore_includes_macos_files_on_macos() {
@@ -35,11 +61,41 @@ function test_platform_002_chezmoiignore_includes_macos_files_on_macos() {
   is_macos || skip "Only relevant on macOS"
   run chezmoi_host_partial managed --source "$SOURCE_ROOT"
   assert_success
-  assert_output --partial ".hammerspoon"
-  assert_output --partial ".config/ghostty"
-  assert_output --partial ".config/kitty"
-  assert_output --partial ".config/karabiner"
-  assert_output --partial ".config/zed"
+  local entries entry source_listing name asserted=0
+  entries="$(darwin_only_entries)"
+  [ -n "$entries" ] || fail "no entries derived from the darwin block of .chezmoiignore"
+  # An ignore entry with no file in the source tree (e.g. .config/karabiner.edn)
+  # cannot appear in managed output on any platform; checking the raw tree —
+  # not chezmoi's evaluation — keeps the sides independent, so a broken guard
+  # that wrongly ignores real entries on macOS still fails the assert below.
+  source_listing="$(find "$SOURCE_ROOT" -mindepth 1)"
+  while IFS= read -r entry; do
+    name="${entry##*/}"
+    name="${name#.}"
+    case "$source_listing" in
+      *"$name"*)
+        assert_output --partial "$entry"
+        asserted=$((asserted + 1))
+        ;;
+    esac
+  done <<< "$entries"
+  [ "$asserted" -gt 0 ] || fail "every darwin-block entry was treated as sourceless; the source-listing check is broken"
+}
+
+function test_platform_003_chezmoiignore_filters_linux_files_on_macos() {
+  _bats_test_init 3 'chezmoiignore filters Linux-only files on macOS'
+  is_macos || skip "Only relevant on macOS"
+  run chezmoi_host_partial managed --source "$SOURCE_ROOT"
+  assert_success
+  # Control: the sibling darwin scripts directory survives the darwin render,
+  # so an empty managed listing cannot satisfy the refutes below.
+  assert_output --partial ".chezmoiscripts/darwin"
+  local entries entry
+  entries="$(linux_only_entries)"
+  [ -n "$entries" ] || fail "no entries derived from the linux block of .chezmoiignore"
+  while IFS= read -r entry; do
+    refute_output --partial "$entry"
+  done <<< "$entries"
 }
 
 function set_up_before_script() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1590,6 +1590,70 @@ SH
   assert_file_exists "$home/plugin-linked"
 }
 
+function test_scripts_0851_obsolete_plugin_removal_accepts_formatted_plugin_json() {
+  _bats_test_init 851 'obsolete plugin removal accepts formatted plugin JSON'
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
+  local fake_bin="$BATS_TEST_TMPDIR/bin"
+  local calls="$BATS_TEST_TMPDIR/herdr.calls"
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/uname" <<'SH'
+#!/bin/sh
+printf 'Darwin\n'
+SH
+  cat > "$fake_bin/herdr" <<'SH'
+#!/bin/sh
+printf '%s\n' "$*" >> "$HERDR_CALLS"
+if [ "$*" = "plugin list --json" ]; then
+  cat <<'JSON'
+{
+  "result": {
+    "plugins": [
+      { "plugin_id": "artisann.zed-herdr" },
+      { "plugin_id": "worktrunk" }
+    ]
+  }
+}
+JSON
+fi
+exit 0
+SH
+  chmod +x "$fake_bin/uname" "$fake_bin/herdr"
+
+  run env HERDR_CALLS="$calls" PATH="$fake_bin:$PATH" bash "$script"
+  assert_success
+  run grep -Fx "plugin uninstall artisann.zed-herdr" "$calls"
+  assert_success
+  run grep -Fx "plugin uninstall worktrunk" "$calls"
+  assert_success
+  run grep -Fx "plugin install dio16/herdr-auto-update -y" "$calls"
+  assert_success
+}
+
+function test_scripts_0852_obsolete_plugin_removal_reports_malformed_entries() {
+  _bats_test_init 852 'obsolete plugin removal reports malformed plugin entries'
+  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
+  local fake_bin="$BATS_TEST_TMPDIR/bin-malformed"
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/uname" <<'SH'
+#!/bin/sh
+printf 'Darwin\n'
+SH
+  cat > "$fake_bin/herdr" <<'SH'
+#!/bin/sh
+if [ "$*" = "plugin list --json" ]; then
+  printf '{"result":{"plugins":[null,{"plugin_id":"worktrunk"}]}}\n'
+fi
+exit 0
+SH
+  chmod +x "$fake_bin/uname" "$fake_bin/herdr"
+
+  run env PATH="$fake_bin:$PATH" bash "$script"
+  assert_success
+  assert_output --partial "failed to inspect obsolete plugin artisann.zed-herdr"
+}
+
 # ask-in-herdr skill script
 # ===========================================
 

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -5057,6 +5057,7 @@ function test_scripts_1103_herdr_pane_labels_descriptor_probe_closes_worker_pipe
     HPL_DESCRIPTOR_PID_FILE="$pid_file" \
     HPL_DESCRIPTOR_BLOCKED_PID_FILE="$blocked_pid_file" \
     HPL_BLOCKED_HERDR_POLLS="$HPL_BLOCKED_HERDR_POLLS" \
+    TMPDIR="$BATS_TEST_TMPDIR" \
     BASHUNIT_BIN="$BATS_TEST_DIRNAME/lib/bashunit" PROBE_FILE="$probe_file" \
     python3 - <<'PY'
 import os
@@ -8127,7 +8128,8 @@ function test_scripts_258_herdr_child_descriptor_probe_passes_under_a_nes() {
   _bats_test_init 258 'herdr-child descriptor probe passes under a nested bashunit run'
   local probe_file="$BATS_TEST_DIRNAME/bashunit/herdr_child_descriptor_probe_test.sh"
   assert_file_exists "$probe_file"
-  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
+  run env NO_COLOR=1 TMPDIR="$BATS_TEST_TMPDIR" \
+    "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
   assert_success
   # Bashunit abbreviates long titles to the terminal width in Docker panes.
   assert_output --partial "All tests passed"
@@ -8144,7 +8146,8 @@ function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
   assert_file_exists "$probe_file"
 
   # Parallel leg: aggregate_parallel_results parses the .result file.
-  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
+  run env NO_COLOR=1 TMPDIR="$BATS_TEST_TMPDIR" \
+    "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
   assert_success
   assert_output --partial "Passed: late child output lands after the result payload"
   assert_output --partial "Assertions: 1 passed, 1 total"
@@ -8152,7 +8155,8 @@ function test_scripts_260_pinned_bashunit_survives_late_child_output_aft() {
   # Sequential leg: extract_result_counts parses the captured execution
   # result. Unpatched it stays exit 0 but reports 0 assertions, so the
   # assertion-count line is the discriminator here, not the status.
-  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
+  run env NO_COLOR=1 TMPDIR="$BATS_TEST_TMPDIR" \
+    "$BATS_TEST_DIRNAME/lib/bashunit" "$probe_file"
   assert_success
   assert_output --partial "Assertions: 1 passed, 1 total"
 }
@@ -8162,7 +8166,8 @@ function test_scripts_259_test_dsl_isolates_parallel_tests_with_the_same_histori
   local probe_file="$BATS_TEST_DIRNAME/bashunit/test_dsl_parallel_isolation_probe_test.sh"
   assert_file_exists "$probe_file"
 
-  run env NO_COLOR=1 "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
+  run env NO_COLOR=1 TMPDIR="$BATS_TEST_TMPDIR" \
+    "$BATS_TEST_DIRNAME/lib/bashunit" -j 2 "$probe_file"
   assert_success
   assert_output --partial "Tests:      2 passed, 2 total"
 }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -4857,7 +4857,11 @@ function test_scripts_0931_herdr_integrations_script_installs_each_target_() {
   skip_if_no_chezmoi
   [[ -f "$HERDR_INTEGRATIONS_TMPL" ]] || skip "herdr-integrations script not found"
   local rendered="$BATS_TEST_TMPDIR/herdr-integrations.sh"
-  chezmoi_full_fixture_finite_stdin execute-template < "$HERDR_INTEGRATIONS_TMPL" > "$rendered"
+  # Render status first: a partial render written straight to the file could
+  # still emit the expected calls and mask a broken deployment template.
+  run --separate-stderr chezmoi_full_fixture_finite_stdin execute-template < "$HERDR_INTEGRATIONS_TMPL"
+  assert_success
+  printf '%s\n' "$output" > "$rendered"
 
   local stub="$BATS_TEST_TMPDIR/stub" calls="$BATS_TEST_TMPDIR/herdr-calls.log"
   mkdir -p "$stub"
@@ -8169,17 +8173,9 @@ function test_scripts_256_morning_cleanup_is_a_no_op_on_its_second_run_of() {
   [ -d "$fake_home/Projects/late/.omc" ]
 }
 
-function test_scripts_257_morning_cleanup_keeps_fresh_trash_entries() {
-  _bats_test_init 257 'morning-cleanup keeps fresh trash entries'
-  local script="$SOURCE_ROOT/dot_local/bin/executable_morning-cleanup.sh"
-  local fake_home="$BATS_TEST_TMPDIR/mc-home-trash"
-  mkdir -p "$fake_home/Projects" "$fake_home/.scratchpad/fresh-entry"
-  printf 'x' > "$fake_home/.scratchpad/fresh-entry/file"
-
-  run env HOME="$fake_home" MORNING_CLEANUP_NO_NOTIFY=1 bash "$script"
-  assert_success
-  [ -d "$fake_home/.scratchpad/fresh-entry" ]
-}
+# The fresh-trash-keep scenario is owned by morning_cleanup_test.sh test 002,
+# which pairs it with the stale-removal leg and a completion stamp; a second
+# copy here would be a duplicate owner.
 
 # Wires the herdr-child descriptor probe into the suite. run-post-apply.sh runs
 # a fixed file list, so without this nested invocation the probe file would be

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -2879,8 +2879,8 @@ PY
   done
 }
 
-function test_scripts_033_herdr_child_signal_and_arm_handshake_resolves_ab() {
-  _bats_test_init 33 'herdr-child signal and arm handshake resolves abort before reporting supervision'
+function test_scripts_033_herdr_child_signal_before_watcher_arm_reports_ab() {
+  _bats_test_init 33 'herdr-child signal before the watcher arm reports the abort, never an armed watcher'
   child_stub_herdr
   run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 STUB_START_CONTEXT=1 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
@@ -2914,9 +2914,10 @@ if '"status":"armed"' in stdout:
     raise AssertionError("pre-arm abort was also reported as armed")
 PY
   assert_success
+}
 
-  teardown
-  setup
+function test_scripts_0332_herdr_child_signal_after_watcher_arm_reports_ar() {
+  _bats_test_init 0332 'herdr-child signal after the confirmed watcher arm reports armed, never a failure'
   child_stub_herdr
   run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 STUB_START_CONTEXT=1 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
@@ -3035,7 +3036,7 @@ function test_scripts_035_herdr_child_detached_timeout_wakes_once_and_late() {
 }
 
 function test_scripts_036_herdr_child_detached_delivery_follows_parent_ter() {
-  _bats_test_init 36 'herdr-child detached delivery follows parent terminal identity and fails closed on session replacement'
+  _bats_test_init 36 'herdr-child detached delivery follows parent terminal identity to a moved pane'
   child_lifecycle_stub_herdr
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
@@ -3044,9 +3045,10 @@ function test_scripts_036_herdr_child_detached_delivery_follows_parent_ter() {
   child_wait_for_log 'agent prompt wT:p7.*event=settled-11'
   run grep -q 'agent prompt wT:p0.*event=' "$CHILD_STUB/calls.log"
   assert_failure
+}
 
-  teardown
-  setup
+function test_scripts_0361_herdr_child_detached_delivery_fails_closed_on_s() {
+  _bats_test_init 0361 'herdr-child detached delivery fails closed on parent session replacement'
   child_lifecycle_stub_herdr
   run child_lifecycle_start --supervision-timeout 5000
   assert_success
@@ -3058,7 +3060,7 @@ function test_scripts_036_herdr_child_detached_delivery_follows_parent_ter() {
 }
 
 function test_scripts_037_herdr_child_detached_delivery_retries_temporary() {
-  _bats_test_init 37 'herdr-child detached delivery retries temporary parent blockage and prompt transport failure'
+  _bats_test_init 37 'herdr-child detached delivery retries temporary parent blockage'
   child_lifecycle_stub_herdr
   printf 'blocked\n' > "$CHILD_STUB/parent-status"
   run child_lifecycle_start --supervision-timeout 5000
@@ -3076,9 +3078,10 @@ function test_scripts_037_herdr_child_detached_delivery_retries_temporary() {
   run grep -c 'event=settled-11' "$CHILD_STUB/successful-prompts.log"
   assert_success
   assert_output 1
+}
 
-  teardown
-  setup
+function test_scripts_0371_herdr_child_detached_delivery_retries_prompt_tr() {
+  _bats_test_init 0371 'herdr-child detached delivery retries a prompt transport failure'
   child_lifecycle_stub_herdr
   printf '1\n' > "$CHILD_STUB/prompt-fail-count"
   run child_lifecycle_start --supervision-timeout 5000
@@ -3130,9 +3133,9 @@ function test_scripts_039_herdr_child_transient_pane_reads_never_become_ch() {
 }
 
 function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
-  _bats_test_init 40 'herdr-child superseded watcher cannot publish failure metadata over a new generation'
+  _bats_test_init 40 'herdr-child superseded watcher exits and removes its stale run directory'
   child_lifecycle_stub_herdr
-  local old_generation old_run new_generation watcher_pid new_watcher_pid reply_pid reply_status attempt=0
+  local old_generation old_run watcher_pid attempt=0
   export HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER="$CHILD_STUB/failure-publish"
   export HERDR_CHILD_TEST_NOW_SEQ=100
   run child_lifecycle_start --supervision-timeout 5000
@@ -3146,10 +3149,12 @@ function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
     sleep 0.01
   done
   assert_dir_not_exists "$old_run"
+}
 
-  teardown
-  setup
+function test_scripts_0401_herdr_child_superseded_watcher_cannot_publish_f() {
+  _bats_test_init 0401 'herdr-child superseded watcher cannot publish failure metadata over a reply takeover generation'
   child_lifecycle_stub_herdr
+  local old_generation new_generation watcher_pid new_watcher_pid reply_pid reply_status attempt=0
   export HERDR_CHILD_TEST_FAILURE_PUBLISH_BARRIER="$CHILD_STUB/failure-publish"
   export HERDR_CHILD_TEST_NOW_SEQ=100
   export HERDR_CHILD_MAX_DELIVERY_RETRIES=1
@@ -3157,7 +3162,6 @@ function test_scripts_040_herdr_child_superseded_watcher_cannot_publish_fa() {
   assert_success
   old_generation="$(cat "$CHILD_STUB/generation")"
   watcher_pid="$(cat "$CHILD_STUB/watcher.pid")"
-  attempt=0
 
   printf '12\n' > "$CHILD_STUB/prompt-fail-count"
   printf 'idle 11\n' > "$CHILD_STUB/child-state"
@@ -4336,7 +4340,7 @@ function test_scripts_067_herdr_child_tab_mode_composes_with_detached_supe() {
 }
 
 function test_scripts_068_herdr_child_tab_mode_preserves_malformed_creatio() {
-  _bats_test_init 68 'herdr-child tab mode preserves malformed creations and cleans owned failures'
+  _bats_test_init 68 'herdr-child tab mode preserves a malformed tab creation without mutating Herdr'
   child_stub_herdr
   STUB_TAB_CREATE_MALFORMED=1 HERDR_WORKSPACE_ID=w1 run child_start \
     --kind claude --tab --wait
@@ -4344,9 +4348,10 @@ function test_scripts_068_herdr_child_tab_mode_preserves_malformed_creatio() {
   assert_output --partial "tab wT:tA was preserved"
   run grep -Eq '^(pane report-metadata|agent start|pane close)' "$CHILD_STUB/calls.log"
   assert_failure
+}
 
-  teardown
-  setup
+function test_scripts_0681_herdr_child_tab_mode_cleans_owned_pane_on_repor() {
+  _bats_test_init 0681 'herdr-child tab mode cleans its owned pane when recording tab ownership fails'
   child_stub_herdr
   STUB_REPORT_FAIL=1 HERDR_WORKSPACE_ID=w1 run child_start \
     --kind claude --tab --wait
@@ -4358,7 +4363,7 @@ function test_scripts_068_herdr_child_tab_mode_preserves_malformed_creatio() {
 }
 
 function test_scripts_069_herdr_child_tab_mode_reports_the_tab_on_timeout() {
-  _bats_test_init 69 'herdr-child tab mode reports the tab on timeout and names it on launch failure'
+  _bats_test_init 69 'herdr-child tab mode reports the tab coordinates on prompt timeout'
   child_stub_herdr
   STUB_PROMPT_TIMEOUT=1 HERDR_WORKSPACE_ID=w1 run child_start \
     --kind claude --tab --wait
@@ -4366,9 +4371,10 @@ function test_scripts_069_herdr_child_tab_mode_reports_the_tab_on_timeout() {
   assert_output --partial "{\"agent\":\"$(child_started_name)\",\"pane\":\"wT:p9\",\"tab\":\"wT:tA\"}"
   run grep -q '^pane close' "$CHILD_STUB/calls.log"
   assert_failure
+}
 
-  teardown
-  setup
+function test_scripts_0691_herdr_child_tab_mode_names_the_tab_on_launch_fa() {
+  _bats_test_init 0691 'herdr-child tab mode names the tab on agent launch failure'
   child_stub_herdr
   STUB_START_MODE=busy HERDR_WORKSPACE_ID=w1 run child_start \
     --kind claude --tab --wait

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -4785,6 +4785,33 @@ function test_scripts_093_herdr_integrations_script_exits_0_and_skips_when() {
   assert_output --partial "skipping agent-state integration refresh"
 }
 
+# Present leg of 093's pair: with herdr on PATH the refresh must actually issue
+# one `integration install <target>` per agent client. The stub records argv,
+# so the oracle is what herdr received at runtime, not the script's source.
+function test_scripts_0931_herdr_integrations_script_installs_each_target_() {
+  _bats_test_init 931 'herdr-integrations script installs each integration target when herdr is present'
+  skip_if_no_chezmoi
+  [[ -f "$HERDR_INTEGRATIONS_TMPL" ]] || skip "herdr-integrations script not found"
+  local rendered="$BATS_TEST_TMPDIR/herdr-integrations.sh"
+  chezmoi_full_fixture_finite_stdin execute-template < "$HERDR_INTEGRATIONS_TMPL" > "$rendered"
+
+  local stub="$BATS_TEST_TMPDIR/stub" calls="$BATS_TEST_TMPDIR/herdr-calls.log"
+  mkdir -p "$stub"
+  cat > "$stub/herdr" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "$calls"
+STUB
+  chmod +x "$stub/herdr"
+
+  run env PATH="$stub:/usr/bin:/bin" bash "$rendered"
+  assert_success
+  assert_output --partial "Refreshed herdr agent-state integrations"
+
+  assert_file_contains "$calls" '^integration install claude$'
+  assert_file_contains "$calls" '^integration install pi$'
+  assert_file_contains "$calls" '^integration install opencode$'
+}
+
 # ===========================================
 # Claude Code PreToolUse hooks
 # ===========================================

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -6897,9 +6897,40 @@ function test_scripts_1208_herdr_pane_labels_icon_constants_stay_independent_of_
   assert_output "$HPL_ICON_BRANCH"
 }
 
+# Gate for the stub-conformance tests. Their oracle is the installed herdr
+# binary (docs/solutions/design-patterns/fakes-need-the-real-binary-as-oracle.md),
+# and each environment answers its absence differently:
+# - workstation without herdr: a missing developer tool -- visible skip;
+# - disposable home under MMS_CI_MINIMAL: push/PR CI renders the CI-minimal
+#   Brewfile, which deliberately guards out `brew "herdr"`
+#   (home/private_dot_config/brewfiles/Brewfile.tmpl), so absence there is
+#   configured, not broken -- visible skip naming that configuration;
+# - disposable home on the full render (nightly / Brewfile-editing runs): the
+#   full Brewfile declares herdr, so absence is a broken environment, and a
+#   skip would silently drop the stubs' only tether to the real binary --
+#   hard fail, the test_scripts_100 bun pattern.
+# The second oracle precondition, a *running* herdr server, stays a visible
+# per-test skip everywhere: the full-render Docker home installs the binary
+# but cannot host a herdr server (herdr is an interactive terminal
+# multiplexer and this suite runs headless under chezmoi apply), so that
+# skip is irreducible there and never a fail.
+require_real_herdr_oracle() {
+  command_exists herdr && return 0
+  case "$(mms_disposable_home_verdict)" in
+    run)
+      if [ -n "${MMS_CI_MINIMAL:-}" ]; then
+        skip "herdr is guarded out of the CI-minimal Brewfile render"
+      fi
+      fail "herdr is missing inside a disposable-home gate, where the full Brewfile declares it (home/private_dot_config/brewfiles/Brewfile.tmpl). The stub-conformance tests cannot skip here -- this environment owns the dependency, and a skip drops the stubs' only tether to the real binary."
+      return 1
+      ;;
+    *) skip "herdr is not installed" ;;
+  esac
+}
+
 function test_scripts_1209_pane_label_stub_snapshot_envelope_matches_real_herdr() {
   _bats_test_init 1209 'pane-label stub api snapshot envelope matches the installed herdr'
-  command_exists herdr || skip "herdr is not installed"
+  require_real_herdr_oracle
   # The stub herdr in helpers/herdr_pane_labels.bash fakes an upstream contract,
   # so nothing written here can say whether it still matches -- only the binary
   # it impersonates can, and it is the oracle for this test. Compare the two at
@@ -6923,6 +6954,107 @@ function test_scripts_1209_pane_label_stub_snapshot_envelope_matches_real_herdr(
   run jq -S -c '.result | keys' <<<"$output"
   assert_success
   assert_output "$real_keys"
+}
+
+# Sorted subset of the given keys that every object selected by the jq
+# expression carries. Key sets, not values: values are machine-specific, the
+# key shape is the upstream contract the stubs impersonate.
+_herdr_consumed_key_subset() {
+  local expr="$1" json="$2"
+  shift 2
+  jq -c "[\$ARGS.positional[] as \$key | select([$expr | has(\$key)] | all) | \$key] | sort" \
+    --args "$@" <<<"$json"
+}
+
+# One herdr reply, three sides: the installed binary must still carry every
+# consumed key (a deployed reader breaks when upstream renames one while this
+# suite stays green), and each stub must then agree with the real binary on
+# exactly that set. The expected side of the stub comparisons is captured
+# from the real binary in the same run, never written here.
+_assert_herdr_consumed_parity() {
+  local expr="$1" real_json="$2" stub_json="$3" lifecycle_json="$4"
+  shift 4
+  local real_keys
+  run _herdr_consumed_key_subset "$expr" "$real_json" "$@"
+  assert_success
+  assert_output "$(jq -n -c '$ARGS.positional | sort' --args "$@")"
+  real_keys="$output"
+  run _herdr_consumed_key_subset "$expr" "$stub_json" "$@"
+  assert_success
+  assert_output "$real_keys"
+  run _herdr_consumed_key_subset "$expr" "$lifecycle_json" "$@"
+  assert_success
+  assert_output "$real_keys"
+}
+
+function test_scripts_2846_child_stub_agent_pane_envelopes_match_real_herdr() {
+  _bats_test_init 2846 'child-agent stub agent list/get and pane get envelopes match the installed herdr'
+  require_real_herdr_oracle
+
+  # child_stub_herdr and child_lifecycle_stub_herdr back the herdr-child
+  # suite, and nothing written in this file can say whether their envelopes
+  # still match the binary they impersonate -- only the binary can
+  # (docs/solutions/design-patterns/fakes-need-the-real-binary-as-oracle.md).
+  # Real captures come first, before any stub directory exists.
+  local herdr_bin real_list real_get real_pane real_name real_pane_id
+  herdr_bin="$(command -v herdr)"
+  # A live server is the second oracle precondition; without one there is no
+  # oracle, so say why instead of falling back to a locally invented shape.
+  real_list="$("$herdr_bin" agent list 2>&1)" \
+    || skip "real herdr answered no agent list (no running server): $real_list"
+  real_name="$(jq -r '.result.agents[0].name // empty' <<<"$real_list")"
+  real_pane_id="$(jq -r '.result.agents[0].pane_id // empty' <<<"$real_list")"
+  if [ -z "$real_name" ] || [ -z "$real_pane_id" ]; then
+    skip "real herdr reports no running agent, so agent get and pane get have no target"
+  fi
+  real_get="$("$herdr_bin" agent get "$real_name" 2>&1)" \
+    || skip "real herdr answered no agent get for $real_name: $real_get"
+  real_pane="$("$herdr_bin" pane get "$real_pane_id" 2>&1)" \
+    || skip "real herdr answered no pane get for $real_pane_id: $real_pane"
+
+  local stub_list stub_get stub_pane lc_list lc_get lc_pane
+  child_stub_herdr
+  # START_CONTEXT makes the launch-contract stub list its parent agent; the
+  # bare default is an empty agents array with no object to compare.
+  stub_list="$(STUB_START_CONTEXT=1 "$CHILD_STUB/herdr" agent list)"
+  stub_get="$("$CHILD_STUB/herdr" agent get child)"
+  stub_pane="$("$CHILD_STUB/herdr" pane get wT:p9)"
+  child_lifecycle_stub_herdr
+  lc_list="$("$CHILD_STUB/herdr" agent list)"
+  lc_get="$("$CHILD_STUB/herdr" agent get child)"
+  lc_pane="$("$CHILD_STUB/herdr" pane get wT:p9)"
+
+  # Comparison depth: exactly the keys the deployed herdr-child modules read
+  # from each reply, nothing deeper -- everything below that belongs to herdr,
+  # and restating it here would reimplement upstream semantics locally, the
+  # failure mode this test exists to avoid. Keys those modules read only via
+  # .get-with-default stay out of the pinned set when real herdr legitimately
+  # omits them: agent_session (absent without a session), focused and
+  # agent_status on list entries, and the pane's tokens / state_labels /
+  # tab_id (a live pane answers with no state_labels key at all). The real
+  # .result also carries a sibling "type" key no script reads; the container
+  # key is the pinned envelope boundary, so "type" stays out too.
+
+  # agent list: json_validate_agents_and_list_names
+  # (home/dot_local/lib/herdr-child-runtime.sh) hard-requires pane_id, agent,
+  # terminal_id, revision, state_change_seq on every agent; name is what
+  # json_has_name/json_has_pair match pairs by, and herdr names every agent
+  # it detects (its CLI addresses agents by name).
+  _assert_herdr_consumed_parity '.result' "$real_list" "$stub_list" "$lc_list" agents
+  _assert_herdr_consumed_parity '.result.agents[]' "$real_list" "$stub_list" "$lc_list" \
+    agent name pane_id revision state_change_seq terminal_id
+
+  # agent get: json_agent_snapshot hard-indexes agent_status,
+  # state_change_seq, terminal_id, pane_id.
+  _assert_herdr_consumed_parity '.result' "$real_get" "$stub_get" "$lc_get" agent
+  _assert_herdr_consumed_parity '.result.agent' "$real_get" "$stub_get" "$lc_get" \
+    agent_status pane_id state_change_seq terminal_id
+
+  # pane get: json_pane_identity hard-indexes pane_id and terminal_id, and
+  # the reap identity check (herdr-child-reap.sh) compares the same two.
+  _assert_herdr_consumed_parity '.result' "$real_pane" "$stub_pane" "$lc_pane" pane
+  _assert_herdr_consumed_parity '.result.pane' "$real_pane" "$stub_pane" "$lc_pane" \
+    pane_id terminal_id
 }
 
 function test_scripts_1162_herdr_pane_labels_plugin_exposes_only_the_approved_pane() {

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1288,21 +1288,6 @@ function test_scripts_9_lint_input_set_excludes_agent_worktrees() {
 
 HERDR_ALIASES="$SOURCE_ROOT/dot_local/lib/herdr-aliases.sh"
 
-function test_scripts_1001_herdr_alias_library_parses_and_exposes_its_source_api() {
-  _bats_test_init 1001 'herdr alias library parses and exposes its source API'
-  run bash -n "$HERDR_ALIASES"
-  assert_success
-
-  run bash -c '
-    source "$1"
-    declare -F herdr_alias_is_valid >/dev/null
-    declare -F herdr_alias_in_pool >/dev/null
-    declare -F herdr_alias_validate_pool >/dev/null
-    declare -F herdr_alias_candidates >/dev/null
-  ' _ "$HERDR_ALIASES"
-  assert_success
-}
-
 function test_scripts_1002_herdr_alias_grammar_validation_is_separate_from_exact_p() {
   _bats_test_init 1002 'herdr alias grammar validation is separate from exact pool membership'
   source "$HERDR_ALIASES"
@@ -1822,8 +1807,6 @@ function test_scripts_1057_ask_sh_performs_no_agent_list_preflight_or_query_and_
   run grep -c '^verify --to red-wolf --pane wT:p9 ' "$CHILD_STUB/child.log"
   assert_success
   assert_output 2
-  run grep -q 'herdr agent list' "$ASK_HERDR_SCRIPT"
-  assert_failure
 }
 
 function test_scripts_1058_ask_sh_discards_buffered_output_when_either_pair_valida() {
@@ -5556,11 +5539,6 @@ function test_scripts_1118_herdr_pane_labels_rejects_a_complete_stale_post_renam
 
 function test_scripts_1119_herdr_pane_labels_contains_no_semantic_naming_or_retire() {
   _bats_test_init 1119 'herdr-pane-labels contains no semantic naming or retired worker interface'
-  run grep -E 'prompt|transcript|model|task|--worker|--agent|--session|--set|HERDR_TASK_SYNC' "$HPL_ENGINE"
-  assert_failure
-  run grep -E -- '--event|--sweep|--sweep-daemon|--ensure-sweep-daemon|--presentation-worker' "$HPL_ENGINE"
-  assert_success
-
   local retired
   for retired in --agent --session --transcript --set --worker; do
     run bash "$HPL_ENGINE" "$retired"

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -211,70 +211,6 @@ _bats_test_init 6 'herdr command palette keybinding is configured'
 assert_file_contains "$HOME/.config/herdr/config.toml" "seigi.command-palette.open"
 }
 
-function test_smoke_007_obsolete_plugin_removal_accepts_formatted_plugin_j() {
-  _bats_test_init 7 'obsolete plugin removal accepts formatted plugin JSON'
-  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
-  local fake_bin="$BATS_TEST_TMPDIR/bin"
-  local calls="$BATS_TEST_TMPDIR/herdr.calls"
-  mkdir -p "$fake_bin"
-
-  cat > "$fake_bin/uname" <<'SH'
-#!/bin/sh
-printf 'Darwin\n'
-SH
-  cat > "$fake_bin/herdr" <<'SH'
-#!/bin/sh
-printf '%s\n' "$*" >> "$HERDR_CALLS"
-if [ "$*" = "plugin list --json" ]; then
-  cat <<'JSON'
-{
-  "result": {
-    "plugins": [
-      { "plugin_id": "artisann.zed-herdr" },
-      { "plugin_id": "worktrunk" }
-    ]
-  }
-}
-JSON
-fi
-exit 0
-SH
-  chmod +x "$fake_bin/uname" "$fake_bin/herdr"
-
-  run env HERDR_CALLS="$calls" PATH="$fake_bin:$PATH" bash "$script"
-  assert_success
-  run grep -Fx "plugin uninstall artisann.zed-herdr" "$calls"
-  assert_success
-  run grep -Fx "plugin uninstall worktrunk" "$calls"
-  assert_success
-  run grep -Fx "plugin install dio16/herdr-auto-update -y" "$calls"
-  assert_success
-}
-
-function test_smoke_008_obsolete_plugin_removal_reports_malformed_entries() {
-  _bats_test_init 8 'obsolete plugin removal reports malformed plugin entries'
-  local script="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_7-install-herdr-github-plugins.sh.tmpl"
-  local fake_bin="$BATS_TEST_TMPDIR/bin-malformed"
-  mkdir -p "$fake_bin"
-
-  cat > "$fake_bin/uname" <<'SH'
-#!/bin/sh
-printf 'Darwin\n'
-SH
-  cat > "$fake_bin/herdr" <<'SH'
-#!/bin/sh
-if [ "$*" = "plugin list --json" ]; then
-  printf '{"result":{"plugins":[null,{"plugin_id":"worktrunk"}]}}\n'
-fi
-exit 0
-SH
-  chmod +x "$fake_bin/uname" "$fake_bin/herdr"
-
-  run env PATH="$fake_bin:$PATH" bash "$script"
-  assert_success
-  assert_output --partial "failed to inspect obsolete plugin artisann.zed-herdr"
-}
-
 # Literal consumed outside this repo: herdr's auto-update plugin reads
 # `trusted_owners` at runtime and only auto-installs plugin updates from that
 # allowlist — a real security boundary, not decoration. Reads the deployed
@@ -672,18 +608,38 @@ function test_smoke_031_herdr_caffeinate_plugin_scripts_are_valid_sh_mac() {
 }
 
 # ===========================================
-# herdr focus-notify plugin (source tree)
+# herdr focus-notify plugin
 # ===========================================
 
 FOCUS_NOTIFY_DIR="$SOURCE_ROOT/private_dot_config/herdr/plugins/herdr-focus-notify"
 
-# Runs notify.py against a fake notifier that records its argv one line per
-# argument, so tests can assert the exact command terminal-notifier would get.
-# $1: event JSON. Extra env for the run comes via focus_notify_env array.
+# Behavior tests 033-035 run the deployed copy first — herdr executes
+# $HOME/.config/..., so a .chezmoiignore rule that drops notify.py from
+# deployment must fail these tests rather than stay green through the
+# checkout (same reasoning as test 1072's deployed manifest). The checkout
+# stays as a secondary leg so Linux CI, where the darwin-only plugin never
+# deploys, still proves the source behavior. Assigns the caller's
+# `notify_targets` via bash dynamic scoping, deployed copy first.
+_focus_notify_targets() {
+  notify_targets=("$FOCUS_NOTIFY_DIR/notify.py")
+  if is_macos; then
+    local deployed="$HOME/.config/herdr/plugins/herdr-focus-notify/notify.py"
+    assert_file_exists "$deployed"
+    notify_targets=("$deployed" "${notify_targets[@]}")
+  fi
+}
+
+# Runs one notify.py ($1) against a fake notifier that records its argv one
+# line per argument, so tests can assert the exact command terminal-notifier
+# would get. $2: event JSON.
 run_focus_notify() {
-  local event_json="$1"
+  local notify_py="$1"
+  local event_json="$2"
   local fake_bin="$BATS_TEST_TMPDIR/fake-notifier"
   FOCUS_NOTIFY_ARGV="$BATS_TEST_TMPDIR/notifier.argv"
+  # A stale argv file from the previous target leg would satisfy (or fail)
+  # this leg's assertions on the wrong evidence.
+  rm -f "$FOCUS_NOTIFY_ARGV"
   cat > "$fake_bin" <<SH
 #!/bin/sh
 printf '%s\n' "\$@" > "$FOCUS_NOTIFY_ARGV"
@@ -692,7 +648,7 @@ SH
   HERDR_PLUGIN_EVENT_JSON="$event_json" \
     HERDR_FOCUS_NOTIFY_NOTIFIER_BIN="$fake_bin" \
     HERDR_BIN_PATH="$BATS_TEST_TMPDIR/dir with space/herdr" \
-    run python3 "$FOCUS_NOTIFY_DIR/notify.py"
+    run python3 "$notify_py"
 }
 
 function test_smoke_032_focus_notify_plugin_compiles() {
@@ -720,12 +676,15 @@ function test_smoke_1072_focus_notify_deployed_manifest_declares_its_run() {
 
 function test_smoke_033_focus_notify_builds_a_safely_quoted_click_comman() {
   _bats_test_init 33 'focus-notify builds a safely quoted click command'
-  # A hostile pane id proves the quoting: nothing here may reach sh as syntax.
-  run_focus_notify '{"event":"pane.agent_status_changed","data":{"pane_id":"w1:p3; $(boom) &","agent_status":"blocked","agent":"codex","display_agent":"Codex"}}'
-  assert_success
-  assert_file_exists "$FOCUS_NOTIFY_ARGV"
+  local notify_targets notify_py
+  _focus_notify_targets
+  for notify_py in "${notify_targets[@]}"; do
+    # A hostile pane id proves the quoting: nothing here may reach sh as syntax.
+    run_focus_notify "$notify_py" '{"event":"pane.agent_status_changed","data":{"pane_id":"w1:p3; $(boom) &","agent_status":"blocked","agent":"codex","display_agent":"Codex"}}'
+    assert_success
+    assert_file_exists "$FOCUS_NOTIFY_ARGV"
 
-  run python3 - "$FOCUS_NOTIFY_ARGV" "$BATS_TEST_TMPDIR/dir with space/herdr" <<'PY'
+    run python3 - "$FOCUS_NOTIFY_ARGV" "$BATS_TEST_TMPDIR/dir with space/herdr" <<'PY'
 import shlex, sys
 argv = open(sys.argv[1], encoding="utf-8").read().split("\n")
 execute = argv[argv.index("-execute") + 1]
@@ -736,32 +695,41 @@ assert argv[argv.index("-group") + 1] == "herdr-w1-p3-boom-", argv
 assert argv[argv.index("-title") + 1] == "Codex needs your input", argv
 assert "-activate" in argv, argv
 PY
-  assert_success
+    assert_success
+  done
 }
 
 function test_smoke_034_focus_notify_stays_quiet_for_non_actionable_stat() {
   _bats_test_init 34 'focus-notify stays quiet for non-actionable statuses and missing pane id'
-  run_focus_notify '{"data":{"pane_id":"w1:p1","agent_status":"working","agent":"codex"}}'
-  assert_success
-  assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
+  local notify_targets notify_py
+  _focus_notify_targets
+  for notify_py in "${notify_targets[@]}"; do
+    run_focus_notify "$notify_py" '{"data":{"pane_id":"w1:p1","agent_status":"working","agent":"codex"}}'
+    assert_success
+    assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
 
-  run_focus_notify '{"data":{"agent_status":"blocked","agent":"codex"}}'
-  assert_success
-  assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
+    run_focus_notify "$notify_py" '{"data":{"agent_status":"blocked","agent":"codex"}}'
+    assert_success
+    assert_file_not_exists "$FOCUS_NOTIFY_ARGV"
+  done
 }
 
 function test_smoke_035_focus_notify_uses_one_notification_group_per_pan() {
   _bats_test_init 35 'focus-notify uses one notification group per pane for duplicate replacement'
-  run_focus_notify '{"data":{"pane_id":"w1:p3","agent_status":"done","agent":"claude"}}'
-  assert_success
+  local notify_targets notify_py
+  _focus_notify_targets
+  for notify_py in "${notify_targets[@]}"; do
+    run_focus_notify "$notify_py" '{"data":{"pane_id":"w1:p3","agent_status":"done","agent":"claude"}}'
+    assert_success
 
-  run python3 - "$FOCUS_NOTIFY_ARGV" <<'PY'
+    run python3 - "$FOCUS_NOTIFY_ARGV" <<'PY'
 import sys
 argv = open(sys.argv[1], encoding="utf-8").read().split("\n")
 assert argv[argv.index("-group") + 1] == "herdr-w1-p3", argv
 assert argv[argv.index("-title") + 1] == "claude finished", argv
 PY
-  assert_success
+    assert_success
+  done
 }
 
 # ===========================================
@@ -916,10 +884,11 @@ function test_smoke_1070_deployed_opencode_agents_local_plugin_injects_from_the_
   assert_success
 }
 
-# Same reasoning as 1065/1068-1070: test 1057 proves the checkout's extension,
-# only the applied home proves the extension Pi will actually load. The bun
-# suite parameterizes its subject through SOURCE_ROOT in chezmoi source layout
-# (dot_pi/...), so a symlink shim maps that layout onto the deployed ~/.pi tree.
+# Same reasoning as 1065/1068-1070: `make test-pi-brew-auto-update` proves the
+# checkout's extension, only the applied home proves the extension Pi will
+# actually load. The bun suite parameterizes its subject through SOURCE_ROOT in
+# chezmoi source layout (dot_pi/...), so a symlink shim maps that layout onto
+# the deployed ~/.pi tree.
 function test_smoke_1056_pi_brew_auto_updater_is_deployed() {
   _bats_test_init 1056 'deployed Pi brew auto updater passes the focused suite'
   local ext="$HOME/.pi/agent/extensions/brew-auto-update/index.ts"
@@ -928,12 +897,6 @@ function test_smoke_1056_pi_brew_auto_updater_is_deployed() {
   mkdir -p "$shim_root"
   ln -s "$HOME/.pi" "$shim_root/dot_pi"
   run env SOURCE_ROOT="$shim_root" bun test "$BATS_TEST_DIRNAME/pi-brew-auto-update.test.ts"
-  assert_success
-}
-
-function test_smoke_1057_pi_brew_auto_updater_focused_tests_pass() {
-  _bats_test_init 1057 'Pi brew auto updater focused tests pass'
-  run bun test "$BATS_TEST_DIRNAME/pi-brew-auto-update.test.ts"
   assert_success
 }
 

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -765,25 +765,12 @@ function test_smoke_1051_herdr_alias_pane_label_and_child_files_are_deployed() {
 
 function test_smoke_1052_herdr_child_and_consult_contracts_use_allocator_owned_p() {
   _bats_test_init 1052 'herdr child and consult contracts use allocator-owned pair addressing'
-  local child="$HOME/.local/bin/herdr-child"
-  local ask="$HOME/.agents/skills/ask-in-herdr/scripts/ask.sh"
-  local contract="$HOME/.claude/shared/child-agent-contract.md"
-  local consult_skill="$HOME/.agents/skills/ask-in-herdr/SKILL.md"
-  local herdr_skill="$HOME/.agents/skills/herdr/SKILL.md"
-
-  run grep -E -- 'start .*--name|case .*--name' "$child"
-  assert_failure
-  run grep -E -- 'consult-\$AGENT|herdr-child.*--name' "$ask"
-  assert_failure
-  assert_file_contains "$ask" 'herdr-child reap --to %s --pane %s'
-  assert_file_contains "$contract" 'herdr-child reap --to <alias> --pane <pane-id>'
-  assert_file_contains "$consult_skill" 'herdr-child reap --to <alias> --pane <pane-id>'
-  assert_file_contains "$herdr_skill" 'callback alias may differ from the launch alias'
-  assert_file_contains "$herdr_skill" 'CALLBACK_ALIAS="\$CHILD_NAME"'
-  assert_file_contains "$herdr_skill" 'herdr-child verify --to "\$CALLBACK_CANDIDATE" --pane "\$CHILD_PANE"'
-  assert_file_contains "$herdr_skill" 'CALLBACK_ALIAS="\$CALLBACK_CANDIDATE"'
-  assert_file_contains "$herdr_skill" 'herdr-child reply --to "\$CALLBACK_ALIAS" --pane "\$CHILD_PANE"'
-  assert_file_contains "$herdr_skill" 'herdr-child reap --to "\$CALLBACK_ALIAS" --pane "\$CHILD_PANE"'
+  # The reap/verify/reply flow itself is owned by scripts_test.sh, which runs
+  # ask.sh and herdr-child against fakes. What remains here is the one command
+  # line agents copy verbatim from the deployed contract document: its literal
+  # shape is the contract.
+  assert_file_contains "$HOME/.claude/shared/child-agent-contract.md" \
+    'herdr-child reap --to <alias> --pane <pane-id>'
 }
 
 function test_smoke_1053_semantic_adapters_are_absent() {
@@ -996,13 +983,6 @@ function test_smoke_1069_deployed_pi_agent_hooks_extension_enforces_the_core() {
 assert_herdr_label_writer_contract() {
   local config="$1"
   local engine="$2"
-  local plugin="$3"
-  local writer_files=(
-    "$engine"
-    "$plugin/herdr-plugin.toml"
-    "$plugin/ensure.sh"
-    "$plugin/sweep.sh"
-  )
   local writer_roots=(
     "$(dirname "$engine")"
     "$(dirname "$config")"
@@ -1011,8 +991,8 @@ assert_herdr_label_writer_contract() {
   # Nothing here asserts config.toml content. Sidebar rows, widths, and which
   # tokens a row renders are the user's presentation preferences in the user's
   # own config; a test that froze them would fail on an intended edit and prove
-  # nothing about the label writer. The config path is kept only to locate the
-  # plugin directory below.
+  # nothing about the label writer. The config path is kept only because its
+  # directory holds the plugin files the writer counts sweep.
 
   run bash -c '
     pattern="$1"; shift
@@ -1027,12 +1007,6 @@ assert_herdr_label_writer_contract() {
   assert_success
   [ "$(printf '%s\n' "$output" | wc -l | tr -d '[:space:]')" -eq 1 ]
 
-  run grep -Ei 'reclaim|manual[-_ ]ownership|ownership[-_ ]notification' \
-    "$engine" "$plugin/herdr-plugin.toml" "$plugin/ensure.sh" "$plugin/sweep.sh"
-  assert_failure
-  run grep -hEi '(^|[^[:alnum:]_])(icon|icons|glyph)([^[:alnum:]_]|$)|nerd[ -]?font' \
-    "${writer_files[@]}"
-  assert_success
   # The engine builds the five codicon glyphs of the $git_ref grammar from
   # bash 3.2-safe octal printf sequences. Raw PUA glyphs are easily lost when
   # files pass through editors or agents, so none may be committed verbatim.
@@ -1047,20 +1021,11 @@ assert_herdr_label_writer_contract() {
   assert_file_contains "$engine" '…'
 }
 
-function test_smoke_1058_herdr_managed_source_preserves_label_writer_ownership() {
-  _bats_test_init 1058 'herdr managed source preserves label-writer ownership boundaries'
-  assert_herdr_label_writer_contract \
-    "$SOURCE_ROOT/private_dot_config/herdr/config.toml" \
-    "$SOURCE_ROOT/dot_local/bin/executable_herdr-pane-labels" \
-    "$SOURCE_ROOT/private_dot_config/herdr/plugins/herdr-pane-labels"
-}
-
 function test_smoke_1059_herdr_deployed_files_preserve_label_writer_ownership() {
   _bats_test_init 1059 'herdr deployed files preserve label-writer ownership boundaries'
   assert_herdr_label_writer_contract \
     "$HOME/.config/herdr/config.toml" \
-    "$HOME/.local/bin/herdr-pane-labels" \
-    "$HOME/.config/herdr/plugins/herdr-pane-labels"
+    "$HOME/.local/bin/herdr-pane-labels"
 }
 
 function test_smoke_1060_herdr_pane_label_plugin_deploys_the_approved_herdr_0_8_() {
@@ -1095,7 +1060,7 @@ function test_smoke_1060_herdr_pane_label_plugin_deploys_the_approved_herdr_0_8_
   assert_file_contains "$manifest" '^id = "sweep"$'
   assert_file_contains "$manifest" '^title = "Pane labels: refresh now"$'
   assert_file_contains "$manifest" '^command = \["sh", "sweep\.sh"\]$'
-  run grep -E '^on = ".*\*|^on = "(pane\.updated|workspace\.focused|tab\.focused|pane\.focused)"|reclaim' "$manifest"
+  run grep -E '^on = ".*\*|^on = "(pane\.updated|workspace\.focused|tab\.focused|pane\.focused)"' "$manifest"
   assert_failure
 }
 
@@ -1110,9 +1075,8 @@ function test_smoke_1061_herdr_pane_label_plugin_keeps_startup_sweep_and_relink_
   assert_file_contains "$plugin/ensure.sh" 'labels.*--ensure-sweep-daemon'
   assert_file_contains "$plugin/ensure.sh" "^  ''|--ensure-sweep-daemon)\$"
   assert_file_contains "$plugin/sweep.sh" 'labels.*--sweep'
-  assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml"'
-  assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh"'
-  assert_file_contains "$relink" 'include "private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh"'
+  # The relink script's hash-trigger includes are owned by test 1062, which
+  # derives them from the template and checks the plugin directory listing.
   assert_file_contains "$relink" 'herdr plugin link'
   assert_file_contains "$relink" 'herdr plugin enable "\$HPL_CUTOVER_PLUGIN_ID"'
 }
@@ -1122,24 +1086,38 @@ function test_smoke_1062_herdr_pane_label_cutover_templates_share_one_safety_bod
   local before="$SOURCE_ROOT/.chezmoiscripts/run_onchange_before_6-quiesce-herdr-pane-labels.sh.tmpl"
   local after="$SOURCE_ROOT/.chezmoiscripts/run_onchange_after_6-link-herdr-pane-labels.sh.tmpl"
   local shared="$SOURCE_ROOT/.chezmoitemplates/herdr-pane-labels-cutover-lib.sh"
-  local file input
-  local inputs=(
-    'dot_local/bin/executable_herdr-pane-labels'
-    'dot_local/lib/herdr-aliases.sh'
-    'private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml'
-    'private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh'
-    'private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh'
-    '.chezmoitemplates/herdr-pane-labels-cutover-lib.sh'
-  )
+  local plugin_rel='private_dot_config/herdr/plugins/herdr-pane-labels'
+  local file path plugin_file before_inputs after_inputs
 
   assert_file_exists "$before"
   assert_file_exists "$after"
   assert_file_exists "$shared"
+
+  # The hash-input list is derived from each template, never hand-copied, so it
+  # cannot drift from what the template actually hashes. Independent sides: the
+  # two templates against each other, every derived path against the source
+  # tree, and the plugin directory listing against the derived list.
+  before_inputs="$(grep -o 'include "[^"]*" | sha256sum' "$before" \
+    | sed 's/^include "//; s/" | sha256sum$//' | sort)"
+  after_inputs="$(grep -o 'include "[^"]*" | sha256sum' "$after" \
+    | sed 's/^include "//; s/" | sha256sum$//' | sort)"
+  [[ -n "$before_inputs" ]] || fail "no hash-trigger includes in $before"
+  [[ -n "$after_inputs" ]] || fail "no hash-trigger includes in $after"
+  assert_equal "$before_inputs" "$after_inputs"
+  while IFS= read -r path; do
+    assert_file_exists "$SOURCE_ROOT/$path"
+  done <<< "$before_inputs"
+  assert_dir_exists "$SOURCE_ROOT/$plugin_rel"
+  for plugin_file in "$SOURCE_ROOT/$plugin_rel"/*; do
+    path="$plugin_rel/${plugin_file##*/}"
+    grep -Fxq -- "$path" <<< "$before_inputs" \
+      || fail "plugin file $path is not a hash-trigger include in $before"
+  done
+
+  # The shared safety body must be included as a body, not only hashed —
+  # matching the closing "}}" excludes the sha256sum trigger lines above.
   for file in "$before" "$after"; do
-    assert_file_contains "$file" 'include "\.chezmoitemplates/herdr-pane-labels-cutover-lib\.sh"'
-    for input in "${inputs[@]}"; do
-      assert_file_contains "$file" "include \"$input\" \\| sha256sum"
-    done
+    assert_file_contains "$file" 'include "\.chezmoitemplates/herdr-pane-labels-cutover-lib\.sh" }}'
   done
   assert_file_contains "$before" 'include "dot_local/lib/herdr-aliases\.sh"'
   assert_file_contains "$before" '^source "\$alias_library"'
@@ -1147,10 +1125,6 @@ function test_smoke_1062_herdr_pane_label_cutover_templates_share_one_safety_bod
   assert_file_contains "$shared" '^        --source task-sync --clear-token task'
   run grep -n -- '--source task-sync.*--seq\|--clear-token task.*--seq' "$shared"
   assert_failure
-  assert_file_contains "$after" 'hpl_cutover_drain_fixed_point'
-  assert_file_contains "$after" 'hpl_cutover_ensure_all'
-  assert_file_contains "$shared" '^hpl_cutover_rollback()'
-  assert_file_contains "$shared" '^hpl_cutover_verify_daemon()'
 }
 
 # ===========================================

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -398,18 +398,31 @@ function test_smoke_016_pi_settings_include_all_managed_packages() {
 }
 
 function test_smoke_017_coding_agents_use_terminal_color_palettes() {
-  _bats_test_init 17 'coding agents use terminal color palettes'
-  run jq -e '.theme == "custom:light-ansi-daltonized"' "$HOME/.claude/settings.json"
+  _bats_test_init 17 'agent theme settings resolve to deployed theme files'
+  # Which palette each client names is a preference; pinning the names failed
+  # every intended theme edit. The contract is referential integrity: a
+  # settings value naming a file-backed theme must resolve to a deployed theme
+  # file, or the client falls back to a broken default. Two independent sides:
+  # the settings value vs the deployed theme file tree.
+  run jq -re '.theme' "$HOME/.claude/settings.json"
   assert_success
-  assert_file_exists "$HOME/.claude/themes/light-ansi-daltonized.json"
+  local claude_theme="$output"
+  # Claude marks file-backed themes with a custom: prefix; a bare name is a
+  # builtin with no file to resolve.
+  case "$claude_theme" in
+    custom:*) assert_file_exists "$HOME/.claude/themes/${claude_theme#custom:}.json" ;;
+  esac
 
-  run jq -e '.theme == "terminal"' "$HOME/.pi/agent/settings.json"
+  # Pi resolves theme names against its themes directory.
+  run jq -re '.theme' "$HOME/.pi/agent/settings.json"
   assert_success
-  assert_file_exists "$HOME/.pi/agent/themes/terminal.json"
+  assert_file_exists "$HOME/.pi/agent/themes/$output.json"
 
-  run jq -e '.theme == "system"' "$HOME/.config/opencode/tui.json"
+  # OpenCode builtin names carry no marker separating them from custom themes,
+  # so the file side cannot be adjudicated here; only the settings side — that
+  # tui.json parses and names a theme — is assertable.
+  run jq -re '.theme' "$HOME/.config/opencode/tui.json"
   assert_success
-  assert_file_not_exists "$HOME/.config/opencode/themes/flexoki-light-forced.json"
 }
 
 function test_smoke_018_opencode_reads_the_shared_writing_style_file_via() {
@@ -539,11 +552,22 @@ function test_smoke_023_executor_cli_resolves_on_path_through_local_bin() {
 }
 
 function test_smoke_024_kitty_includes_its_herdr_bindings_and_keeps_the() {
-  _bats_test_init 24 'kitty includes its herdr bindings and keeps the Alabaster theme (macOS only)'
+  _bats_test_init 24 'kitty includes its herdr bindings and every include resolves (macOS only)'
   is_macos || skip "Not on macOS"
   local config="$HOME/.config/kitty/kitty.conf"
+  # The herdr include is cross-component wiring (tests 26-28 assert herdr.conf
+  # content that only matters if kitty loads it). Which theme is included is a
+  # preference; the contract is referential — kitty silently skips a missing
+  # include, so a dangling one drops its theme or bindings without an error.
+  # Two independent sides: the include statements vs the deployed config dir.
   assert_file_contains "$config" "^include herdr.conf$"
-  assert_file_contains "$config" "^include Alabaster.conf$"
+  local include target
+  run grep -o '^include .*$' "$config"
+  assert_success
+  while IFS= read -r include; do
+    target="${include#include }"
+    assert_file_exists "$HOME/.config/kitty/$target"
+  done <<< "$output"
 }
 
 function test_smoke_025_kitty_font_family_is_one_kitty_accepts_as_monosp() {
@@ -792,14 +816,11 @@ function test_smoke_1052_herdr_child_and_consult_contracts_use_allocator_owned_p
     'herdr-child reap --to <alias> --pane <pane-id>'
 }
 
-function test_smoke_1053_semantic_adapters_are_absent() {
-  _bats_test_init 1053 'semantic adapters are absent'
-  assert_file_not_exists "$HOME/.local/bin/herdr-task-sync"
-  assert_file_not_exists "$HOME/.claude/hooks/herdr-task-sync-hook.sh"
-  assert_file_not_exists "$HOME/.config/opencode/plugins/herdr-task-sync.ts"
-  assert_file_not_exists "$HOME/.pi/agent/extensions/herdr-task-sync.ts"
-}
-
+# Single owner of the task-sync retirement: the absence (no task-sync hook
+# registered anywhere) is paired with the positive capability that replaced it
+# (the native agent-state hook on SessionStart), so a settings file that lost
+# both would still go red. This test also owns the deployed SessionStart
+# registration of herdr-agent-state.sh — do not re-assert it elsewhere.
 function test_smoke_1054_claude_settings_omit_task_sync_hooks_and_retain_native_() {
   _bats_test_init 1054 'claude settings omit task-sync hooks and retain native agent state'
   local settings="$HOME/.claude/settings.json"
@@ -839,9 +860,6 @@ for event, script in (
 ):
     found = commands(event)
     assert any(script in c for c in found), (event, script, found)
-
-session = commands("SessionStart")
-assert any("herdr-agent-state.sh" in c for c in session), session
 HOOKCHECK
   assert_success
 
@@ -871,7 +889,6 @@ function test_smoke_1063_worktree_identity_deploys_and_statusline_records_() {
   assert_success
   local record="$output"
   assert_file_contains "$record" "^$BATS_TEST_TMPDIR$"
-  assert_file_not_exists "$record_home/.cache/herdr-task-sync/agent-cwd/$session"
 }
 
 function test_smoke_1055_pi_local_private_instructions_focused_tests_pass() {
@@ -899,10 +916,19 @@ function test_smoke_1070_deployed_opencode_agents_local_plugin_injects_from_the_
   assert_success
 }
 
+# Same reasoning as 1065/1068-1070: test 1057 proves the checkout's extension,
+# only the applied home proves the extension Pi will actually load. The bun
+# suite parameterizes its subject through SOURCE_ROOT in chezmoi source layout
+# (dot_pi/...), so a symlink shim maps that layout onto the deployed ~/.pi tree.
 function test_smoke_1056_pi_brew_auto_updater_is_deployed() {
-  _bats_test_init 1056 'Pi brew auto updater is deployed'
+  _bats_test_init 1056 'deployed Pi brew auto updater passes the focused suite'
   local ext="$HOME/.pi/agent/extensions/brew-auto-update/index.ts"
   assert_file_exists "$ext"
+  local shim_root="$BATS_TEST_TMPDIR/deployed-pi-source-root"
+  mkdir -p "$shim_root"
+  ln -s "$HOME/.pi" "$shim_root/dot_pi"
+  run env SOURCE_ROOT="$shim_root" bun test "$BATS_TEST_DIRNAME/pi-brew-auto-update.test.ts"
+  assert_success
 }
 
 function test_smoke_1057_pi_brew_auto_updater_focused_tests_pass() {

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -95,11 +95,11 @@ function test_smoke_076_post_apply_orphan_guard_reaps_only_abandoned_wat() {
 
 # One manifest replaces the per-file existence tests. A file that falls out of
 # management (a .chezmoiignore edit, a lost dot_ prefix) keeps `chezmoi verify`
-# green — verify only checks what is still managed — so deployment and
-# management membership are both asserted against this curated list.
-function test_smoke_004_critical_managed_files_are_deployed_and_still_ma() {
-  _bats_test_init 4 'critical managed files are deployed and still managed'
-  local paths=(
+# green — verify only checks what is still managed — so deployment (test 004)
+# and management membership (test 1071) are both asserted against this curated
+# list. The helper assigns the caller's `paths` via bash dynamic scoping.
+_smoke_critical_paths() {
+  paths=(
     .zshrc
     .aliases
     .gitconfig
@@ -155,15 +155,31 @@ function test_smoke_004_critical_managed_files_are_deployed_and_still_ma() {
       .config/herdr/plugins/herdr-focus-notify/notify.py
     )
   fi
+}
+
+function test_smoke_004_critical_managed_files_are_deployed() {
+  _bats_test_init 4 'critical managed files are deployed'
+  local paths
+  _smoke_critical_paths
 
   local p missing=""
   for p in "${paths[@]}"; do
     [ -e "$HOME/$p" ] || missing="$missing $p"
   done
   [ -z "$missing" ] || fail "missing from \$HOME:$missing"
+  # Reached only when nothing is missing; registers the counted assertion the
+  # fail-with-message path above cannot, so bashunit does not flag this test
+  # as assertion-free (risky).
+  assert_equal "$missing" ""
+}
 
-  command_exists chezmoi || return 0
-  local managed unmanaged=""
+function test_smoke_1071_critical_deployed_files_are_still_chezmoi_manag() {
+  _bats_test_init 1071 'critical deployed files are still chezmoi-managed'
+  skip_if_no_chezmoi
+  local paths
+  _smoke_critical_paths
+
+  local p managed unmanaged=""
   run chezmoi_host_partial managed
   assert_success
   managed="$output"
@@ -655,12 +671,15 @@ SH
     run python3 "$FOCUS_NOTIFY_DIR/notify.py"
 }
 
-function test_smoke_032_focus_notify_plugin_compiles_and_declares_its_ru() {
-  _bats_test_init 32 'focus-notify plugin compiles and declares its runtime entrypoint'
+function test_smoke_032_focus_notify_plugin_compiles() {
+  _bats_test_init 32 'focus-notify plugin compiles'
   run env PYTHONPYCACHEPREFIX="$BATS_TEST_TMPDIR/pycache" \
     python3 -m py_compile "$FOCUS_NOTIFY_DIR/notify.py"
   assert_success
+}
 
+function test_smoke_1072_focus_notify_deployed_manifest_declares_its_run() {
+  _bats_test_init 1072 'focus-notify deployed manifest declares its runtime entrypoint (macOS only)'
   # The manifest wires the status event and the interpreter as argv arrays.
   # Literal consumed outside this repo: herdr's plugin loader parses these two
   # keys to decide which event fires the plugin and how to exec it. Assert the
@@ -668,7 +687,7 @@ function test_smoke_032_focus_notify_plugin_compiles_and_declares_its_ru() {
   # source grep wearing a smoke test's name and would stay green when chezmoi
   # never placed the file (same fix as test 009 in commit 50654e2). The plugin
   # is darwin-only per home/.chezmoiignore, so it only deploys on macOS.
-  is_macos || return 0
+  is_macos || skip "Not on macOS"
   local manifest="$HOME/.config/herdr/plugins/herdr-focus-notify/herdr-plugin.toml"
   assert_file_exists "$manifest"
   assert_file_contains "$manifest" '^on = "pane.agent_status_changed"$'

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -347,6 +347,10 @@ function test_smoke_017_coding_agents_use_terminal_color_palettes() {
   # builtin with no file to resolve.
   case "$claude_theme" in
     custom:*) assert_file_exists "$HOME/.claude/themes/${claude_theme#custom:}.json" ;;
+    # A bare name is a Claude builtin owned upstream: it has no file side to
+    # adjudicate here, same as OpenCode below. jq -re already rejected an
+    # empty or missing value, so this arm is a documented no-op, not a hole.
+    *) : ;;
   esac
 
   # Pi resolves theme names against its themes directory.

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -296,40 +296,6 @@ FAKE_OP
   assert_output --partial 'onepasswordRead'
   # oracle: fake op creates this marker only if skip-secrets fails before helper launch.
   assert_file_not_exists "$work/op-launched"
-
-  run env \
-    HOME="$work/home" \
-    MMS_CHEZMOI_UNATTENDED=1 \
-    "$launcher" --profile host-partial -- \
-    diff --source "$SOURCE_ROOT" --destination "$work/home" --config "$cfg" --color=false
-  assert_success
-  assert_output --partial 'partial coverage'
-  assert_output --partial 'home/dot_zshenv.tmpl'
-  assert_output --partial '~/.zshenv'
-}
-
-function test_templates_0095_zshenv_invalid_unattended_profile_fails_before_op() {
-  _bats_test_init 95 'zshenv invalid unattended profile fails before invoking op'
-  local work="$BATS_TEST_TMPDIR/zshenv-invalid-profile"
-  mkdir -p "$work/bin"
-  cat > "$work/bin/op" <<'FAKE_OP'
-#!/bin/sh
-printf launched > "$FAKE_OP_MARKER"
-exit 99
-FAKE_OP
-  chmod +x "$work/bin/op"
-
-  run env \
-    PATH="$work/bin:$PATH" \
-    FAKE_OP_MARKER="$work/op-launched" \
-    MMS_CHEZMOI_UNATTENDED=1 \
-    "$CHEZMOI_UNATTENDED" --profile invalid --finite-stdin -- \
-    execute-template --source "$SOURCE_ROOT" \
-    < "$SOURCE_ROOT/dot_zshenv.tmpl"
-  assert_failure
-  assert_output --partial '--profile must be full-fixture or host-partial'
-  # oracle: fake op creates this marker only if the invalid branch reaches it.
-  assert_file_not_exists "$work/op-launched"
 }
 
 function test_templates_010_zshrc_cached_init_never_splices_two_concurrent_g() {
@@ -431,14 +397,14 @@ function test_templates_014_every_opencode_instructions_entry_is_a_managed_f() {
 # private_settings.json.tmpl retirement contract
 # ===========================================
 function test_templates_0151_private_settings_registers_worktree_identity_prompt_hook() {
-  _bats_test_init 151 'private settings register the worktree identity prompt hook and omit task sync'
+  _bats_test_init 151 'private settings register the worktree identity prompt and session-start hooks'
   BATS_TEST_TMPFILE="$(mktemp)"
   render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
+  run grep -F '{{' "$BATS_TEST_TMPFILE"
+  assert_failure
   run jq -r '.hooks.UserPromptSubmit[]?.hooks[]?.command' "$BATS_TEST_TMPFILE"
   assert_success
   assert_output --partial 'herdr-worktree-identity-hook.sh'
-  run jq -e '[.hooks.UserPromptSubmit[]?.hooks[]?.command] | any(contains("herdr-task-sync-hook.sh")) | not' "$BATS_TEST_TMPFILE"
-  assert_success
   run jq -r '.hooks.SessionStart[]?.hooks[]?.command' "$BATS_TEST_TMPFILE"
   assert_success
   assert_output --partial 'herdr-agent-state.sh'
@@ -453,6 +419,8 @@ function test_templates_0152_private_settings_register_the_precompact_handoff_bu
   _bats_test_init 152 'private settings register the PreCompact handoff builder'
   BATS_TEST_TMPFILE="$(mktemp)"
   render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
+  run grep -F '{{' "$BATS_TEST_TMPFILE"
+  assert_failure
 
   # A hook deployed but never registered is a tracked defect class here, so the
   # registration is asserted alongside the hook rather than left to the smoke
@@ -464,38 +432,6 @@ function test_templates_0152_private_settings_register_the_precompact_handoff_bu
     --source "$SOURCE_ROOT" "$HOME/.claude/hooks/handoff-pre-compact.sh"
   assert_success
   assert_file_exists "$output"
-}
-
-function test_templates_0154_private_settings_carry_every_context_handoff_registration() {
-  _bats_test_init 154 'private settings carry both handoff registrations at once'
-  local command
-  BATS_TEST_TMPFILE="$(mktemp)"
-  render_template "$SOURCE_ROOT/private_dot_claude/private_settings.json.tmpl" > "$BATS_TEST_TMPFILE"
-
-  # Each unit asserts its own registration. This one catches a later edit that
-  # drops one of them while leaving the others in place -- the failure mode no
-  # single-hook assertion can see.
-  run jq -e '
-    ([.hooks.PreCompact[]?.hooks[]?.command] | any(contains("handoff-pre-compact.sh")))
-    and ([.hooks.SessionStart[]?.hooks[]?.command] | any(contains("handoff-session-start.sh")))
-    and ([.hooks.SessionStart[]?.hooks[]?.command] | any(contains("herdr-agent-state.sh")))
-  ' "$BATS_TEST_TMPFILE"
-  assert_success
-
-  # Every hook this work registers must resolve to a chezmoi-managed source, or
-  # it is deployed by nothing. herdr-agent-state.sh is deliberately outside
-  # this loop: `herdr integration install` writes it from
-  # home/.chezmoiscripts/run_onchange_after_3-setup-herdr-integrations.sh.tmpl
-  # and it has no chezmoi source path of its own.
-  while IFS= read -r command; do
-    run chezmoi_host_partial source-path \
-      --source "$SOURCE_ROOT" "$HOME/.claude/hooks/$command"
-    assert_success
-    assert_file_exists "$output"
-  done <<'EOF'
-handoff-pre-compact.sh
-handoff-session-start.sh
-EOF
 }
 
 # ===========================================

--- a/tests/bashunit/templates_test.sh
+++ b/tests/bashunit/templates_test.sh
@@ -607,6 +607,13 @@ function test_templates_021_an_unset_mms_ci_minimal_renders_the_full_brewfil() {
   # assertion in this file while real hosts silently stop getting it.
   assert_line 'brew "git"'
   assert_line --partial 'brew "lazywalker/tap/rgrc"'
+  # node, bun, and gitleaks are asserted only in the minimal render elsewhere,
+  # so they need pinning here too, or moving any of them into the
+  # ci_minimal-only branch would satisfy every assertion in this file while
+  # real hosts silently stop installing them.
+  assert_line 'brew "node"'
+  assert_line --partial 'brew "oven-sh/bun/bun"'
+  assert_line 'brew "gitleaks"'
 
   run render_with_config "$cfg" "$SOURCE_ROOT/$BREWFILE_MACOS_TMPL"
   assert_success

--- a/tests/bashunit/test_dsl_parallel_isolation_probe_test.sh
+++ b/tests/bashunit/test_dsl_parallel_isolation_probe_test.sh
@@ -5,6 +5,19 @@
 source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
 _bats_file_init "${BASH_SOURCE[0]}"
 
+# The two tests rendezvous through marker files, so a sequential run stalls
+# 5s polling for a marker the other test never wrote, then fails misleadingly.
+# The driver (test_scripts_259 in scripts_test.sh) runs this file with -j 2;
+# skip unless the runner actually enabled parallel execution.
+skip_unless_parallel_run() {
+  if declare -F bashunit::parallel::is_enabled >/dev/null; then
+    bashunit::parallel::is_enabled && return 0
+  elif [ "${BASHUNIT_PARALLEL_RUN:-}" = "true" ]; then
+    return 0
+  fi
+  skip "requires the parallel driver (test_scripts_259 runs this file with -j 2)"
+}
+
 assert_parallel_tmpdirs_differ() {
   local own="$1" other="$2" attempt=0
   printf '%s\n' "$BATS_TEST_TMPDIR" > "$_BATS_FILE_TMPROOT/$own"
@@ -19,11 +32,13 @@ assert_parallel_tmpdirs_differ() {
 
 function test_parallel_tmpdir_isolation_first() {
   _bats_test_init 1 'parallel temp directory isolation first probe'
+  skip_unless_parallel_run
   assert_parallel_tmpdirs_differ first second
 }
 
 function test_parallel_tmpdir_isolation_second() {
   _bats_test_init 1 'parallel temp directory isolation second probe'
+  skip_unless_parallel_run
   assert_parallel_tmpdirs_differ second first
 }
 


### PR DESCRIPTION
## Summary

The bashunit suites now fail when the behavior they guard breaks: tests that could hang the whole run, skip half their assertions silently, or stay green while their subject regressed are fixed, and the destructive code paths that had no tests at all now have behavioral coverage.

The branch executes a committed remediation plan (`docs/plans/2026-09-07-test-quality-fixes.md`) produced by a cross-checked audit of `tests/bashunit/`. One commit per plan item; the suite stays green after every commit.

### Oracles that could not fail

- The palette ranking tests pinned titles and shortcuts copied out of the production `commands.toml`, so editing the config rewrote the expectations in the same patch. They now run on test-owned fixtures, plus one inventory test that reads every `shortcuts` declaration at runtime and asserts each ranks its own command first — config and ranker output stay independent sides.
- Source-text greps (function-name checks, absence greps, doc-prose greps, word bans) are deleted where a behavioral test already owns the same contract; each removal names its surviving owner in the commit message.
- Frozen preference pins (theme names, a kitty `include Alabaster.conf` line) became referential-integrity checks: the value a settings file names must resolve to a deployed file.
- The large herdr fakes backing ~200 tests are now calibrated against the real installed binary: key sets of `agent list`/`agent get`/`pane get` replies are compared with the keys the deployed scripts actually hard-read, with the real binary as the expected side.

### Suite reliability

- A signal-handling test could hang the run forever: the fake chezmoi waited for TERM in an unbounded loop and a failed assertion orphaned the launcher. The wait is bounded, a teardown hook reaps the launcher on every exit path, and an injected mid-test failure that previously hung until a 2-minute transport kill now fails in under 2 seconds with no leftover processes.
- Nested bashunit driver runs intermittently aggregated each other's results under `-j 8` because every bashunit scratch dir derives from `$TMPDIR`; each nested invocation now gets an isolated `TMPDIR`.
- Silent `|| return 0` halves of two smoke tests are now visible skips (verified: with chezmoi stripped from PATH or a fake Linux `uname`, they report skipped, not passed).
- Six tests that packed two scenarios behind a mid-test reset are split one test per scenario, so a first-leg failure can no longer retire the second leg. Assertion multiset unchanged.

### New coverage for untested surfaces

- `smart_close.py` (Cmd-W): closes the pane, then the tab, never the last tab; error paths close nothing.
- Palette run paths: `plugin_action` argv, `pane_run` without a target pane, and shell-value appending — a hostile value (`a b; touch PWNED #`) must come back as one inert argument, with the would-be marker file as the negative oracle.
- The chezmoi-unattended launcher's fail-closed guards (malformed invocations, inventory rule, oversized target) and child-status propagation, each rejection paired with a passing control.
- `morning-cleanup.sh`'s trash purge and git worktree/branch cleanup: a fixture with a bare origin proves only the merged-clean worktree and branch are removed while unmerged and dirty ones survive, judged by git's own listings. The script gains one test-only age knob; with it unset the shipped `find` invocation is unchanged — the only `home/` change on the branch.
- The full Brewfile render now pins `gitleaks`, `node`, `bun`; before, moving any of them into the CI-minimal-only branch passed the whole suite while real hosts stopped installing a security scanner.

Every new or reworked test was proven able to fail during development: a hand-inverted guard, dropped include, renamed stub key, or unquoted append turned the relevant test red before the mutation was reverted. The red outputs are recorded in the plan-item commit messages' history, not in the diff.

## Verification

All suites green on macOS: scripts (339 passed + 1 platform skip), smoke (53), palette (61), templates (28), chezmoi_unattended (19, twice), morning_cleanup (3), platform/idempotent/probes. `make lint` clean. `make test-local` confirms the only deployment-facing change is the morning-cleanup knob with no path or template behavior change; pull-request CI is the deployment backstop for both OSes.

A static cross-review of the branch produced four applied fixes (final commit) and left three advisory notes open, all one design question: tests that derive their expected inventory from the same file the render consumes catch additions but not deletions. That is the deliberate trade-off against the hand-copied lists this branch removed; restoring an independent manifest layer is a follow-up decision, not a defect fixed here.
