### PR TITLE
feat(herdr): take the UI palette from the host terminal

### DIFF
--- a/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
+++ b/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
@@ -78,3 +78,20 @@ the per-child watcher covers every ordinary wake today. The cheapest way to earn
 make the short-TTL `supervised` label's expiry surface a visible "supervision lost" signal, turning
 an unmeasured tail into an observed one. That cost was not measured either and should be before it
 is treated as the small step it appears to be.
+
+## Upstream constraint added in 0.9.0 (herdrdev/herdr#1270)
+
+Lifecycle subscriptions start when the request is accepted and replay nothing that happened before
+it. The 0.9.0 socket API documentation states the ordering a client must follow: open
+`events.subscribe` on a separate connection, wait for its acknowledgement, buffer that stream while
+calling `session.snapshot`, install the snapshot, then apply the buffered events in order.
+
+This removes the easiest design for the restart path. A subscriber that reconstructs interest after
+a crash cannot rejoin by asking for missed events, because there are none to ask for. It must
+re-establish the subscription first and only then read the snapshot, and it silently loses every
+transition that occurred while it was down. That gap is exactly the crash-only tail this record was
+deferred against, so the deferral still holds, but the recovery story now has to state what happens
+to a child whose status changed during the subscriber's absence.
+
+Measured on the installed binary: `herdr --version` reports 0.9.0 and `herdr api --help` still lists
+only `snapshot` and `schema`, so the "no CLI surface" half of this record is unchanged.

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -1,13 +1,19 @@
 onboarding = false
 
+# rose-pine-dawn is the light half of the pair; herdr follows the host
+# terminal's reported appearance and swaps to rose-pine in dark mode.
+# Both names are spelled out because sibling inference is documented for
+# other pairs and should not be relied on here.
 [theme]
 name = "rose-pine-dawn"
+auto_switch = true
+light_name = "rose-pine-dawn"
+dark_name = "rose-pine"
 
 [theme.custom]
 panel_bg = "reset"
 
 [experimental]
-kitty_graphics = true
 pane_history = true
 allow_nested = true
 
@@ -64,9 +70,19 @@ sidebar_min_width = 32
 # Custom tokens have no such gap, so every space shows its branch, and the
 # counts read ⇣pull ⇡push ~conflicts +staged !unstaged ?untracked with empty
 # positions omitted.
+# `~` appears in $git_status only as the conflict prefix, so `contains` turns
+# the whole counts token red when a merge is unresolved. Rules are available on
+# `$name` metadata tokens; herdr's own composite `git_status` built-in takes
+# fixed styles only, so this coloring exists because the counts are ours.
+# The hex is fixed while the theme now auto-switches: rose-pine-dawn's love
+# (#b4637a) is the half of the pair that still reads on the dark background,
+# and inline token styles reject theme color names.
 [ui.sidebar.spaces]
 row_gap = 0
-rows = [["state_icon", "workspace"], ["$branch", "$git_status"]]
+rows = [
+  ["state_icon", "workspace"],
+  ["$branch", { token = "$git_status", rules = [{ contains = "~", fg = "#b4637a" }] }],
+]
 
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`

--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -1,14 +1,12 @@
 onboarding = false
 
-# rose-pine-dawn is the light half of the pair; herdr follows the host
-# terminal's reported appearance and swaps to rose-pine in dark mode.
-# Both names are spelled out because sibling inference is documented for
-# other pairs and should not be relied on here.
+# herdr takes its whole palette from the host terminal's ANSI colors instead
+# of carrying a theme of its own, so the UI matches whatever kitty and ghostty
+# are set to and there is no second palette to keep in sync. That also makes
+# theme.auto_switch unnecessary: light and dark follow the terminal, not a
+# pair of herdr theme names.
 [theme]
-name = "rose-pine-dawn"
-auto_switch = true
-light_name = "rose-pine-dawn"
-dark_name = "rose-pine"
+name = "terminal"
 
 [theme.custom]
 panel_bg = "reset"
@@ -70,19 +68,9 @@ sidebar_min_width = 32
 # Custom tokens have no such gap, so every space shows its branch, and the
 # counts read ⇣pull ⇡push ~conflicts +staged !unstaged ?untracked with empty
 # positions omitted.
-# `~` appears in $git_status only as the conflict prefix, so `contains` turns
-# the whole counts token red when a merge is unresolved. Rules are available on
-# `$name` metadata tokens; herdr's own composite `git_status` built-in takes
-# fixed styles only, so this coloring exists because the counts are ours.
-# The hex is fixed while the theme now auto-switches: rose-pine-dawn's love
-# (#b4637a) is the half of the pair that still reads on the dark background,
-# and inline token styles reject theme color names.
 [ui.sidebar.spaces]
 row_gap = 0
-rows = [
-  ["state_icon", "workspace"],
-  ["$branch", { token = "$git_status", rules = [{ contains = "~", fg = "#b4637a" }] }],
-]
+rows = [["state_icon", "workspace"], ["$branch", "$git_status"]]
 
 # Keep workspace and pane as separate built-in tokens so Herdr preserves their
 # distinct styles. herdr-pane-labels assigns `<agent-prefix>:<color-animal>`


### PR DESCRIPTION
## Summary

The herdr UI now takes its colors from the host terminal's ANSI palette instead of carrying a theme of its own, so it matches whatever kitty and ghostty are set to and there is no second palette to keep in sync.

The alternative tried first was herdr 0.9.0's new `theme.auto_switch` with a light/dark theme pair. It would not have fired: it follows the appearance the host terminal reports, and both terminals here are pinned to a light theme with no OS-appearance following, since kitty includes Alabaster and ghostty is set to Flexoki Light. Binding to the palette settles light and dark where they are actually configured. The same release turned `experimental.kitty_graphics` into a deprecated alias for `terminal.kitty_graphics`, which defaults to true, so the key is dropped rather than moved.

Separately, herdrdev/herdr#1270 made lifecycle subscriptions start when the request is accepted and replay nothing earlier. That removes the simplest restart design for the deferred event-subscriber supervisor in `docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md`, which now records the ordering a client must follow and the gap its recovery story has to answer. The deferral itself is unchanged.

## Validation

- Applied live on herdr 0.9.0 before committing: `herdr server reload-config` returned `status: applied` with no diagnostics, and the result was reviewed in the running session.
- `make test-local` exits 0 and renders this source to a byte-identical `~/.config/herdr/config.toml`, so the file no longer appears in its diff at all.
- `herdr config check` reports `config: ok`.
- `tests/bashunit/palette_test.sh`: 61 passed, 61 total. That suite reads `config.toml` for the command palette's action bindings.
- `make test-issues`: 89 passed.
