### PR TITLE
fix(update-pins): stop leaving the chezmoi source clone dirty

### DIFF
--- a/home/.chezmoiexternal.toml
+++ b/home/.chezmoiexternal.toml
@@ -8,7 +8,7 @@
 # parent would delete their managed children out from under them.
 [".oh-my-zsh"]
     type = "archive"
-    url = "https://github.com/ohmyzsh/ohmyzsh/archive/bf77e350e04bd202921a50529e4f54deba3db7e2.tar.gz"
+    url = "https://github.com/ohmyzsh/ohmyzsh/archive/8d10cc948887e3cff29923d758999afa6edf87fb.tar.gz"
     exact = false
     stripComponents = 1
 

--- a/home/dot_local/bin/executable_update-pins
+++ b/home/dot_local/bin/executable_update-pins
@@ -11,6 +11,9 @@
 # 2. Upstream being unreachable is a report, not a failure. One unreachable
 #    pin prints as unknown and the run continues, so `update-all` never looks
 #    broken because GitHub was down.
+# 3. An accepted bump is committed and pushed in the same run. Every clean-tree
+#    guard in the toolchain reads that source clone, so a bump left only on
+#    disk turns into a blocker for the next tool that touches it.
 set -uo pipefail
 
 EXTERNAL_REL=".chezmoiexternal.toml"
@@ -158,6 +161,86 @@ confirm() {
 }
 
 # --------------------------------------------------------------------------
+# Publishing accepted bumps
+#
+# Failing to publish is a report, not a failure: the bump is already written,
+# and the recovery is the one command this prints. Leaving the run half-way
+# through a rebase would be a worse mess than the dirty tree it set out to
+# avoid, so a conflicted rebase is aborted before reporting.
+# --------------------------------------------------------------------------
+
+publish_paths=()
+publish_summaries=()
+
+record_bump() {
+  publish_paths[${#publish_paths[@]}]="$1"
+  publish_summaries[${#publish_summaries[@]}]="$2"
+}
+
+publish_bumps() {
+  local root="$1"
+  local count="${#publish_summaries[@]}"
+  local repo physical subject body push_error index=0
+
+  [ "$count" -gt 0 ] || return 0
+
+  say ""
+  if [ "${UPDATE_PINS_PUBLISH:-1}" = 0 ]; then
+    say "update-pins: publishing disabled; the bumps stay uncommitted"
+    return 0
+  fi
+
+  # `rev-parse` walks up until it finds a repository, so an unrelated ancestor
+  # repository — a home directory under version control — would otherwise
+  # receive the commit. Only the source root itself, or its parent under the
+  # `.chezmoiroot` indirection, is the source's own repository. Both sides of
+  # the comparison are physical paths: `--show-toplevel` resolves symlinks, and
+  # a source root reached through one (macOS `/var` -> `/private/var`) would
+  # otherwise never match its own repository.
+  repo="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null)"
+  physical="$(cd "$root" 2>/dev/null && pwd -P)"
+  if [ -z "$repo" ] || { [ "$repo" != "$physical" ] && [ "$repo" != "${physical%/*}" ]; }; then
+    warn 'the chezmoi source is not a git repository; the bumps stay uncommitted'
+    return 0
+  fi
+
+  if [ "$count" -eq 1 ]; then
+    subject="chore(pins): ${publish_summaries[0]}"
+  else
+    subject="chore(pins): bump $count pins"
+  fi
+  body=""
+  while [ "$index" -lt "$count" ]; do
+    body="$body${publish_summaries[$index]}
+"
+    index=$((index + 1))
+  done
+
+  # Pathspecs, not `-a`: only the files this run rewrote are committed, so
+  # unrelated work already in the source tree or the index stays untouched.
+  if ! git -C "$repo" commit --quiet -m "$subject" -m "$body" -- "${publish_paths[@]}"; then
+    warn "could not commit the bumps in $repo; they stay on disk"
+    return 0
+  fi
+  say "update-pins: committed $count bump(s) in $repo"
+
+  if push_error="$(git -C "$repo" push 2>&1)"; then
+    say 'update-pins: pushed to origin'
+    return 0
+  fi
+
+  # The clone fell behind between runs. One rebase-and-retry covers that;
+  # anything else is the user's call.
+  if git -C "$repo" pull --rebase --quiet && git -C "$repo" push --quiet; then
+    say 'update-pins: rebased onto origin and pushed'
+    return 0
+  fi
+  git -C "$repo" rebase --abort >/dev/null 2>&1
+  warn "$push_error"
+  warn "the bumps are committed but unpushed; finish with: git -C $repo push"
+}
+
+# --------------------------------------------------------------------------
 # Archive pins: Oh My Zsh and the four zsh plugins
 # --------------------------------------------------------------------------
 
@@ -204,6 +287,7 @@ check_archive_pins() {
       if replace_literal "$file" \
         "/archive/$current.tar.gz" "/archive/$latest.tar.gz"; then
         say "  bumped"
+        record_bump "$file" "$repo $(short "$current") -> $(short "$latest")"
       else
         warn "could not rewrite the $repo pin; left unchanged"
       fi
@@ -326,6 +410,7 @@ check_fff_pin() {
   done
   if replace_literal "$@"; then
     say "  bumped with ${#fetched[@]} refreshed checksums"
+    record_bump "$file" "$repo $current -> $latest"
   else
     warn "could not rewrite the $repo pin; left unchanged"
   fi
@@ -426,6 +511,7 @@ EOF
         warn "could not locate \"$requested\" on the $tool line; left unchanged"
       elif replace_literal "$file" "$old_line" "$new_line"; then
         say "  bumped"
+        record_bump "$file" "mise $tool $requested -> $bump"
       else
         warn "could not rewrite the $tool version; left unchanged"
       fi
@@ -459,11 +545,12 @@ main() {
   fi
 
   say "update-pins: chezmoi source $root"
-  say "update-pins: accepted bumps edit the source; run chezmoi apply to deploy"
+  say "update-pins: accepted bumps are committed and pushed; run chezmoi apply to deploy"
   say ""
   check_archive_pins "$external"
   check_fff_pin "$external"
   check_mise_pins "$mise_config"
+  publish_bumps "$root"
 }
 
 main "$@"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -10336,3 +10336,97 @@ n
   refute_output --partial 'mise: nothing outdated'
   assert_pins_files_unchanged
 }
+
+# Turns the fixture source into a real repository tracking a real remote, so
+# the publish assertions read git's own state instead of the script's intent.
+pins_git_fixture() {
+  PINS_ORIGIN="$BATS_TEST_TMPDIR/pins-origin.git"
+  git init --quiet --bare -b main "$PINS_ORIGIN"
+  git -C "$PINS_ROOT" init --quiet -b main
+  git -C "$PINS_ROOT" config user.email 'pins@example.test'
+  git -C "$PINS_ROOT" config user.name 'Pins Fixture'
+  git -C "$PINS_ROOT" add --all
+  git -C "$PINS_ROOT" commit --quiet -m 'fixture baseline'
+  git -C "$PINS_ROOT" remote add origin "$PINS_ORIGIN"
+  git -C "$PINS_ROOT" push --quiet --set-upstream origin main
+}
+
+function test_scripts_1459_update_pins_commits_and_pushes_the_accepted_bump() {
+  _bats_test_init 1459 'update-pins commits and pushes the accepted bump to origin'
+  # #given the drifted source tree as a repository tracking a remote
+  pins_fixture
+  pins_git_fixture
+  local before published="$BATS_TEST_TMPDIR/published-externals"
+  before="$(git -C "$PINS_ROOT" rev-parse HEAD)"
+
+  # #when the first offer is accepted
+  run_pins 'y
+n
+n
+n
+n
+n
+'
+
+  # #then the source is clean again and origin carries the fetched sha
+  assert_success
+  assert_equal "$(git -C "$PINS_ROOT" status --porcelain)" ""
+  assert_equal "$(git -C "$PINS_ROOT" rev-parse 'HEAD~1')" "$before"
+  assert_equal "$(git -C "$PINS_ROOT" rev-parse HEAD)" \
+    "$(git -C "$PINS_ORIGIN" rev-parse main)"
+  git -C "$PINS_ORIGIN" show 'main:.chezmoiexternal.toml' >"$published"
+  assert_file_contains "$published" "/archive/$PINS_STUB_HEAD_SHA\.tar\.gz"
+}
+
+function test_scripts_1460_update_pins_creates_no_commit_when_every_bump_is_declined() {
+  _bats_test_init 1460 'update-pins creates no commit when every bump is declined'
+  # #given the same repository-backed source tree
+  pins_fixture
+  pins_git_fixture
+  local before
+  before="$(git -C "$PINS_ROOT" rev-parse HEAD)"
+
+  # #when every offer is declined
+  run_pins 'n
+n
+n
+n
+n
+n
+'
+
+  # #then nothing was committed and origin never moved
+  assert_success
+  assert_equal "$(git -C "$PINS_ROOT" rev-parse HEAD)" "$before"
+  assert_equal "$(git -C "$PINS_ORIGIN" rev-parse main)" "$before"
+  assert_pins_files_unchanged
+}
+
+function test_scripts_1461_update_pins_publishes_only_the_files_it_rewrote() {
+  _bats_test_init 1461 'update-pins publishes only the files it rewrote'
+  # #given unrelated work already sitting in the source tree: one tracked file
+  # edited by hand and one untracked leftover
+  pins_fixture
+  pins_git_fixture
+  printf 'edited by hand\n' >>"$PINS_MISE"
+  printf 'leftover\n' >"$PINS_ROOT/stray-artifact"
+
+  # #when the first offer is accepted
+  run_pins 'y
+n
+n
+n
+n
+n
+'
+
+  # #then the published commit touches the pinned file alone and the unrelated
+  # work is still there, uncommitted
+  assert_success
+  assert_equal "$(git -C "$PINS_ROOT" show --format= --name-only HEAD)" \
+    '.chezmoiexternal.toml'
+  assert_file_contains "$PINS_MISE" '^edited by hand$'
+  assert_file_exists "$PINS_ROOT/stray-artifact"
+  assert_equal "$(git -C "$PINS_ROOT" status --porcelain --untracked-files=no)" \
+    ' M private_dot_config/mise/config.toml'
+}


### PR DESCRIPTION
## Summary

Accepting a pin bump in `update-pins` no longer leaves the chezmoi source clone dirty. The bump is committed and pushed in the same run, so the next tool that reads that clone is not blocked by it.

`update-pins` writes to `~/.local/share/chezmoi`, which is a separate checkout from the repository working copy. It wrote the accepted bump there and stopped, so the clone stayed dirty until someone mirrored the edit into a working checkout by hand and committed it — the loop that produced `6cf962e`. Meanwhile every clean-tree guard in the toolchain reads that same clone. `skills add` refuses to touch its manifest while the source repository has uncommitted changes, so a bump nobody mirrored turned into a hard block on an unrelated command.

## Design decisions

- **The commit names only the files the run rewrote.** A pathspec commit, not `-a`, so unrelated work already in the source tree or the index is never swept into a pin bump.
- **A conflicted rebase is aborted, not left half-applied.** When the clone fell behind between runs, one `pull --rebase` and a retry covers it. Anything else stops: a repository stuck mid-rebase is a worse state than the dirty tree this set out to avoid.
- **Failing to publish is a report, not a failure.** The bump is already on disk, and the recovery command is printed. This matches the script's existing rule that an unreachable upstream never makes `update-all` look broken.
- **Repository discovery is anchored to the source root**, or its parent under the `.chezmoiroot` indirection. `git rev-parse --show-toplevel` walks up until it finds any repository, so an ancestor under version control — a home directory tracked in git — would otherwise have received the commit. Both sides of that comparison are physical paths, because `--show-toplevel` resolves symlinks and a source root reached through one would never match its own repository.
- **`UPDATE_PINS_PUBLISH=0` opts out** for anyone who wants the old write-only behavior.

The second commit mirrors the oh-my-zsh pin the old manual loop left behind in the clone (`8d10cc94`), which is the last bump that needed the hand-carry this change removes.

## Test plan

Three tests in `tests/bashunit/scripts_test.sh` run against a real repository with a real bare remote, rather than inspecting the script:

- an accepted bump leaves the source clean and lands the fetched sha on origin;
- a declined run creates no commit at all;
- a tracked file edited by hand and an untracked leftover both stay out of the published commit.

The symlink bug above was found by those tests, not by review: on macOS `$TMPDIR` resolves through `/var` -> `/private/var`, the path comparison never matched, and publishing silently disabled itself.

`make lint` and `make test-ubuntu` both pass on this branch. `.chezmoiexternal.toml` changes are deployment-sensitive under `docs/agent-verification.md`, which requires the full Ubuntu run.
