### PR TITLE
fix(herdr): unbreak detached child supervision

### DIFF
--- a/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
+++ b/docs/issues/2026-08-17-001-herdr-event-subscription-supervisor.md
@@ -95,3 +95,21 @@ to a child whose status changed during the subscriber's absence.
 
 Measured on the installed binary: `herdr --version` reports 0.9.0 and `herdr api --help` still lists
 only `snapshot` and `schema`, so the "no CLI surface" half of this record is unchanged.
+
+## Correction (2026-09-09): the liveness beacon was a label herdr never accepted
+
+Both mentions of a short-TTL `supervised` label above describe a mechanism that never
+ran. `herdr pane report-metadata` accepts only `idle`, `working`, `blocked`, `done`, and
+`unknown` as `--state-label` keys, in 0.8.2 exactly as in 0.9.0. It rejects any other key
+with exit 2 in the CLI, before it opens the socket, and discards the whole call including
+the tokens riding along in it. The watcher published its first beacon that way, so every
+`herdr-child start --detach` aborted at `watcher readiness failed: liveness-publish-failed`.
+Detached supervision has not worked since it was written in `fc6b958`.
+
+The beacon is a TTL'd token now, which keeps the expiry property this record leans on: it
+lapses when the watcher stops refreshing it. What that changes here is the premise rather
+than the conclusion. The statement above that the per-child watcher already covers every
+ordinary lifecycle wake was untrue while this was broken, so the crash-only tail was never
+the only gap. The deferral still stands now that the ordinary path is verified live on
+0.9.0: a detached launch arms, the watcher observes the child settle, and it wakes the
+parent.

--- a/home/dot_local/lib/herdr-child-launch.sh
+++ b/home/dot_local/lib/herdr-child-launch.sh
@@ -328,8 +328,12 @@ EOF
   esac
 
   local attempt=1 start_err start_out start_status=1 start_timeout="$timeout"
-  # herdr caps agent startup at five minutes; a longer caller timeout belongs to prompt waiting.
+  # herdr bounds agent startup to more than 3000ms and at most five minutes, and
+  # rejects anything outside that with invalid_agent_timeout, which the retry
+  # loop below does not recover from. A longer caller timeout belongs to prompt
+  # waiting, and a shorter one still has to clear herdr's floor.
   [ "$start_timeout" -le 300000 ] || start_timeout=300000
+  [ "$start_timeout" -ge 3001 ] || start_timeout=3001
   start_err="$(mktemp)"
   start_out="$(mktemp)"
   while [ "$attempt" -le 3 ]; do
@@ -549,11 +553,18 @@ EOF
       trap - HUP INT TERM
       return "$prompt_status"
     fi
+    # herdr documents that neither a timeout nor agent_prompt_stalled proves the
+    # prompt was never delivered, so a stall takes the same route as a timeout:
+    # keep the child and report it. Closing the pane here destroyed a child that
+    # may already have had the task and been working on it.
     if grep -q 'agent_prompt_stalled' "$prompt_err"; then
-      printf 'herdr-child: initial prompt stalled%s\n' "$tab_note" >&2
-    else
-      printf 'herdr-child: initial prompt failed%s\n' "$tab_note" >&2
+      printf 'herdr-child: initial prompt stalled; child preserved for recovery%s\n' "$tab_note" >&2
+      rm -f "$prompt_out" "$prompt_err"
+      trap - HUP INT TERM
+      print_start_result "$name" "$pane" "$tab"
+      return 124
     fi
+    printf 'herdr-child: initial prompt failed%s\n' "$tab_note" >&2
     rm -f "$prompt_out" "$prompt_err"
     cleanup_pane prompt-failure || true
     return 1

--- a/home/dot_local/lib/herdr-child-supervision.sh
+++ b/home/dot_local/lib/herdr-child-supervision.sh
@@ -292,18 +292,20 @@ watcher_publish_failed() {
       sleep 0.01
     done
   fi
+  # "supervision failed" is not one of herdr's five state-label keys, so a call
+  # carrying it was rejected whole and published none of these tokens either.
+  # The reason is a token now; only "blocked" survives as a label because the
+  # child really is blocked on its parent.
   if [ "$preserve_waiting" -eq 1 ]; then
     metadata_report_if_generation "$run_dir" "$pane" "$generation" \
       --source "$SOURCE_ID" --clear-state-labels \
       --state-label 'blocked=waiting for parent' \
-      --state-label "supervision failed=$reason" \
       --token "supervision_failure_reason=$reason" \
       --token "supervision_failure_generation=$generation" \
       --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1
   else
     metadata_report_if_generation "$run_dir" "$pane" "$generation" \
       --source "$SOURCE_ID" --clear-state-labels \
-      --state-label "supervision failed=$reason" \
       --token "supervision_failure_reason=$reason" \
       --token "supervision_failure_generation=$generation" \
       --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1
@@ -343,6 +345,7 @@ clear_supervision_metadata() {
     --clear-token supervision_timeout --clear-token supervision_baseline_seq \
     --clear-token parent_terminal --clear-token parent_session \
     --clear-token child_terminal --clear-token child_session \
+    --clear-token supervised \
     --clear-token supervision_failure_reason \
     --clear-token supervision_failure_generation \
     --clear-token supervision_failure_diagnostic >/dev/null 2>&1
@@ -372,6 +375,12 @@ preserve_callback_waiting_label() {
     --state-label 'blocked=waiting for parent' --ttl-ms "$WAITING_TTL_MS" >/dev/null 2>&1
 }
 
+# The beacon is a token, not a state label. herdr accepts only idle, working,
+# blocked, done and unknown as state-label keys and rejects anything else with
+# exit 2 before it contacts the server, which took the whole call -- tokens
+# included -- down with it. Tokens take any name, and --ttl-ms expires the key
+# on its own, which is the property the beacon needs: it lapses when the
+# watcher stops refreshing it.
 # Liveness carries the same generation precondition as failure publication. A
 # watcher superseded between its ordinary generation check and this call would
 # otherwise stamp supervised=<old-generation> over the live one; the check runs
@@ -380,7 +389,7 @@ preserve_callback_waiting_label() {
 refresh_supervision_liveness() {
   local run_dir="$1" pane="$2" generation="$3"
   metadata_report_if_generation "$run_dir" "$pane" "$generation" --source "$SOURCE_ID" \
-    --state-label "supervised=$generation" --ttl-ms "$SUPERVISED_TTL_MS" >/dev/null 2>&1
+    --token "supervised=$generation" --ttl-ms "$SUPERVISED_TTL_MS" >/dev/null 2>&1
 }
 
 delivery_retry_pause() {
@@ -522,7 +531,6 @@ signal_reap_transition() {
 publish_reap_recovery() {
   local pane="$1" generation="$2"
   metadata_report "$pane" --source "$SOURCE_ID" \
-    --state-label 'supervision failed=reap-close-failed' \
     --token 'supervision_failure_reason=reap-close-failed' \
     --token "supervision_failure_generation=$generation" \
     --token "supervision_failure_diagnostic=$generation" >/dev/null 2>&1

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -2797,7 +2797,7 @@ function test_scripts_029_herdr_child_detached_mode_returns_only_after_liv() {
     'child_session=child-session' 'baseline_seq=10')"
 
   local metadata_call prompt_call
-  metadata_call="$(grep -n 'state-label supervised=' "$CHILD_STUB/calls.log" | cut -d: -f1)"
+  metadata_call="$(grep -n 'token supervised=' "$CHILD_STUB/calls.log" | cut -d: -f1)"
   prompt_call="$(grep -n '^agent prompt' "$CHILD_STUB/calls.log" | cut -d: -f1)"
   [ -n "$metadata_call" ]
   [ "$metadata_call" -lt "$prompt_call" ]
@@ -2814,7 +2814,7 @@ function test_scripts_030_herdr_child_detached_arm_failure_preserves_the_c() {
   assert_output --partial "\"agent\":\"$(child_started_name)\",\"pane\":\"wT:p9\""
   assert_output --partial '"supervision":{"status":"failed","reason":"watcher-arm-failed"'
   assert_file_contains "$CHILD_STUB/calls.log" '^agent prompt'
-  assert_file_contains "$CHILD_STUB/calls.log" 'state-label supervision\\ failed='
+  assert_file_contains "$CHILD_STUB/calls.log" 'token supervision_failure_reason=watcher-arm-failed'
   set -- "$CHILD_STUB/state/runs/"*
   [ "$#" -eq 1 ]
   assert_file_exists "$1/failed.state"
@@ -3281,7 +3281,7 @@ function test_scripts_041_herdr_child_watcher_switches_from_fresh_polling() {
   : > "$CHILD_STUB/wait-release"
   child_wait_for_log 'event=settled-12'
   wait_line="$(grep -n '^agent wait' "$CHILD_STUB/calls.log" | cut -d: -f1 | head -1)"
-  refresh_line="$(grep -n 'state-label supervised=' "$CHILD_STUB/calls.log" | cut -d: -f1 | tail -1)"
+  refresh_line="$(grep -n 'token supervised=' "$CHILD_STUB/calls.log" | cut -d: -f1 | tail -1)"
   [ "$refresh_line" -gt "$wait_line" ]
 }
 
@@ -3307,7 +3307,7 @@ function test_scripts_042_herdr_child_sliced_wait_revalidates_generation_b() {
   done
   [ "$attempt" -lt 500 ]
   assert_dir_not_exists "$old_run"
-  run bash -c 'line=$1; file=$2; ! sed -n "$((line + 1)),\$p" "$file" | grep -q "state-label supervised="' _ \
+  run bash -c 'line=$1; file=$2; ! sed -n "$((line + 1)),\$p" "$file" | grep -q "token supervised="' _ \
     "$wait_line" "$CHILD_STUB/calls.log"
   assert_success
 }
@@ -3733,7 +3733,7 @@ function test_scripts_053_herdr_child_managed_prompt_requires_a_mode_and_a() {
     bash "$HERDR_CHILD" prompt --to orange-panda --pane wT:p9 --wait --timeout 1000 "next task"
   assert_success
   assert_output --partial 'Prompt completed for orange-panda in wT:p9.'
-  run grep -q 'state-label supervised=' "$CHILD_STUB/calls.log"
+  run grep -q 'token supervised=' "$CHILD_STUB/calls.log"
   assert_failure
   assert_file_not_exists "$CHILD_STUB/watcher.pid"
 }
@@ -4487,13 +4487,19 @@ function test_scripts_072_herdr_child_closes_its_pane_after_three_readines() {
   assert_file_contains "$CHILD_STUB/calls.log" '^pane close wT:p9'
 }
 
-function test_scripts_073_herdr_child_distinguishes_a_stalled_initial_prom() {
-  _bats_test_init 73 'herdr-child distinguishes a stalled initial prompt'
+function test_scripts_073_herdr_child_preserves_the_child_when_the_initia() {
+  _bats_test_init 73 'herdr-child preserves the child when the initial prompt stalls'
+  # herdr says agent_prompt_stalled does not prove the prompt was never
+  # delivered, so this takes the same route as test 74's timeout: the pane a
+  # working child may be sitting in must survive, and the caller is handed the
+  # coordinates to recover it.
   child_stub_herdr
   STUB_PROMPT_FAIL=1 run child_start --kind claude --wait
-  assert_failure
+  assert_failure 124
+  assert_output --partial "{\"agent\":\"$(child_started_name)\",\"pane\":\"wT:p9\"}"
   assert_output --partial "initial prompt stalled"
-  assert_file_contains "$CHILD_STUB/calls.log" '^pane close wT:p9'
+  run grep -q '^pane close' "$CHILD_STUB/calls.log"
+  assert_failure
 }
 
 function test_scripts_074_herdr_child_preserves_a_working_pane_when_the_wa() {
@@ -7124,6 +7130,50 @@ function test_scripts_2846_child_stub_agent_pane_envelopes_match_real_herdr() {
   _assert_herdr_consumed_parity '.result' "$real_pane" "$stub_pane" "$lc_pane" pane
   _assert_herdr_consumed_parity '.result.pane' "$real_pane" "$stub_pane" "$lc_pane" \
     pane_id terminal_id
+}
+
+function test_scripts_2847_child_state_label_keys_are_ones_the_installed_() {
+  _bats_test_init 2847 'every state-label key the child scripts send is one the installed herdr accepts'
+  require_real_herdr_oracle
+
+  # child_stub_herdr logs the report-metadata calls it is handed and never
+  # judges them, so the whole child suite stayed green while real herdr
+  # refused `--state-label supervised=` outright and published nothing from
+  # those calls -- tokens included. Only the binary owns the key vocabulary
+  # (docs/solutions/design-patterns/fakes-need-the-real-binary-as-oracle.md).
+  #
+  # herdr validates the key in the CLI before it opens the socket, so this
+  # needs the binary and no session. The pane id is not a real pane, so an
+  # accepted key fails on the pane instead and nothing can mutate. The keys
+  # come from the scripts and the verdict comes from herdr; this file writes
+  # neither side.
+  local probe_pane='wZZ:pZZZ' herdr_bin
+  herdr_bin="$(command -v herdr)"
+
+  # Control first. Without it a probe that rejected every key, or a key list
+  # that came back empty, would both read as a clean pass.
+  run "$herdr_bin" pane report-metadata "$probe_pane" --source child-agent-conformance \
+    --state-label 'definitely-not-a-status=probe' --seq 1
+  assert_failure
+  assert_output --partial 'unknown state label'
+
+  local keys key
+  keys="$(grep -ho -e "--state-label '[a-z ]*=" -e '--state-label "[a-z ]*=' \
+    "$SOURCE_ROOT"/dot_local/lib/herdr-child-*.sh "$HERDR_CHILD" \
+    | sed -e "s/--state-label ['\"]//" -e 's/=$//' | sort -u)"
+  [ -n "$keys" ] || fail 'no --state-label key was found in the child scripts'
+
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    run "$herdr_bin" pane report-metadata "$probe_pane" --source child-agent-conformance \
+      --state-label "$key=probe" --seq 1
+    assert_failure
+    case "$output" in
+      *'unknown state label'*)
+        fail "the child scripts send --state-label $key=, which herdr rejects: $output"
+        ;;
+    esac
+  done <<< "$keys"
 }
 
 function test_scripts_1162_herdr_pane_labels_plugin_exposes_only_the_approved_pane() {


### PR DESCRIPTION
## Summary

`herdr-child start --detach` works. It aborted at launch before this, on every run, since detached supervision was written.

The watcher's first act is to publish a liveness beacon, and it published it as `--state-label supervised=<generation>`. `herdr pane report-metadata` accepts only `idle`, `working`, `blocked`, `done`, and `unknown` as `--state-label` keys, and rejects any other key with exit 2 in the CLI before it opens the socket, discarding the whole call. So the launch died at `watcher readiness failed: liveness-publish-failed`. The same key carried `supervision failed=<reason>`, and that call also carried the failure tokens, so a supervision failure published no diagnosis either. This is not a herdr 0.9.0 regression: the 0.8.2 documentation states the same five keys.

The beacon is a TTL'd token now. Tokens take any name, and `--ttl-ms` expires the key on its own, which is the property the beacon needs: it lapses when the watcher stops refreshing it. The failure reason keeps the tokens it already had; only `blocked` survives as a label, because the child really is blocked on its parent.

Two smaller corrections against the same surface came out of the same check. A prompt that stalls now preserves the child instead of closing its pane, because herdr documents that neither a timeout nor `agent_prompt_stalled` proves the prompt was never delivered, and the wait path treated the two oppositely. It returns 124, which the ask-in-herdr contract already defines as a live child whose wait did not settle. Separately, the `agent start` timeout is now clamped from below as well as above, since herdr rejects 3000ms or less with `invalid_agent_timeout` and the retry loop only recovers from `agent_pane_busy`.

## Why no test caught this

`child_stub_herdr` logs the `report-metadata` calls it is handed and never judges them, so four tests asserted that the call log contained `state-label supervised=` — exactly the key the real binary refuses. The stub pinned our invention rather than herdr's contract, which is the failure mode `docs/solutions/design-patterns/fakes-need-the-real-binary-as-oracle.md` exists to name.

The new conformance test takes the keys from the child scripts and the verdict from the installed herdr, so it writes neither side of the comparison. herdr validates the key in the CLI before opening the socket, so the test needs the binary and no session, and its probe pane is not a real pane, so an accepted key fails on the pane instead and nothing mutates. A deliberately invalid key runs first as a control, because a probe that rejected everything, or an empty key list, would otherwise read as a clean pass.

## Validation

- Live on herdr 0.9.0 from a staged copy of these scripts: a detached launch returns `"supervision":{"status":"armed"}`, the child pane carries `supervised=<generation>` as a token with no state labels, the watcher observes the child settle and wakes the parent, and `reap` closes the pane. The same launch against the deployed scripts aborts at `liveness-publish-failed`.
- The new conformance test was checked both ways: it fails on the pre-fix source and passes on the fixed one.
- `tests/bashunit/scripts_test.sh`: 343 passed, 1 skipped (a Linux-only case, on macOS), 1715 assertions.
- `make lint`, `make test-issues` (89 passed), and `make test-local` (exit 0, both changed libraries render to their expected destinations) all pass.

The attached `--wait` path was smoke-checked live on 0.9.0 before any change and needed none: the child started, took its task, answered, and settled.
