### PR TITLE
Select external leg models by complexity and effort

### DIFF
--- a/docs/issues/2026-09-12-001-select-external-leg-models-by-complexity-and-effort.md
+++ b/docs/issues/2026-09-12-001-select-external-leg-models-by-complexity-and-effort.md
@@ -1,12 +1,13 @@
 ---
 title: "Select External leg models by complexity and effort"
-short_description: "se-external-leg-pair hardcodes Sonnet/high and Terra for every caller; require provider-neutral complexity and effort inputs, preserve one Claude plus one OpenCode leg, and resolve provider-specific models and variants centrally before any tab starts."
+short_description: "se-external-leg-pair now requires provider-neutral complexity and effort, resolves a versioned Claude/OpenCode launch matrix centrally, and publishes the requested and resolved settings with each result."
 type: "follow-up"
 category: "se-pipeline"
 tags: ["external-leg","agent-models","cli-contract","herdr"]
 date: "2026-09-12"
-status: "open"
+status: "done"
 priority: "medium"
+closed: "2026-09-12"
 ---
 
 ## Why this exists
@@ -27,3 +28,7 @@ priority: "medium"
 ## Open decisions
 
 The semantic API and pair invariant are settled. Before implementation, verify the exact initial provider/model matrix, especially `xhigh` and provider-specific support for each effort value, against the installed client catalogs rather than inferring capability from model names.
+
+## Resolution
+
+Implemented required complexity and effort inputs, centralized the versioned provider mapping, migrated all callers to medium/high, published selection diagnostics, and added focused lifecycle plus installed-client conformance coverage.

--- a/home/dot_local/bin/executable_se-external-leg-pair
+++ b/home/dot_local/bin/executable_se-external-leg-pair
@@ -5,7 +5,9 @@ umask 077
 
 usage() {
   cat >&2 <<'EOF'
-Usage: se-external-leg-pair --repo-root DIR --claude-prompt-file FILE
+Usage: se-external-leg-pair --complexity low|medium|high|xhigh
+                            --effort low|medium|high|xhigh|max
+                            --repo-root DIR --claude-prompt-file FILE
                             --opencode-prompt-file FILE
                             [--exposed-document FILE] --result-dir DIR
 EOF
@@ -21,9 +23,21 @@ claude_prompt_file=""
 opencode_prompt_file=""
 exposed_document=""
 result_dir=""
+complexity=""
+effort=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --complexity)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      complexity="$2"
+      shift 2
+      ;;
+    --effort)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      effort="$2"
+      shift 2
+      ;;
     --repo-root)
       [ "$#" -ge 2 ] || { usage; exit 2; }
       repo_root="$2"
@@ -56,6 +70,35 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+[ -n "$complexity" ] || refuse '--complexity is required.'
+case "$complexity" in
+  low)
+    claude_model="sonnet"
+    opencode_model="openai/gpt-5.6-luna"
+    ;;
+  medium)
+    claude_model="sonnet"
+    opencode_model="openai/gpt-5.6-terra"
+    ;;
+  high)
+    claude_model="opus"
+    opencode_model="openai/gpt-5.6-sol"
+    ;;
+  xhigh)
+    claude_model="fable"
+    opencode_model="openai/gpt-6-astra"
+    ;;
+  *) refuse '--complexity must be one of: low, medium, high, xhigh.' ;;
+esac
+[ -n "$effort" ] || refuse '--effort is required.'
+case "$effort" in
+  low|medium|high|xhigh|max) ;;
+  *) refuse '--effort must be one of: low, medium, high, xhigh, max.' ;;
+esac
+mapping_version="external-leg-models/2026-09-12"
+claude_effort="$effort"
+opencode_variant="$effort"
 
 require_absolute() {
   case "$2" in
@@ -229,7 +272,7 @@ create_tab() {
     status=$?
   else
     output="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$repo_root" --no-focus \
-      --env 'OPENCODE_CONFIG_CONTENT={"permission":"allow","agent":{"build":{"permission":"allow","reasoningEffort":"high"}}}' \
+      --env "OPENCODE_CONFIG_CONTENT={\"permission\":\"allow\",\"agent\":{\"build\":{\"permission\":\"allow\",\"model\":\"$opencode_model\",\"variant\":\"$opencode_variant\"}}}" \
       2>"$work_dir/opencode-tab.err")"
     status=$?
   fi
@@ -293,11 +336,11 @@ start_agent() {
   while [ "$attempt" -le 3 ]; do
     if [ "$leg" = claude ]; then
       herdr agent start "$name" --kind claude --pane "$pane" --timeout 60000 -- \
-        --model sonnet --effort high --dangerously-skip-permissions >"$output_file" 2>"$error_file"
+        --model "$claude_model" --effort "$claude_effort" --dangerously-skip-permissions >"$output_file" 2>"$error_file"
       status=$?
     else
       herdr agent start "$name" --kind opencode --pane "$pane" --timeout 60000 -- \
-        --model openai/gpt-5.6-terra --agent build --auto >"$output_file" 2>"$error_file"
+        --model "$opencode_model" --agent build --auto >"$output_file" 2>"$error_file"
       status=$?
     fi
     if [ "$status" -eq 0 ] && python3 -c '
@@ -536,11 +579,26 @@ if ! remove_work_dir; then
 fi
 cleanup_complete=1
 
-python3 - "$stage_dir/result.json" "$classification" "$scan_state" "$claude_state" "$opencode_state" <<'PY'
+python3 - "$stage_dir/result.json" "$classification" "$scan_state" "$claude_state" "$opencode_state" \
+  "$mapping_version" "$complexity" "$effort" "$claude_model" "$claude_effort" \
+  "$opencode_model" "$opencode_variant" <<'PY'
 import json
 import sys
 
-path, classification, scan, claude_state, opencode_state = sys.argv[1:]
+(
+    path,
+    classification,
+    scan,
+    claude_state,
+    opencode_state,
+    mapping,
+    complexity,
+    effort,
+    claude_model,
+    claude_effort,
+    opencode_model,
+    opencode_variant,
+) = sys.argv[1:]
 report_paths = {
     "paired": [
         {"source": "claude", "path": "claude.report"},
@@ -560,6 +618,14 @@ with open(path, "w", encoding="utf-8") as result:
             "cleanup": "complete",
             "legs": {"claude": claude_state, "opencode": opencode_state},
             "reports": report_paths[classification],
+            "selection": {
+                "mapping": mapping,
+                "requested": {"complexity": complexity, "effort": effort},
+                "resolved": {
+                    "claude": {"model": claude_model, "effort": claude_effort},
+                    "opencode": {"model": opencode_model, "variant": opencode_variant},
+                },
+            },
         },
         result,
         indent=2,

--- a/home/private_dot_agents/skills/se-code-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-code-review/SKILL.md
@@ -87,7 +87,7 @@ if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
   exit 1
 fi
 PAIR_STATUS=0
-se-external-leg-pair --repo-root "$REPO_ROOT" \
+se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" \
   --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
   --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
   --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?

--- a/home/private_dot_agents/skills/se-code-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-code-review/SKILL.md
@@ -93,15 +93,15 @@ se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" 
   --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
 ```
 
-After the command returns, load any published result needed for diagnosis, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0` and a complete parseable JSON report from each listed source. One failed or malformed peer degrades coverage; no valid peer report fails the review. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan. Do not pass peer context into `se-simplify`.
+After the command returns, retain `selection` from any parseable published result for the final coverage report, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0` and a complete parseable JSON report from each listed source. One failed or malformed peer degrades coverage; no valid peer report fails the review. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan and the requested and resolved selection. Do not pass peer context into `se-simplify`.
 
 ## Synthesize reports
 
 Merge findings by file, nearby line, and issue substance:
 
 1. **Consensus**: both reports found the same issue.
-2. **Claude-only**: only Sonnet found it.
-3. **OpenCode-only**: only Terra found it.
+2. **Claude-only**: only the Claude peer found it.
+3. **OpenCode-only**: only the OpenCode peer found it.
 4. **Indeterminate-single**: an identical report has no model attribution and is never consensus.
 5. **Contradiction**: the reports disagree on whether the issue exists or what behavior is correct.
 6. **Fix divergence**: they agree on the issue but propose materially different fixes.

--- a/home/private_dot_agents/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-doc-review/SKILL.md
@@ -106,7 +106,7 @@ if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
   exit 1
 fi
 PAIR_STATUS=0
-se-external-leg-pair --repo-root "$REPO_ROOT" \
+se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" \
   --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
   --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
   --exposed-document "$DOC_COPY" --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?

--- a/home/private_dot_agents/skills/se-doc-review/SKILL.md
+++ b/home/private_dot_agents/skills/se-doc-review/SKILL.md
@@ -112,7 +112,7 @@ se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" 
   --exposed-document "$DOC_COPY" --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
 ```
 
-After the command returns, load any published reports needed for synthesis and remove the result and prompt files on every status. Exit `3` then fails the review because peer cleanup is unconfirmed. Otherwise, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`; it is the only pass allowed to mutate the document and starts only after peers can no longer read the checkout state attested by the launch scan. Exit `1` or `2` records both peers as failed but does not suppress the local pass.
+After the command returns, retain `selection` from any parseable published result for the final coverage report, load any published reports needed for synthesis, and remove the result and prompt files on every status. Exit `3` then fails the review because peer cleanup is unconfirmed. Otherwise, invoke the local `ce-doc-review` skill with `mode:headless DOC_PATH`; it is the only pass allowed to mutate the document and starts only after peers can no longer read the checkout state attested by the launch scan. Exit `1` or `2` records both peers as failed but does not suppress the local pass.
 
 Accept an envelope only when Coverage accounts for every attempted persona, its counts reconcile, every surviving finding is routed once with its required fields, and the terminal line is exact. A failed or malformed pass degrades coverage; synthesize any surviving envelopes. Treat `identical-single` as one indeterminate source, never consensus. If all three passes fail, fail the review without modifying the document further.
 
@@ -133,7 +133,7 @@ Present:
 
 ```text
 ## Cross-review synthesis
-Coverage: local personas: <list or failed>; Claude peer: <ok or failed>; OpenCode peer: <ok or failed>
+Coverage: local personas: <list or failed>; Claude peer: <ok or failed>; OpenCode peer: <ok or failed>; selection: <requested and resolved settings, or unavailable>
 ### Consensus (N)
 ### Source-unique findings (M)
 ### Contradictions / fix divergence (K)

--- a/home/private_dot_agents/skills/se-simplify/SKILL.md
+++ b/home/private_dot_agents/skills/se-simplify/SKILL.md
@@ -88,7 +88,7 @@ if ! printf '%s' "$CLAUDE_PROMPT" > "$CLAUDE_PROMPT_FILE" ||
   exit 1
 fi
 PAIR_STATUS=0
-se-external-leg-pair --repo-root "$REPO_ROOT" \
+se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" \
   --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
   --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
   --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?

--- a/home/private_dot_agents/skills/se-simplify/SKILL.md
+++ b/home/private_dot_agents/skills/se-simplify/SKILL.md
@@ -94,7 +94,7 @@ se-external-leg-pair --complexity medium --effort high --repo-root "$REPO_ROOT" 
   --result-dir "$PAIR_RESULT" || PAIR_STATUS=$?
 ```
 
-After the command returns, load any published result needed for diagnosis, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0`. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; no valid peer report fails the simplify run and applies nothing. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan.
+After the command returns, retain `selection` from any parseable published result for the final coverage report, then remove `PAIR_PARENT` on every status before synthesis or return. Require `PAIR_STATUS=0`. Accept a report only when Coverage accounts for all three reviewer dimensions, every surviving finding contains every required field, excluded candidates carry a reason, and the terminal line is exact. One failed or malformed peer degrades coverage; no valid peer report fails the simplify run and applies nothing. Treat `identical-single` as one indeterminate source, never consensus. Report a waived scan and the requested and resolved selection.
 
 ## Synthesize findings
 

--- a/home/private_dot_claude/shared/herdr-peer-launch.md
+++ b/home/private_dot_claude/shared/herdr-peer-launch.md
@@ -12,6 +12,8 @@ PAIR_RESULT="$PAIR_PARENT/result"
 
 PAIR_STATUS=0
 se-external-leg-pair \
+  --complexity medium \
+  --effort high \
   --repo-root "$REPO_ROOT" \
   --claude-prompt-file "$CLAUDE_PROMPT_FILE" \
   --opencode-prompt-file "$OPENCODE_PROMPT_FILE" \
@@ -20,7 +22,18 @@ se-external-leg-pair \
 
 If either prompt tells a peer to read a document outside `REPO_ROOT`, add exactly one `--exposed-document "$ABSOLUTE_DOCUMENT"` so the file is scanned too. This is required for the immutable copy used by `se-doc-review`; the interface supports only one external document per pair.
 
-The command requires `HERDR_ENV=1` and `HERDR_WORKSPACE_ID`. It starts Claude with Sonnet, high effort, and skipped permission prompts; it starts OpenCode with Terra, the build agent, auto mode, and allowed permissions. It also fixes retry limits, waits, report transport, and cleanup, so callers cannot override lifecycle policy. `SE_SKIP_SECRET_SCAN=1` remains the only operator waiver. The result records `"scan": "waived"`, and the caller reports the waiver.
+The command requires `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`, and explicit `--complexity` and `--effort` values. Complexity selects each provider's model; effort becomes Claude's native effort and OpenCode's model variant. It also fixes the pair, permissions, retry limits, waits, report transport, and cleanup, so callers cannot override provider or lifecycle policy. `SE_SKIP_SECRET_SCAN=1` remains the only operator waiver. The result records `"scan": "waived"`, and the caller reports the waiver.
+
+Mapping `external-leg-models/2026-09-12` was verified against Claude Code 2.1.236 and OpenCode 1.18.30:
+
+| Complexity | Claude model | OpenCode model |
+|---|---|---|
+| `low` | `sonnet` | `openai/gpt-5.6-luna` |
+| `medium` | `sonnet` | `openai/gpt-5.6-terra` |
+| `high` | `opus` | `openai/gpt-5.6-sol` |
+| `xhigh` | `fable` | `openai/gpt-6-astra` |
+
+Both clients support `low`, `medium`, `high`, `xhigh`, and `max` effort for these models. The three current callers declare `medium/high`, preserving their previous Sonnet/high and Terra behavior.
 
 ## Result
 
@@ -34,6 +47,9 @@ The command copies usable reports only after every known peer tab closes, then r
 - `cleanup`: always `complete` in a published result.
 - `legs`: lifecycle and transport state for Claude and OpenCode.
 - `reports`: source and relative path for every usable report.
+- `selection`: mapping version, requested semantic values, and launcher-resolved settings sent to each client.
+
+`selection.resolved` records the launch contract for cost and tuning comparisons. A client or organization policy may still substitute or cap those settings after launch; the executable does not claim to observe that effective runtime identity.
 
 Report files preserve the bytes delivered through peer-owned atomic file transport. When both report files are byte-identical, `identical-single` publishes one `identical.report` attributed to `indeterminate`. Duplicate bytes cannot prove two independent reviews, so this is single-source coverage, never consensus.
 
@@ -52,7 +68,7 @@ Load and validate every listed report before removing `PAIR_RESULT` and `PAIR_PA
 The executable:
 
 1. Adds each private report path to its complete caller prompt, then scans the checkout, any external document, and both exact augmented prompts immediately before creating tabs.
-2. Creates two fresh background tabs and starts the fixed Claude and OpenCode peers.
+2. Creates two fresh background tabs and starts the resolved Claude and OpenCode peers.
 3. Submits both prompts whose peers reached ready state before waiting on either peer. A trackable failure in one leg does not stop the other; a successful tab creation with no tab ID stops the pair because cleanup cannot be confirmed.
 4. Accepts only non-empty regular non-symlink report files.
 5. Gives a peer whose initial prompt and wait both succeeded, but whose report is missing or empty, one bounded recovery turn after scanning the recovery prompt and every input it exposes.

--- a/tests/bashunit/external_leg_pair_test.sh
+++ b/tests/bashunit/external_leg_pair_test.sh
@@ -636,8 +636,8 @@ PY
   done
 }
 
-function test_external_leg_pair_1314_mapped_claude_settings_exist_in_the_installed_client() {
-  _bats_test_init 1314 'External leg pair mapped Claude settings exist in the installed client'
+function test_external_leg_pair_1314_mapped_claude_aliases_and_efforts_exist_in_the_installed_client() {
+  _bats_test_init 1314 'External leg pair mapped Claude aliases and efforts exist in the installed client'
   command_exists claude || skip "claude is not installed"
   local help model effort
 
@@ -649,10 +649,12 @@ function test_external_leg_pair_1314_mapped_claude_settings_exist_in_the_install
     assert_success
   done
 
-  for effort in low medium high xhigh max; do
-    run claude --effort "$effort" --version
-    assert_success
-    refute_output --partial 'Unknown --effort value'
+  for model in sonnet opus fable; do
+    for effort in low medium high xhigh max; do
+      run claude --model "$model" --effort "$effort" --version
+      assert_success
+      refute_output --partial 'Unknown --effort value'
+    done
   done
 }
 
@@ -662,7 +664,12 @@ function test_external_leg_pair_1315_mapped_opencode_settings_exist_in_the_insta
   local catalog="$BATS_TEST_TMPDIR/opencode-models"
 
   run opencode models openai --verbose
-  [ "$status" -eq 0 ] || skip "installed opencode has no openai model catalog: $output"
+  if [ "$status" -ne 0 ]; then
+    case "$output" in
+      *'Provider not found: openai'*) skip "installed opencode has no openai model catalog: $output" ;;
+      *) assert_success ;;
+    esac
+  fi
   assert_success
   printf '%s\n' "$output" > "$catalog"
   run python3 - "$catalog" <<'PY'

--- a/tests/bashunit/external_leg_pair_test.sh
+++ b/tests/bashunit/external_leg_pair_test.sh
@@ -210,7 +210,7 @@ function test_external_leg_pair_1301_scans_exact_inputs_before_launch_and_publis
   local result="$PAIR_RESULTS/distinct"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_ASSERT_NO_STAGE_ON_CLOSE=1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
-    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    bash "$PAIR_SCRIPT" --complexity medium --effort high --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" \
       --exposed-document "$PAIR_WORK/document.md" --result-dir "$result"
@@ -287,7 +287,7 @@ function test_external_leg_pair_1302_refuses_before_tabs_and_records_an_explicit
   local refused="$PAIR_RESULTS/refused" waived="$PAIR_RESULTS/waived"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_SCAN_FAIL_AT=1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
-    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    bash "$PAIR_SCRIPT" --complexity medium --effort high --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$refused"
   assert_failure 2
@@ -299,7 +299,8 @@ function test_external_leg_pair_1302_refuses_before_tabs_and_records_an_explicit
 
   rm -f "$PAIR_WORK/alias-count" "$PAIR_WORK/scan-count" "$PAIR_WORK/order.log"
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_SCAN_FAIL_AT=1 SE_SKIP_SECRET_SCAN=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$waived"
   assert_success
@@ -315,7 +316,8 @@ function test_external_leg_pair_1303_rescans_recovery_prompts_and_counts_identic
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=none PAIR_STUB_OPENCODE_MODE=none \
     PAIR_STUB_RECOVER=1 PAIR_STUB_RECOVER_BODY='same report' \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" \
       --exposed-document "$PAIR_WORK/document.md" --result-dir "$result"
@@ -356,7 +358,8 @@ function test_external_leg_pair_1304_withholds_results_when_cleanup_is_incomplet
   local result="$PAIR_RESULTS/cleanup-failed"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLOSE_FAIL_TAB=wT:t1 PAIR_STUB_ASSERT_NO_STAGE_ON_CLOSE=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_failure 3
@@ -384,7 +387,8 @@ function test_external_leg_pair_1305_preserves_a_valid_claude_report_when_openco
   local result="$PAIR_RESULTS/claude-only"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_OPENCODE_MODE=symlink \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_success
@@ -402,7 +406,8 @@ function test_external_leg_pair_1306_preserves_a_valid_opencode_report_when_clau
   local result="$PAIR_RESULTS/opencode-only"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=symlink \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_success
@@ -420,7 +425,8 @@ function test_external_leg_pair_1307_publishes_none_only_after_complete_cleanup(
   local result="$PAIR_RESULTS/none"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CLAUDE_MODE=symlink PAIR_STUB_OPENCODE_MODE=symlink \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_failure 1
@@ -437,7 +443,8 @@ function test_external_leg_pair_1308_treats_untracked_tabs_and_failed_error_clea
   local malformed="$PAIR_RESULTS/malformed-tab" staging="$PAIR_RESULTS/staging-failed"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MALFORMED_TAB_AT=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$malformed"
   assert_failure 3
@@ -449,7 +456,8 @@ function test_external_leg_pair_1308_treats_untracked_tabs_and_failed_error_clea
   rm -rf "$PAIR_WORK"
   pair_stub
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MKTEMP_FAIL_AT=2 PAIR_STUB_RM_FAIL_TRANSPORT=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$staging"
   assert_failure 3
@@ -464,7 +472,8 @@ function test_external_leg_pair_1308_treats_untracked_tabs_and_failed_error_clea
   pair_stub
   local known_tab="$PAIR_RESULTS/known-tab"
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_MISSING_PANE_AT=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$known_tab"
   assert_success
@@ -484,7 +493,7 @@ function test_external_leg_pair_1309_recovers_mixed_start_races_and_keeps_an_ack
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_START_MIXED_TRANSIENT=1 \
     PAIR_STUB_PROMPT_ACK_FAIL_PANE=wT:p1 HERDR_ENV=1 HERDR_WORKSPACE_ID=wT \
-    bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    bash "$PAIR_SCRIPT" --complexity medium --effort high --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_success
@@ -504,7 +513,8 @@ function test_external_leg_pair_1310_degrades_when_one_tab_cannot_start() {
   local result="$PAIR_RESULTS/tab-failed"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_TAB_FAIL_AT=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_success
@@ -522,7 +532,8 @@ function test_external_leg_pair_1311_refuses_to_classify_when_report_comparison_
   local result="$PAIR_RESULTS/compare-failed"
 
   run env PATH="$PAIR_BIN:$PATH" PAIR_STUB_CMP_FAIL=1 \
-    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --repo-root "$PAIR_REPO" \
+    HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" --complexity medium --effort high \
+      --repo-root "$PAIR_REPO" \
       --claude-prompt-file "$PAIR_WORK/claude.prompt" \
       --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
   assert_failure 1
@@ -535,6 +546,148 @@ function test_external_leg_pair_1311_refuses_to_classify_when_report_comparison_
   local transport
   transport="$(dirname "$(cat "$PAIR_WORK/report-p1.path")")"
   assert_dir_not_exists "$transport"
+}
+
+function test_external_leg_pair_1312_refuses_missing_or_unsupported_selection_before_tabs() {
+  _bats_test_init 1312 'External leg pair refuses missing or unsupported selection before tabs'
+  pair_stub
+  local result="$PAIR_RESULTS/refused-selection"
+
+  run env PATH="$PAIR_BIN:$PATH" HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" \
+    --effort high --repo-root "$PAIR_REPO" \
+    --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+    --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 2
+  assert_output --partial '--complexity is required'
+
+  run env PATH="$PAIR_BIN:$PATH" HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" \
+    --complexity medium --repo-root "$PAIR_REPO" \
+    --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+    --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 2
+  assert_output --partial '--effort is required'
+
+  run env PATH="$PAIR_BIN:$PATH" HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" \
+    --complexity extreme --effort high --repo-root "$PAIR_REPO" \
+    --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+    --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 2
+  assert_output --partial '--complexity must be one of: low, medium, high, xhigh'
+
+  run env PATH="$PAIR_BIN:$PATH" HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" \
+    --complexity medium --effort extreme --repo-root "$PAIR_REPO" \
+    --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+    --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+  assert_failure 2
+  assert_output --partial '--effort must be one of: low, medium, high, xhigh, max'
+  assert_file_not_exists "$PAIR_WORK/herdr.log"
+  assert_dir_not_exists "$result"
+}
+
+function test_external_leg_pair_1313_maps_every_complexity_and_effort_to_launch_settings() {
+  _bats_test_init 1313 'External leg pair maps every complexity and effort to launch settings'
+  local selection complexity effort claude_model opencode_model result
+
+  for selection in \
+    'low low sonnet openai/gpt-5.6-luna' \
+    'low medium sonnet openai/gpt-5.6-luna' \
+    'medium high sonnet openai/gpt-5.6-terra' \
+    'high xhigh opus openai/gpt-5.6-sol' \
+    'xhigh max fable openai/gpt-6-astra'; do
+    read -r complexity effort claude_model opencode_model <<< "$selection"
+    rm -rf "$BATS_TEST_TMPDIR/pair"
+    pair_stub
+    result="$PAIR_RESULTS/$complexity-$effort"
+
+    run env PATH="$PAIR_BIN:$PATH" HERDR_ENV=1 HERDR_WORKSPACE_ID=wT bash "$PAIR_SCRIPT" \
+      --complexity "$complexity" --effort "$effort" --repo-root "$PAIR_REPO" \
+      --claude-prompt-file "$PAIR_WORK/claude.prompt" \
+      --opencode-prompt-file "$PAIR_WORK/opencode.prompt" --result-dir "$result"
+    assert_success
+
+    run grep -F -- '--kind claude' "$PAIR_WORK/herdr.log"
+    assert_success
+    assert_output --partial "--model $claude_model"
+    assert_output --partial "--effort $effort"
+    run grep -F -- '--kind opencode' "$PAIR_WORK/herdr.log"
+    assert_success
+    assert_output --partial "--model $opencode_model"
+    run python3 - "$PAIR_WORK/herdr.log" "$effort" "$opencode_model" <<'PY'
+import json
+import shlex
+import sys
+
+for line in open(sys.argv[1], encoding="utf-8"):
+    arguments = shlex.split(line)
+    if arguments[:3] == ["herdr", "tab", "create"] and "--env" in arguments:
+        value = arguments[arguments.index("--env") + 1]
+        config = json.loads(value.split("=", 1)[1])
+        assert config["agent"]["build"]["model"] == sys.argv[3]
+        assert config["agent"]["build"]["variant"] == sys.argv[2]
+        break
+else:
+    raise AssertionError("OpenCode tab environment was not forwarded")
+PY
+    assert_success
+
+    run jq -cS '.selection' "$result/result.json"
+    assert_success
+    assert_output "{\"mapping\":\"external-leg-models/2026-09-12\",\"requested\":{\"complexity\":\"$complexity\",\"effort\":\"$effort\"},\"resolved\":{\"claude\":{\"effort\":\"$effort\",\"model\":\"$claude_model\"},\"opencode\":{\"model\":\"$opencode_model\",\"variant\":\"$effort\"}}}"
+  done
+}
+
+function test_external_leg_pair_1314_mapped_claude_settings_exist_in_the_installed_client() {
+  _bats_test_init 1314 'External leg pair mapped Claude settings exist in the installed client'
+  command_exists claude || skip "claude is not installed"
+  local help model effort
+
+  run claude --help
+  assert_success
+  help="$output"
+  for model in sonnet opus fable; do
+    run grep -F -- "'$model'" <<< "$help"
+    assert_success
+  done
+
+  for effort in low medium high xhigh max; do
+    run claude --effort "$effort" --version
+    assert_success
+    refute_output --partial 'Unknown --effort value'
+  done
+}
+
+function test_external_leg_pair_1315_mapped_opencode_settings_exist_in_the_installed_client() {
+  _bats_test_init 1315 'External leg pair mapped OpenCode settings exist in the installed client'
+  command_exists opencode || skip "opencode is not installed"
+  local catalog="$BATS_TEST_TMPDIR/opencode-models"
+
+  run opencode models openai --verbose
+  [ "$status" -eq 0 ] || skip "installed opencode has no openai model catalog: $output"
+  assert_success
+  printf '%s\n' "$output" > "$catalog"
+  run python3 - "$catalog" <<'PY'
+import json
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+decoder = json.JSONDecoder()
+catalog = {}
+for match in re.finditer(r"^(openai/[^\n]+)\n", text, re.MULTILINE):
+    metadata, _ = decoder.raw_decode(text[match.end():].lstrip())
+    catalog[match.group(1)] = metadata
+
+efforts = {"low", "medium", "high", "xhigh", "max"}
+for model in (
+    "openai/gpt-5.6-luna",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-6-astra",
+):
+    assert model in catalog
+    assert efforts <= set(catalog[model]["variants"])
+PY
+  assert_success
 }
 
 function set_up_before_script() {


### PR DESCRIPTION
## Summary

- require provider-neutral complexity and effort inputs for every external peer pair
- resolve Claude and OpenCode launch settings through one versioned mapping
- publish requested and resolved selections for review diagnostics and migrate all callers explicitly
- validate the mapping, forwarding, refusal paths, cleanup lifecycle, and installed client support

## Why

The shared external-leg lifecycle previously hardcoded one Claude/OpenCode pairing. Semantic inputs let workflows choose capability and reasoning budgets without leaking provider model IDs or duplicating lifecycle code.

## Verification

- `tests/lib/bashunit -j 8 tests/bashunit/external_leg_pair_test.sh` (15 tests, 181 assertions)
- `make lint`
- `make test-local`
- `make test-ubuntu`