### PR TITLE
docs(herdr): note the reload Cmd+N needs after config edits

### DIFF
--- a/home/private_dot_config/herdr/config.toml
+++ b/home/private_dot_config/herdr/config.toml
@@ -17,7 +17,7 @@ allow_nested = true
 
 [keys]
 switch_workspace = "ctrl+shift+1..9"
-new_workspace = ""
+new_workspace = "" # rebound below as a custom command, not dropped
 new_worktree = "prefix+shift+g"
 open_worktree = ["prefix+shift+o", "cmd+shift+o", "prefix+cmd+shift+o"]
 remove_worktree = ["prefix+shift+y", "cmd+shift+k", "prefix+cmd+shift+k"]
@@ -42,6 +42,12 @@ resize_pane_right = "ctrl+alt+right"
 # Herdr 0.9.0 can retain the source workspace's Git identity after a new
 # workspace changes directories (herdrdev/herdr#3214). Start Cmd+N workspaces
 # outside Git without changing the follow policy for tabs and split panes.
+# Cmd+N arrives as \x02N from the terminal (see the Ghostty keybind), which
+# Herdr reads as prefix+shift+n. Run `herdr server reload-config` after editing
+# this pair: the unbind above and this command activate through different paths
+# -- server config vs the client's custom-command manifest -- so a half-applied
+# reload leaves the chord bound to nothing. Herdr logs no config events, so the
+# only symptom is a key that silently stops working.
 [[keys.command]]
 key = "prefix+shift+n"
 type = "shell"


### PR DESCRIPTION
Editing the Cmd+N workspace binding in `home/private_dot_config/herdr/config.toml` now carries the two facts that cost a debugging session to recover. `new_workspace = ""` reads like a deletion but is an intentional rebind — its replacement `[[keys.command]]` sits twenty lines below it. And the pair only takes effect after `herdr server reload-config`, because the unbind applies server-side while custom commands dispatch through the client's manifest; a half-applied reload leaves the chord bound to nothing, with no error and nothing in the logs.

That is exactly how Cmd+N broke. Ghostty sends `\x02N`, which Herdr reads as `prefix+shift+n`; commit bdbf698 split that one working binding into the two halves above, and in the running session they were out of sync. Running `herdr server reload-config` resynchronized them and Cmd+N creates workspaces again — no code was at fault, so this change adds only the comments that make the failure mode discoverable next time.

Verified: `tests/bashunit/palette_test.sh` passes (61 tests — it regex-scans this config for dangling palette bindings, so its coverage includes the edit), and `make test-local` renders the two comment hunks to `~/.config/herdr/config.toml` with no path, template, or ignore behavior changed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
