### PR TITLE
refactor(agents): share worktree identity handoff

### DIFF
--- a/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
+++ b/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "agent-platform"
 tags: ["architecture","worktree-identity","adapter","enhancement","ready-for-agent"]
 date: "2026-09-11"
-status: "in-progress"
+status: "done"
 priority: "low"
+closed: "2026-09-11"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ When either adapter next requires modification, move only the shared TypeScript 
 ## Open decisions
 
 Deferred until one adapter next changes; revalidate that both implementations still match before extracting the shared handoff.
+
+## Resolution
+
+Extracted the matching Pi and OpenCode subprocess handoff into one deployed TypeScript module while preserving client-local event normalization, stdin-only transport, engine discovery, timeout, and fail-open behavior; verified through focused adapter tests and the disposable-home suite.

--- a/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
+++ b/docs/issues/2026-09-11-003-share-the-pi-and-opencode-worktree-identity-handoff.md
@@ -5,7 +5,7 @@ type: "follow-up"
 category: "agent-platform"
 tags: ["architecture","worktree-identity","adapter","enhancement","ready-for-agent"]
 date: "2026-09-11"
-status: "open"
+status: "in-progress"
 priority: "low"
 ---
 

--- a/home/dot_local/lib/agent-hooks/worktree-identity.ts
+++ b/home/dot_local/lib/agent-hooks/worktree-identity.ts
@@ -1,0 +1,59 @@
+// Shared subprocess handoff for the Pi and OpenCode worktree-identity adapters.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ENGINE_NAME = "herdr-worktree-identity";
+const HANDSHAKE_TIMEOUT_MS = 1000;
+
+export type WorktreeIdentityAgent = "pi" | "opencode";
+
+function enginePath(): string {
+  const configured = process.env.HERDR_WORKTREE_IDENTITY_ENGINE;
+  if (configured) return configured;
+  const home = process.env.HOME;
+  if (home) {
+    const local = join(home, ".local", "bin", ENGINE_NAME);
+    if (existsSync(local)) return local;
+  }
+  return ENGINE_NAME;
+}
+
+function engineArgs(agent: WorktreeIdentityAgent, sessionID: string): string[] {
+  const args = ["--agent", agent, "--session", sessionID];
+  if (process.env.HERDR_PANE_ID) args.push("--pane", process.env.HERDR_PANE_ID);
+  if (process.env.HERDR_WORKSPACE_ID) args.push("--workspace", process.env.HERDR_WORKSPACE_ID);
+  return args;
+}
+
+export function handoffWorktreeIdentity(
+  agent: WorktreeIdentityAgent,
+  sessionID: string,
+  prompt: string,
+): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(enginePath(), engineArgs(agent, sessionID), { stdio: ["pipe", "ignore", "ignore"] });
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        child.stdin?.destroy();
+        child.kill("SIGTERM");
+        finish();
+      }, HANDSHAKE_TIMEOUT_MS);
+      timer.unref?.();
+      child.once("error", finish);
+      child.once("close", finish);
+      child.stdin?.once("error", () => {});
+      child.stdin?.end(prompt);
+    } catch {
+      resolve();
+    }
+  });
+}

--- a/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
+++ b/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
@@ -1,11 +1,12 @@
 // Pi prompt adapter for herdr-worktree-identity.
 // @ts-nocheck
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 let handoffWorktreeIdentity: ((agent: "pi", sessionID: string, prompt: string) => Promise<void>) | undefined;
 try {
   ({ handoffWorktreeIdentity } = await import(
-    join(process.env.HOME ?? "", ".local", "lib", "agent-hooks", "worktree-identity.ts")
+    join(process.env.HOME || homedir(), ".local", "lib", "agent-hooks", "worktree-identity.ts")
   ));
 } catch {
   handoffWorktreeIdentity = undefined;

--- a/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
+++ b/home/dot_pi/agent/extensions/herdr-worktree-identity.ts
@@ -1,20 +1,14 @@
 // Pi prompt adapter for herdr-worktree-identity.
 // @ts-nocheck
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import path from "node:path";
+import { join } from "node:path";
 
-const ENGINE_NAME = "herdr-worktree-identity";
-const HANDSHAKE_TIMEOUT_MS = 1000;
-
-function enginePath(): string {
-  if (process.env.HERDR_WORKTREE_IDENTITY_ENGINE) return process.env.HERDR_WORKTREE_IDENTITY_ENGINE;
-  const home = process.env.HOME;
-  if (home) {
-    const local = path.join(home, ".local", "bin", ENGINE_NAME);
-    if (existsSync(local)) return local;
-  }
-  return ENGINE_NAME;
+let handoffWorktreeIdentity: ((agent: "pi", sessionID: string, prompt: string) => Promise<void>) | undefined;
+try {
+  ({ handoffWorktreeIdentity } = await import(
+    join(process.env.HOME ?? "", ".local", "lib", "agent-hooks", "worktree-identity.ts")
+  ));
+} catch {
+  handoffWorktreeIdentity = undefined;
 }
 
 function sessionId(ctx: any): string | undefined {
@@ -26,48 +20,14 @@ function sessionId(ctx: any): string | undefined {
   }
 }
 
-function callEngine(args: string[], prompt: string): Promise<void> {
-  return new Promise((resolve) => {
-    try {
-      const child = spawn(enginePath(), args, { stdio: ["pipe", "ignore", "ignore"] });
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve();
-      };
-      const timer = setTimeout(() => {
-        child.stdin?.destroy();
-        child.kill("SIGTERM");
-        finish();
-      }, HANDSHAKE_TIMEOUT_MS);
-      timer.unref?.();
-      child.once("error", finish);
-      child.once("close", finish);
-      child.stdin?.once("error", () => {});
-      child.stdin?.end(prompt);
-    } catch {
-      resolve();
-    }
-  });
-}
-
-function engineArgs(id: string): string[] {
-  const args = ["--agent", "pi", "--session", id];
-  if (process.env.HERDR_PANE_ID) args.push("--pane", process.env.HERDR_PANE_ID);
-  if (process.env.HERDR_WORKSPACE_ID) args.push("--workspace", process.env.HERDR_WORKSPACE_ID);
-  return args;
-}
-
 export default function registerWorktreeIdentity(pi: any): void {
-  if (process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return;
+  if (!handoffWorktreeIdentity || process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return;
 
   pi.on("before_agent_start", async (event: any, ctx: any) => {
     if (ctx?.hasUI !== true) return;
     const id = sessionId(ctx);
     const prompt = typeof event?.prompt === "string" ? event.prompt : "";
     if (!id || prompt.trim() === "") return;
-    await callEngine(engineArgs(id), prompt);
+    await handoffWorktreeIdentity("pi", id, prompt);
   });
 }

--- a/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
+++ b/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
@@ -2,6 +2,7 @@
 // OpenCode prompt adapter for herdr-worktree-identity. The engine detaches its
 // model worker before this foreground handshake resolves.
 import type { Plugin } from "@opencode-ai/plugin"
+import { homedir } from "node:os"
 import { join } from "node:path"
 
 let handoffWorktreeIdentity:
@@ -9,7 +10,7 @@ let handoffWorktreeIdentity:
   | undefined
 try {
   ;({ handoffWorktreeIdentity } = await import(
-    join(process.env.HOME ?? "", ".local", "lib", "agent-hooks", "worktree-identity.ts"),
+    join(process.env.HOME || homedir(), ".local", "lib", "agent-hooks", "worktree-identity.ts"),
   ))
 } catch {
   handoffWorktreeIdentity = undefined

--- a/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
+++ b/home/private_dot_config/opencode/plugins/herdr-worktree-identity.ts
@@ -2,60 +2,21 @@
 // OpenCode prompt adapter for herdr-worktree-identity. The engine detaches its
 // model worker before this foreground handshake resolves.
 import type { Plugin } from "@opencode-ai/plugin"
-import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
-import path from "node:path"
+import { join } from "node:path"
 
-const ENGINE_NAME = "herdr-worktree-identity"
-const HANDSHAKE_TIMEOUT_MS = 1000
-
-function enginePath(): string {
-  const configured = process.env.HERDR_WORKTREE_IDENTITY_ENGINE
-  if (configured) return configured
-  const home = process.env.HOME
-  if (home) {
-    const local = path.join(home, ".local", "bin", ENGINE_NAME)
-    if (existsSync(local)) return local
-  }
-  return ENGINE_NAME
-}
-
-function callEngine(args: string[], prompt: string): Promise<void> {
-  return new Promise((resolve) => {
-    try {
-      const child = spawn(enginePath(), args, { stdio: ["pipe", "ignore", "ignore"] })
-      let settled = false
-      const finish = () => {
-        if (settled) return
-        settled = true
-        clearTimeout(timer)
-        resolve()
-      }
-      const timer = setTimeout(() => {
-        child.stdin?.destroy()
-        child.kill("SIGTERM")
-        finish()
-      }, HANDSHAKE_TIMEOUT_MS)
-      timer.unref?.()
-      child.once("error", finish)
-      child.once("close", finish)
-      child.stdin?.once("error", () => {})
-      child.stdin?.end(prompt)
-    } catch {
-      resolve()
-    }
-  })
-}
-
-function engineArgs(sessionID: string): string[] {
-  const args = ["--agent", "opencode", "--session", sessionID]
-  if (process.env.HERDR_PANE_ID) args.push("--pane", process.env.HERDR_PANE_ID)
-  if (process.env.HERDR_WORKSPACE_ID) args.push("--workspace", process.env.HERDR_WORKSPACE_ID)
-  return args
+let handoffWorktreeIdentity:
+  | ((agent: "opencode", sessionID: string, prompt: string) => Promise<void>)
+  | undefined
+try {
+  ;({ handoffWorktreeIdentity } = await import(
+    join(process.env.HOME ?? "", ".local", "lib", "agent-hooks", "worktree-identity.ts"),
+  ))
+} catch {
+  handoffWorktreeIdentity = undefined
 }
 
 export const HerdrWorktreeIdentityPlugin: Plugin = async () => {
-  if (process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return {}
+  if (!handoffWorktreeIdentity || process.env.HERDR_ENV !== "1" || process.env.HERDR_WORKTREE_IDENTITY_ACTIVE) return {}
 
   const childSessions = new Set<string>()
   return {
@@ -66,7 +27,7 @@ export const HerdrWorktreeIdentityPlugin: Plugin = async () => {
         .filter((part: any) => part?.type === "text" && typeof part.text === "string")
         .map((part: any) => part.text)
         .join("\n")
-      if (prompt.trim() !== "") await callEngine(engineArgs(sessionID), prompt)
+      if (prompt.trim() !== "") await handoffWorktreeIdentity("opencode", sessionID, prompt)
     },
     event: async ({ event }) => {
       const type = (event as any)?.type

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -9906,8 +9906,9 @@ function test_scripts_1224_opencode_worktree_identity_plugin_uses_deployed_consu
   root="$BATS_TEST_TMPDIR/opencode-adapter"
   home="$root/home"
   deployed="$home/.config/opencode/plugins"
-  mkdir -p "$deployed"
+  mkdir -p "$deployed" "$home/.local/lib"
   hwi_adapter_stub_engine "$root"
+  ln -s "$SOURCE_ROOT/dot_local/lib/agent-hooks" "$home/.local/lib/agent-hooks"
   ln -s "$HWI_OPENCODE_PLUGIN_SOURCE" "$deployed/herdr-worktree-identity.ts"
   cat > "$root/run.ts" <<'TS'
 const { HerdrWorktreeIdentityPlugin } = await import(process.env.HWI_OPENCODE_PLUGIN!);

--- a/tests/pi-herdr-worktree-identity.test.ts
+++ b/tests/pi-herdr-worktree-identity.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const extensionPath = join(import.meta.dir, "../home/dot_pi/agent/extensions/herdr-worktree-identity.ts");
-const { default: registerWorktreeIdentity } = await import(extensionPath);
+const handoffPath = join(import.meta.dir, "../home/dot_local/lib/agent-hooks/worktree-identity.ts");
+const { handoffWorktreeIdentity } = await import(handoffPath);
 const cleanupPaths: string[] = [];
+let loadCount = 0;
 
 afterEach(async () => {
   for (const path of cleanupPaths.splice(0)) await rm(path, { recursive: true, force: true });
@@ -46,10 +48,36 @@ exit 0
   return engine;
 }
 
-function register() {
+async function recordingEngine(root: string): Promise<string> {
+  const engine = join(root, "recording-engine");
+  await writeFile(engine, `#!/usr/bin/env bash
+set -eu
+call="${root}/call-$$"
+mkdir "$call"
+printf '%s\\n' "$@" > "$call/argv"
+cat > "$call/stdin"
+`);
+  await Bun.spawn(["chmod", "+x", engine]).exited;
+  return engine;
+}
+
+async function register() {
+  const home = await temporaryRoot();
+  await mkdir(join(home, ".local", "lib"), { recursive: true });
+  await symlink(join(import.meta.dir, "../home/dot_local/lib/agent-hooks"), join(home, ".local", "lib", "agent-hooks"));
+  const copy = join(await temporaryRoot(), `herdr-worktree-identity-${loadCount++}.ts`);
+  await cp(extensionPath, copy);
+
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
   const handlers = new Map<string, Function>();
-  registerWorktreeIdentity({ on: (event: string, handler: Function) => handlers.set(event, handler) } as never);
-  return handlers;
+  try {
+    const { default: registerWorktreeIdentity } = await import(copy);
+    registerWorktreeIdentity({ on: (event: string, handler: Function) => handlers.set(event, handler) } as never);
+    return handlers;
+  } finally {
+    process.env.HOME = previousHome;
+  }
 }
 
 function context(hasUI = true) {
@@ -57,13 +85,52 @@ function context(hasUI = true) {
 }
 
 describe("Pi worktree identity prompt capture", () => {
+  test("shared handoff preserves each adapter identity and stdin-only transport", async () => {
+    const root = await temporaryRoot();
+    process.env.HERDR_PANE_ID = "pane-shared";
+    process.env.HERDR_WORKSPACE_ID = "workspace-shared";
+    process.env.HERDR_WORKTREE_IDENTITY_ENGINE = await recordingEngine(root);
+
+    await handoffWorktreeIdentity("pi", "session-pi", "Pi shared sentinel");
+    await handoffWorktreeIdentity("opencode", "session-opencode", "OpenCode shared sentinel");
+
+    const calls = (await readdir(root)).filter((entry) => entry.startsWith("call-"));
+    expect(calls).toHaveLength(2);
+    const records = await Promise.all(
+      calls.map(async (entry) => {
+        const call = join(root, entry);
+        return {
+          argv: (await Bun.file(join(call, "argv")).text()).trim().split("\n"),
+          stdin: await Bun.file(join(call, "stdin")).text(),
+        };
+      }),
+    );
+    expect(records).toContainEqual({
+      argv: ["--agent", "pi", "--session", "session-pi", "--pane", "pane-shared", "--workspace", "workspace-shared"],
+      stdin: "Pi shared sentinel",
+    });
+    expect(records).toContainEqual({
+      argv: [
+        "--agent",
+        "opencode",
+        "--session",
+        "session-opencode",
+        "--pane",
+        "pane-shared",
+        "--workspace",
+        "workspace-shared",
+      ],
+      stdin: "OpenCode shared sentinel",
+    });
+  });
+
   test("registers before_agent_start and hands off a stdin-only prompt while derivation remains pending", async () => {
     const root = await temporaryRoot();
     process.env.HERDR_ENV = "1";
     process.env.HERDR_PANE_ID = "pane-pi";
     process.env.HERDR_WORKSPACE_ID = "workspace-pi";
     process.env.HERDR_WORKTREE_IDENTITY_ENGINE = await stubEngine(root);
-    const handlers = register();
+    const handlers = await register();
 
     const handler = handlers.get("before_agent_start");
     expect(handler).toBeDefined();
@@ -84,15 +151,15 @@ describe("Pi worktree identity prompt capture", () => {
   test("does not capture outside herdr, without session UI, or during naming re-entry", async () => {
     const root = await temporaryRoot();
     process.env.HERDR_WORKTREE_IDENTITY_ENGINE = await stubEngine(root);
-    const outside = register();
+    const outside = await register();
     expect(outside.size).toBe(0);
 
     process.env.HERDR_ENV = "1";
-    const headless = register();
+    const headless = await register();
     await headless.get("before_agent_start")?.({ prompt: "headless" }, context(false));
 
     process.env.HERDR_WORKTREE_IDENTITY_ACTIVE = "1";
-    const reentry = register();
+    const reentry = await register();
     expect(reentry.size).toBe(0);
     expect((await readdir(root)).filter((entry) => entry.startsWith("call-")).length).toBe(0);
   });


### PR DESCRIPTION
## Summary

Pi and OpenCode now share one worktree-identity subprocess handoff, preventing their engine discovery, arguments, stdin transport, timeout, and fail-open behavior from drifting independently.

Client event normalization remains in each adapter, and the Claude shell adapter stays separate. The adapters resolve the shared deployed module through `HOME` or the OS account home, preserving engine lookup through `PATH` when `HOME` is unset.

## Testing

- `make test-pi-herdr-worktree-identity`
- `tests/lib/bashunit -j 8 tests/bashunit/scripts_test.sh`
- `make lint`
- `make test-issues`
- `make test-ubuntu`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
