### PR TITLE
refactor(herdr): share detached process hygiene

### DIFF
--- a/docs/issues/2026-09-11-004-share-process-hygiene-across-detached-workers.md
+++ b/docs/issues/2026-09-11-004-share-process-hygiene-across-detached-workers.md
@@ -5,8 +5,9 @@ type: "follow-up"
 category: "herdr"
 tags: ["architecture","detached-worker","process-hygiene","enhancement","ready-for-agent"]
 date: "2026-09-11"
-status: "open"
+status: "done"
 priority: "low"
+closed: "2026-09-12"
 ---
 
 ## Why this exists
@@ -20,3 +21,7 @@ When a Detached worker path next changes, deepen herdr-process.sh to own descrip
 ## Open decisions
 
 Deferred until a worker path next changes; verify persisted process-start compatibility before consolidating implementations.
+
+## Resolution
+
+Centralized detached-worker descriptor closure and canonical PID-plus-start identity in herdr-process.sh, migrated child lifecycle, worktree identity, and pane labels, retained legacy persisted-marker compatibility and cutover safety, and added semantic regression coverage.

--- a/home/.chezmoiscripts/run_onchange_after_6-link-herdr-pane-labels.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_6-link-herdr-pane-labels.sh.tmpl
@@ -5,6 +5,7 @@
 # Hash triggers:
 # # {{ include "dot_local/bin/executable_herdr-pane-labels" | sha256sum }}
 # # {{ include "dot_local/lib/herdr-aliases.sh" | sha256sum }}
+# # {{ include "dot_local/lib/herdr-process.sh" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh" | sha256sum }}

--- a/home/.chezmoiscripts/run_onchange_before_6-quiesce-herdr-pane-labels.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_6-quiesce-herdr-pane-labels.sh.tmpl
@@ -5,6 +5,7 @@
 # Hash triggers:
 # # {{ include "dot_local/bin/executable_herdr-pane-labels" | sha256sum }}
 # # {{ include "dot_local/lib/herdr-aliases.sh" | sha256sum }}
+# # {{ include "dot_local/lib/herdr-process.sh" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/herdr-plugin.toml" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/ensure.sh" | sha256sum }}
 # # {{ include "private_dot_config/herdr/plugins/herdr-pane-labels/sweep.sh" | sha256sum }}

--- a/home/.chezmoitemplates/herdr-pane-labels-cutover-lib.sh
+++ b/home/.chezmoitemplates/herdr-pane-labels-cutover-lib.sh
@@ -260,8 +260,9 @@ hpl_cutover_claim_family() {
 
 hpl_cutover_drain_claim() {
   local lock="$1" engine="$2" kind="$3" namespace="$4" owner_file owner
-  local pid stored_start stored_socket socket start command family
-  local current_owner current_pid current_stored_start current_socket current_command second_start attempt=0
+  local pid stored_start stored_socket socket start canonical_start command family
+  local current_owner current_pid current_stored_start current_socket current_command
+  local second_start second_canonical_start attempt=0
   owner_file="$lock/owner"
   while [ ! -f "$owner_file" ] && [ "$attempt" -lt 3 ]; do
     attempt=$((attempt + 1))
@@ -304,9 +305,11 @@ hpl_cutover_drain_claim() {
     return 0
   fi
   start="$(hpl_cutover_process_start "$pid")"
+  canonical_start="$(LC_ALL=C hpl_cutover_process_start "$pid")"
   command="$(hpl_cutover_process_command "$pid")"
   family="$(hpl_cutover_claim_family "$lock" "$kind")"
-  if [ -z "$start" ] || [ "$start" != "$stored_start" ] || \
+  if [ -z "$start" ] || \
+    { [ "$start" != "$stored_start" ] && [ "$canonical_start" != "$stored_start" ]; } || \
     ! hpl_cutover_command_matches "$command" "$engine" "$family"; then
     hpl_cutover_error "refusing unrelated or unverifiable owner PID $pid from $lock"
     return 1
@@ -318,10 +321,12 @@ hpl_cutover_drain_claim() {
   current_stored_start="$(hpl_cutover_text_field "$owner_file" process_start 2>/dev/null)"
   current_socket="$(hpl_cutover_text_field "$owner_file" socket_path 2>/dev/null)"
   second_start="$(hpl_cutover_process_start "$pid")"
+  second_canonical_start="$(LC_ALL=C hpl_cutover_process_start "$pid")"
   current_command="$(hpl_cutover_process_command "$pid")"
   if ! hpl_cutover_pid_is_live "$pid"; then return 10; fi
   if [ "$current_owner" != "$owner" ] || [ "$current_pid" != "$pid" ] || \
     [ "$current_stored_start" != "$stored_start" ] || [ "$second_start" != "$start" ] || \
+    [ "$second_canonical_start" != "$canonical_start" ] || \
     [ "$current_socket" != "$socket" ] || \
     [ "$current_command" != "$command" ] || \
     ! hpl_cutover_command_matches "$current_command" "$engine" "$family"; then
@@ -929,27 +934,34 @@ EOF
 }
 
 hpl_cutover_verify_daemon() {
-  local socket="$1" engine="$2" cache="$3" namespace lock pid start command
-  local tries=0 second_start second_command
+  local socket="$1" engine="$2" cache="$3" namespace lock pid stored_start start command
+  local tries=0 canonical_start second_stored_start second_start second_canonical_start second_command
   namespace="$cache/sockets/$(hpl_cutover_encode_key "$socket")"
   lock="$namespace/sweep.lock"
   while [ "$tries" -lt 100 ]; do
     tries=$((tries + 1))
     pid="$(cat "$lock/pid" 2>/dev/null)"
     case "$pid" in '' | *[!0-9]*) sleep "${HERDR_PANE_LABELS_CUTOVER_POLL:-0.05}"; continue ;; esac
-    if hpl_cutover_pid_is_live "$pid"; then break; fi
+    stored_start="$(cat "$lock/start" 2>/dev/null)"
+    if hpl_cutover_pid_is_live "$pid" && [ -n "$stored_start" ]; then break; fi
     sleep "${HERDR_PANE_LABELS_CUTOVER_POLL:-0.05}"
   done
   case "${pid:-}" in '' | *[!0-9]*) return 1 ;; esac
   hpl_cutover_pid_is_live "$pid" || return 1
   [ "$(hpl_cutover_socket_for_namespace "$namespace")" = "$socket" ] || return 1
+  canonical_start="$(LC_ALL=C hpl_cutover_process_start "$pid")"
   start="$(hpl_cutover_process_start "$pid")"
   command="$(hpl_cutover_process_command "$pid")"
-  [ -n "$start" ] && hpl_cutover_command_matches "$command" "$engine" daemon || return 1
+  [ -n "$canonical_start" ] && [ "$stored_start" = "$canonical_start" ] && \
+    [ -n "$start" ] && hpl_cutover_command_matches "$command" "$engine" daemon || return 1
   [ "$(cat "$lock/pid" 2>/dev/null)" = "$pid" ] || return 1
+  second_stored_start="$(cat "$lock/start" 2>/dev/null)"
   second_start="$(hpl_cutover_process_start "$pid")"
+  second_canonical_start="$(LC_ALL=C hpl_cutover_process_start "$pid")"
   second_command="$(hpl_cutover_process_command "$pid")"
-  [ "$second_start" = "$start" ] && [ "$second_command" = "$command" ] || return 1
+  [ "$second_stored_start" = "$stored_start" ] && \
+    [ "$second_start" = "$start" ] && [ "$second_canonical_start" = "$canonical_start" ] && \
+    [ "$second_command" = "$command" ] || return 1
   hpl_cutover_trace "daemon-verified:$socket:$pid:$start"
 }
 

--- a/home/dot_local/bin/executable_herdr-pane-labels
+++ b/home/dot_local/bin/executable_herdr-pane-labels
@@ -20,6 +20,8 @@ SCRIPT_DIR="$(cd "$(dirname "$SELF")" 2>/dev/null && pwd -P)" || exit 0
 # The deployed library path is resolved relative to this script.
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/herdr-aliases.sh" || exit 0
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/herdr-process.sh" || exit 0
 
 STATE_DIR="${HERDR_PANE_LABELS_STATE_DIR:-$HOME/.cache/herdr-pane-labels}"
 LOCATION_SOURCE_ID="location-sync"
@@ -183,14 +185,10 @@ max_number() {
   printf '%s' "$max"
 }
 
-process_start_token() {
-  ps -p "$1" -o lstart= 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
-}
-
 claim_owner_id=""
 
 recover_claim() {
-  local lock="$1" attempt="$2" owner pid start socket current_start
+  local lock="$1" attempt="$2" owner pid start socket identity_status
   owner="$(read_state_field "$lock/owner" owner_id)"
   if [ -z "$owner" ]; then
     [ "$attempt" -ge 3 ] || return 1
@@ -204,10 +202,10 @@ recover_claim() {
   start="$(read_state_field "$lock/owner" process_start)"
   socket="$(read_state_field "$lock/owner" socket_path)"
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-    current_start="$(process_start_token "$pid")"
-    if [ "$socket" = "$SOCKET_PATH" ] && \
-      [ -n "$start" ] && [ "$start" = "$current_start" ]; then
-      return 1
+    if [ "$socket" = "$SOCKET_PATH" ]; then
+      process_start_matches "$pid" "$start"
+      identity_status=$?
+      [ "$identity_status" -eq 1 ] || return 1
     fi
   fi
   [ "$(read_state_field "$lock/owner" owner_id)" = "$owner" ] || return 1
@@ -222,7 +220,10 @@ acquire_claim() {
     attempt=$((attempt + 1))
     if mkdir "$lock" 2>/dev/null; then
       owner="$$.$RANDOM.$(now_seq)"
-      start="$(process_start_token "$$")"
+      start="$(process_start_marker "$$")" || {
+        rmdir "$lock" 2>/dev/null || true
+        return 1
+      }
       owner_record="owner_id=$(encode_value "$owner")
 pid=$$
 process_start=$(encode_value "$start")
@@ -263,20 +264,6 @@ retained_location=$(encode_value "")"
   [ -f "$namespace/reconcile.state" ] || \
     atomic_write "$namespace/reconcile.state" "$reconcile_record" || return 1
   return 0
-}
-
-# Agent and test harnesses can keep control pipes on descriptors above stderr.
-# Detached descendants must not keep those pipes alive after their callback or
-# test process has completed. Bash 3.2 reserves descriptor 255 for this script.
-close_inherited_descriptors() {
-  local descriptor fd
-  for descriptor in /dev/fd/*; do
-    fd="${descriptor##*/}"
-    case "$fd" in
-      0 | 1 | 2 | 255 | *[!0-9]*) continue ;;
-    esac
-    eval "exec ${fd}>&-" 2>/dev/null || true
-  done
 }
 
 # ------------------------------------------------------------------- guards
@@ -1772,14 +1759,23 @@ run_sweep_daemon() {
   # A daemon started right after its predecessor was killed finds the lock still
   # there for a moment. Waiting a few seconds beats exiting, which would leave
   # the machine with no daemon at all until the next herdr event.
-  local tries=0
+  local tries=0 start marker_attempt=0
   until mkdir "$SWEEP_LOCK_DIR" 2>/dev/null; do
     tries=$((tries + 1))
     [ "$tries" -ge 3 ] && exit 0
     sleep 1
   done
   printf '%s' "$$" > "$SWEEP_LOCK_DIR/pid" 2>/dev/null
-  process_start_token "$$" > "$SWEEP_LOCK_DIR/start" 2>/dev/null
+  until start="$(process_start_marker "$$")"; do
+    marker_attempt=$((marker_attempt + 1))
+    if [ "$marker_attempt" -ge 3 ]; then
+      rm -f "$SWEEP_LOCK_DIR/pid" 2>/dev/null
+      rmdir "$SWEEP_LOCK_DIR" 2>/dev/null
+      exit 0
+    fi
+    sleep 0.01
+  done
+  printf '%s\n' "$start" > "$SWEEP_LOCK_DIR/start" 2>/dev/null
   # Two traps, not one: a TERM handler that only cleans up would let the loop
   # carry on after it dropped its own lock, and the next hook would then start
   # a second daemon beside the first.
@@ -1811,14 +1807,28 @@ run_sweep_daemon() {
 # Called by the herdr plugin on startup and on agent-status events. A live
 # daemon makes this a no-op; a lock left behind by a killed daemon is cleared.
 ensure_sweep_daemon() {
-  local self="$1" pid start
+  local self="$1" pid start identity_status startup_attempt=0
   [ -z "${HERDR_PANE_LABELS_TEST_NO_DAEMON:-}" ] || return 0
   if [ -d "$SWEEP_LOCK_DIR" ]; then
+    while [ "$startup_attempt" -lt 100 ]; do
+      pid="$(cat "$SWEEP_LOCK_DIR/pid" 2>/dev/null)"
+      case "$pid" in
+        '') ;;
+        *[!0-9]*) break ;;
+        *)
+          kill -0 "$pid" 2>/dev/null || break
+          [ ! -s "$SWEEP_LOCK_DIR/start" ] || break
+          ;;
+      esac
+      startup_attempt=$((startup_attempt + 1))
+      sleep 0.01
+    done
     pid="$(cat "$SWEEP_LOCK_DIR/pid" 2>/dev/null)"
     start="$(cat "$SWEEP_LOCK_DIR/start" 2>/dev/null)"
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && \
-      [ -n "$start" ] && [ "$start" = "$(process_start_token "$pid")" ]; then
-      return 0
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      process_start_matches "$pid" "$start"
+      identity_status=$?
+      [ "$identity_status" -eq 1 ] || return 0
     fi
     rm -f "$SWEEP_LOCK_DIR/pid" "$SWEEP_LOCK_DIR/start" 2>/dev/null
     rmdir "$SWEEP_LOCK_DIR" 2>/dev/null

--- a/home/dot_local/bin/executable_herdr-worktree-identity
+++ b/home/dot_local/bin/executable_herdr-worktree-identity
@@ -959,17 +959,6 @@ worker() {
   process_worktree "$prompt" "$root" "$common" "$resolved_pane"
 }
 
-close_inherited_descriptors() {
-  local descriptor fd
-  for descriptor in /dev/fd/*; do
-    fd="${descriptor##*/}"
-    case "$fd" in
-      0 | 1 | 2 | 255 | *[!0-9]*) continue ;;
-    esac
-    eval "exec ${fd}>&-" 2>/dev/null || true
-  done
-}
-
 detach_worker() {
   local prompt="$1" prompt_file
   local -a worker_args

--- a/home/dot_local/lib/herdr-child-supervision.sh
+++ b/home/dot_local/lib/herdr-child-supervision.sh
@@ -47,9 +47,12 @@ release_arm_guard() {
 }
 
 begin_supervision_transition() {
-  local operation="$1" run_dir="$2" subject="${3:--}"
+  local operation="$1" run_dir="$2" subject="${3:--}" owner_start=""
+  if [ "$operation" = delivery ]; then
+    owner_start="$(process_start_marker "$$")" || return 1
+  fi
   python3 -c 'import fcntl, os, subprocess, sys, tempfile
-operation, run_dir, subject, owner_pid = sys.argv[1:5]
+operation, run_dir, subject, owner_pid, owner_start, process_library = sys.argv[1:7]
 
 def read_state(path):
     try:
@@ -58,10 +61,13 @@ def read_state(path):
     except (OSError, ValueError):
         return {}
 
-def process_start(pid):
-    env = dict(os.environ, LC_ALL="C")
-    result = subprocess.run(["ps", "-p", str(pid), "-o", "lstart="], capture_output=True, text=True, env=env)
-    return result.stdout.strip() if result.returncode == 0 else ""
+def process_start_status(pid, start):
+    result = subprocess.run(
+        ["/bin/bash", "-c", "source \"$1\" && process_start_matches \"$2\" \"$3\"", "_", process_library, pid, start],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode
 
 def atomic_write(name, content):
     fd, tmp = tempfile.mkstemp(prefix=".write.", dir=run_dir)
@@ -88,22 +94,25 @@ try:
             raise SystemExit(2)
         if os.path.isfile(invalidated):
             raise SystemExit(13 if read_state(invalidated).get("reason") == "reap" else 20)
-        start = process_start(owner_pid)
-        if not start:
-            raise SystemExit(1)
-        atomic_write("delivery-pending.state", f"owner_pid={owner_pid}\nowner_start={start}")
+        atomic_write("delivery-pending.state", f"owner_pid={owner_pid}\nowner_start={owner_start}")
     else:
         if os.path.isfile(pending):
             state = read_state(pending)
             pid = state.get("owner_pid", "")
             start = state.get("owner_start", "")
-            if pid.isdigit() and start and process_start(pid) == start:
-                raise SystemExit(1)
+            if pid.isdigit() and start:
+                try:
+                    os.kill(int(pid), 0)
+                except ProcessLookupError:
+                    pass
+                else:
+                    if process_start_status(pid, start) != 1:
+                        raise SystemExit(1)
             os.unlink(pending)
         atomic_write("reap-pending.state", f"status=pending\nowner_pid={owner_pid}\nowner_token={subject}")
         atomic_write("invalidated.state", "reason=reap")
 finally:
-    os.close(lock)' "$operation" "$run_dir" "$subject" "$$"
+    os.close(lock)' "$operation" "$run_dir" "$subject" "$$" "$owner_start" "$SCRIPT_DIR/../lib/herdr-process.sh"
 }
 
 finish_delivery_transition() {
@@ -361,12 +370,14 @@ clear_supervision_state_labels() {
 # written without a verifiable owner is treated as abandoned rather than trusted
 # forever.
 callback_owner_alive() {
-  local run_dir="$1" owner_pid owner_start current_start
+  local run_dir="$1" owner_pid owner_start identity_status
   owner_pid="$(state_value "$run_dir/callback.state" owner_pid)"
   owner_start="$(state_value "$run_dir/callback.state" owner_start)"
   [ -n "$owner_start" ] || return 1
-  current_start="$(process_start_marker "$owner_pid")" || return 1
-  [ "$current_start" = "$owner_start" ]
+  kill -0 "$owner_pid" 2>/dev/null || return 1
+  process_start_matches "$owner_pid" "$owner_start"
+  identity_status=$?
+  [ "$identity_status" -ne 1 ]
 }
 
 preserve_callback_waiting_label() {

--- a/home/dot_local/lib/herdr-process.sh
+++ b/home/dot_local/lib/herdr-process.sh
@@ -15,13 +15,40 @@ close_inherited_descriptors() {
   done
 }
 
-# Prints the kernel's start timestamp for a live process, and fails when the
-# process is gone. A recorded PID alone cannot identify an owner across time
-# because the kernel reuses PIDs; the start timestamp makes the pair unique.
+# Normalize both current markers and persisted markers written by older callers,
+# which trimmed ps output differently.
+_normalize_process_start_marker() {
+  local marker="$1" LC_ALL=C
+  marker="${marker#"${marker%%[![:space:]]*}"}"
+  marker="${marker%"${marker##*[![:space:]]}"}"
+  printf '%s' "$marker"
+}
+
+# Prints a stable start timestamp for a live process. A recorded PID alone
+# cannot identify an owner across time because the kernel reuses PIDs; the
+# start timestamp makes the pair unique.
 process_start_marker() {
   local pid="$1" marker
   case "$pid" in '' | *[!0-9]*) return 1 ;; esac
-  marker="$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null | tr -d '\n')" || return 1
+  marker="$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null)" || return 1
+  marker="$(_normalize_process_start_marker "$marker")"
   [ -n "$marker" ] || return 1
   printf '%s' "$marker"
+}
+
+# Return 0 for the same process, 1 for a malformed or different identity, and
+# 2 when the live marker cannot be read. The ambient-locale comparison keeps
+# short-lived records written by older worktree and pane workers valid across
+# deployment; every new record uses the canonical C-locale marker above.
+process_start_matches() {
+  local pid="$1" expected="$2" current legacy
+  case "$pid" in '' | *[!0-9]*) return 1 ;; esac
+  expected="$(_normalize_process_start_marker "$expected")"
+  [ -n "$expected" ] || return 1
+  current="$(process_start_marker "$pid")" || return 2
+  [ "$current" != "$expected" ] || return 0
+  legacy="$(ps -p "$pid" -o lstart= 2>/dev/null)" || return 2
+  legacy="$(_normalize_process_start_marker "$legacy")"
+  [ -n "$legacy" ] || return 2
+  [ "$legacy" = "$expected" ]
 }

--- a/home/dot_local/lib/herdr-worktree-state.sh
+++ b/home/dot_local/lib/herdr-worktree-state.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # State, claim, and diagnostic primitives for herdr-worktree-identity.
 
+# shellcheck source=home/dot_local/lib/herdr-process.sh
+source "$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/herdr-process.sh"
+
 HERDR_WORKTREE_IDENTITY_STATE_DIR="${HERDR_WORKTREE_IDENTITY_STATE_DIR:-$HOME/.cache/herdr-worktree-identity}"
 
 # Every outcome a state file may carry. Convention alone let write sites invent
@@ -178,10 +181,6 @@ record_number() {
   printf '%s' "$value"
 }
 
-process_start_token() {
-  ps -p "$1" -o lstart= 2>/dev/null | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
-}
-
 # shellcheck disable=SC2034 # Callers read the owner selected by acquire_claim.
 claim_owner_id=""
 
@@ -189,7 +188,7 @@ claim_owner_id=""
 # an unexpected filesystem error. Claim files are fully written before an
 # atomic hard link publishes them, so readers never observe a live blank owner.
 recover_claim() {
-  local lock="$1" attempt="$2" owner pid start current_start observed
+  local lock="$1" attempt="$2" owner pid start identity_status observed
   [ -f "$lock" ] || {
     [ -e "$lock" ] && return 2
     return 0
@@ -206,11 +205,9 @@ recover_claim() {
   pid="$(record_number "$lock" pid)"
   start="$(read_state_field "$lock" process_start)"
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-    current_start="$(process_start_token "$pid")"
-    [ -n "$current_start" ] || return 1
-    if [ -n "$start" ] && [ "$start" = "$current_start" ]; then
-      return 1
-    fi
+    process_start_matches "$pid" "$start"
+    identity_status=$?
+    [ "$identity_status" -eq 1 ] || return 1
   fi
   [ "$(cat "$lock" 2>/dev/null)" = "$observed" ] || return 1
   rm -f "$lock" 2>/dev/null && return 0
@@ -250,8 +247,7 @@ acquire_claim() {
       continue
     fi
     owner="$$.$RANDOM"
-    start="$(process_start_token "$$")"
-    [ -n "$start" ] || return 1
+    start="$(process_start_marker "$$")" || return 1
     owner_record="owner_id=$(encode_value "$owner")
 pid=$$
 process_start=$(encode_value "$start")"

--- a/tests/bashunit/scripts_test.sh
+++ b/tests/bashunit/scripts_test.sh
@@ -79,6 +79,40 @@ teardown() {
 # herdr-worktree-identity state library
 # ===========================================
 
+function test_scripts_1209_shared_process_identity_is_stable_and_accepts_legacy_markers() {
+  _bats_test_init 1209 'shared process identity is stable and accepts legacy persisted markers'
+  local process_library="$SOURCE_ROOT/dot_local/lib/herdr-process.sh"
+  local stub="$BATS_TEST_TMPDIR/process-identity-bin" log="$BATS_TEST_TMPDIR/process-identity-locales.log"
+  mkdir -p "$stub"
+  cat > "$stub/ps" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${LC_ALL-<unset>}" >> "$PROCESS_IDENTITY_LOCALE_LOG"
+if [ "${LC_ALL-}" = C ]; then
+  printf '  Sat Sep 12 06:18:05 2026    \n'
+else
+  printf 'sam 12 sep 2026 06:18:05 UTC\n'
+fi
+SH
+  chmod +x "$stub/ps"
+
+  run env -u LC_ALL -u LC_CTYPE -u LANG PATH="$stub:$PATH" \
+    PROCESS_IDENTITY_LOCALE_LOG="$log" bash -c '
+      set -e
+      source "$1"
+      process_start_marker 42
+      printf "\n"
+      process_start_matches 42 "  Sat Sep 12 06:18:05 2026    "
+      process_start_matches 42 "sam 12 sep 2026 06:18:05 UTC"
+      ! process_start_matches 42 "wrong process start"
+      ! process_start_marker invalid
+    ' _ "$process_library"
+
+  assert_success
+  assert_output 'Sat Sep 12 06:18:05 2026'
+  assert_file_contains "$log" '^C$'
+  assert_file_contains "$log" '^<unset>$'
+}
+
 function test_scripts_1210_worktree_identity_state_library_claims_live_owners_and_recovers_dead_owners() {
   _bats_test_init 1210 'worktree identity claims live owners and recovers dead owners'
   hwi_setup
@@ -329,6 +363,78 @@ function test_scripts_1218_worktree_identity_foreground_hands_off_to_a_detached_
   assert_file_exists "$HWI_WORK/pane-get.ready"
   assert_file_not_contains "$HWI_WORK/herdr.calls" 'do not place this prompt on argv'
   : > "$HWI_WORK/pane-get.release"
+}
+
+function test_scripts_12182_worktree_identity_worker_closes_inherited_descriptors() {
+  _bats_test_init 12182 'worktree identity worker closes inherited descriptors'
+  hwi_setup
+  hwi_create_generated_worktree
+  hwi_write_pane pane-1 codex session-1 workspace-1 "$HWI_CHECKOUT"
+  : > "$HWI_WORK/block-pane-get"
+
+  run env PATH="$HWI_STUB:$HWI_COMMAND_PATH" HWI_ENGINE="$HWI_ENGINE" \
+    HERDR_WORKTREE_IDENTITY_STATE_DIR="$HWI_STATE" python3 - <<'PY'
+import os
+from pathlib import Path
+import select
+import signal
+import subprocess
+import time
+
+work = Path(os.environ["HWI_WORK"])
+release = work / "pane-get.release"
+ready = work / "pane-get.ready"
+control_read, control_write = os.pipe()
+os.set_inheritable(control_write, True)
+proc = subprocess.Popen(
+    [
+        "bash",
+        os.environ["HWI_ENGINE"],
+        "--worker",
+        "--agent", "codex",
+        "--session", "session-1",
+        "--pane", "pane-1",
+        "--workspace", "workspace-1",
+    ],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    env=os.environ.copy(),
+    pass_fds=(control_write,),
+)
+try:
+    assert proc.stdin is not None
+    proc.stdin.write("descriptor handoff\n")
+    proc.stdin.close()
+    os.close(control_write)
+    control_write = -1
+
+    deadline = time.monotonic() + 30
+    while not ready.exists() and time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise AssertionError(f"worker exited before the controlled block with {proc.returncode}")
+        time.sleep(0.02)
+    if not ready.exists():
+        raise AssertionError("worker did not reach the controlled block")
+    if proc.poll() is not None:
+        raise AssertionError("worker exited after publishing the controlled block")
+
+    readable, _, _ = select.select([control_read], [], [], 1)
+    if not readable or os.read(control_read, 1) != b"":
+        raise AssertionError("worker retained the inherited control descriptor")
+finally:
+    release.touch()
+    os.close(control_read)
+    if control_write >= 0:
+        os.close(control_write)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.send_signal(signal.SIGKILL)
+        proc.wait()
+PY
+  assert_success
 }
 
 # ===========================================
@@ -2587,6 +2693,9 @@ SH
   chmod +x "$CHILD_STUB/herdr"
   cat > "$CHILD_STUB/ps" <<'SH'
 #!/usr/bin/env bash
+if [ -f "$CHILD_STUB/fail-ps" ]; then
+  exit 1
+fi
 if [ -f "$CHILD_STUB/observe-ps-locale" ]; then
   printf '%s\n' "${LC_ALL:-unset}" >> "$CHILD_STUB/ps-locales.log"
 fi
@@ -5776,6 +5885,7 @@ function test_scripts_1112_herdr_pane_labels_sources_the_alias_library_relative_
   mkdir -p "$deployed/bin" "$deployed/lib"
   cp "$HPL_ENGINE" "$deployed/bin/herdr-pane-labels"
   cp "$HERDR_ALIASES" "$deployed/lib/herdr-aliases.sh"
+  cp "$SOURCE_ROOT/dot_local/lib/herdr-process.sh" "$deployed/lib/herdr-process.sh"
 
   run env PATH="$deployed/bin:/usr/bin:/bin" bash "$deployed/bin/herdr-pane-labels" --help
   assert_success
@@ -7851,6 +7961,14 @@ function test_scripts_1176_herdr_pane_labels_ensure_sweep_daemon_keeps_a_single_
   run hpl_sweep_run --ensure-sweep-daemon
   assert_success
   assert_equal "$(cat "$sweep_lock/pid")" "$live"
+  cat > "$HPL_STUB/ps" <<'SH'
+#!/bin/sh
+exit 1
+SH
+  chmod +x "$HPL_STUB/ps"
+  run hpl_sweep_run --ensure-sweep-daemon
+  assert_success
+  assert_equal "$(cat "$sweep_lock/pid")" "$live"
   kill "$live" 2>/dev/null || true
 }
 
@@ -7879,10 +7997,21 @@ function test_scripts_1178_herdr_pane_labels_sweep_daemon_exits_after_three_unre
   _bats_test_init 1178 'herdr-pane-labels sweep daemon exits after three unreachable snapshots'
   command -v jq >/dev/null || skip "jq not available"
   hpl_setup
-  local dir daemon_pid i
+  local dir daemon_pid i ps_attempts="$HPL_WORK/ps-attempts"
   dir="$(hpl_socket_dir "$HPL_DEFAULT_SOCKET")"
   : > "$dir/fail-snapshot"
-  HPL_SWEEP_INTERVAL=0.01 hpl_sweep_run --sweep-daemon &
+  cat > "$HPL_STUB/ps" <<'SH'
+#!/usr/bin/env bash
+attempt=0
+[ ! -f "$HPL_PS_ATTEMPTS" ] || attempt="$(cat "$HPL_PS_ATTEMPTS")"
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$HPL_PS_ATTEMPTS"
+[ "$attempt" -ne 1 ] || exit 1
+exec /bin/ps "$@"
+SH
+  chmod +x "$HPL_STUB/ps"
+  HPL_PS_ATTEMPTS="$ps_attempts" HPL_SWEEP_INTERVAL=0.01 \
+    hpl_sweep_run --sweep-daemon &
   daemon_pid=$!
   for i in $(seq 1 $HPL_WAIT_POLLS); do
     kill -0 "$daemon_pid" 2>/dev/null || break
@@ -7894,6 +8023,8 @@ function test_scripts_1178_herdr_pane_labels_sweep_daemon_exits_after_three_unre
     fail "sweep daemon kept polling an unreachable socket"
   fi
   wait "$daemon_pid"
+  run test "$(cat "$ps_attempts")" -ge 2
+  assert_success
   run grep -c '^api snapshot$' "$HPL_LOG"
   assert_output "3"
   assert_dir_not_exists "$(hpl_namespace "$HPL_DEFAULT_SOCKET")/sweep.lock"
@@ -7960,6 +8091,39 @@ pane_snapshot "$(jq -c '.label = "badlabel"' <<< "$base")" | hpl_cutover_snapsh
 exit 0
 CHECK
   run env HOME="$BATS_TEST_TMPDIR/cutover-label-home" bash "$script" "$library"
+  assert_success
+}
+
+function test_scripts_1303_herdr_pane_label_cutover_drains_canonical_claims_under_localized_callers() {
+  _bats_test_init 1303 'herdr pane-label cutover drains canonical claims under localized callers'
+  local library="$SOURCE_ROOT/.chezmoitemplates/herdr-pane-labels-cutover-lib.sh"
+  local lock="$BATS_TEST_TMPDIR/canonical-claim/presentation.claim"
+  mkdir -p "$lock"
+  printf 'owner_id=%s\npid=42\nprocess_start=%s\nsocket_path=%s\n' \
+    "$(printf owner | base64 | tr -d '\n')" \
+    "$(printf 'Sat Sep 12 06:18:05 2026' | base64 | tr -d '\n')" \
+    "$(printf /tmp/localized.sock | base64 | tr -d '\n')" > "$lock/owner"
+
+  run env HOME="$BATS_TEST_TMPDIR/cutover-claim-home" bash -c '
+    source "$1"
+    hpl_cutover_pid_is_live() { return 0; }
+    hpl_cutover_process_start() {
+      if [ "${LC_ALL:-}" = C ]; then
+        printf %s "Sat Sep 12 06:18:05 2026"
+      else
+        printf %s "sam 12 sep 2026 06:18:05 UTC"
+      fi
+    }
+    hpl_cutover_process_command() { printf %s "bash /tmp/engine --presentation-worker"; }
+    hpl_cutover_socket_for_namespace() { printf %s /tmp/localized.sock; }
+    hpl_cutover_command_matches() { return 0; }
+    hpl_cutover_hook() { return 0; }
+    hpl_cutover_wait_pid_gone() { return 0; }
+    kill() { return 0; }
+    hpl_cutover_drain_claim "$2" /tmp/engine new "$3"
+    [ "$?" -eq 10 ]
+  ' _ "$library" "$lock" "${lock%/presentation.claim}"
+
   assert_success
 }
 
@@ -8152,7 +8316,8 @@ case "${1:-}" in
     write_socket
     mkdir -p "$namespace/sweep.lock"
     printf '%s' "$$" > "$namespace/sweep.lock/pid"
-    trap 'rm -f "$namespace/sweep.lock/pid"; rmdir "$namespace/sweep.lock" 2>/dev/null || true; exit 0' INT TERM EXIT
+    LC_ALL=C ps -p "$$" -o lstart= | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' > "$namespace/sweep.lock/start"
+    trap 'rm -f "$namespace/sweep.lock/pid" "$namespace/sweep.lock/start"; rmdir "$namespace/sweep.lock" 2>/dev/null || true; exit 0' INT TERM EXIT
     while :; do sleep 1; done
     ;;
 esac
@@ -8767,6 +8932,7 @@ function test_scripts_265_herdr_child_delivery_claim_keeps_reap_fail_closed_with
   child_wait_for_file "$CHILD_STUB/parent-prompt-accepted"
   assert_file_exists "$run_dir/delivery-pending.state"
 
+  : > "$CHILD_STUB/fail-ps"
   run env PATH="$CHILD_STUB:$PATH" HERDR_ENV=1 HERDR_PANE_ID=wT:p0 \
     HERDR_CHILD_STATE_DIR="$CHILD_STUB/state" \
     bash "$HERDR_CHILD" reap --to "$(child_started_name)" --pane wT:p9
@@ -8774,6 +8940,7 @@ function test_scripts_265_herdr_child_delivery_claim_keeps_reap_fail_closed_with
   assert_output --partial 'supervision generation could not be invalidated'
   assert_file_not_exists "$CHILD_STUB/pane-closed"
 
+  rm "$CHILD_STUB/fail-ps"
   : > "$CHILD_STUB/release-parent-prompt"
   child_wait_for_file "$CHILD_STUB/successful-prompts.log"
   while kill -0 "$watcher_pid" 2>/dev/null && [ "$attempt" -lt 500 ]; do

--- a/tests/bashunit/smoke_test.sh
+++ b/tests/bashunit/smoke_test.sh
@@ -1122,6 +1122,8 @@ function test_smoke_1062_herdr_pane_label_cutover_templates_share_one_safety_bod
   [[ -n "$before_inputs" ]] || fail "no hash-trigger includes in $before"
   [[ -n "$after_inputs" ]] || fail "no hash-trigger includes in $after"
   assert_equal "$before_inputs" "$after_inputs"
+  grep -Fxq 'dot_local/lib/herdr-process.sh' <<< "$before_inputs" \
+    || fail "shared pane-label process dependency is not a cutover hash input"
   while IFS= read -r path; do
     assert_file_exists "$SOURCE_ROOT/$path"
   done <<< "$before_inputs"

--- a/tests/helpers/herdr_pane_labels.bash
+++ b/tests/helpers/herdr_pane_labels.bash
@@ -1070,6 +1070,7 @@ printf '%s\n' 'legacy herdr-child --name launcher' >&2
 exit 1
 SH
   cp "$SOURCE_ROOT/dot_local/lib/herdr-aliases.sh" "$HPL_CUTOVER_HOME/.local/lib/herdr-aliases.sh"
+  cp "$SOURCE_ROOT/dot_local/lib/herdr-process.sh" "$HPL_CUTOVER_HOME/.local/lib/herdr-process.sh"
   cp -R "$HPL_PLUGIN_DIR" "$HPL_CUTOVER_HOME/.config/herdr/plugins/herdr-pane-labels"
   chmod +x "$HPL_CUTOVER_HOME/.local/bin/herdr-pane-labels" "$HPL_CUTOVER_HOME/.local/bin/herdr-child"
   printf '%s\n' '{"result":{"sessions":[{"running":true,"socket_path":"'"$HPL_DEFAULT_SOCKET"'"}]}}' > "$HPL_WORK/sessions.json"


### PR DESCRIPTION
## Summary

Detached Herdr workers now share one implementation for descriptor closure and PID-plus-start identity. This removes divergent locale and validation behavior across child supervision, worktree identity, and pane labels while keeping claims, waits, recovery, and abandonment caller-owned.

## Design

- Emit normalized C-locale process-start markers for every new record while accepting legacy ambient-locale markers during deployment cutover.
- Distinguish identity mismatches from transient `ps` failures so callers fail closed instead of reclaiming state whose owner cannot be verified.
- Reuse shared inherited-descriptor closure in detached workers rather than carrying script-local copies.
- Include the process helper in pane-label cutover hashes and verify daemon lock identity before accepting startup.

## Testing

- Added semantic regression coverage for canonical and legacy markers, PID mismatch, transient `ps` failures, descriptor closure, daemon startup, and localized cutover claims.
- `make lint`
- `python3 scripts/issues validate`
- `make test-ubuntu`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
