### PR TITLE
fix(agent-hooks): guard Pi fff grep queries

### DIFF
--- a/docs/issues/2026-09-05-008-pi-fff-grep-route-needs-the-pattern-arg-dialect.md
+++ b/docs/issues/2026-09-05-008-pi-fff-grep-route-needs-the-pattern-arg-dialect.md
@@ -1,12 +1,13 @@
 ---
 title: "Pi fff-grep route needs the pattern arg dialect"
-short_description: "Pi's fff grep tool is verified as ffgrep (@ff-labs/pi-fff 0.10.6, default mode tools-and-ui), but it sends its query as input.pattern while the agent-hooks core's pi reader only reads input.query, so adding the identifier to the registry alone would make fff-grep-guard applicable to Pi while every real call carries an empty query and silently passes."
+short_description: "Pi's default pi-fff route now maps ffgrep to fff-grep and translates input.pattern into the core's canonical query, so multi-identifier searches reach fff-grep-guard while single identifiers remain allowed."
 type: "follow-up"
 category: "agent-platform"
 tags: ["agent-hooks","fff","pi","tool-identifiers"]
 date: "2026-09-05"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-12"
 ---
 
 ## Why this exists
@@ -58,3 +59,7 @@ U5 therefore left Pi's profile without an fff entry, unchanged from U1.
   per session from session state. A static registry entry covers only the
   default mode; a second entry (`grep: "fff-grep"`) would collide with nothing
   today but would claim a name pi's own builtins do not use.
+
+## Resolution
+
+Mapped Pi's verified ffgrep spelling to the shared fff-grep tool kind and translated its input.pattern argument in both normalization and canary encoding. A direct Pi-wire regression test failed before the fix and now proves that multi-token queries are denied while a single-identifier control passes; the core, Pi adapter, and OpenCode adapter canonical targets pass, and make test-local confirms the managed files map to ~/.local/lib/agent-hooks without deployment-shape changes.

--- a/home/dot_local/lib/agent-hooks/normalize.ts
+++ b/home/dot_local/lib/agent-hooks/normalize.ts
@@ -64,13 +64,14 @@ function readOpencode(raw: any): RawRead {
 
 function readPi(raw: any): RawRead {
   const input = raw?.input ?? {};
+  const clientToolName = str(raw?.toolName);
   return {
-    clientToolName: str(raw?.toolName),
+    clientToolName,
     payload: {
       filePath: str(input.path),
       content: joinParts([input.content, ...editParts(input.edits, "newText")]),
       command: str(input.command),
-      query: str(input.query),
+      query: clientToolName === "ffgrep" ? str(input.pattern) : str(input.query),
       url: str(input.url),
     },
   };
@@ -141,7 +142,11 @@ const WRITERS: Record<ClientId, Writer> = {
           : { content: payload.content }
         : {}),
       ...(payload.command ? { command: payload.command } : {}),
-      ...(payload.query ? { query: payload.query } : {}),
+      ...(payload.query
+        ? tool === "fff-grep"
+          ? { pattern: payload.query }
+          : { query: payload.query }
+        : {}),
       ...(payload.url ? { url: payload.url } : {}),
     },
   }),

--- a/home/dot_local/lib/agent-hooks/registry.ts
+++ b/home/dot_local/lib/agent-hooks/registry.ts
@@ -16,9 +16,8 @@ import type {
 
 // The fff MCP tool is spelled per client: Claude namespaces it mcp__fff__grep,
 // opencode flattens the server name to fff_grep (observed against the shipped
-// fff MCP server, U4). Pi's spelling is still unverified, so its profile omits
-// the tool and the derivation declares the policy inapplicable there
-// statically instead of missing it silently (R3).
+// fff MCP server, U4), and pi-fff exposes ffgrep in its default tools-and-ui
+// mode. Pi's argument dialect for this route is handled in normalize.ts.
 export const CLIENT_PROFILES: ClientProfile[] = [
   {
     client: "claude",
@@ -40,7 +39,7 @@ export const CLIENT_PROFILES: ClientProfile[] = [
   },
   {
     client: "pi",
-    tools: { edit: "edit", write: "write", bash: "bash" },
+    tools: { edit: "edit", write: "write", bash: "bash", ffgrep: "fff-grep" },
     outcomes: ["block"],
   },
 ];

--- a/tests/agent-hooks-core.test.ts
+++ b/tests/agent-hooks-core.test.ts
@@ -315,8 +315,8 @@ describe("applicability derivation", () => {
     expect(core.applicableClients(registry, policy)).toEqual(["claude"]);
   });
 
-  test("a tool absent from a profile makes its policy inapplicable there", () => {
-    // #given the shipped profiles, where pi still has no verified fff tool
+  test("the fff grep policy is applicable through every shipped profile", () => {
+    // #given a block policy for the fff grep tool
     const policy = {
       name: "fixture-query-guard",
       tools: ["fff-grep"],
@@ -327,8 +327,8 @@ describe("applicability derivation", () => {
     // #when applicability is derived
     const clients = core.applicableClients(registryWith([policy]), policy);
 
-    // #then it is declared statically, not missed at runtime
-    expect(clients).toEqual(["claude", "opencode"]);
+    // #then each verified spelling is declared statically
+    expect(clients).toEqual(["claude", "opencode", "pi"]);
   });
 });
 
@@ -757,6 +757,7 @@ describe("selfcheck canary over the shipped registry (R8)", () => {
     expect(results.map((result: any) => `${result.policy}@${result.client}`).sort()).toEqual([
       "fff-grep-guard@claude",
       "fff-grep-guard@opencode",
+      "fff-grep-guard@pi",
       "zsh-reserved-name-guard@claude",
       "zsh-reserved-name-guard@opencode",
       "zsh-reserved-name-guard@pi",

--- a/tests/agent-hooks-pi-adapter.test.ts
+++ b/tests/agent-hooks-pi-adapter.test.ts
@@ -177,6 +177,26 @@ describe("pi arg dialect reaches Claude's verdicts (R3, KTD8)", () => {
     expect(clearances).toBeGreaterThan(0);
   });
 
+  test("the fff route pi exposes denies a multi-token query and allows one identifier", async () => {
+    // #given the deny and control in pi-fff's observed wire shape
+    const denied = policyFixture("fff-grep-guard", "fff/multi-token bare query is denied");
+    const allowed = policyFixture("fff-grep-guard", "fff/single identifier passes");
+    const host = await loadExtension(CORE_DIR);
+
+    // #when both go through pi-fff's default tool spelling and argument dialect
+    const deniedDecision = await callToolCall(host, {
+      toolName: "ffgrep",
+      input: { pattern: denied.payload.query },
+    });
+    const allowedDecision = await callToolCall(host, {
+      toolName: "ffgrep",
+      input: { pattern: allowed.payload.query },
+    });
+
+    // #then only the multi-token query is refused
+    expect(deniedDecision).toEqual({ block: true, reason: denied.text });
+    expect(allowedDecision).toBeUndefined();
+  });
 });
 
 // --- scenario 3: fail-open by absence ---------------------------------------


### PR DESCRIPTION
## Summary

Pi's default `pi-fff` grep calls now reach `fff-grep-guard`, so multi-token bare searches are blocked instead of silently passing with an empty normalized query. The route maps `ffgrep` and translates its `input.pattern` field while preserving Pi's existing `input.query` handling for other tools. The unconfigured override-mode `grep` spelling remains out of scope.

Related: `2026-09-05-008`

## Validation

- `make test-agent-hooks-core` (55 passed)
- `make test-agent-hooks-pi` (8 passed, including the observed Pi wire shape and its single-identifier control)
- `make test-agent-hooks-opencode` (7 passed)
- `make test-issues` (60 passed)
- `make test-local` (managed agent-hooks files mapped without deployment-shape changes)
