### PR TITLE
fix(agents): restore fail-closed external secret scans

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -170,8 +170,24 @@ jobs:
       - name: Install chezmoi
         run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
 
-      - name: Add chezmoi to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Add managed tools to PATH
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+
+      # Linux minimal runs skip the Brewfile installer, but the scanner tests
+      # require the real detector as their independent oracle.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          if [ -z "${MMS_CI_MINIMAL:-}" ]; then
+            echo "full Brewfile run installs gitleaks during apply"
+            exit 0
+          fi
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" gitleaks
+          gitleaks version
 
       # The command palette shells out to `fzf --filter` and refuses to start
       # without it. Ubuntu's apt fzf predates --accept-nth, which the palette
@@ -184,8 +200,8 @@ jobs:
         env:
           FZF_VERSION: "0.74.3"
 
-      # Post-apply Pi and TypeScript tests invoke bun from the runner-facing
-      # PATH; Linuxbrew's prefix is intentionally not exported by this job.
+      # Minimal runs have no Linuxbrew packages, so post-apply Pi and TypeScript
+      # tests still need bun on the runner-facing PATH.
       - name: Install bun
         uses: oven-sh/setup-bun@v2
 

--- a/docs/issues/2026-09-04-001-pre-external-secret-scan-covers-one-of-five-external-peer-launch-paths.md
+++ b/docs/issues/2026-09-04-001-pre-external-secret-scan-covers-one-of-five-external-peer-launch-paths.md
@@ -1,12 +1,13 @@
 ---
 title: "Pre-external secret scan covers one of five external-peer launch paths"
-short_description: "The gitleaks gate that once scanned every path shipping repo content to external models died with the Smithers runtime; se-code-review, se-simplify, se-plan and ask-in-herdr now start Claude and OpenCode peers over the live checkout with no scan, leaving se-doc-review's single-document scan as the only surviving coverage."
+short_description: "External peer launches, recovery prompts, and ask-in-herdr follow-ups now pass through a hardened fail-closed gitleaks boundary that scans the live checkout and explicit payloads before each dispatch."
 type: "bug"
 category: "agent-platform"
 tags: ["secret-scanning","gitleaks","external-llm","security-boundary","regression"]
 date: "2026-09-04"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-09-11"
 ---
 
 ## Why this exists
@@ -65,4 +66,7 @@ an immutable review snapshot is out of scope.
 
 None. `docs/decisions/0012-scan-the-full-checkout-before-external-peer-launches.md` resolves the
 gate location, scan scope, launch cadence, `ask-in-herdr` coverage, and accepted residual race.
-This issue remains open for implementation and verification only.
+
+## Resolution
+
+Added the shared pre-external-secret-scan command with pinned/redacted fail-closed verdicts, trusted detector configuration, canonical target handling, and escaping-directory-symlink rejection. Wired both scans in the shared se-* peer lifecycle, scanned se-doc-review's frozen document payload, and added scan-enforcing ask-in-herdr launch, recovery, prompt, and reply paths. Added real-gitleaks semantic controls and deployed-path coverage. Verified make lint, focused bashunit suites, issue validation, and final make test-ubuntu (exit 0).

--- a/docs/issues/2026-09-04-001-pre-external-secret-scan-covers-one-of-five-external-peer-launch-paths.md
+++ b/docs/issues/2026-09-04-001-pre-external-secret-scan-covers-one-of-five-external-peer-launch-paths.md
@@ -69,4 +69,4 @@ gate location, scan scope, launch cadence, `ask-in-herdr` coverage, and accepted
 
 ## Resolution
 
-Added the shared pre-external-secret-scan command with pinned/redacted fail-closed verdicts, trusted detector configuration, canonical target handling, and escaping-directory-symlink rejection. Wired both scans in the shared se-* peer lifecycle, scanned se-doc-review's frozen document payload, and added scan-enforcing ask-in-herdr launch, recovery, prompt, and reply paths. Added real-gitleaks semantic controls and deployed-path coverage. Verified make lint, focused bashunit suites, issue validation, and final make test-ubuntu (exit 0).
+Added the shared pre-external-secret-scan command with pinned/redacted fail-closed verdicts, trusted detector configuration, canonical target handling, and escaping-directory-symlink rejection. Wired one full-checkout scan into each shared se-* review pair and standalone ask-in-herdr launch, with fresh scans before recovery, prompt, and reply turns. Added real-gitleaks semantic controls and deployed-path coverage. Verified make lint, focused bashunit suites, issue validation, and final make test-ubuntu (exit 0).

--- a/docs/solutions/architecture-patterns/pre-external-secret-boundary-for-coding-agent-pipelines.md
+++ b/docs/solutions/architecture-patterns/pre-external-secret-boundary-for-coding-agent-pipelines.md
@@ -1,7 +1,7 @@
 ---
 title: Pre-external secret boundary for coding-agent pipelines
 date: 2026-08-14
-last_updated: 2026-08-21
+last_updated: 2026-09-11
 category: architecture-patterns
 module: agent-platform
 problem_type: architecture_pattern
@@ -127,24 +127,25 @@ Six transferable rules for any pipeline that sends repo content to an external s
 
 **Known operational hole (session history).** Because secret-scan is nested inside the work stage's green branch, a run parked at the work gate never scans; merging a branch from such a run means the diff was never scanned. The observed compensation was a manual grep pass over the diff (api key/token/`sk-`/`ghp_`/`AKIA`/private-key headers/`op://` patterns) before merging.
 
-**Coverage regression (standalone harnesses) — REOPENED 2026-09-01.** This gap was closed on
+**Coverage regression (standalone harnesses) — RESTORED 2026-09-11.** This gap was closed on
 2026-08-14 (`2026-07-27-002`, done) by a shared pre-external gate, `enforcePreExternalGate` in
 `dot_smithers/workflows/lib/pre-external-gate.ts`, which both standalone harnesses passed through
 before dispatching their legs; the follow-up tree-tier (`preExternalTreeGate`) closed the
 pre-`baseSha` exposure on 2026-08-15 (`2026-08-14-009`, done). **That gate was deleted with the
-Smithers runtime and nothing replaced it.**
+Smithers runtime and nothing replaced it until issue `2026-09-04-001`.**
 
-Current state, verified against the tree: five skills launch external peers through
-`home/private_dot_claude/shared/herdr-peer-launch.md` — `se-doc-review`, `se-code-review`,
-`se-simplify`, `se-plan`, and `ask-in-herdr`. The launch starts a Claude peer and an OpenCode peer
-rooted at the live checkout with permission prompts suppressed, so two third-party model providers
-read repository content. Only `se-doc-review/SKILL.md:27` scans first, and it scans a single
-document (`gitleaks dir` over `$DOC_PATH`), not a diff range or the tree. `gitleaks` appears in
-exactly three tracked files: that skill, `Brewfile.tmpl`, and `templates_test.sh`.
+Current state: `pre-external-secret-scan` is the shared scanner primitive. It pins gitleaks exit
+codes, redacts output, uses a trusted default-rule configuration instead of target or environment
+configuration, rejects directory symlinks escaping a scan root, and fails closed on missing tools
+or unexpected results. `herdr-peer-launch.md` scans the live checkout and both prompts before tab
+creation, then scans again immediately before prompt submission. `se-doc-review` additionally scans
+the frozen document copy peers receive. `ask-in-herdr` scans its working directory, complete prompt,
+and added skill paths before launch; its recovery, ordinary follow-up, and blocked-reply paths scan
+again before sending another peer turn.
 
-Rule 1 below therefore states a boundary the repository does not currently hold at every crossing.
-The guidance is unchanged and still correct; the implementation stopped satisfying it. This is a
-potential product regression, not doc drift, and no repository issue tracks it.
+The peers still run against a live filesystem rather than an immutable sandbox. A scan attests the
+state it reads and cannot prevent a concurrent same-user process from changing that state afterward;
+filesystem containment remains separate work under `2026-08-18-002`.
 
 ## Related
 

--- a/docs/solutions/architecture-patterns/pre-external-secret-boundary-for-coding-agent-pipelines.md
+++ b/docs/solutions/architecture-patterns/pre-external-secret-boundary-for-coding-agent-pipelines.md
@@ -138,10 +138,10 @@ Current state: `pre-external-secret-scan` is the shared scanner primitive. It pi
 codes, redacts output, uses a trusted default-rule configuration instead of target or environment
 configuration, rejects directory symlinks escaping a scan root, and fails closed on missing tools
 or unexpected results. `herdr-peer-launch.md` scans the live checkout and both prompts before tab
-creation, then scans again immediately before prompt submission. `se-doc-review` additionally scans
-the frozen document copy peers receive. `ask-in-herdr` scans its working directory, complete prompt,
-and added skill paths before launch; its recovery, ordinary follow-up, and blocked-reply paths scan
-again before sending another peer turn.
+creation, once per review pair. `se-doc-review` freezes the document peers receive before entering
+that lifecycle. `ask-in-herdr` scans its working directory, complete prompt, and added skill paths
+once before each standalone launch; its recovery, ordinary follow-up, and blocked-reply paths scan
+before sending another peer turn.
 
 The peers still run against a live filesystem rather than an immutable sandbox. A scan attests the
 state it reads and cannot prevent a concurrent same-user process from changing that state afterward;

--- a/home/dot_local/bin/executable_pre-external-secret-scan
+++ b/home/dot_local/bin/executable_pre-external-secret-scan
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -u
+
+usage() {
+  printf 'Usage: pre-external-secret-scan [--stdin] <path>...\n' >&2
+}
+
+refuse() {
+  printf 'pre-external secret gate REFUSED: %s Nothing was sent externally.\n' "$1" >&2
+  exit 1
+}
+
+scan() {
+  local kind="$1" target="$2" output status
+  shift 2
+
+  set +e
+  if [ "$kind" = stdin ]; then
+    output="$(gitleaks stdin --config "$config_file" --gitleaks-ignore-path "$ignore_file" \
+      --ignore-gitleaks-allow --no-banner --no-color --redact --exit-code 2 --timeout 120 "$@" 2>&1)"
+  else
+    output="$(gitleaks dir --config "$config_file" --gitleaks-ignore-path "$ignore_file" \
+      --ignore-gitleaks-allow --no-banner --no-color --redact --exit-code 2 --timeout 120 \
+      --follow-symlinks -- "$target" "$@" 2>&1)"
+  fi
+  status=$?
+  set -e
+
+  case "$status" in
+    0) printf 'pre-external secret scan clean: %s\n' "$target" >&2 ;;
+    2)
+      [ -z "$output" ] || printf '%s\n' "$output" >&2
+      refuse "FOUND secrets in $target."
+      ;;
+    *)
+      [ -z "$output" ] || printf '%s\n' "$output" >&2
+      refuse "gitleaks exited with unexpected code $status while scanning $target."
+      ;;
+  esac
+}
+
+reject_external_directory_symlinks() {
+  local root="$1" link resolved
+  [ -d "$root" ] || return 0
+  if ! find "$root" -type l -print0 > "$symlink_file"; then
+    refuse "could not inspect symlinks under $root."
+  fi
+  while IFS= read -r -d '' link; do
+    resolved="$(realpath -- "$link" 2>/dev/null)" \
+      || refuse "symlink cannot be resolved: $link."
+    if [ -d "$resolved" ]; then
+      case "$resolved" in
+        "$root"|"$root"/*) ;;
+        *) refuse "directory symlink escapes scan root: $link -> $resolved." ;;
+      esac
+    fi
+  done < "$symlink_file"
+}
+
+scan_stdin=0
+if [ "${1:-}" = --stdin ]; then
+  scan_stdin=1
+  shift
+fi
+[ "$#" -gt 0 ] || { usage; exit 2; }
+
+if [ "${SE_SKIP_SECRET_SCAN:-0}" = 1 ]; then
+  printf 'pre-external secret scan SKIPPED by operator because SE_SKIP_SECRET_SCAN is set.\n' >&2
+  exit 0
+fi
+
+command -v gitleaks >/dev/null 2>&1 \
+  || refuse 'gitleaks is not on PATH.'
+command -v realpath >/dev/null 2>&1 \
+  || refuse 'realpath is not on PATH.'
+command -v find >/dev/null 2>&1 \
+  || refuse 'find is not on PATH.'
+
+config_file="$(mktemp)" || refuse 'could not create the trusted scanner configuration.'
+ignore_file="$(mktemp)" || { rm -f "$config_file"; refuse 'could not create the trusted scanner ignore file.'; }
+symlink_file="$(mktemp)" || { rm -f "$config_file" "$ignore_file"; refuse 'could not create the symlink inventory.'; }
+trap 'rm -f "$config_file" "$ignore_file" "$symlink_file"' EXIT
+cat > "$config_file" <<'TOML'
+[extend]
+useDefault = true
+TOML
+: > "$ignore_file"
+
+for target in "$@"; do
+  [ -e "$target" ] || refuse "scan target does not exist: $target."
+  canonical_target="$(realpath -- "$target" 2>/dev/null)" \
+    || refuse "scan target cannot be resolved: $target."
+  reject_external_directory_symlinks "$canonical_target"
+  scan path "$canonical_target"
+done
+
+if [ "$scan_stdin" -eq 1 ]; then
+  scan stdin '<stdin>'
+fi

--- a/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
+++ b/home/private_dot_agents/skills/ask-in-herdr/SKILL.md
@@ -28,6 +28,10 @@ bash ~/.agents/skills/ask-in-herdr/scripts/ask.sh <agent> "<question>" [flags]
 
 The script refuses to run when `HERDR_ENV` is unset or `herdr-child` is unavailable. It has no headless mode and no `--headless` flag.
 
+## Secret boundary
+
+Before starting a child, the script runs `pre-external-secret-scan` over the working directory, the complete question, and every added skill path. Only a clean gitleaks verdict permits launch; a detected secret, unavailable scanner, invalid path, timeout, or unexpected scanner result returns `status=refused` before content reaches the external model. Set `SE_SKIP_SECRET_SCAN=1` only as an explicit per-invocation waiver; the script reports that the input was sent unscanned. Every ordinary follow-up and blocked-child reply must use the skill's `follow-up.sh` wrapper, which derives the live pane's working directory and repeats the scan before delivery.
+
 ## Models and tool posture
 
 If the caller supplies no model, opencode uses `openai/gpt-5.5` and pi uses `openai-codex/gpt-5.5`. These defaults preserve a cross-model second opinion for a claude parent.
@@ -58,12 +62,12 @@ Only `status=answered` puts an answer on stdout, and it comes from the report fi
 | `ask.sh: status=blocked` | 1 | The child settled at `blocked`. The transport is retained. |
 | `ask.sh: status=working` | 124 | The wait did not settle. The child pane remains live, stdout can be partial, and the transport is retained. |
 | `ask.sh: status=undelivered` | 1 | The pane, start, or initial prompt failed before a usable answer existed. |
-| `ask.sh: status=refused` | 2 | Arguments or the requested posture are invalid. |
+| `ask.sh: status=refused` | 2 | Arguments or posture are invalid, or the pre-external secret scan refused launch. |
 | `ask.sh: status=no-report` | 3 | The child settled, but no report file existed after the recovery request. |
 | `ask.sh: status=empty-report` | 4 | The report file existed but was empty after the recovery request. |
 | `ask.sh: status=bad-report` | 5 | The report path was a symlink or not a regular file. It was never read. |
 
-The script prints a close hint on stderr before the status line. `herdr-child` allocates the alias; the script consumes the returned alias-plus-pane pair and verifies its terminal identity before exposing output. Keep the pane for a managed follow-up, or close it with the reported `herdr-child reap --to <alias> --pane <pane-id>` command. Use `herdr-child prompt --to <alias> --pane <pane-id> --wait '<task>'` for that attached follow-up.
+The script prints a close hint on stderr before the status line. `herdr-child` allocates the alias; the script consumes the returned alias-plus-pane pair and verifies its terminal identity before exposing output. Keep the pane for a managed follow-up, or close it with the reported `herdr-child reap --to <alias> --pane <pane-id>` command. Use `bash ~/.agents/skills/ask-in-herdr/scripts/follow-up.sh prompt <alias> <pane-id> '<task>'` for an ordinary follow-up and replace `prompt` with `reply` for a blocked-child decision, repeating every original `--skills` path. The wrapper reports delivery state; read the peer's resulting answer from its pane through the normal Herdr flow.
 
 For `status=answered`, the script also submits a cleanup reminder to the parent agent's pane. Herdr queues that prompt while the parent is working. The reminder is best effort: a delivery failure prints a warning but does not discard or downgrade the answer already read.
 

--- a/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh
+++ b/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_ask.sh
@@ -56,6 +56,10 @@ if ! command -v herdr >/dev/null 2>&1; then
   printf 'ask.sh: herdr is not on PATH\n' >&2
   status_exit refused 2
 fi
+if ! command -v pre-external-secret-scan >/dev/null 2>&1; then
+  printf 'ask.sh: pre-external-secret-scan is not on PATH\n' >&2
+  status_exit refused 2
+fi
 
 posture=ro
 [ "$RW" -eq 0 ] || posture=rw
@@ -89,6 +93,16 @@ trap 'rm -f "$question_file" "$start_out" "$start_err" "$read_out" "$read_err" "
   printf 'Do not use a file-editing tool. After the file is durable, return the same answer as usual.\n'
   printf 'Do not write any other file.\n'
 } > "$question_file"
+
+scan_paths=("$CWD" "$question_file")
+if [ "$SKILLS_COUNT" -gt 0 ]; then
+  set +u
+  for skill in "${SKILLS[@]}"; do scan_paths+=("$skill"); done
+  set -u
+fi
+if ! pre-external-secret-scan "${scan_paths[@]}"; then
+  status_exit refused 2
+fi
 
 args=(start --kind "$AGENT" --posture "$posture" --cwd "$CWD" \
   --prompt-file "$question_file" --wait --timeout 1800000)
@@ -207,17 +221,24 @@ case "$agent_status" in
     classify_report
     report_state=$?
     set -e
+    recovery_scan_refused=0
     if [ "$report_state" -eq 3 ] || [ "$report_state" -eq 4 ]; then
       # One bounded request to persist an answer the child already produced,
       # mirroring recover_peer_report in ~/.claude/shared/herdr-peer-launch.md.
-      herdr-child prompt --to "$started_name" --pane "$pane" --wait --timeout 120000 \
-        "The report transport file at $report_path is missing or empty. Write your exact complete previous answer, byte-for-byte, using your shell: write it to $report_path.tmp and then rename that file to $report_path. Do not use a file-editing tool. Then reply with only the path." \
-        >/dev/null 2>&1 || true
+      recovery_prompt="The report transport file at $report_path is missing or empty. Write your exact complete previous answer, byte-for-byte, using your shell: write it to $report_path.tmp and then rename that file to $report_path. Do not use a file-editing tool. Then reply with only the path."
+      printf '%s\n' "$recovery_prompt" > "$question_file"
+      if pre-external-secret-scan "${scan_paths[@]}"; then
+        herdr-child prompt --to "$started_name" --pane "$pane" --wait --timeout 120000 \
+          "$recovery_prompt" >/dev/null 2>&1 || true
+      else
+        recovery_scan_refused=1
+      fi
       set +e
       classify_report
       report_state=$?
       set -e
     fi
+    [ "$recovery_scan_refused" -eq 0 ] || status_exit refused 2
     if [ "$report_state" -ne 0 ]; then
       # The pane text is evidence of what happened, never the answer.
       cat "$read_out" >&2
@@ -230,13 +251,24 @@ case "$agent_status" in
     fi
     cat "$report_path"
     close_hint
+    printf -v follow_up_cmd \
+      'bash ~/.agents/skills/ask-in-herdr/scripts/follow-up.sh prompt %q %q '\''<task>'\''' \
+      "$started_name" "$pane"
+    if [ "$SKILLS_COUNT" -gt 0 ]; then
+      set +u
+      for skill in "${SKILLS[@]}"; do
+        printf -v escaped_skill '%q' "$skill"
+        follow_up_cmd="$follow_up_cmd --skills $escaped_skill"
+      done
+      set -u
+    fi
     printf -v reminder '%s\n\n%s\n%s\n%s\n%s\n%s' \
       "[child-settled v1 agent=$started_name pane=$pane]" \
       "The child is $agent_status and its initial answer has been read." \
       'If another turn may have run, read its current output before reaping.' \
       'If no follow-up is needed, run:' \
       "herdr-child reap --to $started_name --pane $pane" \
-      "If you need a follow-up, run: herdr-child prompt --to $started_name --pane $pane --wait '<task>'."
+      "If you need a follow-up, run: $follow_up_cmd"
     if ! herdr agent prompt "$HERDR_PANE_ID" "$reminder" >/dev/null 2>&1; then
       printf 'ask.sh: warning: could not queue the cleanup reminder for %s in pane %s\n' "$started_name" "$pane" >&2
     fi

--- a/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_follow-up.sh
+++ b/home/private_dot_agents/skills/ask-in-herdr/scripts/executable_follow-up.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf 'Usage: follow-up.sh <prompt|reply> <alias> <pane-id> <text> [--skills DIR]...\n' >&2
+}
+
+status_exit() {
+  local status="$1" code="$2"
+  printf 'follow-up.sh: status=%s\n' "$status" >&2
+  exit "$code"
+}
+
+[ $# -ge 4 ] || { usage; status_exit refused 2; }
+mode="$1"
+name="$2"
+pane="$3"
+question="$4"
+shift 4
+case "$mode" in prompt|reply) ;; *) usage; status_exit refused 2 ;; esac
+skills_count=0
+skills=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skills) [ $# -ge 2 ] || { usage; status_exit refused 2; }; skills+=("$2"); skills_count=$((skills_count + 1)); shift 2 ;;
+    *) printf "follow-up.sh: unknown flag '%s'\n" "$1" >&2; status_exit refused 2 ;;
+  esac
+done
+
+[ "${HERDR_ENV:-}" = 1 ] || { printf 'follow-up.sh: peer consults require HERDR_ENV=1\n' >&2; status_exit refused 2; }
+command -v herdr-child >/dev/null 2>&1 \
+  || { printf 'follow-up.sh: herdr-child is not on PATH\n' >&2; status_exit refused 2; }
+command -v herdr >/dev/null 2>&1 \
+  || { printf 'follow-up.sh: herdr is not on PATH\n' >&2; status_exit refused 2; }
+command -v pre-external-secret-scan >/dev/null 2>&1 \
+  || { printf 'follow-up.sh: pre-external-secret-scan is not on PATH\n' >&2; status_exit refused 2; }
+
+pane_json="$(herdr pane get "$pane")" \
+  || { printf 'follow-up.sh: child pane is unavailable\n' >&2; status_exit refused 2; }
+cwd="$(printf '%s' "$pane_json" | python3 -c 'import json,sys
+pane_id=sys.argv[1]
+pane=json.load(sys.stdin).get("result",{}).get("pane",{})
+cwd=pane.get("cwd","")
+if pane.get("pane_id") != pane_id or not cwd: raise SystemExit(1)
+print(cwd)' "$pane")" \
+  || { printf 'follow-up.sh: child pane has no trustworthy working directory\n' >&2; status_exit refused 2; }
+
+question_file="$(mktemp)"
+trap 'rm -f "$question_file"' EXIT
+printf '%s\n' "$question" > "$question_file"
+scan_paths=("$cwd" "$question_file")
+if [ "$skills_count" -gt 0 ]; then
+  set +u
+  for skill in "${skills[@]}"; do scan_paths+=("$skill"); done
+  set -u
+fi
+if ! pre-external-secret-scan "${scan_paths[@]}"; then
+  status_exit refused 2
+fi
+
+set +e
+if [ "$mode" = prompt ]; then
+  herdr-child prompt --to "$name" --pane "$pane" --wait "$question"
+else
+  herdr-child reply --to "$name" --pane "$pane" "$question"
+fi
+prompt_status=$?
+set -e
+case "$prompt_status" in
+  0) status_exit delivered 0 ;;
+  124) status_exit working 124 ;;
+  *) status_exit delivery-unknown 1 ;;
+esac

--- a/home/private_dot_agents/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-doc-review/SKILL.md
@@ -22,7 +22,7 @@ Treat tokens beginning with `mode:` as flags. The remaining token, when present,
 
 Record whether the wrapper was invoked with `mode:headless`; delivery uses that mode after synthesis.
 
-## Freeze and scan peer input
+## Freeze peer input
 
 Copy the document to an isolated temporary directory while preserving its basename and extension:
 
@@ -32,9 +32,7 @@ DOC_COPY="$DOC_STAGE_DIR/$(basename "$DOC_PATH")"
 cp "$DOC_PATH" "$DOC_COPY"
 ```
 
-The external payload includes this copy. Run `pre-external-secret-scan "$DOC_COPY"` before creating tabs. Any nonzero result refuses the peer launch and sends nothing externally. In that path, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`, deliver its envelope with degraded peer coverage, and remove the staged copy. `SE_SKIP_SECRET_SCAN=1` deliberately waives this gate; report that fact.
-
-Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. The copy remains untouched after its scan so the verdict describes the staged peer input at scan time.
+Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. The copy remains untouched while the peers run. The shared peer lifecycle owns the one pre-launch full-checkout scan and its fail-closed fallback.
 
 ## Dispatch fresh peers
 

--- a/home/private_dot_agents/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-doc-review/SKILL.md
@@ -22,17 +22,9 @@ Treat tokens beginning with `mode:` as flags. The remaining token, when present,
 
 Record whether the wrapper was invoked with `mode:headless`; delivery uses that mode after synthesis.
 
-## Scan and freeze peer input
+## Freeze and scan peer input
 
-The external payload is the document itself. Unless `SE_SKIP_SECRET_SCAN` is set to a non-empty value other than `0`, require `gitleaks` and run this fail-closed scan before creating tabs:
-
-```bash
-gitleaks dir --no-banner --redact --exit-code 2 "$DOC_PATH"
-```
-
-Any nonzero exit or unavailable scanner refuses the peer launch and sends nothing externally. In that path, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`. Then deliver its envelope with degraded peer coverage. The override deliberately skips this gate; report that fact.
-
-After a clean or explicitly waived scan, copy the document to an isolated temporary directory while preserving its basename and extension:
+Copy the document to an isolated temporary directory while preserving its basename and extension:
 
 ```bash
 DOC_STAGE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/se-doc-review.XXXXXX")
@@ -40,7 +32,9 @@ DOC_COPY="$DOC_STAGE_DIR/$(basename "$DOC_PATH")"
 cp "$DOC_PATH" "$DOC_COPY"
 ```
 
-Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. This keeps both peer inputs stable while local `safe_auto` edits land on the real document.
+The external payload includes this copy. Run `pre-external-secret-scan "$DOC_COPY"` before creating tabs. Any nonzero result refuses the peer launch and sends nothing externally. In that path, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`, deliver its envelope with degraded peer coverage, and remove the staged copy. `SE_SKIP_SECRET_SCAN=1` deliberately waives this gate; report that fact.
+
+Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. The copy remains untouched after its scan so the verdict describes the staged peer input at scan time.
 
 ## Dispatch fresh peers
 
@@ -102,7 +96,7 @@ canonical schema. An empty review still includes Coverage with explicit zero
 counts. End with the exact line: Review complete
 ```
 
-After the shared lifecycle submits both prompts and before it waits, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`. The local pass is the only review allowed to mutate the document. Whether the local pass succeeds or fails, resume the shared lifecycle through peer read and tab closure.
+Complete the shared lifecycle through peer read and tab closure before invoking the local `ce-doc-review` skill with `mode:headless DOC_PATH`. The local pass is the only review allowed to mutate the document, and it starts only after peers can no longer read the checkout state attested by the launch scan.
 
 Accept an envelope only when Coverage accounts for every attempted persona, its counts reconcile, every surviving finding is routed once with its required fields, and the terminal line is exact. A failed or malformed pass degrades coverage; synthesize any surviving envelopes. If all three passes fail, fail the review without modifying the document further.
 

--- a/home/private_dot_claude/shared/child-agent-contract.md
+++ b/home/private_dot_claude/shared/child-agent-contract.md
@@ -239,6 +239,6 @@ Detached lifecycle and callback markers carry both generation and event:
 [child-ask v2 generation=<nonce> event=callback-<seq> agent=<name> pane=<pane-id>]
 ```
 
-Attached callbacks retain `[child-ask v1 agent=<alias> pane=<pane-id>]`. The callback alias is resolved from the live launch pane and may differ from the launch alias; the parent verifies that pair before reply or reap. Parent decisions use `[parent-reply v1 ...]` for attached children and `[parent-reply v2 ...]` for detached continuations. `ask-in-herdr` retains its attached `[child-settled v1 ...]` reminder and exact `herdr-child reap --to <alias> --pane <pane-id>` syntax.
+Attached callbacks retain `[child-ask v1 agent=<alias> pane=<pane-id>]`. The callback alias is resolved from the live launch pane and may differ from the launch alias; the parent verifies that pair before reply or reap. Parent decisions use `[parent-reply v1 ...]` for attached children and `[parent-reply v2 ...]` for detached continuations. `ask-in-herdr` retains its attached `[child-settled v1 ...]` reminder and exact `herdr-child reap --to <alias> --pane <pane-id>` syntax. For an `ask-in-herdr` child, its scan-enforcing `follow-up.sh` wrapper owns duties 5 and 6 instead of the raw commands above.
 
 Markers identify and version messages. They do not authenticate senders and do not claim exactly-once delivery. A confirmed receipt suppresses a known exact duplicate; an uncertain post-delivery failure may deliver the same marker again.

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -10,9 +10,20 @@ Resolve these values before launch:
 - `CLAUDE_PROMPT`: the calling skill's complete Claude dispatch brief.
 - `OPENCODE_PROMPT`: the calling skill's complete OpenCode dispatch brief.
 
-Require `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`, `herdr`, `claude`, `opencode`, and `herdr-peer-alias`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
+Require `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`, `herdr`, `claude`, `opencode`, `herdr-peer-alias`, and `pre-external-secret-scan`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
 
 The **cleanup boundary** begins when the report transport directory is created. Track each created tab ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every tab created by this run and removes its report transport files before control returns to the calling skill.
+
+## Scan exposed content
+
+Before allocating aliases or creating tabs, scan the live checkout and both dispatch prompts:
+
+```bash
+printf '%s\n%s\n' "$CLAUDE_PROMPT" "$OPENCODE_PROMPT" \
+  | pre-external-secret-scan --stdin "$REPO_ROOT"
+```
+
+Exit `0` is the only permission to continue. On any nonzero result, stop this lifecycle before reading another section and report that no tab or report transport was created. The command submits tracked, modified, and untracked filesystem content to gitleaks's trusted default detector rules rather than scanning only a Git range. Detected secrets, a missing scanner, a timeout, an invalid target, or any unexpected scanner status refuse the launch. Scanner findings are redacted before they reach output. `SE_SKIP_SECRET_SCAN=1` is an explicit operator waiver; the caller must report that the external peer input was not scanned. No other value waives the scan.
 
 ## Create tabs
 
@@ -106,6 +117,8 @@ Before ending this turn, write the exact complete report you are returning, byte
 
 Submit both augmented prompts before either wait can block:
 
+Immediately before submission, repeat the **Scan exposed content** command against the now-augmented prompt values. A nonzero result enters the cleanup boundary without prompting either peer. This second verdict checks content again after tab and agent startup; both pre-dispatch scans must pass before submission.
+
 ```bash
 herdr agent prompt "$CLAUDE_PANE" "$CLAUDE_PROMPT"
 herdr agent prompt "$OPENCODE_PANE" "$OPENCODE_PROMPT"
@@ -134,12 +147,14 @@ report_is_delivered() {
 }
 
 recover_peer_report() {
-  local pane="$1" report_path="$2"
+  local pane="$1" report_path="$2" recovery_prompt
   [ ! -L "$report_path" ] || return 1
   report_is_delivered "$report_path" && return 0
 
-  herdr agent prompt "$pane" \
-    "The report transport file is missing or empty. Write your exact complete previous report, byte-for-byte, atomically through $report_path.tmp and rename it to $report_path. Then reply with only the path." \
+  recovery_prompt="The report transport file is missing or empty. Write your exact complete previous report, byte-for-byte, atomically through $report_path.tmp and rename it to $report_path. Then reply with only the path."
+  printf '%s\n' "$recovery_prompt" \
+    | pre-external-secret-scan --stdin "$REPO_ROOT" || return 1
+  herdr agent prompt "$pane" "$recovery_prompt" \
     --wait --timeout 120000 || return 1
 
   report_is_delivered "$report_path"

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -117,8 +117,6 @@ Before ending this turn, write the exact complete report you are returning, byte
 
 Submit both augmented prompts before either wait can block:
 
-Immediately before submission, repeat the **Scan exposed content** command against the now-augmented prompt values. A nonzero result enters the cleanup boundary without prompting either peer. This second verdict checks content again after tab and agent startup; both pre-dispatch scans must pass before submission.
-
 ```bash
 herdr agent prompt "$CLAUDE_PANE" "$CLAUDE_PROMPT"
 herdr agent prompt "$OPENCODE_PANE" "$OPENCODE_PROMPT"

--- a/home/private_dot_config/brewfiles/Brewfile.tmpl
+++ b/home/private_dot_config/brewfiles/Brewfile.tmpl
@@ -57,7 +57,7 @@ brew "ripgrep"      # rg
 brew "bat"
 {{ end -}}
 brew "jq"
-{{/* gitleaks is kept for the fail-closed se-doc-review secret scan */ -}}
+{{/* gitleaks is required by the fail-closed external peer launch boundary */ -}}
 brew "gitleaks"
 
 {{ if $full -}}

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -1738,8 +1738,105 @@ SH
 # ask-in-herdr skill script
 # ===========================================
 
+PRE_EXTERNAL_SECRET_SCAN="$SOURCE_ROOT/dot_local/bin/executable_pre-external-secret-scan"
 ASK_HERDR_DIR="$SOURCE_ROOT/private_dot_agents/skills/ask-in-herdr/scripts"
 ASK_HERDR_SCRIPT="$ASK_HERDR_DIR/executable_ask.sh"
+ASK_HERDR_FOLLOW_UP="$ASK_HERDR_DIR/executable_follow-up.sh"
+
+function test_scripts_1225_pre_external_secret_scan_accepts_clean_references_and_rejects_a_real_leak() {
+  _bats_test_init 1225 'pre-external secret scan accepts clean references and rejects a real leak'
+  if ! command_exists gitleaks; then
+    [ "${MMS_DISPOSABLE_HOME:-0}" != 1 ] || fail "gitleaks is missing from the disposable-home test process"
+    skip "gitleaks is not installed"
+  fi
+  local clean_dir="$BATS_TEST_TMPDIR/scan-clean"
+  local leak_dir="$BATS_TEST_TMPDIR/scan-leak"
+  local token
+  mkdir -p "$clean_dir" "$leak_dir"
+  printf '%s\n' 'onepasswordRead "op://Private/Example/credential"' > "$clean_dir/config.tmpl"
+  token='ghp_''A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'
+  printf 'token=%s # gitleaks:allow\n' "$token" > "$leak_dir/config"
+  cat > "$leak_dir/.gitleaks.toml" <<'TOML'
+title = "checkout-controlled empty rules"
+TOML
+
+  run bash "$PRE_EXTERNAL_SECRET_SCAN" "$clean_dir"
+  assert_success
+  assert_output --partial 'pre-external secret scan clean'
+
+  run bash -c 'printf "%s\n" '\''onepasswordRead "op://Private/Example/credential"'\'' | bash "$1" --stdin "$2"' \
+    _ "$PRE_EXTERNAL_SECRET_SCAN" "$clean_dir"
+  assert_success
+  assert_output --partial 'pre-external secret scan clean: <stdin>'
+
+  run bash "$PRE_EXTERNAL_SECRET_SCAN" "$clean_dir" "$leak_dir"
+  assert_failure 1
+  assert_output --partial 'pre-external secret gate REFUSED'
+  assert_output --partial 'FOUND secrets'
+  refute_output --partial "$token"
+
+  run bash -c 'printf "prompt=%s\n" "$3" | bash "$1" --stdin "$2"' \
+    _ "$PRE_EXTERNAL_SECRET_SCAN" "$clean_dir" "$token"
+  assert_failure 1
+  assert_output --partial 'FOUND secrets in <stdin>'
+  refute_output --partial "$token"
+
+  local option_parent="$BATS_TEST_TMPDIR/scan-option"
+  mkdir -p "$option_parent/--exit-code=0"
+  printf 'token=%s\n' "$token" > "$option_parent/--exit-code=0/config"
+  run bash -c 'cd "$1" && bash "$2" --exit-code=0' \
+    _ "$option_parent" "$PRE_EXTERNAL_SECRET_SCAN"
+  assert_failure 1
+  assert_output --partial 'FOUND secrets'
+
+  local linked_root="$BATS_TEST_TMPDIR/scan-linked-root"
+  mkdir -p "$linked_root"
+  ln -s "$leak_dir" "$linked_root/outside"
+  run bash "$PRE_EXTERNAL_SECRET_SCAN" "$linked_root"
+  assert_failure 1
+  assert_output --partial 'directory symlink escapes scan root'
+
+  run env SE_SKIP_SECRET_SCAN=1 bash "$PRE_EXTERNAL_SECRET_SCAN" "$leak_dir"
+  assert_success
+  assert_output --partial 'SKIPPED by operator'
+
+  run env SE_SKIP_SECRET_SCAN=false bash "$PRE_EXTERNAL_SECRET_SCAN" "$leak_dir"
+  assert_failure 1
+  assert_output --partial 'FOUND secrets'
+
+  run env GITLEAKS_CONFIG_TOML='title = "ambient empty rules"' \
+    bash "$PRE_EXTERNAL_SECRET_SCAN" "$leak_dir"
+  assert_failure 1
+  assert_output --partial 'FOUND secrets'
+}
+
+function test_scripts_1226_pre_external_secret_scan_fails_closed_without_a_clean_scanner_verdict() {
+  _bats_test_init 1226 'pre-external secret scan fails closed without a clean scanner verdict'
+  local empty_bin="$BATS_TEST_TMPDIR/scan-empty-bin"
+  local bad_bin="$BATS_TEST_TMPDIR/scan-bad-bin"
+  local scan_dir="$BATS_TEST_TMPDIR/scan-input"
+  mkdir -p "$empty_bin" "$bad_bin" "$scan_dir"
+  cat > "$bad_bin/gitleaks" <<'SH'
+#!/bin/sh
+exit 7
+SH
+  chmod +x "$bad_bin/gitleaks"
+
+  run env PATH="$empty_bin:/usr/bin:/bin" /bin/bash "$PRE_EXTERNAL_SECRET_SCAN" "$scan_dir"
+  assert_failure 1
+  assert_output --partial 'gitleaks is not on PATH'
+  assert_output --partial 'Nothing was sent externally'
+
+  run env PATH="$bad_bin:/usr/bin:/bin" /bin/bash "$PRE_EXTERNAL_SECRET_SCAN" "$scan_dir"
+  assert_failure 1
+  assert_output --partial 'unexpected code 7'
+  assert_output --partial 'Nothing was sent externally'
+
+  run bash "$PRE_EXTERNAL_SECRET_SCAN" "$scan_dir/missing"
+  assert_failure 1
+  assert_output --partial 'scan target does not exist'
+  assert_output --partial 'Nothing was sent externally'
+}
 
 ask_live_stub() {
   CHILD_STUB="$(mktemp -d)"
@@ -1787,7 +1884,9 @@ case "${1:-}" in
       stub_rp2=""; [ ! -f "$CHILD_STUB/report-path" ] || read -r stub_rp2 < "$CHILD_STUB/report-path"
       [ -z "$stub_rp2" ] || printf '%s\n' "${STUB_REPORT_BODY:-RECOVERED answer}" > "$stub_rp2"
     fi
+    exit "${STUB_PROMPT_STATUS:-0}"
     ;;
+  reply) exit "${STUB_REPLY_STATUS:-0}" ;;
   verify)
     count=0; [ ! -f "$CHILD_STUB/verify-count" ] || read -r count < "$CHILD_STUB/verify-count"
     count=$((count + 1)); printf '%s\n' "$count" > "$CHILD_STUB/verify-count"
@@ -1800,6 +1899,23 @@ case "${1:-}" in
     ;;
   *) exit 2 ;;
 esac
+SH
+  cat > "$CHILD_STUB/pre-external-secret-scan" <<'SH'
+#!/usr/bin/env bash
+printf '%q ' "$@" >> "$CHILD_STUB/scan.log"; printf '\n' >> "$CHILD_STUB/scan.log"
+scan_count=0
+[ ! -f "$CHILD_STUB/scan-count" ] || read -r scan_count < "$CHILD_STUB/scan-count"
+scan_count=$((scan_count + 1))
+printf '%s\n' "$scan_count" > "$CHILD_STUB/scan-count"
+[ "${STUB_SCAN_FAIL_AT:-0}" -ne "$scan_count" ] || exit 1
+if [ -n "${STUB_SCAN_MATCH:-}" ]; then
+  for scan_arg in "$@"; do
+    if [ -f "$scan_arg" ] && grep -q -- "$STUB_SCAN_MATCH" "$scan_arg"; then exit 1; fi
+    if [ "${STUB_SCAN_DIRS:-0}" = 1 ] && [ -d "$scan_arg" ] && \
+       grep -R -q -- "$STUB_SCAN_MATCH" "$scan_arg"; then exit 1; fi
+  done
+fi
+exit "${STUB_SCAN_STATUS:-0}"
 SH
   cat > "$CHILD_STUB/herdr" <<'SH'
 #!/usr/bin/env bash
@@ -1825,12 +1941,12 @@ case "$1 $2" in
     ;;
   "pane get")
     if [ "${STUB_WAITING_LABEL:-0}" = 1 ]; then
-      printf '{"result":{"pane":{"pane_id":"wT:p9","terminal_id":"term-child","state_labels":{"blocked":"waiting for parent"}}}}\n'
-    else printf '{"result":{"pane":{"pane_id":"wT:p9","terminal_id":"term-child"}}}\n'; fi ;;
+      printf '{"result":{"pane":{"pane_id":"wT:p9","terminal_id":"term-child","cwd":"%s","state_labels":{"blocked":"waiting for parent"}}}}\n' "${STUB_PANE_CWD:-$PWD}"
+    else printf '{"result":{"pane":{"pane_id":"wT:p9","terminal_id":"term-child","cwd":"%s"}}}\n' "${STUB_PANE_CWD:-$PWD}"; fi ;;
   *) exit 2 ;;
 esac
 SH
-  chmod +x "$CHILD_STUB/herdr-child" "$CHILD_STUB/herdr"
+  chmod +x "$CHILD_STUB/herdr-child" "$CHILD_STUB/herdr" "$CHILD_STUB/pre-external-secret-scan"
 }
 
 function test_scripts_1051_ask_in_herdr_script_requires_arguments() {
@@ -1881,6 +1997,73 @@ function test_scripts_1053_ask_sh_refuses_outside_herdr_and_when_herdr_child_is_
   rm -rf "$no_child"
 }
 
+function test_scripts_1227_ask_sh_refuses_before_launch_when_the_secret_scan_is_not_clean() {
+  _bats_test_init 1227 'ask.sh refuses before launch when the secret scan is not clean'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_SCAN_MATCH=question-secret-marker HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_SCRIPT" claude question-secret-marker --skills "$ASK_HERDR_DIR"
+  assert_failure 2
+  assert_line --index "$(( ${#lines[@]} - 1 ))" "ask.sh: status=refused"
+  assert_file_not_exists "$CHILD_STUB/child.log"
+  assert_file_contains "$CHILD_STUB/scan.log" "$PWD"
+  assert_file_contains "$CHILD_STUB/scan.log" "$ASK_HERDR_DIR"
+}
+
+function test_scripts_1228_ask_in_herdr_follow_up_rescans_the_question_before_prompting() {
+  _bats_test_init 1228 'ask-in-herdr follow-up rescans the question before prompting'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_SCAN_MATCH=follow-up-secret-marker HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 follow-up-secret-marker
+  assert_failure 2
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'follow-up.sh: status=refused'
+  assert_file_not_exists "$CHILD_STUB/child.log"
+
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 clean-question
+  assert_success
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'follow-up.sh: status=delivered'
+  assert_file_contains "$CHILD_STUB/child.log" '^prompt --to red-wolf --pane wT:p9 --wait clean-question'
+
+  run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" reply red-wolf wT:p9 clean-decision
+  assert_success
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'follow-up.sh: status=delivered'
+  assert_file_contains "$CHILD_STUB/child.log" '^reply --to red-wolf --pane wT:p9 clean-decision'
+
+  ask_live_stub
+  local secret_cwd="$BATS_TEST_TMPDIR/follow-up-secret-cwd"
+  mkdir -p "$secret_cwd"
+  printf '%s\n' follow-up-secret-marker > "$secret_cwd/secret"
+  run env PATH="$CHILD_STUB:$PATH" STUB_SCAN_MATCH=follow-up-secret-marker STUB_SCAN_DIRS=1 \
+    STUB_PANE_CWD="$secret_cwd" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 clean-question
+  assert_failure 2
+  assert_file_not_exists "$CHILD_STUB/child.log"
+
+  ask_live_stub
+  local clean_cwd="$BATS_TEST_TMPDIR/follow-up-clean-cwd"
+  local secret_skills="$BATS_TEST_TMPDIR/follow-up-secret-skills"
+  mkdir -p "$clean_cwd" "$secret_skills"
+  printf '%s\n' follow-up-secret-marker > "$secret_skills/secret"
+  run env PATH="$CHILD_STUB:$PATH" STUB_SCAN_MATCH=follow-up-secret-marker STUB_SCAN_DIRS=1 \
+    STUB_PANE_CWD="$clean_cwd" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 clean-question --skills "$secret_skills"
+  assert_failure 2
+  assert_file_not_exists "$CHILD_STUB/child.log"
+
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_PROMPT_STATUS=124 HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 clean-question
+  assert_failure 124
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'follow-up.sh: status=working'
+
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_PROMPT_STATUS=1 HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
+    bash "$ASK_HERDR_FOLLOW_UP" prompt red-wolf wT:p9 clean-question
+  assert_failure 1
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'follow-up.sh: status=delivery-unknown'
+}
+
 function test_scripts_1054_ask_sh_starts_a_read_only_live_child_and_returns_its_an() {
   _bats_test_init 1054 'ask.sh starts a read-only live child and returns its answer'
   ask_live_stub
@@ -1900,6 +2083,7 @@ function test_scripts_1054_ask_sh_starts_a_read_only_live_child_and_returns_its_
   assert_file_contains "$CHILD_STUB/parent-prompt" 'initial answer has been read'
   assert_file_contains "$CHILD_STUB/parent-prompt" 'read its current output before reaping'
   assert_file_contains "$CHILD_STUB/parent-prompt" 'herdr-child reap --to red-wolf --pane wT:p9'
+  assert_file_contains "$CHILD_STUB/parent-prompt" 'ask-in-herdr/scripts/follow-up.sh prompt red-wolf wT:p9'
   assert_file_contains "$CHILD_STUB/herdr.log" '^agent prompt wT:p0 '
 }
 
@@ -2125,6 +2309,16 @@ function test_scripts_1068_ask_sh_reports_no_report_after_one_failed_recovery() 
   assert_file_exists "$CHILD_STUB/recover.log"
   run grep -c 'prompt' "$CHILD_STUB/recover.log"
   assert_output '1'
+}
+
+function test_scripts_1229_ask_sh_reports_refusal_when_the_recovery_scan_is_not_clean() {
+  _bats_test_init 1229 'ask.sh reports refusal when the recovery scan is not clean'
+  ask_live_stub
+  run env PATH="$CHILD_STUB:$PATH" STUB_REPORT=none STUB_SCAN_FAIL_AT=2 \
+    HERDR_ENV=1 HERDR_PANE_ID=wT:p0 bash "$ASK_HERDR_SCRIPT" claude question
+  assert_failure 2
+  assert_line --index "$(( ${#lines[@]} - 1 ))" 'ask.sh: status=refused'
+  assert_file_not_exists "$CHILD_STUB/recover.log"
 }
 
 function test_scripts_1069_ask_sh_returns_a_recovered_report_as_a_normal_answer() {

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -769,13 +769,17 @@ PY
 # herdr alias presentation (engine, native integrations, sidebar)
 # ===========================================
 
-function test_smoke_1051_herdr_alias_pane_label_and_child_files_are_deployed() {
-  _bats_test_init 1051 'herdr alias, pane-label, and child files are deployed'
+function test_smoke_1051_herdr_alias_pane_label_child_and_secret_scan_files_are_deployed() {
+  _bats_test_init 1051 'herdr alias, pane-label, child, and secret scan files are deployed'
   assert_file_exists "$HOME/.local/lib/herdr-aliases.sh"
   assert_file_exists "$HOME/.local/bin/herdr-pane-labels"
   assert_file_executable "$HOME/.local/bin/herdr-pane-labels"
   assert_file_exists "$HOME/.local/bin/herdr-child"
   assert_file_executable "$HOME/.local/bin/herdr-child"
+  assert_file_exists "$HOME/.local/bin/pre-external-secret-scan"
+  assert_file_executable "$HOME/.local/bin/pre-external-secret-scan"
+  assert_file_exists "$HOME/.agents/skills/ask-in-herdr/scripts/follow-up.sh"
+  assert_file_executable "$HOME/.agents/skills/ask-in-herdr/scripts/follow-up.sh"
 }
 
 function test_smoke_1052_herdr_child_and_consult_contracts_use_allocator_owned_p() {

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -180,12 +180,13 @@ class TestDotfilesWorkflow(unittest.TestCase):
 
     def gate_script(self, text, job_name):
         """The shell body of the Brewfile-diff gate, ready to execute."""
-        step = self.named_step_block(
-            self.job_block(text, job_name),
-            "Install the full Brewfiles when the diff touches one",
-        )
+        return self.step_script(text, job_name, "Install the full Brewfiles when the diff touches one")
+
+    def step_script(self, text, job_name, step_name):
+        """A named step's literal shell body, ready to execute."""
+        step = self.named_step_block(self.job_block(text, job_name), step_name)
         match = re.search(r"^        run: \|\n(?P<body>(?:^ {10}.*\n|^\n)+)", step, re.MULTILINE)
-        self.assertIsNotNone(match, "gate step must declare a literal run: block")
+        self.assertIsNotNone(match, "%s must declare a literal run: block" % step_name)
         return textwrap.dedent(match.group("body"))
 
     def git_environment(self, home):
@@ -318,6 +319,92 @@ class TestDotfilesWorkflow(unittest.TestCase):
                     full,
                     "a PR that edits a Brewfile must install the full set: %s" % output,
                 )
+
+    def test_ubuntu_exports_paths_for_chezmoi_and_linuxbrew_tools(self):
+        script = self.step_script(self.workflow_text(), "test-ubuntu", "Add managed tools to PATH")
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            github_path = home / "github_path"
+            environment = dict(os.environ, HOME=str(home), GITHUB_PATH=str(github_path))
+            result = subprocess.run(
+                ["bash", "-e", "-c", script],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            exported = github_path.read_text(encoding="utf-8").splitlines()
+
+        self.assertIn(str(home / ".local" / "bin"), exported)
+        self.assertIn("/home/linuxbrew/.linuxbrew/bin", exported)
+
+    def test_ubuntu_gitleaks_installer_deploys_a_runnable_cli(self):
+        text = self.workflow_text()
+        job = self.job_block(text, "test-ubuntu")
+        step = self.named_step_block(job, "Install gitleaks")
+        version = self.step_value(step, "GITLEAKS_VERSION").strip('"')
+        self.assertEqual(version, "8.30.1")
+        script = self.step_script(text, "test-ubuntu", "Install gitleaks")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            bin_dir = home / ".local" / "bin"
+            fixture_dir = root / "fixture"
+            stub_dir = root / "stubs"
+            bin_dir.mkdir(parents=True)
+            fixture_dir.mkdir()
+            stub_dir.mkdir()
+
+            gitleaks = fixture_dir / "gitleaks"
+            gitleaks.write_text("#!/bin/sh\nprintf 'fixture-gitleaks\\n'\n", encoding="utf-8")
+            gitleaks.chmod(0o755)
+            archive = root / "gitleaks.tar.gz"
+            subprocess.run(
+                ["tar", "-czf", str(archive), "-C", str(fixture_dir), "gitleaks"],
+                check=True,
+            )
+
+            curl_log = root / "curl.log"
+            curl = stub_dir / "curl"
+            curl.write_text(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CURL_LOG\"\ncat \"$GITLEAKS_ARCHIVE\"\n",
+                encoding="utf-8",
+            )
+            curl.chmod(0o755)
+            environment = dict(
+                os.environ,
+                HOME=str(home),
+                PATH="%s:%s:%s" % (stub_dir, bin_dir, os.environ["PATH"]),
+                CURL_LOG=str(curl_log),
+                GITLEAKS_ARCHIVE=str(archive),
+                GITLEAKS_VERSION=version,
+                MMS_CI_MINIMAL="",
+            )
+            full_result = subprocess.run(
+                ["bash", "-e", "-c", script],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(full_result.returncode, 0, full_result.stdout + full_result.stderr)
+            self.assertFalse(curl_log.exists())
+            self.assertFalse((bin_dir / "gitleaks").exists())
+
+            environment["MMS_CI_MINIMAL"] = "1"
+            result = subprocess.run(
+                ["bash", "-e", "-c", script],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(result.stdout.strip(), "fixture-gitleaks")
+            self.assertTrue((bin_dir / "gitleaks").is_file())
+            self.assertIn(
+                "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/"
+                "gitleaks_8.30.1_linux_x64.tar.gz",
+                curl_log.read_text(encoding="utf-8").splitlines(),
+            )
 
     def test_every_job_declares_a_timeout(self):
         # Presence only — ceiling values are owned by issue 2026-08-21-008.


### PR DESCRIPTION
## Summary

External Claude, OpenCode, and Pi peer workflows now stop before sending checkout or prompt content unless `gitleaks` returns a clean, redacted verdict. This restores the fail-closed boundary removed with Smithers and follows ADR-0012's cadence of one full-checkout scan per review pair or standalone launch.

## Design Decisions

- The scanner ignores checkout-controlled configuration and inline allow comments, handles exit codes explicitly, rejects directory symlinks that escape the scan root, and treats missing tools, timeouts, and unknown failures as refusal.
- `ask-in-herdr` rescans recovery prompts, follow-ups, and blocked-child replies because each is a new external dispatch.
- `SE_SKIP_SECRET_SCAN=1` is the only waiver, and callers report when it is used.

## Validation

- `make test-ubuntu`
- `make lint`
- `make test-issues`

Related: `2026-09-04-001`
