### PR TITLE
fix(agent-hooks): enforce Pi Codex shell policies

### DIFF
--- a/docs/issues/2026-09-05-009-pi-codex-conversion-tool-names-bypass-the-agent-hooks-pi-profile.md
+++ b/docs/issues/2026-09-05-009-pi-codex-conversion-tool-names-bypass-the-agent-hooks-pi-profile.md
@@ -1,12 +1,13 @@
 ---
 title: "Pi codex-conversion tool names bypass the agent-hooks pi profile"
-short_description: "Under the deployed openai-codex provider Pi's tool surface is exec_command/apply_patch, not the bash/edit/write names the registry's pi profile lists, so every policy is inert there; confirmed live on 2026-09-06 when a reserved-name command that Claude Code and OpenCode both deny executed normally in Pi while selfcheck still reported pi: current with green canaries, because the canaries dispatch registry tool names no real Pi call carries."
+short_description: "Pi's profile now maps exec_command to bash and reads input.cmd, with adapter regression coverage and a live Pi 0.85.1/openai-codex denial confirming policies reach real Codex-provider shell calls."
 type: "bug"
 category: "agent-platform"
 tags: ["agent-hooks","pi","tool-identifiers","codex"]
 date: "2026-09-05"
-status: "open"
+status: "done"
 priority: "high"
+closed: "2026-09-12"
 ---
 
 ## Why this exists
@@ -98,3 +99,7 @@ those names, so every canary-green route is unreachable in practice.
 That is the sharpest form of this issue. R8 says selfcheck detects a fully dead
 path, not an unreachable one, and this is what an unreachable path looks like
 from the outside: entirely green.
+
+## Resolution
+
+Mapped Pi's observed exec_command tool to the canonical bash kind, normalized input.cmd alongside builtin input.command, and added calibrated core and adapter coverage with an ordinary-variable control. Verified the regression red before the mapping, both focused suites green afterward, make test-local mapped the managed files as expected, make test-ubuntu passed, and a live Pi 0.85.1 session with openai-codex plus pi-codex-conversion 3.0.33 emitted exec_command/input.cmd and received the zsh-reserved-name-guard denial. apply_patch remains intentionally unmapped until a shipped edit/write policy has a verified envelope parser.

--- a/home/dot_local/lib/agent-hooks/fixtures.ts
+++ b/home/dot_local/lib/agent-hooks/fixtures.ts
@@ -21,6 +21,7 @@ const WRITE_BODY = "assert_file_not_exists /tmp/gone\n";
 const EDIT_BODY = "expect(result).toBe(1);";
 const MULTI_EDIT_BODY = "first replacement\nsecond replacement";
 const COMMAND = "status=$? && exit $status";
+const CODEX_COMMAND = "make test-ubuntu; status=$?; print -- FINAL_EXIT:$status; exit $status";
 const QUERY = "KnowledgeContextField console";
 const URL = "https://example.com/docs";
 
@@ -78,6 +79,17 @@ export const DIALECT_FIXTURES: DialectFixture[] = [
       claude: { tool_name: "Bash", tool_input: { command: COMMAND } },
       opencode: { tool: "bash", args: { command: COMMAND } },
       pi: { toolName: "bash", input: { command: COMMAND } },
+    },
+  },
+  {
+    // Observed in pi 0.84.4 with npm:@howaboua/pi-codex-conversion and the
+    // openai-codex provider selected. The extension replaces builtin `bash`
+    // with `exec_command` and names its command field `cmd`.
+    name: "codex exec command",
+    tool: "bash",
+    payload: { command: CODEX_COMMAND },
+    raw: {
+      pi: { toolName: "exec_command", input: { cmd: CODEX_COMMAND } },
     },
   },
   {

--- a/home/dot_local/lib/agent-hooks/normalize.ts
+++ b/home/dot_local/lib/agent-hooks/normalize.ts
@@ -4,7 +4,7 @@
 // each client actually sends:
 //   claude   tool_input.content / file_path / new_string / edits[].new_string
 //   opencode args.content / filePath | file_path / newString
-//   pi       input.content / path / edits[].newText
+//   pi       input.content / path / edits[].newText / command | cmd
 // Content is aggregated across the full-content and edit fields alike: a Write
 // call carries its text only in `content`, and dropping it would let full-file
 // writes past every content policy.
@@ -69,7 +69,7 @@ function readPi(raw: any): RawRead {
     payload: {
       filePath: str(input.path),
       content: joinParts([input.content, ...editParts(input.edits, "newText")]),
-      command: str(input.command),
+      command: str(input.command) || str(input.cmd),
       query: str(input.query),
       url: str(input.url),
     },

--- a/home/dot_local/lib/agent-hooks/registry.ts
+++ b/home/dot_local/lib/agent-hooks/registry.ts
@@ -40,7 +40,10 @@ export const CLIENT_PROFILES: ClientProfile[] = [
   },
   {
     client: "pi",
-    tools: { edit: "edit", write: "write", bash: "bash" },
+    // pi-codex-conversion replaces builtin `bash` with `exec_command`. Its
+    // `apply_patch` remains intentionally unmapped until a shipped policy needs
+    // edit/write payloads and the patch envelope has a verified parser.
+    tools: { edit: "edit", write: "write", bash: "bash", exec_command: "bash" },
     outcomes: ["block"],
   },
 ];

--- a/tests/agent-hooks-pi-adapter.test.ts
+++ b/tests/agent-hooks-pi-adapter.test.ts
@@ -140,6 +140,39 @@ describe("tool_call deny and allow (R3)", () => {
   });
 });
 
+describe("openai-codex tool_call dialect (R3)", () => {
+  test("exec_command is denied from its observed input.cmd wire shape", async () => {
+    // #given the shipped known-bad command in pi-codex-conversion's wire shape
+    const policy = policyFixture("zsh-reserved-name-guard", "zsh/flags the status capture idiom");
+    const fixture = corpus.fixture("codex exec command");
+    const host = await loadExtension(CORE_DIR);
+    expect(fixture.payload.command).toBe(policy.payload.command);
+
+    // #when the handler receives the provider's real tool spelling and field
+    const decision = await callToolCall(host, fixture.raw.pi);
+
+    // #then the same policy and reason reached by builtin bash deny the call
+    expect(decision).toEqual({ block: true, reason: policy.text });
+  });
+
+  test("exec_command allows the nearby ordinary-variable control", async () => {
+    // #given the same codex wire shape with a name zsh does not reserve
+    const policy = policyFixture(
+      "zsh-reserved-name-guard",
+      "zsh/an ordinary name zsh accepts is not blocked",
+    );
+    const fixture = corpus.fixture("codex exec command");
+    const raw = { ...fixture.raw.pi, input: { cmd: policy.payload.command } };
+    const host = await loadExtension(CORE_DIR);
+
+    // #when it reaches the same handler
+    const decision = await callToolCall(host, raw);
+
+    // #then pi reads the absent return as allow
+    expect(decision).toBeUndefined();
+  });
+});
+
 // --- scenario 2: the pi arg dialect -----------------------------------------
 
 describe("pi arg dialect reaches Claude's verdicts (R3, KTD8)", () => {


### PR DESCRIPTION
## Summary

Pi's deployed `openai-codex` tool surface now reaches shared agent-hook policies instead of silently bypassing them. The Pi profile maps `exec_command` to canonical `bash`, and normalization reads `input.cmd` while retaining the builtin `bash` and `input.command` dialect.

`apply_patch` remains intentionally unmapped until a shipped edit/write policy needs it and its patch envelope has a verified parser. Regression coverage exercises both a reserved-name denial and an ordinary-variable control through the observed Codex wire shape.

## Verification

- `make test-agent-hooks-pi`
- `make test-agent-hooks-core`
- `make test-local`
- `make test-issues`
- `make test-ubuntu`
- Live Pi 0.85.1 with `openai-codex` and `pi-codex-conversion` 3.0.33 emitted `exec_command` with `input.cmd` and received the `zsh-reserved-name-guard` denial.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-gpt--5.6--sol-6366f1)
