### PR TITLE
docs(agents): define sandbox-safe mailbox boundary

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -7,6 +7,12 @@ Shared domain vocabulary for this project — entities, named processes, and sta
 ### Child-agent contract
 The agreement between a parent agent and child agents launched into sibling panes or their own `--tab`. `herdr-child` allocates each child a registered `color-animal` alias and returns it with the pane ID. Attached `--wait` keeps the result inside the current parent turn and arms no watcher. Managed `--detach` captures parent and child terminal/session identity, a fresh-state baseline, and a generation; an external per-child watcher then wakes the parent with generation-and-event markers for settlement, blockage, timeout, or unplanned disappearance. A child decision uses `ask`/`reply`; ordinary follow-ups use pair-addressed `prompt --wait|--detach`; reap requires the verified alias-plus-pane pair, invalidates supervision before pane closure, and preserves sibling panes in a child-owned tab. Lifecycle settlement is a wake signal, not a task verdict. Markers and metadata coordinate cooperative same-user clients and are not authorization credentials.
 
+### Agent mailbox
+The target communication boundary through which agents exchange durable, addressed messages without receiving the host control authority used to deliver them. A host-owned broker authenticates the sender, authorizes the recipient, records the message before delivery, and delegates wake-up to Herdr. Message contents are never executable authority by themselves; their type and the sender's role decide whether they are data, a question, or a continuation from a parent.
+
+### Launch relationship graph
+The communication authority created when one agent launches another. It records which parent, child, and explicitly connected peer relationships may address one another; being a live agent on the same machine or in the same repository grants no messaging authority. The graph authorizes delivery, while agent aliases and pane IDs remain coordination identity rather than credentials.
+
 ### herdr-worktree-identity
 The component that derives one multi-word branch name from a generated worktree session's prompt, renames the authorized branch once with attribution, and gives the workspace the same final name. The alias system exclusively owns pane, tab, and agent identity. A contended claim writes a diagnostic but has no terminal outcome, so the next naming event retries it.
 

--- a/docs/decisions/0013-use-a-host-owned-mailbox-for-sandboxed-agent-communication.md
+++ b/docs/decisions/0013-use-a-host-owned-mailbox-for-sandboxed-agent-communication.md
@@ -1,0 +1,68 @@
+---
+title: Use a host-owned mailbox for sandboxed agent communication
+status: accepted
+date: 2026-09-12
+supersedes: []
+---
+
+# ADR-0013: Use a host-owned mailbox for sandboxed agent communication
+
+## Context
+
+The child-agent contract currently carries decisions through `herdr-child
+ask/reply`. A child invokes host-side Herdr control to wake its parent, so a
+sandbox must either expose that control surface or break the mandatory return
+channel. Exposing it gives the child more authority than message delivery
+requires and makes a narrow filesystem or process boundary harder to reason
+about.
+
+The project separately tracks what a child may do inside its worktree and what
+it can reach outside one in
+`docs/issues/2026-08-18-001-launch-time-permission-mode-for-child-agents.md` and
+`docs/issues/2026-08-18-002-sandbox-a-child-agents-filesystem-access.md`. Agent
+communication crosses both boundaries: it must remain available inside a
+sandbox without becoming a route to arbitrary host control.
+
+## Considered options
+
+- Keep direct `herdr-child ask/reply` and grant each sandbox access to the Herdr
+  control surface.
+- Add a mailbox while permanently retaining direct callbacks as a second
+  communication path.
+- Put a mailbox broker outside the sandbox and make it the sole agent-to-agent
+  communication boundary.
+- Adopt a specific MCP mailbox product before fixing the transport contract.
+
+## Decision
+
+Use a host-owned mailbox broker as the target communication boundary for
+agents. The broker persists a message before delivery, authenticates its sender,
+authorizes its recipient from the launch relationship graph, and asks a
+host-side Herdr adapter to wake an idle recipient. Only that adapter may access
+Herdr control. A sandboxed agent receives a capability for the mailbox, not the
+Herdr CLI or control socket.
+
+Message authority is typed and role-bound. Questions and peer messages are data;
+only an authorized parent task or reply may direct a child to continue work. The
+broker transports and authorizes messages but never executes their contents.
+
+The first implementation slice replaces only parent-child `ask/reply`. Direct
+callbacks remain during migration and are removed after mailbox delivery,
+wake-up, retry, and cleanup reach behavioral parity. Sibling communication,
+file reservations, attachments, task orchestration, and cross-project delivery
+are deferred.
+
+This decision does not select a mailbox product or sandbox runtime. An existing
+MCP mailbox may back the contract if a trial proves the required identity,
+authorization, delivery, and containment properties. Launch-time permission
+rules remain an inner policy layer; the sandbox remains the boundary on what a
+process can actually reach.
+
+## Consequences
+
+VM and container sandboxes no longer need a general bridge to host-side Herdr
+control, but the mailbox broker becomes security- and lifecycle-critical.
+Delivery can repeat across retries or wake-up recovery, so consumers must handle
+duplicate messages without repeating the represented decision or action.
+Implementation and verification are tracked in
+`docs/issues/2026-09-12-002-replace-child-ask-reply-with-a-sandbox-safe-mailbox.md`.

--- a/docs/issues/2026-09-12-002-replace-child-ask-reply-with-a-sandbox-safe-mailbox.md
+++ b/docs/issues/2026-09-12-002-replace-child-ask-reply-with-a-sandbox-safe-mailbox.md
@@ -1,0 +1,22 @@
+---
+title: "Replace child ask/reply with a sandbox-safe mailbox"
+short_description: "A host-owned durable broker must let sandboxed parent and child agents exchange typed, authorized messages and wake recipients without exposing Herdr control; the policy prototype is preserved on branch `prototype-logic-2026-08-18`."
+type: "idea"
+category: "agent-platform"
+tags: ["agent-platform","agent-mailbox","sandbox"]
+date: "2026-09-12"
+status: "open"
+priority: "high"
+---
+
+## Why this exists
+
+The current `herdr-child ask/reply` path lets a child invoke host-side Herdr control directly. A sandbox that preserves that access keeps a broad escape path, while removing it breaks the mandatory return channel. ADR-0013 selects a host-owned mailbox broker as the target communication boundary.
+
+## Scope
+
+Replace only the current parent-child ask/reply flow. Persist each message before delivery, wake an idle recipient through a host-side Herdr adapter, authenticate both agents from their launch relationship, and enforce typed role-based message authority. Keep direct ask/reply until parity is proved, then remove it. Peer-to-peer messaging, file reservations, attachments, cross-project delivery, task orchestration, and selection of a sandbox runtime are outside this first slice.
+
+## Open decisions
+
+Choose whether the first backend is a narrow repository-owned broker or an adapter over an existing MCP mailbox; define acknowledgement, retry, deduplication, retention, and cleanup behavior; prove that a sandbox can reach only the mailbox capability while the host adapter alone can reach Herdr.


### PR DESCRIPTION
## Summary

Sandboxed child agents now have a documented target communication boundary that does not require access to Herdr control. ADR-0015 selects a host-owned mailbox that persists and authorizes messages, while a host-side adapter alone wakes recipients through Herdr.

The decision remains independent of any mailbox product or sandbox runtime. The first implementation slice replaces parent-child `ask/reply`; broader peer coordination stays deferred and is tracked in #253.

## Decisions

- Treat launch-time permissions as an inner policy layer and the sandbox as the resource boundary.
- Give sandboxed agents mailbox capabilities instead of the Herdr CLI or control socket.
- Authorize delivery through the launch relationship graph and interpret message authority by type and sender role.
- Persist messages before wake-up and require duplicate-safe handling across retries.
- Keep direct callbacks during migration, then remove them after behavioral parity is proved.

The policy prototype remains on the separate `prototype-logic-2026-08-18` branch.

## Verification

- `git diff --check`
- GitHub issue #253 read-back confirmed its body, labels, and open state

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/gpt--5.6--sol-000000)
