### PR TITLE
refactor(agents): enforce peer lifecycle and state ownership

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -61,6 +61,9 @@ A single review or analysis pass executed by a separate, headless agent-CLI proc
 
 One failed leg degrades a review's coverage; losing every leg fails it.
 
+### External leg pair
+Two fresh External legs given the same review scope through separate agents and classified together. The pair provides paired coverage only when both reports are independently attributable, valid, and distinct; one failed or invalid leg degrades it to single-source coverage, as does a byte-identical pair. Pair classification describes coverage, never agreement or corroboration between findings.
+
 ### Captured child
 A subprocess whose output the caller captures instead of passing through, which makes the caller responsible for the child's input as well. Capturing is itself what hides a prompt: the question renders into a buffer nobody is reading while the child waits on an input channel it still holds. So a captured child is denied that channel, and a flag or environment variable asking the child not to prompt counts as a request the callee may decline, never as the guarantee.
 

--- a/docs/issues/2026-09-11-001-make-external-leg-pair-lifecycle-executable.md
+++ b/docs/issues/2026-09-11-001-make-external-leg-pair-lifecycle-executable.md
@@ -1,0 +1,27 @@
+---
+title: "Make External leg pair lifecycle executable"
+short_description: "Replace the prose-only paired peer lifecycle with one tested executable that owns scanning, launch, report transport, classification, and cleanup for three review workflows."
+type: "follow-up"
+category: "se-pipeline"
+tags: ["architecture","external-leg","semantic-tests","enhancement","ready-for-agent"]
+date: "2026-09-11"
+status: "done"
+priority: "high"
+closed: "2026-09-11"
+---
+
+## Why this exists
+
+se-code-review, se-doc-review, and se-simplify currently reenact a 206-line Markdown procedure, so lifecycle safety and cleanup are not enforced through an executable test surface.
+
+## Scope
+
+Add se-external-leg-pair with fixed launch policy, exact exposed-content scanning, atomic result publication, degraded-coverage classification, and fail-closed cleanup; migrate the three callers and reduce herdr-peer-launch.md to interface documentation. Preserve SE_SKIP_SECRET_SCAN=1 with an explicit waived result.
+
+## Open decisions
+
+None. The interface and caller ownership decisions were accepted during the architecture review.
+
+## Resolution
+
+Implemented the executable External leg pair lifecycle, migrated all three callers, added semantic regression coverage, and verified the deployed checkout with make test-ubuntu.

--- a/docs/issues/2026-09-11-002-deepen-herdr-worktree-state-record-ownership.md
+++ b/docs/issues/2026-09-11-002-deepen-herdr-worktree-state-record-ownership.md
@@ -1,0 +1,27 @@
+---
+title: "Deepen herdr-worktree state record ownership"
+short_description: "Move the durable identity record schema, compatibility translation, and atomic named-field updates into herdr-worktree-state.sh without changing worktree outcomes or marker authorization."
+type: "follow-up"
+category: "herdr"
+tags: ["architecture","worktree-identity","semantic-tests","enhancement","ready-for-agent"]
+date: "2026-09-11"
+status: "done"
+priority: "high"
+closed: "2026-09-11"
+---
+
+## Why this exists
+
+The state module owns outcome names and storage primitives, while the 1,057-line executable still assembles the full record at 21 write sites and tests manually reproduce its encoding.
+
+## Scope
+
+Give the existing state module one named-field atomic write interface that preserves unspecified fields and old attribution_failed records; keep Git mutation, Generated-worktree marker authorization, and outcome selection in the executable. Route tests through the interface except for one legacy-format fixture.
+
+## Open decisions
+
+None. Compatibility, seam placement, and test-surface decisions were accepted during the architecture review.
+
+## Resolution
+
+Moved durable identity record ownership into herdr-worktree-state.sh with named-field updates, compatibility translation, and semantic coverage; verified the deployed checkout with make test-ubuntu.

--- a/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
+++ b/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
@@ -1,0 +1,22 @@
+---
+title: "Share the Pi and OpenCode worktree-identity handoff"
+short_description: "Consolidate duplicated engine discovery, stdin transport, timeout, and fail-open settlement when either TypeScript adapter next changes."
+type: "follow-up"
+category: "agent-platform"
+tags: ["architecture","worktree-identity","adapter","enhancement","ready-for-agent"]
+date: "2026-09-11"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Pi and OpenCode independently implement the same one-second subprocess handoff, creating a real two-adapter seam where transport behavior can drift.
+
+## Scope
+
+When either adapter next requires modification, move only the shared TypeScript engine handoff behind one internal interface; keep client event normalization local and keep the Claude shell adapter separate.
+
+## Open decisions
+
+Deferred until one adapter next changes; revalidate that both implementations still match before extracting the shared handoff.

--- a/docs/issues/2026-09-11-004-share-process-hygiene-across-detached-workers.md
+++ b/docs/issues/2026-09-11-004-share-process-hygiene-across-detached-workers.md
@@ -1,0 +1,22 @@
+---
+title: "Share process hygiene across Detached workers"
+short_description: "Adopt one descriptor-closure and process-identity implementation across Herdr Detached workers when a worker path next changes."
+type: "follow-up"
+category: "herdr"
+tags: ["architecture","detached-worker","process-hygiene","enhancement","ready-for-agent"]
+date: "2026-09-11"
+status: "open"
+priority: "low"
+---
+
+## Why this exists
+
+Descriptor closure is copied three times and process-start identity has divergent locale and validation behavior, while the existing shared process module serves only the Child-agent contract.
+
+## Scope
+
+When a Detached worker path next changes, deepen herdr-process.sh to own descriptor closure and stable PID-plus-start identity for child lifecycle, worktree identity, and pane labels; leave claims, waits, recovery, and abandonment in each caller.
+
+## Open decisions
+
+Deferred until a worker path next changes; verify persisted process-start compatibility before consolidating implementations.

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -308,37 +308,6 @@ recorded_first_prompt() {
   printf '%s' "$stored"
 }
 
-diagnostic_file_for_state() {
-  printf '%s.diagnostics.log' "${1%.state}"
-}
-
-write_identity_state() {
-  local file="$1" root="$2" common="$3" workspace="$4" original="$5" outcome="$6" authorization="$7"
-  local title="${8:-}" slug="${9:-}" branch="${10:-}"
-  # Read compatibility for state written before the rename. A state file is a
-  # cache entry, but the re-write paths carry an existing outcome forward, so an
-  # in-flight underscored value would otherwise be refused below and strand the
-  # state. Translating here guarantees only the canonical spelling is persisted.
-  [ "$outcome" = attribution_failed ] && outcome=attribution-failed
-  # An outcome outside the whitelist is a programming error in one of the write
-  # sites, not runtime contention. Refuse the write so an unreachable state never
-  # reaches a reader, and leave the evidence where every other state-write
-  # failure leaves it -- callers already treat a nonzero return that way.
-  if ! is_legal_outcome "$outcome"; then
-    record_diagnostic "$(diagnostic_file_for_state "$file")" illegal-outcome "outcome=$outcome workspace=$workspace" || true
-    return 1
-  fi
-  atomic_write "$file" "checkout_root=$(encode_value "$root")
-repository_anchor=$(encode_value "$common")
-workspace=$(encode_value "$workspace")
-original_branch=$(encode_value "$original")
-branch=$(encode_value "$branch")
-outcome=$(encode_value "$outcome")
-authorization=$(encode_value "$authorization")
-title=$(encode_value "$title")
-slug=$(encode_value "$slug")"
-}
-
 ensure_identity() {
   local state="$1" root="$2" prompt="$3" title slug identity
   title="$(read_state_field "$state" title)"
@@ -346,16 +315,14 @@ ensure_identity() {
   [ -n "$title" ] && [ "$(slug_word_count "$slug")" -ge 2 ] && return 0
   identity="$(derive_identity "$prompt" "$root")"
   IFS=$'\037' read -r title slug <<< "$identity"
-  write_identity_state "$state" "$root" "$(read_state_field "$state" repository_anchor)" "$workspace" \
-    "$(read_state_field "$state" original_branch)" "$(read_state_field "$state" outcome)" authorized "$title" "$slug" \
-    "$(read_state_field "$state" branch)" || true
+  write_identity_state "$state" title "$title" slug "$slug" || true
   [ -n "$title" ] && [ "$(slug_word_count "$slug")" -ge 2 ]
 }
 
 record_unresolved() {
   local reason="$1" observed="$2" file
   file="$(session_state_file "$session")"
-  write_identity_state "$file" '' '' "$workspace" '' unresolved '' || true
+  write_identity_state "$file" workspace "$workspace" outcome unresolved || true
   record_diagnostic "$(diagnostic_file_for_state "$file")" "$reason" "$observed" || true
 }
 
@@ -413,35 +380,35 @@ is_linked_worktree() {
 }
 
 authorize_worktree() {
-  local root="$1" common="$2" branch marker original state observed title slug outcome renamed_branch
+  local root="$1" common="$2" branch marker original state observed
   branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || {
     record_unresolved detached-head "checkout=$root"
     return 0
   }
   state="$(worktree_state_file "$common" "$root")"
   original="$(read_state_field "$state" original_branch)"
-  title="$(read_state_field "$state" title)"
-  slug="$(read_state_field "$state" slug)"
-  outcome="$(read_state_field "$state" outcome)"
-  renamed_branch="$(read_state_field "$state" branch)"
   [ -n "$original" ] || original="$branch"
   marker="$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)" || {
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
+    write_identity_state "$state" checkout_root "$root" repository_anchor "$common" workspace "$workspace" \
+      original_branch "$original" outcome declined authorization '' || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-path-unavailable "checkout=$root branch=$branch" || true
     return 0
   }
   if [ ! -f "$marker" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
+    write_identity_state "$state" checkout_root "$root" repository_anchor "$common" workspace "$workspace" \
+      original_branch "$original" outcome declined authorization '' || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-missing "checkout=$root branch=$branch marker=$marker" || true
     return 0
   fi
   observed="$(head -n 1 "$marker" 2>/dev/null)"
   if [ "$observed" != "$original" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" declined '' "$title" "$slug" "$renamed_branch" || true
+    write_identity_state "$state" checkout_root "$root" repository_anchor "$common" workspace "$workspace" \
+      original_branch "$original" outcome declined authorization '' || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" marker-mismatched "checkout=$root branch=$branch original_branch=$original marker_branch=$observed" || true
     return 0
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$outcome" authorized "$title" "$slug" "$renamed_branch" || true
+  write_identity_state "$state" checkout_root "$root" repository_anchor "$common" workspace "$workspace" \
+    original_branch "$original" authorization authorized || true
 }
 
 branch_name_available() {
@@ -567,11 +534,11 @@ wait_for_claim_test_barrier() {
 }
 
 retry_attribution() {
-  local root="$1" common="$2" state="$3" original="$4" branch="$5" marker="$6" title="$7" slug="$8"
+  local root="$1" state="$2" original="$3" branch="$4" marker="$5"
   if write_attribution "$root" "$original" "$branch" "$marker"; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome prepared || true
   else
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" attribution-failed authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome attribution-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" attribution-failed "checkout=$root branch=$branch" || true
   fi
 }
@@ -599,16 +566,14 @@ read_workspace_label() {
 # Re-read the pane immediately before the external rename: the original
 # lookup can be stale after an occupant, session, or workspace change.
 label_workspace() {
-  local root="$1" common="$2" state="$3" expected_pane="$4" desired_outcome="$5"
-  local original title slug branch desired_name outcome payload fields final_pane final_agent final_session final_workspace current_label
-  original="$(read_state_field "$state" original_branch)"
-  title="$(read_state_field "$state" title)"
+  local root="$1" state="$2" expected_pane="$3" desired_outcome="$4"
+  local slug branch desired_name outcome payload fields final_pane final_agent final_session final_workspace current_label
   slug="$(read_state_field "$state" slug)"
   branch="$(read_state_field "$state" branch)"
   desired_name="${branch:-$slug}"
   outcome="$(read_state_field "$state" outcome)"
   if [ -z "$desired_name" ] || [ -z "$workspace" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome workspace-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-unavailable "checkout=$root workspace=${workspace:-missing}" || true
     return 1
   fi
@@ -620,7 +585,7 @@ label_workspace() {
       }
       if [ "$current_label" = "$desired_name" ]; then
         if [ "$outcome" = workspace-prepared ]; then
-          write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+          write_identity_state "$state" outcome "$desired_outcome" || {
             record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace name=$desired_name" || true
             return 1
           }
@@ -631,28 +596,28 @@ label_workspace() {
   esac
   wait_for_workspace_revalidation_test_barrier || return 1
   payload="$(run_herdr pane get "$expected_pane")" || {
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome workspace-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-unreachable "pane=$expected_pane workspace=$workspace" || true
     return 1
   }
   fields="$(printf '%s' "$payload" | pane_fields)" || {
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome workspace-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-pane-malformed "pane=$expected_pane workspace=$workspace" || true
     return 1
   }
   IFS=$'\037' read -r final_pane final_agent final_session final_workspace _ <<< "$fields"
   if [ "$final_pane" != "$expected_pane" ] || [ "$final_agent" != "$agent" ] || \
     [ "$final_session" != "$session" ] || [ "$final_workspace" != "$workspace" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+    write_identity_state "$state" outcome workspace-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-occupant-changed "pane=$expected_pane observed_pane=$final_pane agent=$final_agent session=$final_session workspace=$final_workspace" || true
     return 1
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-prepared authorized "$title" "$slug" "$branch" || {
+  write_identity_state "$state" outcome workspace-prepared || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-prepared-state-write-failed "workspace=$workspace name=$desired_name" || true
     return 1
   }
   if run_herdr workspace rename "$workspace" "$desired_name" >/dev/null; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+    write_identity_state "$state" outcome "$desired_outcome" || {
       record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace name=$desired_name" || true
       return 1
     }
@@ -663,13 +628,13 @@ label_workspace() {
     return 1
   }
   if [ "$current_label" = "$desired_name" ]; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" "$desired_outcome" authorized "$title" "$slug" "$branch" || {
+    write_identity_state "$state" outcome "$desired_outcome" || {
       record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-terminal-state-write-failed "workspace=$workspace name=$desired_name" || true
       return 1
     }
     return 0
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" workspace-failed authorized "$title" "$slug" "$branch" || true
+  write_identity_state "$state" outcome workspace-failed || true
   record_diagnostic "$(diagnostic_file_for_state "$state")" workspace-rename-failed "pane=$expected_pane workspace=$workspace name=$desired_name" || true
   return 1
 }
@@ -701,7 +666,7 @@ apply_branch_rename() {
         return 11
       fi
       if [ -n "$candidate" ] && [ "$branch" = "$candidate" ]; then
-        retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+        retry_attribution "$root" "$state" "$original" "$candidate" "$marker"
         [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
         return 11
       fi
@@ -727,7 +692,7 @@ apply_branch_rename() {
       ;;
     attribution-failed | attribution_failed)
       if [ "$branch" = "$candidate" ]; then
-        retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+        retry_attribution "$root" "$state" "$original" "$candidate" "$marker"
       else
         record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-attribution-failure "checkout=$root branch=$branch expected_branch=$candidate" || true
         return 10
@@ -811,7 +776,7 @@ apply_branch_rename() {
     release_claim "$lock" "$owner"
     return 11
   fi
-  write_identity_state "$state" "$root" "$common" "$workspace" "$original" prepared authorized "$title" "$slug" "$candidate" || {
+  write_identity_state "$state" branch "$candidate" outcome prepared || {
     record_diagnostic "$(diagnostic_file_for_state "$state")" prepared-state-write-failed "checkout=$root branch=$branch candidate=$candidate" || true
     release_claim "$lock" "$owner"
     return 11
@@ -847,12 +812,12 @@ apply_branch_rename() {
     return 11
   fi
   if ! git -C "$root" branch -m "$candidate"; then
-    write_identity_state "$state" "$root" "$common" "$workspace" "$original" branch-failed authorized "$title" "$slug" "$candidate" || true
+    write_identity_state "$state" outcome branch-failed || true
     record_diagnostic "$(diagnostic_file_for_state "$state")" branch-rename-failed "checkout=$root branch=$branch candidate=$candidate" || true
     release_claim "$lock" "$owner"
     return 11
   fi
-  retry_attribution "$root" "$common" "$state" "$original" "$candidate" "$marker" "$title" "$slug"
+  retry_attribution "$root" "$state" "$original" "$candidate" "$marker"
   release_claim "$lock" "$owner"
   [ "$(read_state_field "$state" outcome)" = prepared ] && return 0
   return 11
@@ -868,7 +833,7 @@ process_worktree_locked() {
   case "$outcome" in
     declined) return 0 ;;
     workspace-only)
-      label_workspace "$root" "$common" "$state" "$resolved_pane" workspace-only || true
+      label_workspace "$root" "$state" "$resolved_pane" workspace-only || true
       return 0
       ;;
     complete)
@@ -876,13 +841,11 @@ process_worktree_locked() {
       expected_branch="$(read_state_field "$state" branch)"
       observed_branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null)" || observed_branch=''
       if [ -n "$expected_branch" ] && [ "$observed_branch" != "$expected_branch" ]; then
-        write_identity_state "$state" "$root" "$common" "$workspace" \
-          "$(read_state_field "$state" original_branch)" workspace-only authorized \
-          "$(read_state_field "$state" title)" "$(read_state_field "$state" slug)" "$expected_branch" || true
+        write_identity_state "$state" outcome workspace-only || true
         record_diagnostic "$(diagnostic_file_for_state "$state")" branch-moved-after-complete "checkout=$root branch=$observed_branch expected_branch=$expected_branch" || true
         terminal_outcome='workspace-only'
       fi
-      label_workspace "$root" "$common" "$state" "$resolved_pane" "$terminal_outcome" || true
+      label_workspace "$root" "$state" "$resolved_pane" "$terminal_outcome" || true
       return 0
       ;;
   esac
@@ -894,8 +857,8 @@ process_worktree_locked() {
   apply_branch_rename "$root" "$common" "$state" "$(git -C "$root" rev-parse --path-format=absolute --git-path herdr-generated-worktree 2>/dev/null)"
   branch_status=$?
   case "$branch_status" in
-    0) label_workspace "$root" "$common" "$state" "$resolved_pane" complete || true ;;
-    10) label_workspace "$root" "$common" "$state" "$resolved_pane" workspace-only || true ;;
+    0) label_workspace "$root" "$state" "$resolved_pane" complete || true ;;
+    10) label_workspace "$root" "$state" "$resolved_pane" workspace-only || true ;;
   esac
 }
 
@@ -985,7 +948,7 @@ worker() {
   if ! is_linked_worktree "$root"; then
     local primary_state
     primary_state="$(session_state_file "$session")"
-    write_identity_state "$primary_state" "$root" '' "$workspace" '' declined '' || true
+    write_identity_state "$primary_state" checkout_root "$root" workspace "$workspace" outcome declined authorization '' || true
     record_diagnostic "$(diagnostic_file_for_state "$primary_state")" primary-checkout "checkout=$root" || true
     return 0
   fi

--- a/home/dot_local/bin/executable_se-external-leg-pair
+++ b/home/dot_local/bin/executable_se-external-leg-pair
@@ -1,0 +1,588 @@
+#!/usr/bin/env bash
+
+set -u
+umask 077
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: se-external-leg-pair --repo-root DIR --claude-prompt-file FILE
+                            --opencode-prompt-file FILE
+                            [--exposed-document FILE] --result-dir DIR
+EOF
+}
+
+refuse() {
+  printf 'se-external-leg-pair: refused: %s\n' "$1" >&2
+  exit 2
+}
+
+repo_root=""
+claude_prompt_file=""
+opencode_prompt_file=""
+exposed_document=""
+result_dir=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      repo_root="$2"
+      shift 2
+      ;;
+    --claude-prompt-file)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      claude_prompt_file="$2"
+      shift 2
+      ;;
+    --opencode-prompt-file)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      opencode_prompt_file="$2"
+      shift 2
+      ;;
+    --exposed-document)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      [ -z "$exposed_document" ] || refuse '--exposed-document may be supplied only once.'
+      exposed_document="$2"
+      shift 2
+      ;;
+    --result-dir)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      result_dir="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      refuse "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_absolute() {
+  case "$2" in
+    /*) ;;
+    *) refuse "$1 must be an absolute path." ;;
+  esac
+}
+
+require_regular_file() {
+  local label="$1" file="$2" allow_empty="${3:-0}"
+  require_absolute "$label" "$file"
+  [ ! -L "$file" ] || refuse "$label must not be a symlink."
+  [ -f "$file" ] && [ -r "$file" ] || refuse "$label must be a readable regular file."
+  [ "$allow_empty" -eq 1 ] || [ -s "$file" ] || refuse "$label must not be empty."
+}
+
+[ -n "$repo_root" ] || refuse '--repo-root is required.'
+[ -n "$claude_prompt_file" ] || refuse '--claude-prompt-file is required.'
+[ -n "$opencode_prompt_file" ] || refuse '--opencode-prompt-file is required.'
+[ -n "$result_dir" ] || refuse '--result-dir is required.'
+require_absolute '--repo-root' "$repo_root"
+[ ! -L "$repo_root" ] || refuse '--repo-root must not be a symlink.'
+[ -d "$repo_root" ] && [ -r "$repo_root" ] || refuse '--repo-root must be a readable directory.'
+require_regular_file '--claude-prompt-file' "$claude_prompt_file"
+require_regular_file '--opencode-prompt-file' "$opencode_prompt_file"
+[ -z "$exposed_document" ] || require_regular_file '--exposed-document' "$exposed_document" 1
+require_absolute '--result-dir' "$result_dir"
+[ ! -e "$result_dir" ] && [ ! -L "$result_dir" ] || refuse '--result-dir must not exist.'
+result_parent="${result_dir%/*}"
+[ -n "$result_parent" ] || result_parent="/"
+[ -d "$result_parent" ] && [ -w "$result_parent" ] || refuse '--result-dir parent must be a writable directory.'
+
+[ "${HERDR_ENV:-}" = 1 ] || refuse 'HERDR_ENV=1 is required.'
+[ -n "${HERDR_WORKSPACE_ID:-}" ] || refuse 'HERDR_WORKSPACE_ID is required.'
+for dependency in herdr herdr-peer-alias pre-external-secret-scan claude opencode python3; do
+  command -v "$dependency" >/dev/null 2>&1 || refuse "$dependency is not on PATH."
+done
+
+work_dir=""
+stage_dir=""
+cleanup_complete=0
+cleanup_unconfirmed=0
+claude_tab=""
+opencode_tab=""
+claude_pane=""
+opencode_pane=""
+claude_name=""
+opencode_name=""
+claude_state="not-created"
+opencode_state="not-created"
+claude_usable=0
+opencode_usable=0
+
+close_tabs() {
+  local failed=0
+
+  if [ -n "$claude_tab" ]; then
+    if herdr tab close "$claude_tab" >/dev/null 2>&1; then
+      claude_tab=""
+    else
+      printf 'se-external-leg-pair: cleanup failed for tab %s\n' "$claude_tab" >&2
+      failed=1
+    fi
+  fi
+  if [ -n "$opencode_tab" ]; then
+    if herdr tab close "$opencode_tab" >/dev/null 2>&1; then
+      opencode_tab=""
+    else
+      printf 'se-external-leg-pair: cleanup failed for tab %s\n' "$opencode_tab" >&2
+      failed=1
+    fi
+  fi
+  [ "$cleanup_unconfirmed" -eq 0 ] || failed=1
+
+  [ "$failed" -eq 0 ]
+}
+
+remove_work_dir() {
+  if [ -n "$work_dir" ]; then
+    if ! rm -rf -- "$work_dir" 2>/dev/null || [ -e "$work_dir" ] || [ -L "$work_dir" ]; then
+      printf 'se-external-leg-pair: cleanup failed for transport %s\n' "$work_dir" >&2
+      return 1
+    fi
+    work_dir=""
+  fi
+  return 0
+}
+
+cleanup_runtime() {
+  local failed=0
+
+  close_tabs || failed=1
+  remove_work_dir || failed=1
+
+  [ "$failed" -eq 0 ] || return 1
+  cleanup_complete=1
+  return 0
+}
+
+on_exit() {
+  local status=$?
+  if [ "$cleanup_complete" -eq 0 ] && ! cleanup_runtime; then
+    status=3
+  fi
+  if [ -n "$stage_dir" ] && { [ -e "$stage_dir" ] || [ -L "$stage_dir" ]; }; then
+    if ! rm -rf -- "$stage_dir" 2>/dev/null; then
+      printf 'se-external-leg-pair: cleanup failed for staging %s\n' "$stage_dir" >&2
+      status=3
+    fi
+  fi
+  trap - EXIT
+  exit "$status"
+}
+
+on_signal() {
+  exit "$1"
+}
+
+trap on_exit EXIT
+trap 'on_signal 129' HUP
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/se-external-leg-pair.XXXXXX")" \
+  || refuse 'could not create private transport directory.'
+chmod 700 "$work_dir" || refuse 'could not protect private transport directory.'
+
+run_id="$(date +%s)-$$-$RANDOM"
+claude_name="$(herdr-peer-alias "claude|$run_id|$repo_root")" \
+  || refuse 'could not allocate the Claude alias.'
+[ -n "$claude_name" ] || refuse 'Claude alias allocation returned empty output.'
+opencode_name="$(herdr-peer-alias "opencode|$run_id|$repo_root" "$claude_name")" \
+  || refuse 'could not allocate the OpenCode alias.'
+[ -n "$opencode_name" ] || refuse 'OpenCode alias allocation returned empty output.'
+[ "$claude_name" != "$opencode_name" ] || refuse 'peer alias allocation returned a duplicate.'
+
+claude_report="$work_dir/claude.report"
+opencode_report="$work_dir/opencode.report"
+claude_scan_prompt="$work_dir/claude.prompt"
+opencode_scan_prompt="$work_dir/opencode.prompt"
+
+claude_prompt="$(cat "$claude_prompt_file")"
+opencode_prompt="$(cat "$opencode_prompt_file")"
+claude_prompt="$claude_prompt
+
+[peer-report-transport]
+Report path: $claude_report
+Before ending this turn, write the exact complete report byte-for-byte to the report path. Write it atomically through $claude_report.tmp and rename the completed file to $claude_report. The report file is authoritative. Return the same report normally after it is durable. Do not write any other file."
+opencode_prompt="$opencode_prompt
+
+[peer-report-transport]
+Report path: $opencode_report
+Before ending this turn, write the exact complete report byte-for-byte to the report path. Write it atomically through $opencode_report.tmp and rename the completed file to $opencode_report. The report file is authoritative. Return the same report normally after it is durable. Do not write any other file."
+printf '%s' "$claude_prompt" > "$claude_scan_prompt" || refuse 'could not prepare the Claude prompt.'
+printf '%s' "$opencode_prompt" > "$opencode_scan_prompt" || refuse 'could not prepare the OpenCode prompt.'
+
+if [ -n "$exposed_document" ]; then
+  pre-external-secret-scan "$repo_root" "$exposed_document" "$claude_scan_prompt" "$opencode_scan_prompt" \
+    || refuse 'the initial secret scan did not return clean.'
+else
+  pre-external-secret-scan "$repo_root" "$claude_scan_prompt" "$opencode_scan_prompt" \
+    || refuse 'the initial secret scan did not return clean.'
+fi
+scan_state="clean"
+[ "${SE_SKIP_SECRET_SCAN:-0}" != 1 ] || scan_state="waived"
+
+create_tab() {
+  local leg="$1" output status tab pane
+  if [ "$leg" = claude ]; then
+    output="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$repo_root" --no-focus 2>"$work_dir/claude-tab.err")"
+    status=$?
+  else
+    output="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$repo_root" --no-focus \
+      --env 'OPENCODE_CONFIG_CONTENT={"permission":"allow","agent":{"build":{"permission":"allow","reasoningEffort":"high"}}}' \
+      2>"$work_dir/opencode-tab.err")"
+    status=$?
+  fi
+  if [ "$status" -ne 0 ]; then
+    [ "$leg" != claude ] || claude_state="tab-create-failed"
+    [ "$leg" != opencode ] || opencode_state="tab-create-failed"
+    return 1
+  fi
+
+  tab="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("result",{}).get("tab",{}).get("tab_id", ""))' 2>/dev/null || true)"
+  pane="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("result",{}).get("root_pane",{}).get("pane_id", ""))' 2>/dev/null || true)"
+  if [ "$leg" = claude ]; then
+    claude_tab="$tab"
+    claude_pane="$pane"
+    claude_state="tab-created"
+    if [ -z "$tab" ] || [ -z "$pane" ]; then
+      claude_state="tab-malformed"
+      if [ -z "$tab" ]; then
+        printf 'se-external-leg-pair: cleanup unconfirmed: Claude tab creation returned no tab ID.\n' >&2
+        cleanup_unconfirmed=1
+      fi
+      return 1
+    fi
+  else
+    opencode_tab="$tab"
+    opencode_pane="$pane"
+    opencode_state="tab-created"
+    if [ -z "$tab" ] || [ -z "$pane" ]; then
+      opencode_state="tab-malformed"
+      if [ -z "$tab" ]; then
+        printf 'se-external-leg-pair: cleanup unconfirmed: OpenCode tab creation returned no tab ID.\n' >&2
+        cleanup_unconfirmed=1
+      fi
+      return 1
+    fi
+  fi
+  return 0
+}
+
+create_tab claude || true
+[ "$cleanup_unconfirmed" -eq 0 ] || exit 3
+create_tab opencode || true
+[ "$cleanup_unconfirmed" -eq 0 ] || exit 3
+
+start_agent() {
+  local leg="$1" name pane other output_file error_file status combined attempt=1 busy_retry=0 name_retry=0
+  if [ "$leg" = claude ]; then
+    [ "$claude_state" = tab-created ] || return 1
+    name="$claude_name"
+    pane="$claude_pane"
+    other="$opencode_name"
+  else
+    [ "$opencode_state" = tab-created ] || return 1
+    name="$opencode_name"
+    pane="$opencode_pane"
+    other="$claude_name"
+  fi
+  output_file="$work_dir/$leg-start.out"
+  error_file="$work_dir/$leg-start.err"
+
+  while [ "$attempt" -le 3 ]; do
+    if [ "$leg" = claude ]; then
+      herdr agent start "$name" --kind claude --pane "$pane" --timeout 60000 -- \
+        --model sonnet --effort high --dangerously-skip-permissions >"$output_file" 2>"$error_file"
+      status=$?
+    else
+      herdr agent start "$name" --kind opencode --pane "$pane" --timeout 60000 -- \
+        --model openai/gpt-5.6-terra --agent build --auto >"$output_file" 2>"$error_file"
+      status=$?
+    fi
+    if [ "$status" -eq 0 ] && python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+raise SystemExit(0 if data.get("result", {}).get("agent", {}).get("interactive_ready") is True else 1)
+' < "$output_file" 2>/dev/null; then
+      [ "$leg" != claude ] || { claude_name="$name"; claude_state="started"; }
+      [ "$leg" != opencode ] || { opencode_name="$name"; opencode_state="started"; }
+      return 0
+    fi
+
+    combined="$(cat "$output_file" "$error_file" 2>/dev/null)"
+    case "$combined" in
+      *agent_pane_busy*)
+        [ "$busy_retry" -eq 0 ] || break
+        busy_retry=1
+        sleep 2
+        ;;
+      *agent_name_taken*)
+        [ "$name_retry" -eq 0 ] || break
+        name_retry=1
+        name="$(herdr-peer-alias "$leg-retry|$run_id|$repo_root" "$other")" || break
+        [ -n "$name" ] || break
+        ;;
+      *) break ;;
+    esac
+    attempt=$((attempt + 1))
+  done
+
+  [ "$leg" != claude ] || claude_state="start-failed"
+  [ "$leg" != opencode ] || opencode_state="start-failed"
+  return 1
+}
+
+start_agent claude || true
+start_agent opencode || true
+
+prompt_agent() {
+  local leg="$1" pane prompt
+  if [ "$leg" = claude ]; then
+    [ "$claude_state" = started ] || return 1
+    pane="$claude_pane"
+    prompt="$claude_prompt"
+  else
+    [ "$opencode_state" = started ] || return 1
+    pane="$opencode_pane"
+    prompt="$opencode_prompt"
+  fi
+  if herdr agent prompt "$pane" "$prompt" >/dev/null; then
+    [ "$leg" != claude ] || claude_state="prompted"
+    [ "$leg" != opencode ] || opencode_state="prompted"
+    return 0
+  fi
+  [ "$leg" != claude ] || claude_state="prompt-failed"
+  [ "$leg" != opencode ] || opencode_state="prompt-failed"
+  return 1
+}
+
+prompt_agent claude || true
+prompt_agent opencode || true
+
+wait_agent() {
+  local leg="$1" pane
+  if [ "$leg" = claude ]; then
+    case "$claude_state" in prompted|prompt-failed) ;; *) return 1 ;; esac
+    pane="$claude_pane"
+  else
+    case "$opencode_state" in prompted|prompt-failed) ;; *) return 1 ;; esac
+    pane="$opencode_pane"
+  fi
+  if herdr agent wait "$pane" --timeout 1800000 >/dev/null 2>&1; then
+    return 0
+  fi
+  [ "$leg" != claude ] || claude_state="wait-failed"
+  [ "$leg" != opencode ] || opencode_state="wait-failed"
+  return 1
+}
+
+wait_agent claude || true
+wait_agent opencode || true
+
+# 0 delivered, 3 absent, 4 empty, 5 non-regular or symlink.
+classify_report() {
+  local report="$1"
+  [ ! -L "$report" ] || return 5
+  if [ -e "$report" ] && [ ! -f "$report" ]; then return 5; fi
+  [ -e "$report" ] || return 3
+  [ -s "$report" ] || return 4
+  [ -r "$report" ] || return 5
+  return 0
+}
+
+set_collected_state() {
+  local leg="$1" state="$2" usable="$3"
+  if [ "$leg" = claude ]; then
+    claude_state="$state"
+    claude_usable="$usable"
+  else
+    opencode_state="$state"
+    opencode_usable="$usable"
+  fi
+}
+
+collect_report() {
+  local leg="$1" pane report report_state recovery_prompt recovery_file prompt_status
+  if [ "$leg" = claude ]; then
+    pane="$claude_pane"
+    report="$claude_report"
+    case "$claude_state" in prompted|prompt-failed|wait-failed) ;; *) return 1 ;; esac
+  else
+    pane="$opencode_pane"
+    report="$opencode_report"
+    case "$opencode_state" in prompted|prompt-failed|wait-failed) ;; *) return 1 ;; esac
+  fi
+
+  classify_report "$report"
+  report_state=$?
+  if [ "$report_state" -eq 0 ]; then
+    set_collected_state "$leg" delivered 1
+    return 0
+  fi
+  if { [ "$report_state" -eq 3 ] || [ "$report_state" -eq 4 ]; } && \
+    { [ "$leg" = claude ] && [ "$claude_state" = prompted ] || \
+      [ "$leg" = opencode ] && [ "$opencode_state" = prompted ]; }; then
+    recovery_prompt="The report transport file is missing or empty. Write your exact complete previous report byte-for-byte, atomically through $report.tmp, and rename it to $report. Then reply with only the path.
+Recovery report path: $report"
+    recovery_file="$work_dir/$leg-recovery.prompt"
+    printf '%s' "$recovery_prompt" > "$recovery_file" || {
+      set_collected_state "$leg" recovery-preparation-failed 0
+      return 1
+    }
+    if [ -n "$exposed_document" ]; then
+      pre-external-secret-scan "$repo_root" "$exposed_document" "$recovery_file" || {
+        set_collected_state "$leg" recovery-scan-refused 0
+        return 1
+      }
+    else
+      pre-external-secret-scan "$repo_root" "$recovery_file" || {
+        set_collected_state "$leg" recovery-scan-refused 0
+        return 1
+      }
+    fi
+    herdr agent prompt "$pane" "$recovery_prompt" --wait --timeout 120000 >/dev/null 2>&1
+    prompt_status=$?
+    classify_report "$report"
+    report_state=$?
+    if [ "$report_state" -eq 0 ]; then
+      set_collected_state "$leg" recovered 1
+      return 0
+    fi
+    [ "$prompt_status" -eq 0 ] || {
+      set_collected_state "$leg" recovery-failed 0
+      return 1
+    }
+  fi
+
+  case "$report_state" in
+    3) set_collected_state "$leg" missing 0 ;;
+    4) set_collected_state "$leg" empty 0 ;;
+    *) set_collected_state "$leg" malformed 0 ;;
+  esac
+  return 1
+}
+
+collect_report claude || true
+collect_report opencode || true
+
+if ! close_tabs; then
+  remove_work_dir || true
+  exit 3
+fi
+
+stage_dir="$(mktemp -d "$result_parent/.se-external-leg-pair.XXXXXX")" || {
+  printf 'se-external-leg-pair: could not stage the result.\n' >&2
+  exit 1
+}
+
+copy_report() {
+  python3 - "$1" "$2" <<'PY'
+import os
+import shutil
+import stat
+import sys
+
+source, destination = sys.argv[1:]
+flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+descriptor = os.open(source, flags)
+try:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size == 0:
+        raise SystemExit(1)
+    with os.fdopen(descriptor, "rb", closefd=False) as input_file:
+        with open(destination, "xb") as output_file:
+            shutil.copyfileobj(input_file, output_file)
+finally:
+    os.close(descriptor)
+PY
+}
+
+if [ "$claude_usable" -eq 1 ] && ! copy_report "$claude_report" "$stage_dir/claude.report"; then
+  rm -f "$stage_dir/claude.report"
+  claude_state="copy-failed"
+  claude_usable=0
+fi
+if [ "$opencode_usable" -eq 1 ] && ! copy_report "$opencode_report" "$stage_dir/opencode.report"; then
+  rm -f "$stage_dir/opencode.report"
+  opencode_state="copy-failed"
+  opencode_usable=0
+fi
+
+classification="none"
+if [ "$claude_usable" -eq 1 ] && [ "$opencode_usable" -eq 1 ]; then
+  cmp -s "$stage_dir/claude.report" "$stage_dir/opencode.report"
+  compare_status=$?
+  case "$compare_status" in
+    0)
+      classification="identical-single"
+      mv "$stage_dir/claude.report" "$stage_dir/identical.report" || exit 1
+      rm -f "$stage_dir/opencode.report" || exit 1
+      ;;
+    1) classification="paired" ;;
+    *)
+      printf 'se-external-leg-pair: could not compare peer reports.\n' >&2
+      exit 1
+      ;;
+  esac
+elif [ "$claude_usable" -eq 1 ]; then
+  classification="claude-only"
+elif [ "$opencode_usable" -eq 1 ]; then
+  classification="opencode-only"
+fi
+
+if ! remove_work_dir; then
+  exit 3
+fi
+cleanup_complete=1
+
+python3 - "$stage_dir/result.json" "$classification" "$scan_state" "$claude_state" "$opencode_state" <<'PY'
+import json
+import sys
+
+path, classification, scan, claude_state, opencode_state = sys.argv[1:]
+report_paths = {
+    "paired": [
+        {"source": "claude", "path": "claude.report"},
+        {"source": "opencode", "path": "opencode.report"},
+    ],
+    "identical-single": [{"source": "indeterminate", "path": "identical.report"}],
+    "claude-only": [{"source": "claude", "path": "claude.report"}],
+    "opencode-only": [{"source": "opencode", "path": "opencode.report"}],
+    "none": [],
+}
+with open(path, "w", encoding="utf-8") as result:
+    json.dump(
+        {
+            "interface": "se-external-leg-pair/v1",
+            "classification": classification,
+            "scan": scan,
+            "cleanup": "complete",
+            "legs": {"claude": claude_state, "opencode": opencode_state},
+            "reports": report_paths[classification],
+        },
+        result,
+        indent=2,
+        sort_keys=True,
+    )
+    result.write("\n")
+PY
+[ "$?" -eq 0 ] || exit 1
+
+python3 - "$stage_dir" "$result_dir" <<'PY'
+import os
+import sys
+
+source, destination = sys.argv[1:]
+if os.path.lexists(destination):
+    raise SystemExit(1)
+os.rename(source, destination)
+PY
+[ "$?" -eq 0 ] || {
+  printf 'se-external-leg-pair: could not publish the result.\n' >&2
+  exit 1
+}
+stage_dir=""
+
+[ "$classification" != none ] || exit 1
+exit 0

--- a/home/dot_local/lib/herdr-worktree-state.sh
+++ b/home/dot_local/lib/herdr-worktree-state.sh
@@ -99,6 +99,71 @@ read_state_field() {
   printf '%s' "$encoded" | base64 -d 2>/dev/null || true
 }
 
+diagnostic_file_for_state() {
+  printf '%s.diagnostics.log' "${1%.state}"
+}
+
+# Update named fields and atomically persist the complete durable record.
+# Unspecified fields retain their current values so callers describe only the
+# domain observation that changed rather than reconstructing storage state.
+write_identity_state() {
+  local file="$1" field value
+  shift
+  local checkout_root repository_anchor workspace original_branch branch outcome authorization title slug
+  checkout_root="$(read_state_field "$file" checkout_root)"
+  repository_anchor="$(read_state_field "$file" repository_anchor)"
+  workspace="$(read_state_field "$file" workspace)"
+  original_branch="$(read_state_field "$file" original_branch)"
+  branch="$(read_state_field "$file" branch)"
+  outcome="$(read_state_field "$file" outcome)"
+  authorization="$(read_state_field "$file" authorization)"
+  title="$(read_state_field "$file" title)"
+  slug="$(read_state_field "$file" slug)"
+
+  while [ "$#" -gt 0 ]; do
+    [ "$#" -ge 2 ] || {
+      record_diagnostic "$(diagnostic_file_for_state "$file")" invalid-record-update "field=$1" || true
+      return 1
+    }
+    field="$1"
+    value="$2"
+    shift 2
+    case "$field" in
+      checkout_root) checkout_root="$value" ;;
+      repository_anchor) repository_anchor="$value" ;;
+      workspace) workspace="$value" ;;
+      original_branch) original_branch="$value" ;;
+      branch) branch="$value" ;;
+      outcome) outcome="$value" ;;
+      authorization) authorization="$value" ;;
+      title) title="$value" ;;
+      slug) slug="$value" ;;
+      *)
+        record_diagnostic "$(diagnostic_file_for_state "$file")" invalid-record-field "field=$field" || true
+        return 1
+        ;;
+    esac
+  done
+
+  # Read compatibility for records written before outcome names were
+  # canonicalized. Every subsequent write emits only the canonical spelling.
+  [ "$outcome" != attribution_failed ] || outcome=attribution-failed
+  if ! is_legal_outcome "$outcome"; then
+    record_diagnostic "$(diagnostic_file_for_state "$file")" illegal-outcome "outcome=$outcome workspace=$workspace" || true
+    return 1
+  fi
+
+  atomic_write "$file" "checkout_root=$(encode_value "$checkout_root")
+repository_anchor=$(encode_value "$repository_anchor")
+workspace=$(encode_value "$workspace")
+original_branch=$(encode_value "$original_branch")
+branch=$(encode_value "$branch")
+outcome=$(encode_value "$outcome")
+authorization=$(encode_value "$authorization")
+title=$(encode_value "$title")
+slug=$(encode_value "$slug")"
+}
+
 record_number() {
   local file="$1" key="$2" line value=""
   [ -f "$file" ] || return 0

--- a/home/private_dot_agents/skills/se-code-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-code-review/SKILL.md
@@ -25,9 +25,7 @@ Empty target arguments review the current branch against its detected base. Reco
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
-
-Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It defines the `se-external-leg-pair` interface and result contract. Set `REPO_ROOT` to the current checkout and compose the following complete dispatch briefs as `CLAUDE_PROMPT` and `OPENCODE_PROMPT`.
 
 ### Shared review contract
 
@@ -76,7 +74,26 @@ Use the `ce-code-review` skill with these exact arguments:
 mode:agent <resolved arguments>
 ```
 
-Execute the shared lifecycle through tab closure. Require a complete parseable JSON report from each peer. One failed or malformed peer degrades coverage; two failed peers fail the review. Do not pass peer context into `se-simplify`.
+Write the complete prompts to private files and invoke the lifecycle once:
+
+```bash
+PAIR_PARENT=$(mktemp -d "${TMPDIR:-/tmp}/se-code-review-pair.XXXXXX") || exit 1
+CLAUDE_PROMPT_FILE="$PAIR_PARENT/claude.prompt"
+OPENCODE_PROMPT_FILE="$PAIR_PARENT/opencode.prompt"
+PAIR_RESULT="$PAIR_PARENT/result"
+if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
+  ! printf '%s' "$OPENCODE_PROMPT" > "$OPENCODE_PROMPT_FILE"; then
+  rm -rf "$PAIR_PARENT"
+  exit 1
+fi
+PAIR_STATUS=0
+se-external-leg-pair --repo-root "$REPO_ROOT" \
+  --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
+  --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
+  --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
+```
+
+After the command returns, load any published result needed for diagnosis, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0` and a complete parseable JSON report from each listed source. One failed or malformed peer degrades coverage; no valid peer report fails the review. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan. Do not pass peer context into `se-simplify`.
 
 ## Synthesize reports
 
@@ -85,8 +102,9 @@ Merge findings by file, nearby line, and issue substance:
 1. **Consensus**: both reports found the same issue.
 2. **Claude-only**: only Sonnet found it.
 3. **OpenCode-only**: only Terra found it.
-4. **Contradiction**: the reports disagree on whether the issue exists or what behavior is correct.
-5. **Fix divergence**: they agree on the issue but propose materially different fixes.
+4. **Indeterminate-single**: an identical report has no model attribution and is never consensus.
+5. **Contradiction**: the reports disagree on whether the issue exists or what behavior is correct.
+6. **Fix divergence**: they agree on the issue but propose materially different fixes.
 
 Keep the highest supported severity. Treat cross-model agreement as stronger evidence, not proof. Use the most conservative supported verdict unless it depends only on a finding rejected during synthesis.
 

--- a/home/private_dot_agents/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-doc-review/SKILL.md
@@ -27,18 +27,18 @@ Record whether the wrapper was invoked with `mode:headless`; delivery uses that 
 Copy the document to an isolated temporary directory while preserving its basename and extension:
 
 ```bash
-DOC_STAGE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/se-doc-review.XXXXXX")
-DOC_COPY="$DOC_STAGE_DIR/$(basename "$DOC_PATH")"
-cp "$DOC_PATH" "$DOC_COPY"
+DOC_STAGE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/se-doc-review.XXXXXX") || exit 1
+DOC_INPUT_DIR="$DOC_STAGE_DIR/input"
+mkdir "$DOC_INPUT_DIR" || { rm -rf "$DOC_STAGE_DIR"; exit 1; }
+DOC_COPY="$DOC_INPUT_DIR/$(basename "$DOC_PATH")"
+cp "$DOC_PATH" "$DOC_COPY" || { rm -rf "$DOC_STAGE_DIR"; exit 1; }
 ```
 
 Peers review `DOC_COPY`; the local pass reviews `DOC_PATH`. The copy remains untouched while the peers run. The shared peer lifecycle owns the one pre-launch full-checkout scan and its fail-closed fallback.
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It owns tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
-
-Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It defines the `se-external-leg-pair` interface and result contract. Set `REPO_ROOT` to the current checkout and compose the following complete dispatch briefs as `CLAUDE_PROMPT` and `OPENCODE_PROMPT`.
 
 ### Claude prompt
 
@@ -94,9 +94,27 @@ canonical schema. An empty review still includes Coverage with explicit zero
 counts. End with the exact line: Review complete
 ```
 
-Complete the shared lifecycle through peer read and tab closure before invoking the local `ce-doc-review` skill with `mode:headless DOC_PATH`. The local pass is the only review allowed to mutate the document, and it starts only after peers can no longer read the checkout state attested by the launch scan.
+Write the complete prompts to private files and invoke the lifecycle once:
 
-Accept an envelope only when Coverage accounts for every attempted persona, its counts reconcile, every surviving finding is routed once with its required fields, and the terminal line is exact. A failed or malformed pass degrades coverage; synthesize any surviving envelopes. If all three passes fail, fail the review without modifying the document further.
+```bash
+CLAUDE_PROMPT_FILE="$DOC_STAGE_DIR/claude.prompt"
+OPENCODE_PROMPT_FILE="$DOC_STAGE_DIR/opencode.prompt"
+PAIR_RESULT="$DOC_STAGE_DIR/pair-result"
+if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
+  ! printf '%s' "$OPENCODE_PROMPT" > "$OPENCODE_PROMPT_FILE"; then
+  rm -rf "$DOC_STAGE_DIR"
+  exit 1
+fi
+PAIR_STATUS=0
+se-external-leg-pair --repo-root "$REPO_ROOT" \
+  --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
+  --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
+  --exposed-document "$DOC_COPY" --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
+```
+
+After the command returns, load any published reports needed for synthesis and remove the result and prompt files on every status. Exit `3` then fails the review because peer cleanup is unconfirmed. Otherwise, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`; it is the only pass allowed to mutate the document and starts only after peers can no longer read the checkout state attested by the launch scan. Exit `1` or `2` records both peers as failed but does not suppress the local pass.
+
+Accept an envelope only when Coverage accounts for every attempted persona, its counts reconcile, every surviving finding is routed once with its required fields, and the terminal line is exact. A failed or malformed pass degrades coverage; synthesize any surviving envelopes. Treat `identical-single` as one indeterminate source, never consensus. If all three passes fail, fail the review without modifying the document further.
 
 Remove the temporary document copy and its empty staging directory after tab closure or any earlier failure.
 

--- a/home/private_dot_agents/skills/se-simplify/SKILL.md
+++ b/home/private_dot_agents/skills/se-simplify/SKILL.md
@@ -23,9 +23,7 @@ Capture the pre-apply worktree state so simplify-owned edits can be distinguishe
 
 ## Dispatch fresh peers
 
-Read `~/.claude/shared/herdr-peer-launch.md` in full. It is the single source of truth for tab creation, exact models and permissions, concurrent dispatch, wait and read behavior, and close-before-synthesis cleanup.
-
-Set `REPO_ROOT` to the current checkout. Supply the following dispatch briefs as the reference's `CLAUDE_PROMPT` and `OPENCODE_PROMPT` inputs.
+Read `~/.claude/shared/herdr-peer-launch.md` in full. It defines the `se-external-leg-pair` interface and result contract. Set `REPO_ROOT` to the current checkout and compose the following complete dispatch briefs as `CLAUDE_PROMPT` and `OPENCODE_PROMPT`.
 
 ### Claude prompt
 
@@ -77,11 +75,30 @@ Write `Findings: none` when no item survives. End with the exact line:
 Simplify review complete
 ```
 
-Execute the shared lifecycle through tab closure. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; two failed peers fail the simplify run and apply nothing.
+Write the complete prompts to private files and invoke the lifecycle once:
+
+```bash
+PAIR_PARENT=$(mktemp -d "${TMPDIR:-/tmp}/se-simplify-pair.XXXXXX") || exit 1
+CLAUDE_PROMPT_FILE="$PAIR_PARENT/claude.prompt"
+OPENCODE_PROMPT_FILE="$PAIR_PARENT/opencode.prompt"
+PAIR_RESULT="$PAIR_PARENT/result"
+if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
+  ! printf '%s' "$OPENCODE_PROMPT" > "$OPENCODE_PROMPT_FILE"; then
+  rm -rf "$PAIR_PARENT"
+  exit 1
+fi
+PAIR_STATUS=0
+se-external-leg-pair --repo-root "$REPO_ROOT" \
+  --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
+  --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
+  --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
+```
+
+After the command returns, load any published result needed for diagnosis, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0`. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; no valid peer report fails the simplify run and applies nothing. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan.
 
 ## Synthesize findings
 
-Merge findings into consensus, Claude-only, OpenCode-only, contradictions, and behavior-preservation uncertainty.
+Merge findings into consensus, Claude-only, OpenCode-only, indeterminate-single, contradictions, and behavior-preservation uncertainty. Keep indeterminate-single findings unattributed to either model.
 
 - Accept defensible consensus and unique findings.
 - Exclude contradictions, false positives, low-value churn, and proposals that cannot prove equivalent output, errors, side effects, or ordering.

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -1,206 +1,62 @@
-# Fresh Herdr peer lifecycle
+# External leg pair interface
 
-This is the single source of truth for the peer mechanics shared by `se-code-review`, `se-doc-review`, and `se-simplify`. The calling skill owns scope, peer prompts, report validation, synthesis, and apply policy. Read this file in full before every launch.
+An External leg pair is one Claude review and one OpenCode review of the same input. `se-external-leg-pair` owns their shared executable lifecycle for `se-code-review`, `se-doc-review`, and `se-simplify`. Calling skills own scope, complete peer prompts, report-schema validation, synthesis, and apply policy.
 
-## Inputs
+## Invocation
 
-Resolve these values before launch:
-
-- `REPO_ROOT`: absolute path to the checkout both peers inspect.
-- `CLAUDE_PROMPT`: the calling skill's complete Claude dispatch brief.
-- `OPENCODE_PROMPT`: the calling skill's complete OpenCode dispatch brief.
-
-Require `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`, `herdr`, `claude`, `opencode`, `herdr-peer-alias`, and `pre-external-secret-scan`. There is no headless fallback. Every run creates new sessions; never resume, reuse, or retain a peer from this or another phase.
-
-The **cleanup boundary** begins when the report transport directory is created. Track each created tab ID immediately. Any non-recoverable launch, prompt, wait, read, or validation failure closes every tab created by this run and removes its report transport files before control returns to the calling skill.
-
-## Scan exposed content
-
-Before allocating aliases or creating tabs, scan the live checkout and both dispatch prompts:
+Write each complete caller-owned prompt to an absolute path naming a private, readable, non-empty regular file that is not a symlink, then run:
 
 ```bash
-printf '%s\n%s\n' "$CLAUDE_PROMPT" "$OPENCODE_PROMPT" \
-  | pre-external-secret-scan --stdin "$REPO_ROOT"
+PAIR_PARENT=$(mktemp -d "${TMPDIR:-/tmp}/se-external-leg-pair-result.XXXXXX") || exit 1
+PAIR_RESULT="$PAIR_PARENT/result"
+
+PAIR_STATUS=0
+se-external-leg-pair \
+  --repo-root "$REPO_ROOT" \
+  --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
+  --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
+  --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
 ```
 
-Exit `0` is the only permission to continue. On any nonzero result, stop this lifecycle before reading another section and report that no tab or report transport was created. The command submits tracked, modified, and untracked filesystem content to gitleaks's trusted default detector rules rather than scanning only a Git range. Detected secrets, a missing scanner, a timeout, an invalid target, or any unexpected scanner status refuse the launch. Scanner findings are redacted before they reach output. `SE_SKIP_SECRET_SCAN=1` is an explicit operator waiver; the caller must report that the external peer input was not scanned. No other value waives the scan.
+If either prompt tells a peer to read a document outside `REPO_ROOT`, add exactly one `--exposed-document "$ABSOLUTE_DOCUMENT"` so the file is scanned too. This is required for the immutable copy used by `se-doc-review`; the interface supports only one external document per pair.
 
-## Create tabs
+The command requires `HERDR_ENV=1` and `HERDR_WORKSPACE_ID`. It starts Claude with Sonnet, high effort, and skipped permission prompts; it starts OpenCode with Terra, the build agent, auto mode, and allowed permissions. It also fixes retry limits, waits, report transport, and cleanup, so callers cannot override lifecycle policy. `SE_SKIP_SECRET_SCAN=1` remains the only operator waiver. The result records `"scan": "waived"`, and the caller reports the waiver.
 
-A peer's registered name is an allocator-owned `color-animal` alias, never a semantic name. Pane-label reconciliation renames any registered agent whose name falls outside that pool, and a live non-pool name also fails the pane-label cutover. `herdr-peer-alias <seed> [reserved-alias ...]` prints one alias that no live agent holds; the second call reserves the first peer's alias, which is picked but not yet registered:
+## Result
 
-```bash
-PEER_RUN_ID="$(date +%s)-$$"
-CLAUDE_NAME="$(herdr-peer-alias "claude|$PEER_RUN_ID|$REPO_ROOT")"
-OPENCODE_NAME="$(herdr-peer-alias "opencode|$PEER_RUN_ID|$REPO_ROOT" "$CLAUDE_NAME")"
+The command copies usable reports only after every known peer tab closes, then removes private transport before publishing `PAIR_RESULT`. Cleanup failure exits `3` and publishes nothing. Stderr identifies any resource it could not remove or any successful tab creation that returned no trackable tab ID.
 
-PEER_REPORT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/se-peer-$PEER_RUN_ID.XXXXXX")
-chmod 700 "$PEER_REPORT_DIR"
-CLAUDE_REPORT_PATH="$PEER_REPORT_DIR/claude.report"
-OPENCODE_REPORT_PATH="$PEER_REPORT_DIR/opencode.report"
-```
+`result.json` contains:
 
-Allocation runs before the cleanup boundary opens. A failed or empty allocation aborts the launch with no tab created and nothing to clean up.
+- `interface`: always `se-external-leg-pair/v1`.
+- `classification`: `paired`, `claude-only`, `opencode-only`, `identical-single`, or `none`.
+- `scan`: `clean` or `waived`.
+- `cleanup`: always `complete` in a published result.
+- `legs`: lifecycle and transport state for Claude and OpenCode.
+- `reports`: source and relative path for every usable report.
 
-Create one full-size background tab per peer, rooted at the repository without taking focus. Tab labels belong to pane-label reconciliation, which overwrites any manual label on its next pass, so create both tabs unlabelled:
+Report files preserve the bytes delivered through peer-owned atomic file transport. When both report files are byte-identical, `identical-single` publishes one `identical.report` attributed to `indeterminate`. Duplicate bytes cannot prove two independent reviews, so this is single-source coverage, never consensus.
 
-```bash
-CLAUDE_TAB_STATE=$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" \
-  --cwd "$REPO_ROOT" --no-focus)
-CLAUDE_TAB=$(printf '%s' "$CLAUDE_TAB_STATE" \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
-CLAUDE_PANE=$(printf '%s' "$CLAUDE_TAB_STATE" \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
+Exit statuses:
 
-OPENCODE_TAB_STATE=$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" \
-  --cwd "$REPO_ROOT" --no-focus \
-  --env 'OPENCODE_CONFIG_CONTENT={"permission":"allow","agent":{"build":{"permission":"allow","reasoningEffort":"high"}}}')
-OPENCODE_TAB=$(printf '%s' "$OPENCODE_TAB_STATE" \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
-OPENCODE_PANE=$(printf '%s' "$OPENCODE_TAB_STATE" \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
-```
+- `0`: cleanup completed and at least one report is available.
+- `1`: cleanup completed but no report is available, or result publication failed.
+- `2`: refused before peer creation because input, environment, dependencies, or the initial scan were invalid.
+- `3`: cleanup was incomplete; synthesis is forbidden.
+- `129`, `130`, or `143`: the process received HUP, INT, or TERM and cleanup completed. Incomplete cleanup overrides these with `3`.
 
-A freshly created tab's root pane can make its following `agent start` return `agent_pane_busy`. On that exact error, wait two seconds and retry the same start once. A failed retry enters the cleanup boundary. A generic startup timeout enters cleanup immediately without retry.
+Load and validate every listed report before removing `PAIR_RESULT` and `PAIR_PARENT`. A delivered file is transport evidence only; the calling skill decides whether its content is a valid review report. Pane reads are diagnostic and never appear in the result.
 
-## Start exact peers
+## Ordering guarantees
 
-Start Claude with Sonnet, effort `high`, and permission bypass:
+The executable:
 
-```bash
-herdr agent start "$CLAUDE_NAME" \
-  --kind claude \
-  --pane "$CLAUDE_PANE" \
-  --timeout 60000 \
-  -- \
-  --model sonnet \
-  --effort high \
-  --dangerously-skip-permissions
-```
+1. Adds each private report path to its complete caller prompt, then scans the checkout, any external document, and both exact augmented prompts immediately before creating tabs.
+2. Creates two fresh background tabs and starts the fixed Claude and OpenCode peers.
+3. Submits both prompts whose peers reached ready state before waiting on either peer. A trackable failure in one leg does not stop the other; a successful tab creation with no tab ID stops the pair because cleanup cannot be confirmed.
+4. Accepts only non-empty regular non-symlink report files.
+5. Gives a peer whose initial prompt and wait both succeeded, but whose report is missing or empty, one bounded recovery turn after scanning the recovery prompt and every input it exposes.
+6. Classifies byte-identical reports as one source.
+7. Attempts all tab and transport cleanup before publishing any result.
 
-Start OpenCode with Terra, high reasoning effort from the build-agent config, and permission bypass:
-
-```bash
-herdr agent start "$OPENCODE_NAME" \
-  --kind opencode \
-  --pane "$OPENCODE_PANE" \
-  --timeout 60000 \
-  -- \
-  --model openai/gpt-5.6-terra \
-  --agent build \
-  --auto
-```
-
-The interactive OpenCode entrypoint does not accept the run command's variant flag; keep high reasoning in `agent.build.reasoningEffort`. Do not substitute another model, effort, agent, permission posture, launcher, or reused session.
-
-Each start is complete only when the command succeeds and reports `interactive_ready:true`. Enter the cleanup boundary before prompting if either peer fails this criterion.
-
-Another client can claim an alias between allocation and start. On the exact error `agent_name_taken`, run `herdr-peer-alias` again for that peer with the other peer's alias reserved, then retry the same start once with the new alias; a second failure enters the cleanup boundary.
-
-After a successful start, `$CLAUDE_PANE` and `$OPENCODE_PANE` are the authoritative targets for every later prompt, wait, and read. Pane-label reconciliation may reallocate a peer's alias at any time, so never address a peer by name after start; a pane ID is stable for the life of its pane.
-
-## Prompt both peers
-
-Append the report transport contract to each calling prompt. This is the only permitted file-write exception in a report-only peer: it does not permit changes to the checkout, reviewed document, or any other file.
-
-```bash
-CLAUDE_PROMPT="$CLAUDE_PROMPT
-
-[peer-report-transport]
-Before ending this turn, write the exact complete report you are returning, byte-for-byte, to $CLAUDE_REPORT_PATH. Write it atomically through $CLAUDE_REPORT_PATH.tmp and rename the completed file to $CLAUDE_REPORT_PATH. The file is the authoritative report transport. After it is durable, return the same report in the UI as usual. Do not write any other file."
-
-OPENCODE_PROMPT="$OPENCODE_PROMPT
-
-[peer-report-transport]
-Before ending this turn, write the exact complete report you are returning, byte-for-byte, to $OPENCODE_REPORT_PATH. Write it atomically through $OPENCODE_REPORT_PATH.tmp and rename the completed file to $OPENCODE_REPORT_PATH. The file is the authoritative report transport. After it is durable, return the same report in the UI as usual. Do not write any other file."
-```
-
-Submit both augmented prompts before either wait can block:
-
-```bash
-herdr agent prompt "$CLAUDE_PANE" "$CLAUDE_PROMPT"
-herdr agent prompt "$OPENCODE_PANE" "$OPENCODE_PROMPT"
-```
-
-After both submissions, perform any concurrent local work explicitly defined by the calling skill. Skills with no concurrent work proceed directly to waiting.
-
-## Wait and collect
-
-```bash
-herdr agent wait "$CLAUDE_PANE" --timeout 1800000
-herdr agent wait "$OPENCODE_PANE" --timeout 1800000
-```
-
-The report files are the primary transport. A settled peer that did not create a non-empty regular report file gets one bounded recovery prompt to persist its previous answer. A symlink left at the report path is refused outright and never retried: it is a malformed delivery, not a missing one.
-
-```bash
-report_is_delivered() {
-  local report_path="$1"
-  # -f and -s follow symlinks, so a peer could point the report at any file the
-  # caller can read and have its content synthesized as that peer's review.
-  # Refuse the path without opening it. This is a coherence guard, not a
-  # containment boundary: a same-user peer is not contained by it.
-  [ ! -L "$report_path" ] || return 1
-  [ -f "$report_path" ] && [ -s "$report_path" ]
-}
-
-recover_peer_report() {
-  local pane="$1" report_path="$2" recovery_prompt
-  [ ! -L "$report_path" ] || return 1
-  report_is_delivered "$report_path" && return 0
-
-  recovery_prompt="The report transport file is missing or empty. Write your exact complete previous report, byte-for-byte, atomically through $report_path.tmp and rename it to $report_path. Then reply with only the path."
-  printf '%s\n' "$recovery_prompt" \
-    | pre-external-secret-scan --stdin "$REPO_ROOT" || return 1
-  herdr agent prompt "$pane" "$recovery_prompt" \
-    --wait --timeout 120000 || return 1
-
-  report_is_delivered "$report_path"
-}
-
-CLAUDE_TRANSPORT_OK=1
-if ! recover_peer_report "$CLAUDE_PANE" "$CLAUDE_REPORT_PATH"; then
-  CLAUDE_TRANSPORT_OK=0
-  CLAUDE_DIAGNOSTIC=$(herdr agent read "$CLAUDE_PANE" --source visible --lines 200 --format text || true)
-fi
-
-OPENCODE_TRANSPORT_OK=1
-if ! recover_peer_report "$OPENCODE_PANE" "$OPENCODE_REPORT_PATH"; then
-  OPENCODE_TRANSPORT_OK=0
-  OPENCODE_DIAGNOSTIC=$(herdr agent read "$OPENCODE_PANE" --source recent-unwrapped --lines 200 --format text || true)
-fi
-
-[ "$CLAUDE_TRANSPORT_OK" -eq 0 ] || CLAUDE_REPORT=$(<"$CLAUDE_REPORT_PATH")
-[ "$OPENCODE_TRANSPORT_OK" -eq 0 ] || OPENCODE_REPORT=$(<"$OPENCODE_REPORT_PATH")
-```
-
-A settled state is only a wake-up signal. Pane-backed reads can silently omit alternate-screen history and are diagnostic only; never accept `CLAUDE_DIAGNOSTIC` or `OPENCODE_DIAGNOSTIC` as a report. A failed transport degrades that peer. The calling skill must still validate the complete file-backed report before accepting it.
-
-Two delivered reports are not yet two reviews. Compare them before synthesis, while both files still exist:
-
-```bash
-PEER_REPORTS_IDENTICAL=0
-if [ "$CLAUDE_TRANSPORT_OK" -eq 1 ] && [ "$OPENCODE_TRANSPORT_OK" -eq 1 ] \
-  && cmp -s "$CLAUDE_REPORT_PATH" "$OPENCODE_REPORT_PATH"; then
-  PEER_REPORTS_IDENTICAL=1
-fi
-```
-
-A byte-identical pair is one review delivered twice: one peer performed no independent work, whatever the cause. It degrades exactly like one failed or malformed peer — the run carries single-source coverage, and the surviving report is the single source. It is never consensus, never agreement, and never corroboration of any finding it contains. The calling skill must state the degraded single-source coverage plainly in its synthesis output, name the run as one peer's review rather than two, and grade every finding as unique to that one source. This comparison is exact: a near-identical pair — the same review re-wrapped, reindented, or reserialized — is not detected here and still reads as agreement.
-
-## Close and clean before synthesis
-
-After collecting every available report into memory, close both tabs and remove the transport directory before synthesis:
-
-```bash
-CLEANUP_ERRORS=""
-herdr tab close "$CLAUDE_TAB" || CLEANUP_ERRORS="$CLEANUP_ERRORS tab:$CLAUDE_TAB"
-herdr tab close "$OPENCODE_TAB" || CLEANUP_ERRORS="$CLEANUP_ERRORS tab:$OPENCODE_TAB"
-rm -f "$CLAUDE_REPORT_PATH" "$CLAUDE_REPORT_PATH.tmp" \
-  "$OPENCODE_REPORT_PATH" "$OPENCODE_REPORT_PATH.tmp" \
-  || CLEANUP_ERRORS="$CLEANUP_ERRORS reports:$PEER_REPORT_DIR"
-rmdir "$PEER_REPORT_DIR" || CLEANUP_ERRORS="$CLEANUP_ERRORS directory:$PEER_REPORT_DIR"
-[ -z "$CLEANUP_ERRORS" ] || printf 'peer cleanup incomplete:%s\n' "$CLEANUP_ERRORS" >&2
-```
-
-Tab closure and report-directory removal complete the cleanup boundary. Attempt every recorded tab closure and every cleanup command even when an earlier command fails; report any tab or transport path that remains.
+Provided cleanup completes, one failed leg does not discard a valid peer report. The calling skill decides whether its own workflow can continue with degraded coverage.

--- a/tests/bashunit/external_leg_pair_test.sh
+++ b/tests/bashunit/external_leg_pair_test.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# post-apply: 15 host-safe
+# Semantic coverage for the paired External leg lifecycle executable.
+source "$(dirname "${BASH_SOURCE[0]}")/test-dsl.bash"
+_bats_file_init "${BASH_SOURCE[0]}"
+
+load 'helpers/common'
+
+PAIR_SCRIPT="${PAIR_SCRIPT_OVERRIDE:-$SOURCE_ROOT/dot_local/bin/executable_se-external-leg-pair}"
+
+pair_stub() {
+  PAIR_WORK="$BATS_TEST_TMPDIR/pair"
+  PAIR_BIN="$PAIR_WORK/bin"
+  PAIR_REPO="$PAIR_WORK/repository"
+  PAIR_RESULTS="$PAIR_WORK/results"
+  mkdir -p "$PAIR_BIN" "$PAIR_REPO" "$PAIR_RESULTS"
+  PAIR_REAL_MKTEMP="$(command -v mktemp)"
+  PAIR_REAL_RM="$(command -v rm)"
+  PAIR_REAL_CMP="$(command -v cmp)"
+  export PAIR_WORK PAIR_REAL_MKTEMP PAIR_REAL_RM PAIR_REAL_CMP
+
+  cat > "$PAIR_BIN/cmp" <<'SH'
+#!/usr/bin/env bash
+[ "${PAIR_STUB_CMP_FAIL:-0}" != 1 ] || exit 2
+exec "$PAIR_REAL_CMP" "$@"
+SH
+
+  cat > "$PAIR_BIN/mktemp" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$PAIR_WORK/mktemp-count" ] || read -r count < "$PAIR_WORK/mktemp-count"
+count=$((count + 1))
+printf '%s\n' "$count" > "$PAIR_WORK/mktemp-count"
+[ "${PAIR_STUB_MKTEMP_FAIL_AT:-0}" -ne "$count" ] || exit 1
+exec "$PAIR_REAL_MKTEMP" "$@"
+SH
+
+  cat > "$PAIR_BIN/rm" <<'SH'
+#!/usr/bin/env bash
+if [ "${PAIR_STUB_RM_FAIL_TRANSPORT:-0}" = 1 ]; then
+  for argument in "$@"; do
+    case "$argument" in
+      */se-external-leg-pair.*) exit 1 ;;
+    esac
+  done
+fi
+exec "$PAIR_REAL_RM" "$@"
+SH
+
+  cat > "$PAIR_BIN/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$PAIR_BIN/herdr-peer-alias" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$PAIR_WORK/alias-count" ] || read -r count < "$PAIR_WORK/alias-count"
+count=$((count + 1))
+printf '%s\n' "$count" > "$PAIR_WORK/alias-count"
+case "$count" in
+  1) printf 'blue-fox\n' ;;
+  2) printf 'green-owl\n' ;;
+  *) printf 'amber-hare\n' ;;
+esac
+SH
+
+  cat > "$PAIR_BIN/pre-external-secret-scan" <<'SH'
+#!/usr/bin/env bash
+count=0
+[ ! -f "$PAIR_WORK/scan-count" ] || read -r count < "$PAIR_WORK/scan-count"
+count=$((count + 1))
+printf '%s\n' "$count" > "$PAIR_WORK/scan-count"
+printf 'scan %s\n' "$count" >> "$PAIR_WORK/order.log"
+index=0
+for target in "$@"; do
+  index=$((index + 1))
+  printf '%s\n' "$target" >> "$PAIR_WORK/scan-$count.paths"
+  [ ! -f "$target" ] || cp "$target" "$PAIR_WORK/scan-$count-$index.input"
+done
+[ "${SE_SKIP_SECRET_SCAN:-0}" = 1 ] && exit 0
+[ "${PAIR_STUB_SCAN_FAIL_AT:-0}" -ne "$count" ]
+SH
+
+  cat > "$PAIR_BIN/herdr" <<'SH'
+#!/usr/bin/env bash
+printf 'herdr' >> "$PAIR_WORK/herdr.log"
+printf ' %q' "$@" >> "$PAIR_WORK/herdr.log"
+printf '\n' >> "$PAIR_WORK/herdr.log"
+printf '%s %s\n' "${1:-}" "${2:-}" >> "$PAIR_WORK/order.log"
+
+case "${1:-} ${2:-}" in
+  "tab create")
+    count=0
+    [ ! -f "$PAIR_WORK/tab-count" ] || read -r count < "$PAIR_WORK/tab-count"
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$PAIR_WORK/tab-count"
+    if [ "${PAIR_STUB_TAB_FAIL_AT:-0}" -eq "$count" ]; then
+      printf 'tab create failed\n' >&2
+      exit 1
+    fi
+    if [ "${PAIR_STUB_MALFORMED_TAB_AT:-0}" -eq "$count" ]; then
+      printf '{"result":{"tab":{},"root_pane":{"pane_id":"wT:p%s"}}}\n' "$count"
+    elif [ "${PAIR_STUB_MISSING_PANE_AT:-0}" -eq "$count" ]; then
+      printf '{"result":{"tab":{"tab_id":"wT:t%s"},"root_pane":{}}}\n' "$count"
+    else
+      printf '{"result":{"tab":{"tab_id":"wT:t%s"},"root_pane":{"pane_id":"wT:p%s"}}}\n' "$count" "$count"
+    fi
+    ;;
+  "agent start")
+    count=0
+    [ ! -f "$PAIR_WORK/start-count" ] || read -r count < "$PAIR_WORK/start-count"
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$PAIR_WORK/start-count"
+    if [ "${PAIR_STUB_START_MIXED_TRANSIENT:-0}" = 1 ] && [ "$count" -eq 1 ]; then
+      printf 'agent_pane_busy\n' >&2
+      exit 1
+    fi
+    if [ "${PAIR_STUB_START_MIXED_TRANSIENT:-0}" = 1 ] && [ "$count" -eq 2 ]; then
+      printf 'agent_name_taken\n' >&2
+      exit 1
+    fi
+    printf '{"result":{"agent":{"interactive_ready":true}}}\n'
+    ;;
+  "agent prompt")
+    pane="$3"
+    prompt="$4"
+    prompt_file="$PAIR_WORK/prompt-${pane##*:}"
+    printf '%s' "$prompt" > "$prompt_file"
+    report_path=""
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        'Report path: '*) report_path="${line#Report path: }" ;;
+        'Recovery report path: '*) report_path="${line#Recovery report path: }" ;;
+      esac
+    done < "$prompt_file"
+    [ -z "$report_path" ] || printf '%s' "$report_path" > "$PAIR_WORK/report-${pane##*:}.path"
+
+    if [ "${5:-}" = --wait ]; then
+      if [ "${PAIR_STUB_RECOVER:-0}" = 1 ] && [ -n "$report_path" ]; then
+        printf '%s' "${PAIR_STUB_RECOVER_BODY:-recovered}" > "$report_path"
+      fi
+    elif [ -n "$report_path" ]; then
+      case "$pane" in
+        wT:p1) mode="${PAIR_STUB_CLAUDE_MODE:-write}"; body="${PAIR_STUB_CLAUDE_REPORT:-claude report}" ;;
+        *) mode="${PAIR_STUB_OPENCODE_MODE:-write}"; body="${PAIR_STUB_OPENCODE_REPORT:-opencode report}" ;;
+      esac
+      if [ "${PAIR_STUB_PROMPT_ACK_FAIL_PANE:-}" = "$pane" ]; then
+        printf '%s' "$report_path" > "$PAIR_WORK/pending-${pane##*:}.path"
+        printf '%s' "$mode" > "$PAIR_WORK/pending-${pane##*:}.mode"
+        printf '%s' "$body" > "$PAIR_WORK/pending-${pane##*:}.body"
+        exit 1
+      fi
+      case "$mode" in
+        write) printf '%s' "$body" > "$report_path" ;;
+        empty) : > "$report_path" ;;
+        symlink) ln -s /etc/hosts "$report_path" ;;
+        none) : ;;
+      esac
+    fi
+    printf '{"result":{"agent":{"agent_status":"working"}}}\n'
+    ;;
+  "agent wait")
+    pane="$3"
+    if [ -f "$PAIR_WORK/pending-${pane##*:}.path" ]; then
+      report_path="$(cat "$PAIR_WORK/pending-${pane##*:}.path")"
+      mode="$(cat "$PAIR_WORK/pending-${pane##*:}.mode")"
+      body="$(cat "$PAIR_WORK/pending-${pane##*:}.body")"
+      case "$mode" in
+        write) printf '%s' "$body" > "$report_path" ;;
+        empty) : > "$report_path" ;;
+        symlink) ln -s /etc/hosts "$report_path" ;;
+        none) : ;;
+      esac
+    fi
+    exit 0
+    ;;
+  "agent read")
+    printf 'diagnostic only\n'
+    ;;
+  "tab close")
+    printf '%s\n' "$3" >> "$PAIR_WORK/closed-tabs"
+    if [ "${PAIR_STUB_ASSERT_NO_STAGE_ON_CLOSE:-0}" = 1 ]; then
+      for candidate in "$PAIR_RESULTS"/.se-external-leg-pair.*; do
+        [ ! -e "$candidate" ] && [ ! -L "$candidate" ] || exit 1
+      done
+    fi
+    [ "${PAIR_STUB_CLOSE_FAIL_TAB:-}" != "$3" ]
+    ;;
+  *) exit 2 ;;
+esac
+SH
+
+  cat > "$PAIR_BIN/claude" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cp "$PAIR_BIN/claude" "$PAIR_BIN/opencode"
+  chmod +x "$PAIR_BIN/cmp" "$PAIR_BIN/mktemp" "$PAIR_BIN/rm" "$PAIR_BIN/sleep" "$PAIR_BIN/herdr-peer-alias" "$PAIR_BIN/pre-external-secret-scan" \
+    "$PAIR_BIN/herdr" "$PAIR_BIN/claude" "$PAIR_BIN/opencode"
+
+  printf 'claude scope' > "$PAIR_WORK/claude.prompt"
+  printf 'opencode scope' > "$PAIR_WORK/opencode.prompt"
+  printf 'frozen document' > "$PAIR_WORK/document.md"
+}
+
+function test_external_leg_pair_1301_scans_exact_inputs_before_launch_and_publishes_distinct_reports() {
+  _bats_test_init 1301 'External leg pair scans exact inputs before launch and publishes distinct reports'
+  pair_stub
+  local result="$PAIR_RESULTS/distinct"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_ASSERT_NO_STAGE_ON_CLOSE=1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
+    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" \
+      --exposed-document "$PAIR_WORK/document.md" --result-dir "$result"
+  assert_success
+
+  run jq -cS '{classification,cleanup,interface,reports,scan}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"paired","cleanup":"complete","interface":"se-external-leg-pair/v1","reports":[{"path":"claude.report","source":"claude"},{"path":"opencode.report","source":"opencode"}],"scan":"clean"}'
+  run cmp -s "$result/claude.report" <(printf 'claude report')
+  assert_success
+  run cmp -s "$result/opencode.report" <(printf 'opencode report')
+  assert_success
+
+  run python3 - "$PAIR_WORK/order.log" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+assert lines.index("scan 1") < lines.index("tab create")
+prompts = [i for i, line in enumerate(lines) if line == "agent prompt"]
+waits = [i for i, line in enumerate(lines) if line == "agent wait"]
+assert len(prompts) == 2
+assert len(waits) == 2
+assert max(prompts) < min(waits)
+PY
+  assert_success
+
+  run python3 - "$PAIR_WORK" <<'PY'
+import pathlib
+import sys
+
+work = pathlib.Path(sys.argv[1])
+paths = (work / "scan-1.paths").read_text().splitlines()
+assert pathlib.Path(paths[0]).samefile(work / "repository")
+assert pathlib.Path(paths[1]).samefile(work / "document.md")
+assert pathlib.Path(paths[2]).name == "claude.prompt"
+assert pathlib.Path(paths[3]).name == "opencode.prompt"
+assert len(paths) == 4
+claude_prompt = (work / "scan-1-3.input").read_text()
+opencode_prompt = (work / "scan-1-4.input").read_text()
+assert claude_prompt.startswith("claude scope")
+assert opencode_prompt.startswith("opencode scope")
+assert "Report path: " in claude_prompt
+assert "Report path: " in opencode_prompt
+assert claude_prompt != opencode_prompt
+PY
+  assert_success
+  run cmp -s "$PAIR_WORK/scan-1-3.input" "$PAIR_WORK/prompt-p1"
+  assert_success
+  run cmp -s "$PAIR_WORK/scan-1-4.input" "$PAIR_WORK/prompt-p2"
+  assert_success
+  local transport
+  transport="$(dirname "$(cat "$PAIR_WORK/report-p1.path")")"
+  assert_dir_not_exists "$transport"
+  run python3 - "$PAIR_RESULTS" <<'PY'
+import pathlib
+import sys
+
+assert not list(pathlib.Path(sys.argv[1]).glob(".se-external-leg-pair.*"))
+PY
+  assert_success
+  run grep -F -- '--kind claude' "$PAIR_WORK/herdr.log"
+  assert_success
+  assert_output --partial '--model sonnet'
+  assert_output --partial '--effort high'
+  run grep -F -- '--kind opencode' "$PAIR_WORK/herdr.log"
+  assert_success
+  assert_output --partial '--model openai/gpt-5.6-terra'
+  assert_output --partial '--agent build'
+}
+
+function test_external_leg_pair_1302_refuses_before_tabs_and_records_an_explicit_scan_waiver() {
+  _bats_test_init 1302 'External leg pair refuses before tabs and records an explicit scan waiver'
+  pair_stub
+  local refused="$PAIR_RESULTS/refused" waived="$PAIR_RESULTS/waived"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_SCAN_FAIL_AT=1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
+    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$refused"
+  assert_failure 2
+  assert_dir_not_exists "$refused"
+  assert_file_not_exists "$PAIR_WORK/herdr.log"
+  local refused_transport
+  refused_transport="$(dirname "$(sed -n '2p' "$PAIR_WORK/scan-1.paths")")"
+  assert_dir_not_exists "$refused_transport"
+
+  rm -f "$PAIR_WORK/alias-count" "$PAIR_WORK/scan-count" "$PAIR_WORK/order.log"
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_SCAN_FAIL_AT=1 SE_SKIP_SECRET_SCAN=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$waived"
+  assert_success
+  run jq -r '.scan' "$waived/result.json"
+  assert_success
+  assert_output waived
+}
+
+function test_external_leg_pair_1303_rescans_recovery_prompts_and_counts_identical_reports_once() {
+  _bats_test_init 1303 'External leg pair rescans recovery prompts and counts identical reports once'
+  pair_stub
+  local result="$PAIR_RESULTS/identical"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=none PAIR_STUB_OPENCODE_MODE=none \
+    PAIR_STUB_RECOVER=1 PAIR_STUB_RECOVER_BODY='same report' \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" \
+      --exposed-document "$PAIR_WORK/document.md" --result-dir "$result"
+  assert_success
+  run jq -cS '{classification,legs,reports}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"identical-single","legs":{"claude":"recovered","opencode":"recovered"},"reports":[{"path":"identical.report","source":"indeterminate"}]}'
+  assert_file_exists "$result/identical.report"
+  assert_file_not_exists "$result/claude.report"
+  assert_file_not_exists "$result/opencode.report"
+  run cmp -s "$result/identical.report" <(printf 'same report')
+  assert_success
+  run cat "$PAIR_WORK/scan-count"
+  assert_success
+  assert_output 3
+  run python3 - "$PAIR_WORK" <<'PY'
+import pathlib
+import sys
+
+work = pathlib.Path(sys.argv[1])
+for count, pane in ((2, "p1"), (3, "p2")):
+    paths = (work / f"scan-{count}.paths").read_text().splitlines()
+    assert pathlib.Path(paths[0]).samefile(work / "repository")
+    assert pathlib.Path(paths[1]).samefile(work / "document.md")
+    assert pathlib.Path(paths[2]).name.endswith("recovery.prompt")
+    assert len(paths) == 3
+    assert (work / f"scan-{count}-3.input").read_bytes() == (work / f"prompt-{pane}").read_bytes()
+order = (work / "order.log").read_text().splitlines()
+assert order.index("scan 2") < order.index("agent prompt", order.index("scan 2"))
+assert order.index("scan 3") < order.index("agent prompt", order.index("scan 3"))
+PY
+  assert_success
+}
+
+function test_external_leg_pair_1304_withholds_results_when_cleanup_is_incomplete() {
+  _bats_test_init 1304 'External leg pair withholds results when cleanup is incomplete'
+  pair_stub
+  local result="$PAIR_RESULTS/cleanup-failed"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLOSE_FAIL_TAB=wT:t1 PAIR_STUB_ASSERT_NO_STAGE_ON_CLOSE=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 3
+  assert_dir_not_exists "$result"
+  run cat "$PAIR_WORK/closed-tabs"
+  assert_success
+  assert_line --index 0 wT:t1
+  assert_line --index 1 wT:t2
+  assert_line --index 2 wT:t1
+  local transport
+  transport="$(dirname "$(cat "$PAIR_WORK/report-p1.path")")"
+  assert_dir_not_exists "$transport"
+  run python3 - "$PAIR_RESULTS" <<'PY'
+import pathlib
+import sys
+
+assert not list(pathlib.Path(sys.argv[1]).glob(".se-external-leg-pair.*"))
+PY
+  assert_success
+}
+
+function test_external_leg_pair_1305_preserves_a_valid_claude_report_when_opencode_fails() {
+  _bats_test_init 1305 'External leg pair preserves a valid Claude report when OpenCode fails'
+  pair_stub
+  local result="$PAIR_RESULTS/claude-only"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_OPENCODE_MODE=symlink \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_success
+  run jq -cS '{classification,legs,reports}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"claude-only","legs":{"claude":"delivered","opencode":"malformed"},"reports":[{"path":"claude.report","source":"claude"}]}'
+  run cmp -s "$result/claude.report" <(printf 'claude report')
+  assert_success
+  assert_file_not_exists "$result/opencode.report"
+}
+
+function test_external_leg_pair_1306_preserves_a_valid_opencode_report_when_claude_fails() {
+  _bats_test_init 1306 'External leg pair preserves a valid OpenCode report when Claude fails'
+  pair_stub
+  local result="$PAIR_RESULTS/opencode-only"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=symlink \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_success
+  run jq -cS '{classification,legs,reports}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"opencode-only","legs":{"claude":"malformed","opencode":"delivered"},"reports":[{"path":"opencode.report","source":"opencode"}]}'
+  run cmp -s "$result/opencode.report" <(printf 'opencode report')
+  assert_success
+  assert_file_not_exists "$result/claude.report"
+}
+
+function test_external_leg_pair_1307_publishes_none_only_after_complete_cleanup() {
+  _bats_test_init 1307 'External leg pair publishes none only after complete cleanup'
+  pair_stub
+  local result="$PAIR_RESULTS/none"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=symlink PAIR_STUB_OPENCODE_MODE=symlink \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 1
+  run jq -cS '{classification,cleanup,legs,reports}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"none","cleanup":"complete","legs":{"claude":"malformed","opencode":"malformed"},"reports":[]}'
+  assert_file_not_exists "$result/claude.report"
+  assert_file_not_exists "$result/opencode.report"
+}
+
+function test_external_leg_pair_1308_treats_untracked_tabs_and_failed_error_cleanup_as_exit_three() {
+  _bats_test_init 1308 'External leg pair treats untracked tabs and failed error cleanup as exit three'
+  pair_stub
+  local malformed="$PAIR_RESULTS/malformed-tab" staging="$PAIR_RESULTS/staging-failed"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MALFORMED_TAB_AT=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$malformed"
+  assert_failure 3
+  assert_dir_not_exists "$malformed"
+  local malformed_transport
+  malformed_transport="$(dirname "$(sed -n '2p' "$PAIR_WORK/scan-1.paths")")"
+  assert_dir_not_exists "$malformed_transport"
+
+  rm -rf "$PAIR_WORK"
+  pair_stub
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MKTEMP_FAIL_AT=2 PAIR_STUB_RM_FAIL_TRANSPORT=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$staging"
+  assert_failure 3
+  assert_output --partial 'could not stage the result'
+  assert_output --partial 'cleanup failed for transport'
+  assert_dir_not_exists "$staging"
+  run cat "$PAIR_WORK/mktemp-count"
+  assert_success
+  assert_output 2
+
+  rm -rf "$PAIR_WORK"
+  pair_stub
+  local known_tab="$PAIR_RESULTS/known-tab"
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MISSING_PANE_AT=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$known_tab"
+  assert_success
+  run jq -cS '{classification,legs}' "$known_tab/result.json"
+  assert_success
+  assert_output '{"classification":"opencode-only","legs":{"claude":"tab-malformed","opencode":"delivered"}}'
+  run cat "$PAIR_WORK/closed-tabs"
+  assert_success
+  assert_line --index 0 wT:t1
+  assert_line --index 1 wT:t2
+}
+
+function test_external_leg_pair_1309_recovers_mixed_start_races_and_keeps_an_ack_lost_report() {
+  _bats_test_init 1309 'External leg pair recovers mixed start races and keeps an ack-lost report'
+  pair_stub
+  local result="$PAIR_RESULTS/transient"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_START_MIXED_TRANSIENT=1 \
+    PAIR_STUB_PROMPT_ACK_FAIL_PANE=wT:p1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
+    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_success
+  run jq -cS '{classification,legs}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"paired","legs":{"claude":"delivered","opencode":"delivered"}}'
+  run cat "$PAIR_WORK/start-count"
+  assert_success
+  assert_output 4
+  run grep -F 'agent start amber-hare' "$PAIR_WORK/herdr.log"
+  assert_success
+}
+
+function test_external_leg_pair_1310_degrades_when_one_tab_cannot_start() {
+  _bats_test_init 1310 'External leg pair degrades when one tab cannot start'
+  pair_stub
+  local result="$PAIR_RESULTS/tab-failed"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_TAB_FAIL_AT=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_success
+  run jq -cS '{classification,legs,reports}' "$result/result.json"
+  assert_success
+  assert_output '{"classification":"opencode-only","legs":{"claude":"tab-create-failed","opencode":"delivered"},"reports":[{"path":"opencode.report","source":"opencode"}]}'
+  run cat "$PAIR_WORK/closed-tabs"
+  assert_success
+  assert_output wT:t2
+}
+
+function test_external_leg_pair_1311_refuses_to_classify_when_report_comparison_fails() {
+  _bats_test_init 1311 'External leg pair refuses to classify when report comparison fails'
+  pair_stub
+  local result="$PAIR_RESULTS/compare-failed"
+
+  run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CMP_FAIL=1 \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 1
+  assert_output --partial 'could not compare peer reports'
+  assert_dir_not_exists "$result"
+  run cat "$PAIR_WORK/closed-tabs"
+  assert_success
+  assert_line --index 0 wT:t1
+  assert_line --index 1 wT:t2
+  local transport
+  transport="$(dirname "$(cat "$PAIR_WORK/report-p1.path")")"
+  assert_dir_not_exists "$transport"
+}
+
+function set_up_before_script() {
+  :
+}
+
+function tear_down_after_script() {
+  _bats_file_cleanup
+}
+
+function tear_down() { _bats_run_teardown; }

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -822,15 +822,9 @@ function test_scripts_1191_worktree_identity_recovers_a_prepared_rename() {
   local common state
   common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
   state="$(hwi_identity_state_path)"
-  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
-repository_anchor=$(encode_value "$common")
-workspace=$(encode_value workspace-1)
-original_branch=$(encode_value "$HWI_BRANCH")
-branch=$(encode_value recover-prepared-rename)
-outcome=$(encode_value prepared)
-authorization=$(encode_value authorized)
-title=$(encode_value 'Recover prepared rename')
-slug=$(encode_value recover-prepared-rename)"
+  write_identity_state "$state" checkout_root "$HWI_CHECKOUT" repository_anchor "$common" \
+    workspace workspace-1 original_branch "$HWI_BRANCH" branch recover-prepared-rename \
+    outcome prepared authorization authorized title 'Recover prepared rename' slug recover-prepared-rename
 
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
     bash "$HWI_ENGINE" --worker --agent codex --session session-1 --pane pane-1 --workspace workspace-1 <<< 'Later event'
@@ -958,15 +952,9 @@ function test_scripts_1196_worktree_identity_recovers_prepared_attribution_after
   common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
   state="$(hwi_identity_state_path)"
   marker="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-path herdr-generated-worktree)"
-  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
-repository_anchor=$(encode_value "$common")
-workspace=$(encode_value workspace-1)
-original_branch=$(encode_value "$HWI_BRANCH")
-branch=$(encode_value "$branch")
-outcome=$(encode_value prepared)
-authorization=$(encode_value authorized)
-title=$(encode_value 'Recover prepared attribution')
-slug=$(encode_value recover-prepared-attribution)"
+  write_identity_state "$state" checkout_root "$HWI_CHECKOUT" repository_anchor "$common" \
+    workspace workspace-1 original_branch "$HWI_BRANCH" branch "$branch" outcome prepared \
+    authorization authorized title 'Recover prepared attribution' slug recover-prepared-attribution
   git -C "$HWI_CHECKOUT" branch -m "$branch"
 
   run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
@@ -1010,15 +998,9 @@ function test_scripts_1198_worktree_identity_treats_a_prepared_revert_as_agent_o
   local common state candidate=prepared-agent-revert
   common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
   state="$(hwi_identity_state_path)"
-  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
-repository_anchor=$(encode_value "$common")
-workspace=$(encode_value workspace-1)
-original_branch=$(encode_value "$HWI_BRANCH")
-branch=$(encode_value "$candidate")
-outcome=$(encode_value prepared)
-authorization=$(encode_value authorized)
-title=$(encode_value 'Prepared agent revert')
-slug=$(encode_value prepared-agent-revert)"
+  write_identity_state "$state" checkout_root "$HWI_CHECKOUT" repository_anchor "$common" \
+    workspace workspace-1 original_branch "$HWI_BRANCH" branch "$candidate" outcome prepared \
+    authorization authorized title 'Prepared agent revert' slug prepared-agent-revert
   git -C "$HWI_CHECKOUT" branch -m "$candidate"
   git -C "$HWI_CHECKOUT" branch -m "$HWI_BRANCH"
 
@@ -1040,15 +1022,9 @@ function test_scripts_1199_worktree_identity_treats_a_prepared_branch_move_as_ag
   local common state candidate=prepared-candidate-move
   common="$(git -C "$HWI_CHECKOUT" rev-parse --path-format=absolute --git-common-dir)"
   state="$(hwi_identity_state_path)"
-  atomic_write "$state" "checkout_root=$(encode_value "$HWI_CHECKOUT")
-repository_anchor=$(encode_value "$common")
-workspace=$(encode_value workspace-1)
-original_branch=$(encode_value "$HWI_BRANCH")
-branch=$(encode_value "$candidate")
-outcome=$(encode_value prepared)
-authorization=$(encode_value authorized)
-title=$(encode_value 'Prepared candidate move')
-slug=$(encode_value prepared-candidate-move)"
+  write_identity_state "$state" checkout_root "$HWI_CHECKOUT" repository_anchor "$common" \
+    workspace workspace-1 original_branch "$HWI_BRANCH" branch "$candidate" outcome prepared \
+    authorization authorized title 'Prepared candidate move' slug prepared-candidate-move
   git -C "$HWI_CHECKOUT" branch -m "$candidate"
   git -C "$HWI_CHECKOUT" branch -m agent-owned-after-prepare
 
@@ -1108,6 +1084,93 @@ function test_scripts_1201_worktree_identity_reconciles_a_persist_failed_workspa
   assert_success
   assert_equal "$(read_state_field "$state" outcome)" complete
   assert_equal "$(hwi_workspace_rename_count)" 1
+}
+
+function test_scripts_1305_worktree_state_named_writes_preserve_unspecified_fields() {
+  _bats_test_init 1305 'worktree state named writes preserve unspecified fields atomically'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  local state="$HWI_WORK/named.state" title='A title with = and enough bytes to exercise wrapped base64 encoding 0123456789 0123456789'
+
+  run write_identity_state "$state" \
+    checkout_root /checkout repository_anchor /repository workspace workspace-1 \
+    original_branch worktree/original branch proposed-branch outcome prepared \
+    authorization authorized title "$title" slug proposed-branch
+  assert_success
+  run write_identity_state "$state" outcome complete
+  assert_success
+  assert_equal "$(read_state_field "$state" checkout_root)" /checkout
+  assert_equal "$(read_state_field "$state" repository_anchor)" /repository
+  assert_equal "$(read_state_field "$state" workspace)" workspace-1
+  assert_equal "$(read_state_field "$state" original_branch)" worktree/original
+  assert_equal "$(read_state_field "$state" branch)" proposed-branch
+  assert_equal "$(read_state_field "$state" authorization)" authorized
+  assert_equal "$(read_state_field "$state" title)" "$title"
+  assert_equal "$(read_state_field "$state" slug)" proposed-branch
+  assert_equal "$(read_state_field "$state" outcome)" complete
+
+  cp "$state" "$HWI_WORK/before-unknown.state"
+  run write_identity_state "$state" outcome declined invented_field value
+  assert_failure 1
+  run cmp -s "$state" "$HWI_WORK/before-unknown.state"
+  assert_success
+  run write_identity_state "$state" outcome declined title
+  assert_failure 1
+  run cmp -s "$state" "$HWI_WORK/before-unknown.state"
+  assert_success
+  run write_identity_state "$state" outcome impossible
+  assert_failure 1
+  run cmp -s "$state" "$HWI_WORK/before-unknown.state"
+  assert_success
+  local diagnostics
+  diagnostics="$(diagnostic_file_for_state "$state")"
+  assert_file_contains "$diagnostics" 'reason=invalid-record-field '
+  assert_file_contains "$diagnostics" 'reason=invalid-record-update '
+  assert_file_contains "$diagnostics" 'reason=illegal-outcome '
+
+  hwi_write_mv_proxy
+  : > "$HWI_WORK/fail-terminal-state-write"
+  : > "$HWI_WORK/workspace.label"
+  cp "$state" "$HWI_WORK/before-mv-failure.state"
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" \
+    bash -c 'source "$1"; write_identity_state "$2" outcome declined' _ "$HWI_STATE_LIBRARY" "$state"
+  assert_failure 1
+  run cmp -s "$state" "$HWI_WORK/before-mv-failure.state"
+  assert_success
+  run bash -c 'compgen -G "$1/.record.*" >/dev/null' _ "${state%/*}"
+  assert_failure 1
+}
+
+function test_scripts_1306_worktree_state_rewrites_the_legacy_outcome_canonically() {
+  _bats_test_init 1306 'worktree state accepts a legacy outcome and rewrites it canonically'
+  hwi_setup
+  source "$HWI_STATE_LIBRARY"
+  local state="$HWI_WORK/legacy.state"
+  atomic_write "$state" "checkout_root=$(encode_value /checkout)
+repository_anchor=$(encode_value /repository)
+workspace=$(encode_value workspace-1)
+original_branch=$(encode_value worktree/original)
+branch=$(encode_value renamed-branch)
+outcome=$(encode_value attribution_failed)
+authorization=$(encode_value authorized)
+title=$(encode_value 'Legacy title')
+slug=$(encode_value legacy-title)"
+
+  assert_equal "$(read_state_field "$state" outcome)" attribution_failed
+  run write_identity_state "$state" title 'Updated title'
+  assert_success
+  assert_equal "$(read_state_field "$state" outcome)" attribution-failed
+  assert_equal "$(read_state_field "$state" branch)" renamed-branch
+  assert_equal "$(read_state_field "$state" title)" 'Updated title'
+
+  local illegal="$HWI_WORK/illegal.state"
+  atomic_write "$illegal" "outcome=$(encode_value impossible)"
+  cp "$illegal" "$HWI_WORK/before-illegal.state"
+  run write_identity_state "$illegal" title 'Rejected update'
+  assert_failure 1
+  run cmp -s "$illegal" "$HWI_WORK/before-illegal.state"
+  assert_success
+  assert_file_contains "$(diagnostic_file_for_state "$illegal")" 'reason=illegal-outcome '
 }
 
 function test_scripts_1202_worktree_identity_rejects_marker_owner_changes_at_commit() {

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -778,6 +778,8 @@ function test_smoke_1051_herdr_alias_pane_label_child_and_secret_scan_files_are_
   assert_file_executable "$HOME/.local/bin/herdr-child"
   assert_file_exists "$HOME/.local/bin/pre-external-secret-scan"
   assert_file_executable "$HOME/.local/bin/pre-external-secret-scan"
+  assert_file_exists "$HOME/.local/bin/se-external-leg-pair"
+  assert_file_executable "$HOME/.local/bin/se-external-leg-pair"
   assert_file_exists "$HOME/.agents/skills/ask-in-herdr/scripts/follow-up.sh"
   assert_file_executable "$HOME/.agents/skills/ask-in-herdr/scripts/follow-up.sh"
 }

--- a/tests/helpers/herdr_worktree_identity.bash
+++ b/tests/helpers/herdr_worktree_identity.bash
@@ -1,6 +1,6 @@
 # Herdr worktree-identity harness. Load after helpers/common.
 
-HWI_STATE_LIBRARY="$SOURCE_ROOT/dot_local/lib/herdr-worktree-state.sh"
+HWI_STATE_LIBRARY="${HWI_STATE_LIBRARY_OVERRIDE:-$SOURCE_ROOT/dot_local/lib/herdr-worktree-state.sh}"
 export HWI_STATE_LIBRARY
 HWI_ENGINE="$SOURCE_ROOT/dot_local/bin/executable_herdr-worktree-identity"
 HWI_WORKTREE_SETUP_PLUGIN="$SOURCE_ROOT/private_dot_config/herdr/plugins/worktree-setup/setup.ts"


### PR DESCRIPTION
## Summary

External code and document reviews now run through one executable lifecycle that scans exact inputs, launches both peers, preserves usable degraded results, and proves cleanup before publishing. Worktree identity updates now name only the fields they change, while the shared state module owns record shape, compatibility translation, validation, and atomic persistence.

These changes ship together because both replace repeated agent-side procedure with a smaller enforceable interface. The PR also records 2 lower-priority deepening opportunities without implementing them prematurely.

```mermaid
flowchart TB
    Callers[Review skills] --> Pair[se-external-leg-pair]
    Pair --> Scan[Secret scan]
    Pair --> Claude[Claude peer]
    Pair --> OpenCode[OpenCode peer]
    Claude --> Reports[Private report transport]
    OpenCode --> Reports
    Reports --> Pair
    Pair --> Result[Atomic classified result]

    Identity[Worktree identity engine] --> State[herdr-worktree-state]
    State --> Record[Durable identity record]
```

## Design Decisions

- The lifecycle publishes nothing until every trackable peer tab closes and private transport is removed. Incomplete cleanup exits `3` and forbids synthesis.
- One failed leg does not discard a valid report when cleanup succeeds. Results distinguish `paired`, single-model, `identical-single`, and `none` coverage.
- Byte-identical peer reports become one indeterminate source rather than false cross-model consensus.
- Initial and recovery prompts cross the existing ADR-0012 fail-closed scan boundary. `SE_SKIP_SECRET_SCAN=1` remains an explicit, reported operator waiver.
- Worktree state writes preserve unspecified fields and canonicalize the legacy `attribution_failed` outcome on the next write.
- Git mutation, marker authorization, and outcome selection remain in the worktree identity engine; the state module owns only the durable record boundary.

## Verification

- `make test-ubuntu`: passed against the final deployment-relevant state.
- `make lint`: passed.
- `make test-issues`: 60 tests passed.
- External lifecycle suite: 11 tests, 90 assertions passed.
- Worktree identity suite: 43 tests, 282 assertions passed.
- New regression tests were calibrated red against minimal report-manifest and state-preservation mutants, then green against the implementation.
- A live Herdr run exercised degraded coverage: Claude failed to start, OpenCode recovered its file-backed report, the result published as `opencode-only`, and both peer panes closed.

## Post-Deploy Monitoring & Validation

- Owner: maintainer applying the chezmoi update.
- Window: the first 3 runs across `se-code-review`, `se-doc-review`, or `se-simplify` after deployment and client restart.
- Healthy signals: exit `0`, `cleanup: complete`, listed report files present, no peer tabs left behind, and degraded classifications disclosed when applicable.
- Failure searches: `se-external-leg-pair: refused`, `cleanup failed`, `cleanup unconfirmed`, `could not compare peer reports`, and exit `3`.
- Mitigation trigger: any leaked peer tab, published result with incomplete cleanup, or caller treating `identical-single` as consensus. Stop synthesis, close remaining owned tabs, and revert the lifecycle commit before another external review.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-GPT--5.6--Sol-000000)
