### PR TITLE
fix(skills): drop metarhia data-structures from the manifest

### DIFF
--- a/home/private_dot_config/agent-skills/manifest
+++ b/home/private_dot_config/agent-skills/manifest
@@ -8,4 +8,4 @@ Nutlope/variate *
 humanlayer/skills show-me
 claude-office-skills/skills pdf-extraction
 will-ness-ai/skills grill-design
-metarhia/skills data-structures error-handling js-gof
+metarhia/skills error-handling js-gof


### PR DESCRIPTION
`chezmoi apply` (and any `skills sync`) was hard-failing with `skills: missing canonical skill tree: .../data-structures`. The cause is upstream: `metarhia/metaskills`'s `data-structures/SKILL.md` has invalid YAML frontmatter (an unquoted colon in the `description` value), which the upstream `skills@latest` CLI silently skips while still exiting 0 — our own sync script then correctly notices the skill never landed and aborts. Dropping `data-structures` from the `metarhia/skills` manifest line unblocks the sync; `error-handling` and `js-gof` from the same source are unaffected and stay.

Verified with `npx skills@latest add metarhia/skills --list`, which reports the YAML parse error and omits `data-structures` from its resolved skill list, matching the deployed lock file (which already has entries only for `error-handling`/`js-gof` from this source). `make test-local` confirms the manifest edit maps to the expected destination with no other path or template changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
